### PR TITLE
Remove profile section from cw4-registry's Cargo.toml

### DIFF
--- a/contracts/cw4-registry/Cargo.toml
+++ b/contracts/cw4-registry/Cargo.toml
@@ -15,17 +15,6 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-opt-level = 3
-debug = false
-rpath = false
-lto = true
-debug-assertions = false
-codegen-units = 1
-panic = 'abort'
-incremental = false
-overflow-checks = true
-
 [features]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]


### PR DESCRIPTION
Profiles for non-root packages are ignored by cargo. Running `cargo
metadata --format-version 1 --no-deps` before this change would thus
result in the following warning:

```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /Users/zekemedley/Desktop/projects/juno/dao-contracts/contracts/cw4-registry/Cargo.toml
workspace: /Users/zekemedley/Desktop/projects/juno/dao-contracts/Cargo.toml
```

This causes trouble for emacs cargo-minor-mode as when it attempts to
build the project getting the metadata results in a non-zero exit
code.

The release profile in cw4-registry is identical to the one in the
project root so this being ignored does not change the intended
release profile for that crate.