### PR TITLE
Add ProposalCount query to dao and multisig

### DIFF
--- a/contracts/cw3-dao/src/contract.rs
+++ b/contracts/cw3-dao/src/contract.rs
@@ -389,6 +389,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             start_before,
             limit,
         } => to_binary(&query_reverse_proposals(deps, env, start_before, limit)?),
+        QueryMsg::ProposalCount {} => to_binary(&query_proposal_count(deps)),
         QueryMsg::ListVotes {
             proposal_id,
             start_after,
@@ -539,6 +540,12 @@ fn query_reverse_proposals(
         .collect();
 
     Ok(ProposalListResponse { proposals: props? })
+}
+
+fn query_proposal_count(deps: Deps) -> u64 {
+    PROPOSALS
+        .keys(deps.storage, None, None, Order::Descending)
+        .count() as u64
 }
 
 fn query_vote(deps: Deps, proposal_id: u64, voter: String) -> StdResult<VoteResponse> {

--- a/contracts/cw3-dao/src/msg.rs
+++ b/contracts/cw3-dao/src/msg.rs
@@ -170,6 +170,8 @@ pub enum QueryMsg {
         start_before: Option<u64>,
         limit: Option<u32>,
     },
+    /// Returns the number of proposals in the DAO (u64)
+    ProposalCount {},
     /// Returns VoteResponse
     Vote { proposal_id: u64, voter: String },
     /// Returns VoteListResponse

--- a/contracts/cw3-dao/src/tests.rs
+++ b/contracts/cw3-dao/src/tests.rs
@@ -582,12 +582,24 @@ mod tests {
             None,
         );
 
+        let prop_count: u64 = app
+            .wrap()
+            .query_wasm_smart(&dao_addr, &QueryMsg::ProposalCount {})
+            .unwrap();
+        assert_eq!(prop_count, 0);
+
         // create proposal with 1 vote power
         let proposal = pay_somebody_proposal();
         let res = app
             .execute_contract(Addr::unchecked(VOTER1), dao_addr.clone(), &proposal, &[])
             .unwrap();
         let proposal_id1: u64 = res.custom_attrs(1)[2].value.parse().unwrap();
+
+        let prop_count: u64 = app
+            .wrap()
+            .query_wasm_smart(&dao_addr, &QueryMsg::ProposalCount {})
+            .unwrap();
+        assert_eq!(prop_count, 1);
 
         // another proposal
         app.update_block(next_block);
@@ -615,6 +627,12 @@ mod tests {
             .unwrap();
         let proposal_id3: u64 = res.custom_attrs(1)[2].value.parse().unwrap();
         let proposed_at = app.block_info();
+
+        let prop_count: u64 = app
+            .wrap()
+            .query_wasm_smart(&dao_addr, &QueryMsg::ProposalCount {})
+            .unwrap();
+        assert_eq!(prop_count, 3);
 
         // next block, let's query them all... make sure status is properly updated (1 should be rejected in query)
         app.update_block(next_block);

--- a/contracts/cw3-multisig/src/msg.rs
+++ b/contracts/cw3-multisig/src/msg.rs
@@ -173,6 +173,8 @@ pub enum QueryMsg {
         start_before: Option<u64>,
         limit: Option<u32>,
     },
+    /// Returns the number of proposals in the multisig (u64)
+    ProposalCount {},
     /// Returns VoteResponse
     Vote { proposal_id: u64, voter: String },
     /// Returns VoteListResponse


### PR DESCRIPTION
Resolves #113

Adds a `ProposalCount {}` query type to get the total number of proposals in a DAO or a Multisig.