### PR TITLE
Add limits to queries and token add/remove execution

### DIFF
--- a/contracts/cw3-dao/src/error.rs
+++ b/contracts/cw3-dao/src/error.rs
@@ -47,4 +47,7 @@ pub enum ContractError {
 
     #[error("Got a submessage reply with unknown id: {id}")]
     UnknownReplyId { id: u64 },
+
+    #[error("Request size ({size}) is above limit of ({max})")]
+    OversizedRequest { size: u64, max: u64 },
 }

--- a/contracts/cw3-dao/src/helpers.rs
+++ b/contracts/cw3-dao/src/helpers.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::{
-    to_binary, Addr, BlockInfo, CosmosMsg, Deps, Env, MessageInfo, StdResult, Uint128, WasmMsg,
+    to_binary, Addr, BlockInfo, CosmosMsg, Deps, Env, MessageInfo, StdError, StdResult, Uint128,
+    WasmMsg,
 };
 use cw20::Cw20ExecuteMsg;
 
@@ -10,6 +11,7 @@ use cw20_gov::msg::{
 use crate::{
     query::ProposalResponse,
     state::{parse_id, Proposal, GOV_TOKEN},
+    ContractError,
 };
 
 pub fn get_deposit_message(
@@ -112,4 +114,23 @@ pub fn map_proposal(
         threshold,
         deposit_amount: prop.deposit,
     })
+}
+
+pub fn get_and_check_limit(limit: Option<u32>, max: u32, default: u32) -> StdResult<u32> {
+    match limit {
+        Some(l) => {
+            if l <= max {
+                Ok(l)
+            } else {
+                Err(StdError::GenericErr {
+                    msg: ContractError::OversizedRequest {
+                        size: l as u64,
+                        max: max as u64,
+                    }
+                    .to_string(),
+                })
+            }
+        }
+        None => Ok(default),
+    }
 }


### PR DESCRIPTION
- Limits on query operations stop queries from silently returning less
  than the requested number of results even when more are available.
- Limits on token add/remove executions stop these from causing out of
  gas issues.