### PR TITLE
Update deploy local script to use cw20 non-stakable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f703e4d6a955bf16ce5864c7883f324d8c17fd49b1250aaebc95f9d4ae7db3"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus",
+ "cw-storage-plus 0.10.3",
  "cw0",
  "schemars",
  "serde",
@@ -196,7 +196,7 @@ dependencies = [
  "anyhow",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus",
+ "cw-storage-plus 0.10.3",
  "cw0",
  "derivative",
  "itertools",
@@ -218,6 +218,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-storage-plus"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d7ee1963302b0ac2a9d42fe0faec826209c17452bfd36fbfd9d002a88929261"
+dependencies = [
+ "cosmwasm-std",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw-utils"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef842a1792e4285beff7b3b518705f760fa4111dc1e296e53f3e92d1ef7f6220"
+dependencies = [
+ "cosmwasm-std",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "cw0"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,7 +259,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7002e6f9c1a1ef3915dca704a6306ba00c39495efd928551d6077c734f9a3d8"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus",
+ "cw-storage-plus 0.10.3",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw2"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d81d7c359d6c1fba3aa83dad7ec6f999e512571380ae62f81257c3db569743"
+dependencies = [
+ "cosmwasm-std",
+ "cw-storage-plus 0.11.1",
  "schemars",
  "serde",
 ]
@@ -254,16 +289,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw20"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9671d7edef5608acaf5b2f1e473ee3f501eced2cd4f7392e2106c8cf02ba0720"
+dependencies = [
+ "cosmwasm-std",
+ "cw-utils",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "cw20-base"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f5df0a946a4a58dd4fdb158ff1595c55774beeef76d09f108b547bce572dcf"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus",
+ "cw-storage-plus 0.10.3",
  "cw0",
- "cw2",
- "cw20",
+ "cw2 0.10.3",
+ "cw20 0.10.3",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw20-base"
+version = "0.11.1"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 0.11.1",
+ "cw-utils",
+ "cw2 0.11.1",
+ "cw20 0.11.1",
  "schemars",
  "serde",
  "thiserror",
@@ -288,11 +350,11 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-storage-plus",
+ "cw-storage-plus 0.10.3",
  "cw0",
- "cw2",
- "cw20",
- "cw20-base",
+ "cw2 0.10.3",
+ "cw20 0.10.3",
+ "cw20-base 0.10.3",
  "cw3",
  "schemars",
  "serde",
@@ -307,11 +369,11 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-storage-plus",
+ "cw-storage-plus 0.10.3",
  "cw0",
- "cw2",
- "cw20",
- "cw20-base",
+ "cw2 0.10.3",
+ "cw20 0.10.3",
+ "cw20-base 0.10.3",
  "cw3",
  "cw4",
  "cw4-group",
@@ -327,7 +389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc4c986c0f79a6d46e071f70c4ec933fb1e4ad7689f1f38df091e47a52c4530"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus",
+ "cw-storage-plus 0.10.3",
  "schemars",
  "serde",
 ]
@@ -340,9 +402,9 @@ checksum = "6ee0e5e0afc8b8c0da6da3ccfcabc85a5d6303eaee3052b2c4120f6ce5a586bc"
 dependencies = [
  "cosmwasm-std",
  "cw-controllers",
- "cw-storage-plus",
+ "cw-storage-plus 0.10.3",
  "cw0",
- "cw2",
+ "cw2 0.10.3",
  "cw4",
  "schemars",
  "serde",
@@ -359,9 +421,9 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-multi-test",
- "cw-storage-plus",
+ "cw-storage-plus 0.10.3",
  "cw0",
- "cw2",
+ "cw2 0.10.3",
  "cw4",
  "cw4-group",
  "schemars",
@@ -752,11 +814,11 @@ dependencies = [
  "cosmwasm-storage",
  "cw-controllers",
  "cw-multi-test",
- "cw-storage-plus",
+ "cw-storage-plus 0.10.3",
  "cw0",
- "cw2",
- "cw20",
- "cw20-base",
+ "cw2 0.10.3",
+ "cw20 0.10.3",
+ "cw20-base 0.10.3",
  "schemars",
  "serde",
  "thiserror",

--- a/contracts/cw20-base/.cargo/config
+++ b/contracts/cw20-base/.cargo/config
@@ -1,0 +1,6 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+integration-test = "test --test integration"
+schema = "run --example schema"

--- a/contracts/cw20-base/Cargo.toml
+++ b/contracts/cw20-base/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "cw20-base"
+version = "0.11.1"
+authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
+edition = "2018"
+description = "Basic implementation of a CosmWasm-20 compliant token"
+license = "Apache-2.0"
+repository = "https://github.com/CosmWasm/cw-plus"
+homepage = "https://cosmwasm.com"
+documentation = "https://docs.cosmwasm.com"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[dependencies]
+cw-utils = { version = "0.11.1" }
+cw2 = { version = "0.11.1" }
+cw20 = { version = "0.11.1" }
+cw-storage-plus = { version = "0.11.1" }
+cosmwasm-std = { version = "1.0.0-beta3" }
+schemars = "0.8.1"
+serde = { version = "1.0.103", default-features = false, features = ["derive"] }
+thiserror = { version = "1.0.23" }
+
+[dev-dependencies]
+cosmwasm-schema = { version = "1.0.0-beta3" }

--- a/contracts/cw20-base/NOTICE
+++ b/contracts/cw20-base/NOTICE
@@ -1,0 +1,14 @@
+CW20-Base: A reference implementation for fungible token on CosmWasm
+Copyright (C) 2020 Confio OÜ
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/contracts/cw20-base/README.md
+++ b/contracts/cw20-base/README.md
@@ -1,0 +1,48 @@
+# CW20 Basic
+
+This is a basic implementation of a cw20 contract. It implements
+the [CW20 spec](../../packages/cw20/README.md) and is designed to
+be deployed as is, or imported into other contracts to easily build
+cw20-compatible tokens with custom logic.
+
+Implements:
+
+- [x] CW20 Base
+- [x] Mintable extension
+- [x] Allowances extension
+
+## Running this contract
+
+You will need Rust 1.44.1+ with `wasm32-unknown-unknown` target installed.
+
+You can run unit tests on this via: 
+
+`cargo test`
+
+Once you are happy with the content, you can compile it to wasm via:
+
+```
+RUSTFLAGS='-C link-arg=-s' cargo wasm
+cp ../../target/wasm32-unknown-unknown/release/cw20_base.wasm .
+ls -l cw20_base.wasm
+sha256sum cw20_base.wasm
+```
+
+Or for a production-ready (optimized) build, run a build command in the
+the repository root: https://github.com/CosmWasm/cw-plus#compiling.
+
+## Importing this contract
+
+You can also import much of the logic of this contract to build another
+ERC20-contract, such as a bonding curve, overiding or extending what you
+need.
+
+Basically, you just need to write your handle function and import 
+`cw20_base::contract::handle_transfer`, etc and dispatch to them.
+This allows you to use custom `ExecuteMsg` and `QueryMsg` with your additional
+calls, but then use the underlying implementation for the standard cw20
+messages you want to support. The same with `QueryMsg`. You *could* reuse `instantiate`
+as it, but it is likely you will want to change it. And it is rather simple.
+
+Look at [`cw20-staking`](../cw20-staking/README.md) for an example of how to "inherit"
+all this token functionality and combine it with custom logic.

--- a/contracts/cw20-base/examples/schema.rs
+++ b/contracts/cw20-base/examples/schema.rs
@@ -1,0 +1,26 @@
+use std::env::current_dir;
+use std::fs::create_dir_all;
+
+use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
+
+use cw20::{
+    AllAccountsResponse, AllAllowancesResponse, AllowanceResponse, BalanceResponse,
+    TokenInfoResponse,
+};
+use cw20_base::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+
+fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
+    create_dir_all(&out_dir).unwrap();
+    remove_schemas(&out_dir).unwrap();
+
+    export_schema(&schema_for!(InstantiateMsg), &out_dir);
+    export_schema(&schema_for!(ExecuteMsg), &out_dir);
+    export_schema(&schema_for!(QueryMsg), &out_dir);
+    export_schema(&schema_for!(AllowanceResponse), &out_dir);
+    export_schema(&schema_for!(BalanceResponse), &out_dir);
+    export_schema(&schema_for!(TokenInfoResponse), &out_dir);
+    export_schema(&schema_for!(AllAllowancesResponse), &out_dir);
+    export_schema(&schema_for!(AllAccountsResponse), &out_dir);
+}

--- a/contracts/cw20-base/src/allowances.rs
+++ b/contracts/cw20-base/src/allowances.rs
@@ -1,0 +1,744 @@
+use cosmwasm_std::{
+    attr, Addr, Binary, BlockInfo, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult,
+    Storage, Uint128,
+};
+use cw20::{AllowanceResponse, Cw20ReceiveMsg, Expiration};
+
+use crate::error::ContractError;
+use crate::state::{ALLOWANCES, BALANCES, TOKEN_INFO};
+
+pub fn execute_increase_allowance(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    spender: String,
+    amount: Uint128,
+    expires: Option<Expiration>,
+) -> Result<Response, ContractError> {
+    let spender_addr = deps.api.addr_validate(&spender)?;
+    if spender_addr == info.sender {
+        return Err(ContractError::CannotSetOwnAccount {});
+    }
+
+    ALLOWANCES.update(
+        deps.storage,
+        (&info.sender, &spender_addr),
+        |allow| -> StdResult<_> {
+            let mut val = allow.unwrap_or_default();
+            if let Some(exp) = expires {
+                val.expires = exp;
+            }
+            val.allowance += amount;
+            Ok(val)
+        },
+    )?;
+
+    let res = Response::new().add_attributes(vec![
+        attr("action", "increase_allowance"),
+        attr("owner", info.sender),
+        attr("spender", spender),
+        attr("amount", amount),
+    ]);
+    Ok(res)
+}
+
+pub fn execute_decrease_allowance(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    spender: String,
+    amount: Uint128,
+    expires: Option<Expiration>,
+) -> Result<Response, ContractError> {
+    let spender_addr = deps.api.addr_validate(&spender)?;
+    if spender_addr == info.sender {
+        return Err(ContractError::CannotSetOwnAccount {});
+    }
+
+    let key = (&info.sender, &spender_addr);
+    // load value and delete if it hits 0, or update otherwise
+    let mut allowance = ALLOWANCES.load(deps.storage, key)?;
+    if amount < allowance.allowance {
+        // update the new amount
+        allowance.allowance = allowance
+            .allowance
+            .checked_sub(amount)
+            .map_err(StdError::overflow)?;
+        if let Some(exp) = expires {
+            allowance.expires = exp;
+        }
+        ALLOWANCES.save(deps.storage, key, &allowance)?;
+    } else {
+        ALLOWANCES.remove(deps.storage, key);
+    }
+
+    let res = Response::new().add_attributes(vec![
+        attr("action", "decrease_allowance"),
+        attr("owner", info.sender),
+        attr("spender", spender),
+        attr("amount", amount),
+    ]);
+    Ok(res)
+}
+
+// this can be used to update a lower allowance - call bucket.update with proper keys
+pub fn deduct_allowance(
+    storage: &mut dyn Storage,
+    owner: &Addr,
+    spender: &Addr,
+    block: &BlockInfo,
+    amount: Uint128,
+) -> Result<AllowanceResponse, ContractError> {
+    ALLOWANCES.update(storage, (owner, spender), |current| {
+        match current {
+            Some(mut a) => {
+                if a.expires.is_expired(block) {
+                    Err(ContractError::Expired {})
+                } else {
+                    // deduct the allowance if enough
+                    a.allowance = a
+                        .allowance
+                        .checked_sub(amount)
+                        .map_err(StdError::overflow)?;
+                    Ok(a)
+                }
+            }
+            None => Err(ContractError::NoAllowance {}),
+        }
+    })
+}
+
+pub fn execute_transfer_from(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    owner: String,
+    recipient: String,
+    amount: Uint128,
+) -> Result<Response, ContractError> {
+    let rcpt_addr = deps.api.addr_validate(&recipient)?;
+    let owner_addr = deps.api.addr_validate(&owner)?;
+
+    // deduct allowance before doing anything else have enough allowance
+    deduct_allowance(deps.storage, &owner_addr, &info.sender, &env.block, amount)?;
+
+    BALANCES.update(
+        deps.storage,
+        &owner_addr,
+        |balance: Option<Uint128>| -> StdResult<_> {
+            Ok(balance.unwrap_or_default().checked_sub(amount)?)
+        },
+    )?;
+    BALANCES.update(
+        deps.storage,
+        &rcpt_addr,
+        |balance: Option<Uint128>| -> StdResult<_> { Ok(balance.unwrap_or_default() + amount) },
+    )?;
+
+    let res = Response::new().add_attributes(vec![
+        attr("action", "transfer_from"),
+        attr("from", owner),
+        attr("to", recipient),
+        attr("by", info.sender),
+        attr("amount", amount),
+    ]);
+    Ok(res)
+}
+
+pub fn execute_burn_from(
+    deps: DepsMut,
+
+    env: Env,
+    info: MessageInfo,
+    owner: String,
+    amount: Uint128,
+) -> Result<Response, ContractError> {
+    let owner_addr = deps.api.addr_validate(&owner)?;
+
+    // deduct allowance before doing anything else have enough allowance
+    deduct_allowance(deps.storage, &owner_addr, &info.sender, &env.block, amount)?;
+
+    // lower balance
+    BALANCES.update(
+        deps.storage,
+        &owner_addr,
+        |balance: Option<Uint128>| -> StdResult<_> {
+            Ok(balance.unwrap_or_default().checked_sub(amount)?)
+        },
+    )?;
+    // reduce total_supply
+    TOKEN_INFO.update(deps.storage, |mut meta| -> StdResult<_> {
+        meta.total_supply = meta.total_supply.checked_sub(amount)?;
+        Ok(meta)
+    })?;
+
+    let res = Response::new().add_attributes(vec![
+        attr("action", "burn_from"),
+        attr("from", owner),
+        attr("by", info.sender),
+        attr("amount", amount),
+    ]);
+    Ok(res)
+}
+
+pub fn execute_send_from(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    owner: String,
+    contract: String,
+    amount: Uint128,
+    msg: Binary,
+) -> Result<Response, ContractError> {
+    let rcpt_addr = deps.api.addr_validate(&contract)?;
+    let owner_addr = deps.api.addr_validate(&owner)?;
+
+    // deduct allowance before doing anything else have enough allowance
+    deduct_allowance(deps.storage, &owner_addr, &info.sender, &env.block, amount)?;
+
+    // move the tokens to the contract
+    BALANCES.update(
+        deps.storage,
+        &owner_addr,
+        |balance: Option<Uint128>| -> StdResult<_> {
+            Ok(balance.unwrap_or_default().checked_sub(amount)?)
+        },
+    )?;
+    BALANCES.update(
+        deps.storage,
+        &rcpt_addr,
+        |balance: Option<Uint128>| -> StdResult<_> { Ok(balance.unwrap_or_default() + amount) },
+    )?;
+
+    let attrs = vec![
+        attr("action", "send_from"),
+        attr("from", &owner),
+        attr("to", &contract),
+        attr("by", &info.sender),
+        attr("amount", amount),
+    ];
+
+    // create a send message
+    let msg = Cw20ReceiveMsg {
+        sender: info.sender.into(),
+        amount,
+        msg,
+    }
+    .into_cosmos_msg(contract)?;
+
+    let res = Response::new().add_message(msg).add_attributes(attrs);
+    Ok(res)
+}
+
+pub fn query_allowance(deps: Deps, owner: String, spender: String) -> StdResult<AllowanceResponse> {
+    let owner_addr = deps.api.addr_validate(&owner)?;
+    let spender_addr = deps.api.addr_validate(&spender)?;
+    let allowance = ALLOWANCES
+        .may_load(deps.storage, (&owner_addr, &spender_addr))?
+        .unwrap_or_default();
+    Ok(allowance)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use cosmwasm_std::testing::{mock_dependencies_with_balance, mock_env, mock_info};
+    use cosmwasm_std::{coins, CosmosMsg, SubMsg, Timestamp, WasmMsg};
+    use cw20::{Cw20Coin, TokenInfoResponse};
+
+    use crate::contract::{execute, instantiate, query_balance, query_token_info};
+    use crate::msg::{ExecuteMsg, InstantiateMsg};
+
+    fn get_balance<T: Into<String>>(deps: Deps, address: T) -> Uint128 {
+        query_balance(deps, address.into()).unwrap().balance
+    }
+
+    // this will set up the instantiation for other tests
+    fn do_instantiate<T: Into<String>>(
+        mut deps: DepsMut,
+        addr: T,
+        amount: Uint128,
+    ) -> TokenInfoResponse {
+        let instantiate_msg = InstantiateMsg {
+            name: "Auto Gen".to_string(),
+            symbol: "AUTO".to_string(),
+            decimals: 3,
+            initial_balances: vec![Cw20Coin {
+                address: addr.into(),
+                amount,
+            }],
+            mint: None,
+            marketing: None,
+        };
+        let info = mock_info("creator", &[]);
+        let env = mock_env();
+        instantiate(deps.branch(), env, info, instantiate_msg).unwrap();
+        query_token_info(deps.as_ref()).unwrap()
+    }
+
+    #[test]
+    fn increase_decrease_allowances() {
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
+
+        let owner = String::from("addr0001");
+        let spender = String::from("addr0002");
+        let info = mock_info(owner.as_ref(), &[]);
+        let env = mock_env();
+        do_instantiate(deps.as_mut(), owner.clone(), Uint128::new(12340000));
+
+        // no allowance to start
+        let allowance = query_allowance(deps.as_ref(), owner.clone(), spender.clone()).unwrap();
+        assert_eq!(allowance, AllowanceResponse::default());
+
+        // set allowance with height expiration
+        let allow1 = Uint128::new(7777);
+        let expires = Expiration::AtHeight(5432);
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: spender.clone(),
+            amount: allow1,
+            expires: Some(expires),
+        };
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+
+        // ensure it looks good
+        let allowance = query_allowance(deps.as_ref(), owner.clone(), spender.clone()).unwrap();
+        assert_eq!(
+            allowance,
+            AllowanceResponse {
+                allowance: allow1,
+                expires
+            }
+        );
+
+        // decrease it a bit with no expire set - stays the same
+        let lower = Uint128::new(4444);
+        let allow2 = allow1.checked_sub(lower).unwrap();
+        let msg = ExecuteMsg::DecreaseAllowance {
+            spender: spender.clone(),
+            amount: lower,
+            expires: None,
+        };
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        let allowance = query_allowance(deps.as_ref(), owner.clone(), spender.clone()).unwrap();
+        assert_eq!(
+            allowance,
+            AllowanceResponse {
+                allowance: allow2,
+                expires
+            }
+        );
+
+        // increase it some more and override the expires
+        let raise = Uint128::new(87654);
+        let allow3 = allow2 + raise;
+        let new_expire = Expiration::AtTime(Timestamp::from_seconds(8888888888));
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: spender.clone(),
+            amount: raise,
+            expires: Some(new_expire),
+        };
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+        let allowance = query_allowance(deps.as_ref(), owner.clone(), spender.clone()).unwrap();
+        assert_eq!(
+            allowance,
+            AllowanceResponse {
+                allowance: allow3,
+                expires: new_expire
+            }
+        );
+
+        // decrease it below 0
+        let msg = ExecuteMsg::DecreaseAllowance {
+            spender: spender.clone(),
+            amount: Uint128::new(99988647623876347),
+            expires: None,
+        };
+        execute(deps.as_mut(), env, info, msg).unwrap();
+        let allowance = query_allowance(deps.as_ref(), owner, spender).unwrap();
+        assert_eq!(allowance, AllowanceResponse::default());
+    }
+
+    #[test]
+    fn allowances_independent() {
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
+
+        let owner = String::from("addr0001");
+        let spender = String::from("addr0002");
+        let spender2 = String::from("addr0003");
+        let info = mock_info(owner.as_ref(), &[]);
+        let env = mock_env();
+        do_instantiate(deps.as_mut(), &owner, Uint128::new(12340000));
+
+        // no allowance to start
+        assert_eq!(
+            query_allowance(deps.as_ref(), owner.clone(), spender.clone()).unwrap(),
+            AllowanceResponse::default()
+        );
+        assert_eq!(
+            query_allowance(deps.as_ref(), owner.clone(), spender2.clone()).unwrap(),
+            AllowanceResponse::default()
+        );
+        assert_eq!(
+            query_allowance(deps.as_ref(), spender.clone(), spender2.clone()).unwrap(),
+            AllowanceResponse::default()
+        );
+
+        // set allowance with height expiration
+        let allow1 = Uint128::new(7777);
+        let expires = Expiration::AtHeight(5432);
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: spender.clone(),
+            amount: allow1,
+            expires: Some(expires),
+        };
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+
+        // set other allowance with no expiration
+        let allow2 = Uint128::new(87654);
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: spender2.clone(),
+            amount: allow2,
+            expires: None,
+        };
+        execute(deps.as_mut(), env, info, msg).unwrap();
+
+        // check they are proper
+        let expect_one = AllowanceResponse {
+            allowance: allow1,
+            expires,
+        };
+        let expect_two = AllowanceResponse {
+            allowance: allow2,
+            expires: Expiration::Never {},
+        };
+        assert_eq!(
+            query_allowance(deps.as_ref(), owner.clone(), spender.clone()).unwrap(),
+            expect_one
+        );
+        assert_eq!(
+            query_allowance(deps.as_ref(), owner.clone(), spender2.clone()).unwrap(),
+            expect_two
+        );
+        assert_eq!(
+            query_allowance(deps.as_ref(), spender.clone(), spender2.clone()).unwrap(),
+            AllowanceResponse::default()
+        );
+
+        // also allow spender -> spender2 with no interference
+        let info = mock_info(spender.as_ref(), &[]);
+        let env = mock_env();
+        let allow3 = Uint128::new(1821);
+        let expires3 = Expiration::AtTime(Timestamp::from_seconds(3767626296));
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: spender2.clone(),
+            amount: allow3,
+            expires: Some(expires3),
+        };
+        execute(deps.as_mut(), env, info, msg).unwrap();
+        let expect_three = AllowanceResponse {
+            allowance: allow3,
+            expires: expires3,
+        };
+        assert_eq!(
+            query_allowance(deps.as_ref(), owner.clone(), spender.clone()).unwrap(),
+            expect_one
+        );
+        assert_eq!(
+            query_allowance(deps.as_ref(), owner, spender2.clone()).unwrap(),
+            expect_two
+        );
+        assert_eq!(
+            query_allowance(deps.as_ref(), spender, spender2).unwrap(),
+            expect_three
+        );
+    }
+
+    #[test]
+    fn no_self_allowance() {
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
+
+        let owner = String::from("addr0001");
+        let info = mock_info(owner.as_ref(), &[]);
+        let env = mock_env();
+        do_instantiate(deps.as_mut(), &owner, Uint128::new(12340000));
+
+        // self-allowance
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: owner.clone(),
+            amount: Uint128::new(7777),
+            expires: None,
+        };
+        let err = execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap_err();
+        assert_eq!(err, ContractError::CannotSetOwnAccount {});
+
+        // decrease self-allowance
+        let msg = ExecuteMsg::DecreaseAllowance {
+            spender: owner,
+            amount: Uint128::new(7777),
+            expires: None,
+        };
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert_eq!(err, ContractError::CannotSetOwnAccount {});
+    }
+
+    #[test]
+    fn transfer_from_respects_limits() {
+        let mut deps = mock_dependencies_with_balance(&[]);
+        let owner = String::from("addr0001");
+        let spender = String::from("addr0002");
+        let rcpt = String::from("addr0003");
+
+        let start = Uint128::new(999999);
+        do_instantiate(deps.as_mut(), &owner, start);
+
+        // provide an allowance
+        let allow1 = Uint128::new(77777);
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: spender.clone(),
+            amount: allow1,
+            expires: None,
+        };
+        let info = mock_info(owner.as_ref(), &[]);
+        let env = mock_env();
+        execute(deps.as_mut(), env, info, msg).unwrap();
+
+        // valid transfer of part of the allowance
+        let transfer = Uint128::new(44444);
+        let msg = ExecuteMsg::TransferFrom {
+            owner: owner.clone(),
+            recipient: rcpt.clone(),
+            amount: transfer,
+        };
+        let info = mock_info(spender.as_ref(), &[]);
+        let env = mock_env();
+        let res = execute(deps.as_mut(), env, info, msg).unwrap();
+        assert_eq!(res.attributes[0], attr("action", "transfer_from"));
+
+        // make sure money arrived
+        assert_eq!(
+            get_balance(deps.as_ref(), owner.clone()),
+            start.checked_sub(transfer).unwrap()
+        );
+        assert_eq!(get_balance(deps.as_ref(), rcpt.clone()), transfer);
+
+        // ensure it looks good
+        let allowance = query_allowance(deps.as_ref(), owner.clone(), spender.clone()).unwrap();
+        let expect = AllowanceResponse {
+            allowance: allow1.checked_sub(transfer).unwrap(),
+            expires: Expiration::Never {},
+        };
+        assert_eq!(expect, allowance);
+
+        // cannot send more than the allowance
+        let msg = ExecuteMsg::TransferFrom {
+            owner: owner.clone(),
+            recipient: rcpt.clone(),
+            amount: Uint128::new(33443),
+        };
+        let info = mock_info(spender.as_ref(), &[]);
+        let env = mock_env();
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert!(matches!(err, ContractError::Std(StdError::Overflow { .. })));
+
+        // let us increase limit, but set the expiration (default env height is 12_345)
+        let info = mock_info(owner.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: spender.clone(),
+            amount: Uint128::new(1000),
+            expires: Some(Expiration::AtHeight(env.block.height)),
+        };
+        execute(deps.as_mut(), env, info, msg).unwrap();
+
+        // we should now get the expiration error
+        let msg = ExecuteMsg::TransferFrom {
+            owner,
+            recipient: rcpt,
+            amount: Uint128::new(33443),
+        };
+        let info = mock_info(spender.as_ref(), &[]);
+        let env = mock_env();
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert_eq!(err, ContractError::Expired {});
+    }
+
+    #[test]
+    fn burn_from_respects_limits() {
+        let mut deps = mock_dependencies_with_balance(&[]);
+        let owner = String::from("addr0001");
+        let spender = String::from("addr0002");
+
+        let start = Uint128::new(999999);
+        do_instantiate(deps.as_mut(), &owner, start);
+
+        // provide an allowance
+        let allow1 = Uint128::new(77777);
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: spender.clone(),
+            amount: allow1,
+            expires: None,
+        };
+        let info = mock_info(owner.as_ref(), &[]);
+        let env = mock_env();
+        execute(deps.as_mut(), env, info, msg).unwrap();
+
+        // valid burn of part of the allowance
+        let transfer = Uint128::new(44444);
+        let msg = ExecuteMsg::BurnFrom {
+            owner: owner.clone(),
+            amount: transfer,
+        };
+        let info = mock_info(spender.as_ref(), &[]);
+        let env = mock_env();
+        let res = execute(deps.as_mut(), env, info, msg).unwrap();
+        assert_eq!(res.attributes[0], attr("action", "burn_from"));
+
+        // make sure money burnt
+        assert_eq!(
+            get_balance(deps.as_ref(), owner.clone()),
+            start.checked_sub(transfer).unwrap()
+        );
+
+        // ensure it looks good
+        let allowance = query_allowance(deps.as_ref(), owner.clone(), spender.clone()).unwrap();
+        let expect = AllowanceResponse {
+            allowance: allow1.checked_sub(transfer).unwrap(),
+            expires: Expiration::Never {},
+        };
+        assert_eq!(expect, allowance);
+
+        // cannot burn more than the allowance
+        let msg = ExecuteMsg::BurnFrom {
+            owner: owner.clone(),
+            amount: Uint128::new(33443),
+        };
+        let info = mock_info(spender.as_ref(), &[]);
+        let env = mock_env();
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert!(matches!(err, ContractError::Std(StdError::Overflow { .. })));
+
+        // let us increase limit, but set the expiration (default env height is 12_345)
+        let info = mock_info(owner.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: spender.clone(),
+            amount: Uint128::new(1000),
+            expires: Some(Expiration::AtHeight(env.block.height)),
+        };
+        execute(deps.as_mut(), env, info, msg).unwrap();
+
+        // we should now get the expiration error
+        let msg = ExecuteMsg::BurnFrom {
+            owner,
+            amount: Uint128::new(33443),
+        };
+        let info = mock_info(spender.as_ref(), &[]);
+        let env = mock_env();
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert_eq!(err, ContractError::Expired {});
+    }
+
+    #[test]
+    fn send_from_respects_limits() {
+        let mut deps = mock_dependencies_with_balance(&[]);
+        let owner = String::from("addr0001");
+        let spender = String::from("addr0002");
+        let contract = String::from("cool-dex");
+        let send_msg = Binary::from(r#"{"some":123}"#.as_bytes());
+
+        let start = Uint128::new(999999);
+        do_instantiate(deps.as_mut(), &owner, start);
+
+        // provide an allowance
+        let allow1 = Uint128::new(77777);
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: spender.clone(),
+            amount: allow1,
+            expires: None,
+        };
+        let info = mock_info(owner.as_ref(), &[]);
+        let env = mock_env();
+        execute(deps.as_mut(), env, info, msg).unwrap();
+
+        // valid send of part of the allowance
+        let transfer = Uint128::new(44444);
+        let msg = ExecuteMsg::SendFrom {
+            owner: owner.clone(),
+            amount: transfer,
+            contract: contract.clone(),
+            msg: send_msg.clone(),
+        };
+        let info = mock_info(spender.as_ref(), &[]);
+        let env = mock_env();
+        let res = execute(deps.as_mut(), env, info, msg).unwrap();
+        assert_eq!(res.attributes[0], attr("action", "send_from"));
+        assert_eq!(1, res.messages.len());
+
+        // we record this as sent by the one who requested, not the one who was paying
+        let binary_msg = Cw20ReceiveMsg {
+            sender: spender.clone(),
+            amount: transfer,
+            msg: send_msg.clone(),
+        }
+        .into_binary()
+        .unwrap();
+        assert_eq!(
+            res.messages[0],
+            SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: contract.clone(),
+                msg: binary_msg,
+                funds: vec![],
+            }))
+        );
+
+        // make sure money sent
+        assert_eq!(
+            get_balance(deps.as_ref(), owner.clone()),
+            start.checked_sub(transfer).unwrap()
+        );
+        assert_eq!(get_balance(deps.as_ref(), contract.clone()), transfer);
+
+        // ensure it looks good
+        let allowance = query_allowance(deps.as_ref(), owner.clone(), spender.clone()).unwrap();
+        let expect = AllowanceResponse {
+            allowance: allow1.checked_sub(transfer).unwrap(),
+            expires: Expiration::Never {},
+        };
+        assert_eq!(expect, allowance);
+
+        // cannot send more than the allowance
+        let msg = ExecuteMsg::SendFrom {
+            owner: owner.clone(),
+            amount: Uint128::new(33443),
+            contract: contract.clone(),
+            msg: send_msg.clone(),
+        };
+        let info = mock_info(spender.as_ref(), &[]);
+        let env = mock_env();
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert!(matches!(err, ContractError::Std(StdError::Overflow { .. })));
+
+        // let us increase limit, but set the expiration to current block (expired)
+        let info = mock_info(owner.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: spender.clone(),
+            amount: Uint128::new(1000),
+            expires: Some(Expiration::AtHeight(env.block.height)),
+        };
+        execute(deps.as_mut(), env, info, msg).unwrap();
+
+        // we should now get the expiration error
+        let msg = ExecuteMsg::SendFrom {
+            owner,
+            amount: Uint128::new(33443),
+            contract,
+            msg: send_msg,
+        };
+        let info = mock_info(spender.as_ref(), &[]);
+        let env = mock_env();
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert_eq!(err, ContractError::Expired {});
+    }
+}

--- a/contracts/cw20-base/src/contract.rs
+++ b/contracts/cw20-base/src/contract.rs
@@ -1,0 +1,1923 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{
+    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128,
+};
+
+use cw2::set_contract_version;
+use cw20::{
+    BalanceResponse, Cw20Coin, Cw20ReceiveMsg, DownloadLogoResponse, EmbeddedLogo, Logo, LogoInfo,
+    MarketingInfoResponse, MinterResponse, TokenInfoResponse,
+};
+
+use crate::allowances::{
+    execute_burn_from, execute_decrease_allowance, execute_increase_allowance, execute_send_from,
+    execute_transfer_from, query_allowance,
+};
+use crate::enumerable::{query_all_accounts, query_all_allowances};
+use crate::error::ContractError;
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use crate::state::{MinterData, TokenInfo, BALANCES, LOGO, MARKETING_INFO, TOKEN_INFO};
+
+// version info for migration info
+const CONTRACT_NAME: &str = "crates.io:cw20-base";
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const LOGO_SIZE_CAP: usize = 5 * 1024;
+
+/// Checks if data starts with XML preamble
+fn verify_xml_preamble(data: &[u8]) -> Result<(), ContractError> {
+    // The easiest way to perform this check would be just match on regex, however regex
+    // compilation is heavy and probably not worth it.
+
+    let preamble = data
+        .split_inclusive(|c| *c == b'>')
+        .next()
+        .ok_or(ContractError::InvalidXmlPreamble {})?;
+
+    const PREFIX: &[u8] = b"<?xml ";
+    const POSTFIX: &[u8] = b"?>";
+
+    if !(preamble.starts_with(PREFIX) && preamble.ends_with(POSTFIX)) {
+        Err(ContractError::InvalidXmlPreamble {})
+    } else {
+        Ok(())
+    }
+
+    // Additionally attributes format could be validated as they are well defined, as well as
+    // comments presence inside of preable, but it is probably not worth it.
+}
+
+/// Validates XML logo
+fn verify_xml_logo(logo: &[u8]) -> Result<(), ContractError> {
+    verify_xml_preamble(logo)?;
+
+    if logo.len() > LOGO_SIZE_CAP {
+        Err(ContractError::LogoTooBig {})
+    } else {
+        Ok(())
+    }
+}
+
+/// Validates png logo
+fn verify_png_logo(logo: &[u8]) -> Result<(), ContractError> {
+    // PNG header format:
+    // 0x89 - magic byte, out of ASCII table to fail on 7-bit systems
+    // "PNG" ascii representation
+    // [0x0d, 0x0a] - dos style line ending
+    // 0x1a - dos control character, stop displaying rest of the file
+    // 0x0a - unix style line ending
+    const HEADER: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+    if logo.len() > LOGO_SIZE_CAP {
+        Err(ContractError::LogoTooBig {})
+    } else if !logo.starts_with(&HEADER) {
+        Err(ContractError::InvalidPngHeader {})
+    } else {
+        Ok(())
+    }
+}
+
+/// Checks if passed logo is correct, and if not, returns an error
+fn verify_logo(logo: &Logo) -> Result<(), ContractError> {
+    match logo {
+        Logo::Embedded(EmbeddedLogo::Svg(logo)) => verify_xml_logo(logo),
+        Logo::Embedded(EmbeddedLogo::Png(logo)) => verify_png_logo(logo),
+        Logo::Url(_) => Ok(()), // Any reasonable url validation would be regex based, probably not worth it
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    mut deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    // check valid token info
+    msg.validate()?;
+    // create initial accounts
+    let total_supply = create_accounts(&mut deps, &msg.initial_balances)?;
+
+    if let Some(limit) = msg.get_cap() {
+        if total_supply > limit {
+            return Err(StdError::generic_err("Initial supply greater than cap").into());
+        }
+    }
+
+    let mint = match msg.mint {
+        Some(m) => Some(MinterData {
+            minter: deps.api.addr_validate(&m.minter)?,
+            cap: m.cap,
+        }),
+        None => None,
+    };
+
+    // store token info
+    let data = TokenInfo {
+        name: msg.name,
+        symbol: msg.symbol,
+        decimals: msg.decimals,
+        total_supply,
+        mint,
+    };
+    TOKEN_INFO.save(deps.storage, &data)?;
+
+    if let Some(marketing) = msg.marketing {
+        let logo = if let Some(logo) = marketing.logo {
+            verify_logo(&logo)?;
+            LOGO.save(deps.storage, &logo)?;
+
+            match logo {
+                Logo::Url(url) => Some(LogoInfo::Url(url)),
+                Logo::Embedded(_) => Some(LogoInfo::Embedded),
+            }
+        } else {
+            None
+        };
+
+        let data = MarketingInfoResponse {
+            project: marketing.project,
+            description: marketing.description,
+            marketing: marketing
+                .marketing
+                .map(|addr| deps.api.addr_validate(&addr))
+                .transpose()?,
+            logo,
+        };
+        MARKETING_INFO.save(deps.storage, &data)?;
+    }
+
+    Ok(Response::default())
+}
+
+pub fn create_accounts(deps: &mut DepsMut, accounts: &[Cw20Coin]) -> StdResult<Uint128> {
+    let mut total_supply = Uint128::zero();
+    for row in accounts {
+        let address = deps.api.addr_validate(&row.address)?;
+        BALANCES.save(deps.storage, &address, &row.amount)?;
+        total_supply += row.amount;
+    }
+    Ok(total_supply)
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::Transfer { recipient, amount } => {
+            execute_transfer(deps, env, info, recipient, amount)
+        }
+        ExecuteMsg::Burn { amount } => execute_burn(deps, env, info, amount),
+        ExecuteMsg::Send {
+            contract,
+            amount,
+            msg,
+        } => execute_send(deps, env, info, contract, amount, msg),
+        ExecuteMsg::Mint { recipient, amount } => execute_mint(deps, env, info, recipient, amount),
+        ExecuteMsg::IncreaseAllowance {
+            spender,
+            amount,
+            expires,
+        } => execute_increase_allowance(deps, env, info, spender, amount, expires),
+        ExecuteMsg::DecreaseAllowance {
+            spender,
+            amount,
+            expires,
+        } => execute_decrease_allowance(deps, env, info, spender, amount, expires),
+        ExecuteMsg::TransferFrom {
+            owner,
+            recipient,
+            amount,
+        } => execute_transfer_from(deps, env, info, owner, recipient, amount),
+        ExecuteMsg::BurnFrom { owner, amount } => execute_burn_from(deps, env, info, owner, amount),
+        ExecuteMsg::SendFrom {
+            owner,
+            contract,
+            amount,
+            msg,
+        } => execute_send_from(deps, env, info, owner, contract, amount, msg),
+        ExecuteMsg::UpdateMarketing {
+            project,
+            description,
+            marketing,
+        } => execute_update_marketing(deps, env, info, project, description, marketing),
+        ExecuteMsg::UploadLogo(logo) => execute_upload_logo(deps, env, info, logo),
+    }
+}
+
+pub fn execute_transfer(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    recipient: String,
+    amount: Uint128,
+) -> Result<Response, ContractError> {
+    if amount == Uint128::zero() {
+        return Err(ContractError::InvalidZeroAmount {});
+    }
+
+    let rcpt_addr = deps.api.addr_validate(&recipient)?;
+
+    BALANCES.update(
+        deps.storage,
+        &info.sender,
+        |balance: Option<Uint128>| -> StdResult<_> {
+            Ok(balance.unwrap_or_default().checked_sub(amount)?)
+        },
+    )?;
+    BALANCES.update(
+        deps.storage,
+        &rcpt_addr,
+        |balance: Option<Uint128>| -> StdResult<_> { Ok(balance.unwrap_or_default() + amount) },
+    )?;
+
+    let res = Response::new()
+        .add_attribute("action", "transfer")
+        .add_attribute("from", info.sender)
+        .add_attribute("to", recipient)
+        .add_attribute("amount", amount);
+    Ok(res)
+}
+
+pub fn execute_burn(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    amount: Uint128,
+) -> Result<Response, ContractError> {
+    if amount == Uint128::zero() {
+        return Err(ContractError::InvalidZeroAmount {});
+    }
+
+    // lower balance
+    BALANCES.update(
+        deps.storage,
+        &info.sender,
+        |balance: Option<Uint128>| -> StdResult<_> {
+            Ok(balance.unwrap_or_default().checked_sub(amount)?)
+        },
+    )?;
+    // reduce total_supply
+    TOKEN_INFO.update(deps.storage, |mut info| -> StdResult<_> {
+        info.total_supply = info.total_supply.checked_sub(amount)?;
+        Ok(info)
+    })?;
+
+    let res = Response::new()
+        .add_attribute("action", "burn")
+        .add_attribute("from", info.sender)
+        .add_attribute("amount", amount);
+    Ok(res)
+}
+
+pub fn execute_mint(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    recipient: String,
+    amount: Uint128,
+) -> Result<Response, ContractError> {
+    if amount == Uint128::zero() {
+        return Err(ContractError::InvalidZeroAmount {});
+    }
+
+    let mut config = TOKEN_INFO.load(deps.storage)?;
+    if config.mint.is_none() || config.mint.as_ref().unwrap().minter != info.sender {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    // update supply and enforce cap
+    config.total_supply += amount;
+    if let Some(limit) = config.get_cap() {
+        if config.total_supply > limit {
+            return Err(ContractError::CannotExceedCap {});
+        }
+    }
+    TOKEN_INFO.save(deps.storage, &config)?;
+
+    // add amount to recipient balance
+    let rcpt_addr = deps.api.addr_validate(&recipient)?;
+    BALANCES.update(
+        deps.storage,
+        &rcpt_addr,
+        |balance: Option<Uint128>| -> StdResult<_> { Ok(balance.unwrap_or_default() + amount) },
+    )?;
+
+    let res = Response::new()
+        .add_attribute("action", "mint")
+        .add_attribute("to", recipient)
+        .add_attribute("amount", amount);
+    Ok(res)
+}
+
+pub fn execute_send(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    contract: String,
+    amount: Uint128,
+    msg: Binary,
+) -> Result<Response, ContractError> {
+    if amount == Uint128::zero() {
+        return Err(ContractError::InvalidZeroAmount {});
+    }
+
+    let rcpt_addr = deps.api.addr_validate(&contract)?;
+
+    // move the tokens to the contract
+    BALANCES.update(
+        deps.storage,
+        &info.sender,
+        |balance: Option<Uint128>| -> StdResult<_> {
+            Ok(balance.unwrap_or_default().checked_sub(amount)?)
+        },
+    )?;
+    BALANCES.update(
+        deps.storage,
+        &rcpt_addr,
+        |balance: Option<Uint128>| -> StdResult<_> { Ok(balance.unwrap_or_default() + amount) },
+    )?;
+
+    let res = Response::new()
+        .add_attribute("action", "send")
+        .add_attribute("from", &info.sender)
+        .add_attribute("to", &contract)
+        .add_attribute("amount", amount)
+        .add_message(
+            Cw20ReceiveMsg {
+                sender: info.sender.into(),
+                amount,
+                msg,
+            }
+            .into_cosmos_msg(contract)?,
+        );
+    Ok(res)
+}
+
+pub fn execute_update_marketing(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    project: Option<String>,
+    description: Option<String>,
+    marketing: Option<String>,
+) -> Result<Response, ContractError> {
+    let mut marketing_info = MARKETING_INFO
+        .may_load(deps.storage)?
+        .ok_or(ContractError::Unauthorized {})?;
+
+    if marketing_info
+        .marketing
+        .as_ref()
+        .ok_or(ContractError::Unauthorized {})?
+        != &info.sender
+    {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    match project {
+        Some(empty) if empty.trim().is_empty() => marketing_info.project = None,
+        Some(project) => marketing_info.project = Some(project),
+        None => (),
+    }
+
+    match description {
+        Some(empty) if empty.trim().is_empty() => marketing_info.description = None,
+        Some(description) => marketing_info.description = Some(description),
+        None => (),
+    }
+
+    match marketing {
+        Some(empty) if empty.trim().is_empty() => marketing_info.marketing = None,
+        Some(marketing) => marketing_info.marketing = Some(deps.api.addr_validate(&marketing)?),
+        None => (),
+    }
+
+    if marketing_info.project.is_none()
+        && marketing_info.description.is_none()
+        && marketing_info.marketing.is_none()
+        && marketing_info.logo.is_none()
+    {
+        MARKETING_INFO.remove(deps.storage);
+    } else {
+        MARKETING_INFO.save(deps.storage, &marketing_info)?;
+    }
+
+    let res = Response::new().add_attribute("action", "update_marketing");
+    Ok(res)
+}
+
+pub fn execute_upload_logo(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    logo: Logo,
+) -> Result<Response, ContractError> {
+    let mut marketing_info = MARKETING_INFO
+        .may_load(deps.storage)?
+        .ok_or(ContractError::Unauthorized {})?;
+
+    verify_logo(&logo)?;
+
+    if marketing_info
+        .marketing
+        .as_ref()
+        .ok_or(ContractError::Unauthorized {})?
+        != &info.sender
+    {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    LOGO.save(deps.storage, &logo)?;
+
+    let logo_info = match logo {
+        Logo::Url(url) => LogoInfo::Url(url),
+        Logo::Embedded(_) => LogoInfo::Embedded,
+    };
+
+    marketing_info.logo = Some(logo_info);
+    MARKETING_INFO.save(deps.storage, &marketing_info)?;
+
+    let res = Response::new().add_attribute("action", "upload_logo");
+    Ok(res)
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Balance { address } => to_binary(&query_balance(deps, address)?),
+        QueryMsg::TokenInfo {} => to_binary(&query_token_info(deps)?),
+        QueryMsg::Minter {} => to_binary(&query_minter(deps)?),
+        QueryMsg::Allowance { owner, spender } => {
+            to_binary(&query_allowance(deps, owner, spender)?)
+        }
+        QueryMsg::AllAllowances {
+            owner,
+            start_after,
+            limit,
+        } => to_binary(&query_all_allowances(deps, owner, start_after, limit)?),
+        QueryMsg::AllAccounts { start_after, limit } => {
+            to_binary(&query_all_accounts(deps, start_after, limit)?)
+        }
+        QueryMsg::MarketingInfo {} => to_binary(&query_marketing_info(deps)?),
+        QueryMsg::DownloadLogo {} => to_binary(&query_download_logo(deps)?),
+    }
+}
+
+pub fn query_balance(deps: Deps, address: String) -> StdResult<BalanceResponse> {
+    let address = deps.api.addr_validate(&address)?;
+    let balance = BALANCES
+        .may_load(deps.storage, &address)?
+        .unwrap_or_default();
+    Ok(BalanceResponse { balance })
+}
+
+pub fn query_token_info(deps: Deps) -> StdResult<TokenInfoResponse> {
+    let info = TOKEN_INFO.load(deps.storage)?;
+    let res = TokenInfoResponse {
+        name: info.name,
+        symbol: info.symbol,
+        decimals: info.decimals,
+        total_supply: info.total_supply,
+    };
+    Ok(res)
+}
+
+pub fn query_minter(deps: Deps) -> StdResult<Option<MinterResponse>> {
+    let meta = TOKEN_INFO.load(deps.storage)?;
+    let minter = match meta.mint {
+        Some(m) => Some(MinterResponse {
+            minter: m.minter.into(),
+            cap: m.cap,
+        }),
+        None => None,
+    };
+    Ok(minter)
+}
+
+pub fn query_marketing_info(deps: Deps) -> StdResult<MarketingInfoResponse> {
+    Ok(MARKETING_INFO.may_load(deps.storage)?.unwrap_or_default())
+}
+
+pub fn query_download_logo(deps: Deps) -> StdResult<DownloadLogoResponse> {
+    let logo = LOGO.load(deps.storage)?;
+    match logo {
+        Logo::Embedded(EmbeddedLogo::Svg(logo)) => Ok(DownloadLogoResponse {
+            mime_type: "image/svg+xml".to_owned(),
+            data: logo,
+        }),
+        Logo::Embedded(EmbeddedLogo::Png(logo)) => Ok(DownloadLogoResponse {
+            mime_type: "image/png".to_owned(),
+            data: logo,
+        }),
+        Logo::Url(_) => Err(StdError::not_found("logo")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cosmwasm_std::testing::{
+        mock_dependencies, mock_dependencies_with_balance, mock_env, mock_info,
+    };
+    use cosmwasm_std::{coins, from_binary, Addr, CosmosMsg, StdError, SubMsg, WasmMsg};
+
+    use super::*;
+    use crate::msg::InstantiateMarketingInfo;
+
+    fn get_balance<T: Into<String>>(deps: Deps, address: T) -> Uint128 {
+        query_balance(deps, address.into()).unwrap().balance
+    }
+
+    // this will set up the instantiation for other tests
+    fn do_instantiate_with_minter(
+        deps: DepsMut,
+        addr: &str,
+        amount: Uint128,
+        minter: &str,
+        cap: Option<Uint128>,
+    ) -> TokenInfoResponse {
+        _do_instantiate(
+            deps,
+            addr,
+            amount,
+            Some(MinterResponse {
+                minter: minter.to_string(),
+                cap,
+            }),
+        )
+    }
+
+    // this will set up the instantiation for other tests
+    fn do_instantiate(deps: DepsMut, addr: &str, amount: Uint128) -> TokenInfoResponse {
+        _do_instantiate(deps, addr, amount, None)
+    }
+
+    // this will set up the instantiation for other tests
+    fn _do_instantiate(
+        mut deps: DepsMut,
+        addr: &str,
+        amount: Uint128,
+        mint: Option<MinterResponse>,
+    ) -> TokenInfoResponse {
+        let instantiate_msg = InstantiateMsg {
+            name: "Auto Gen".to_string(),
+            symbol: "AUTO".to_string(),
+            decimals: 3,
+            initial_balances: vec![Cw20Coin {
+                address: addr.to_string(),
+                amount,
+            }],
+            mint: mint.clone(),
+            marketing: None,
+        };
+        let info = mock_info("creator", &[]);
+        let env = mock_env();
+        let res = instantiate(deps.branch(), env, info, instantiate_msg).unwrap();
+        assert_eq!(0, res.messages.len());
+
+        let meta = query_token_info(deps.as_ref()).unwrap();
+        assert_eq!(
+            meta,
+            TokenInfoResponse {
+                name: "Auto Gen".to_string(),
+                symbol: "AUTO".to_string(),
+                decimals: 3,
+                total_supply: amount,
+            }
+        );
+        assert_eq!(get_balance(deps.as_ref(), addr), amount);
+        assert_eq!(query_minter(deps.as_ref()).unwrap(), mint,);
+        meta
+    }
+
+    const PNG_HEADER: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+
+    mod instantiate {
+        use super::*;
+
+        #[test]
+        fn basic() {
+            let mut deps = mock_dependencies();
+            let amount = Uint128::from(11223344u128);
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![Cw20Coin {
+                    address: String::from("addr0000"),
+                    amount,
+                }],
+                mint: None,
+                marketing: None,
+            };
+            let info = mock_info("creator", &[]);
+            let env = mock_env();
+            let res = instantiate(deps.as_mut(), env, info, instantiate_msg).unwrap();
+            assert_eq!(0, res.messages.len());
+
+            assert_eq!(
+                query_token_info(deps.as_ref()).unwrap(),
+                TokenInfoResponse {
+                    name: "Cash Token".to_string(),
+                    symbol: "CASH".to_string(),
+                    decimals: 9,
+                    total_supply: amount,
+                }
+            );
+            assert_eq!(
+                get_balance(deps.as_ref(), "addr0000"),
+                Uint128::new(11223344)
+            );
+        }
+
+        #[test]
+        fn mintable() {
+            let mut deps = mock_dependencies();
+            let amount = Uint128::new(11223344);
+            let minter = String::from("asmodat");
+            let limit = Uint128::new(511223344);
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![Cw20Coin {
+                    address: "addr0000".into(),
+                    amount,
+                }],
+                mint: Some(MinterResponse {
+                    minter: minter.clone(),
+                    cap: Some(limit),
+                }),
+                marketing: None,
+            };
+            let info = mock_info("creator", &[]);
+            let env = mock_env();
+            let res = instantiate(deps.as_mut(), env, info, instantiate_msg).unwrap();
+            assert_eq!(0, res.messages.len());
+
+            assert_eq!(
+                query_token_info(deps.as_ref()).unwrap(),
+                TokenInfoResponse {
+                    name: "Cash Token".to_string(),
+                    symbol: "CASH".to_string(),
+                    decimals: 9,
+                    total_supply: amount,
+                }
+            );
+            assert_eq!(
+                get_balance(deps.as_ref(), "addr0000"),
+                Uint128::new(11223344)
+            );
+            assert_eq!(
+                query_minter(deps.as_ref()).unwrap(),
+                Some(MinterResponse {
+                    minter,
+                    cap: Some(limit),
+                }),
+            );
+        }
+
+        #[test]
+        fn mintable_over_cap() {
+            let mut deps = mock_dependencies();
+            let amount = Uint128::new(11223344);
+            let minter = String::from("asmodat");
+            let limit = Uint128::new(11223300);
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![Cw20Coin {
+                    address: String::from("addr0000"),
+                    amount,
+                }],
+                mint: Some(MinterResponse {
+                    minter,
+                    cap: Some(limit),
+                }),
+                marketing: None,
+            };
+            let info = mock_info("creator", &[]);
+            let env = mock_env();
+            let err = instantiate(deps.as_mut(), env, info, instantiate_msg).unwrap_err();
+            assert_eq!(
+                err,
+                StdError::generic_err("Initial supply greater than cap").into()
+            );
+        }
+
+        mod marketing {
+            use super::*;
+
+            #[test]
+            fn basic() {
+                let mut deps = mock_dependencies();
+                let instantiate_msg = InstantiateMsg {
+                    name: "Cash Token".to_string(),
+                    symbol: "CASH".to_string(),
+                    decimals: 9,
+                    initial_balances: vec![],
+                    mint: None,
+                    marketing: Some(InstantiateMarketingInfo {
+                        project: Some("Project".to_owned()),
+                        description: Some("Description".to_owned()),
+                        marketing: Some("marketing".to_owned()),
+                        logo: Some(Logo::Url("url".to_owned())),
+                    }),
+                };
+
+                let info = mock_info("creator", &[]);
+                let env = mock_env();
+                let res = instantiate(deps.as_mut(), env, info, instantiate_msg).unwrap();
+                assert_eq!(0, res.messages.len());
+
+                assert_eq!(
+                    query_marketing_info(deps.as_ref()).unwrap(),
+                    MarketingInfoResponse {
+                        project: Some("Project".to_owned()),
+                        description: Some("Description".to_owned()),
+                        marketing: Some(Addr::unchecked("marketing")),
+                        logo: Some(LogoInfo::Url("url".to_owned())),
+                    }
+                );
+
+                let err = query_download_logo(deps.as_ref()).unwrap_err();
+                assert!(
+                    matches!(err, StdError::NotFound { .. }),
+                    "Expected StdError::NotFound, received {}",
+                    err
+                );
+            }
+
+            #[test]
+            fn invalid_marketing() {
+                let mut deps = mock_dependencies();
+                let instantiate_msg = InstantiateMsg {
+                    name: "Cash Token".to_string(),
+                    symbol: "CASH".to_string(),
+                    decimals: 9,
+                    initial_balances: vec![],
+                    mint: None,
+                    marketing: Some(InstantiateMarketingInfo {
+                        project: Some("Project".to_owned()),
+                        description: Some("Description".to_owned()),
+                        marketing: Some("m".to_owned()),
+                        logo: Some(Logo::Url("url".to_owned())),
+                    }),
+                };
+
+                let info = mock_info("creator", &[]);
+                let env = mock_env();
+                instantiate(deps.as_mut(), env, info, instantiate_msg).unwrap_err();
+
+                let err = query_download_logo(deps.as_ref()).unwrap_err();
+                assert!(
+                    matches!(err, StdError::NotFound { .. }),
+                    "Expected StdError::NotFound, received {}",
+                    err
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn can_mint_by_minter() {
+        let mut deps = mock_dependencies();
+
+        let genesis = String::from("genesis");
+        let amount = Uint128::new(11223344);
+        let minter = String::from("asmodat");
+        let limit = Uint128::new(511223344);
+        do_instantiate_with_minter(deps.as_mut(), &genesis, amount, &minter, Some(limit));
+
+        // minter can mint coins to some winner
+        let winner = String::from("lucky");
+        let prize = Uint128::new(222_222_222);
+        let msg = ExecuteMsg::Mint {
+            recipient: winner.clone(),
+            amount: prize,
+        };
+
+        let info = mock_info(minter.as_ref(), &[]);
+        let env = mock_env();
+        let res = execute(deps.as_mut(), env, info, msg).unwrap();
+        assert_eq!(0, res.messages.len());
+        assert_eq!(get_balance(deps.as_ref(), genesis), amount);
+        assert_eq!(get_balance(deps.as_ref(), winner.clone()), prize);
+
+        // but cannot mint nothing
+        let msg = ExecuteMsg::Mint {
+            recipient: winner.clone(),
+            amount: Uint128::zero(),
+        };
+        let info = mock_info(minter.as_ref(), &[]);
+        let env = mock_env();
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert_eq!(err, ContractError::InvalidZeroAmount {});
+
+        // but if it exceeds cap (even over multiple rounds), it fails
+        // cap is enforced
+        let msg = ExecuteMsg::Mint {
+            recipient: winner,
+            amount: Uint128::new(333_222_222),
+        };
+        let info = mock_info(minter.as_ref(), &[]);
+        let env = mock_env();
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert_eq!(err, ContractError::CannotExceedCap {});
+    }
+
+    #[test]
+    fn others_cannot_mint() {
+        let mut deps = mock_dependencies();
+        do_instantiate_with_minter(
+            deps.as_mut(),
+            &String::from("genesis"),
+            Uint128::new(1234),
+            &String::from("minter"),
+            None,
+        );
+
+        let msg = ExecuteMsg::Mint {
+            recipient: String::from("lucky"),
+            amount: Uint128::new(222),
+        };
+        let info = mock_info("anyone else", &[]);
+        let env = mock_env();
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert_eq!(err, ContractError::Unauthorized {});
+    }
+
+    #[test]
+    fn no_one_mints_if_minter_unset() {
+        let mut deps = mock_dependencies();
+        do_instantiate(deps.as_mut(), &String::from("genesis"), Uint128::new(1234));
+
+        let msg = ExecuteMsg::Mint {
+            recipient: String::from("lucky"),
+            amount: Uint128::new(222),
+        };
+        let info = mock_info("genesis", &[]);
+        let env = mock_env();
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert_eq!(err, ContractError::Unauthorized {});
+    }
+
+    #[test]
+    fn instantiate_multiple_accounts() {
+        let mut deps = mock_dependencies();
+        let amount1 = Uint128::from(11223344u128);
+        let addr1 = String::from("addr0001");
+        let amount2 = Uint128::from(7890987u128);
+        let addr2 = String::from("addr0002");
+        let instantiate_msg = InstantiateMsg {
+            name: "Bash Shell".to_string(),
+            symbol: "BASH".to_string(),
+            decimals: 6,
+            initial_balances: vec![
+                Cw20Coin {
+                    address: addr1.clone(),
+                    amount: amount1,
+                },
+                Cw20Coin {
+                    address: addr2.clone(),
+                    amount: amount2,
+                },
+            ],
+            mint: None,
+            marketing: None,
+        };
+        let info = mock_info("creator", &[]);
+        let env = mock_env();
+        let res = instantiate(deps.as_mut(), env, info, instantiate_msg).unwrap();
+        assert_eq!(0, res.messages.len());
+
+        assert_eq!(
+            query_token_info(deps.as_ref()).unwrap(),
+            TokenInfoResponse {
+                name: "Bash Shell".to_string(),
+                symbol: "BASH".to_string(),
+                decimals: 6,
+                total_supply: amount1 + amount2,
+            }
+        );
+        assert_eq!(get_balance(deps.as_ref(), addr1), amount1);
+        assert_eq!(get_balance(deps.as_ref(), addr2), amount2);
+    }
+
+    #[test]
+    fn queries_work() {
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
+        let addr1 = String::from("addr0001");
+        let amount1 = Uint128::from(12340000u128);
+
+        let expected = do_instantiate(deps.as_mut(), &addr1, amount1);
+
+        // check meta query
+        let loaded = query_token_info(deps.as_ref()).unwrap();
+        assert_eq!(expected, loaded);
+
+        let _info = mock_info("test", &[]);
+        let env = mock_env();
+        // check balance query (full)
+        let data = query(
+            deps.as_ref(),
+            env.clone(),
+            QueryMsg::Balance { address: addr1 },
+        )
+        .unwrap();
+        let loaded: BalanceResponse = from_binary(&data).unwrap();
+        assert_eq!(loaded.balance, amount1);
+
+        // check balance query (empty)
+        let data = query(
+            deps.as_ref(),
+            env,
+            QueryMsg::Balance {
+                address: String::from("addr0002"),
+            },
+        )
+        .unwrap();
+        let loaded: BalanceResponse = from_binary(&data).unwrap();
+        assert_eq!(loaded.balance, Uint128::zero());
+    }
+
+    #[test]
+    fn transfer() {
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
+        let addr1 = String::from("addr0001");
+        let addr2 = String::from("addr0002");
+        let amount1 = Uint128::from(12340000u128);
+        let transfer = Uint128::from(76543u128);
+        let too_much = Uint128::from(12340321u128);
+
+        do_instantiate(deps.as_mut(), &addr1, amount1);
+
+        // cannot transfer nothing
+        let info = mock_info(addr1.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::Transfer {
+            recipient: addr2.clone(),
+            amount: Uint128::zero(),
+        };
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert_eq!(err, ContractError::InvalidZeroAmount {});
+
+        // cannot send more than we have
+        let info = mock_info(addr1.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::Transfer {
+            recipient: addr2.clone(),
+            amount: too_much,
+        };
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert!(matches!(err, ContractError::Std(StdError::Overflow { .. })));
+
+        // cannot send from empty account
+        let info = mock_info(addr2.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::Transfer {
+            recipient: addr1.clone(),
+            amount: transfer,
+        };
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert!(matches!(err, ContractError::Std(StdError::Overflow { .. })));
+
+        // valid transfer
+        let info = mock_info(addr1.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::Transfer {
+            recipient: addr2.clone(),
+            amount: transfer,
+        };
+        let res = execute(deps.as_mut(), env, info, msg).unwrap();
+        assert_eq!(res.messages.len(), 0);
+
+        let remainder = amount1.checked_sub(transfer).unwrap();
+        assert_eq!(get_balance(deps.as_ref(), addr1), remainder);
+        assert_eq!(get_balance(deps.as_ref(), addr2), transfer);
+        assert_eq!(
+            query_token_info(deps.as_ref()).unwrap().total_supply,
+            amount1
+        );
+    }
+
+    #[test]
+    fn burn() {
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
+        let addr1 = String::from("addr0001");
+        let amount1 = Uint128::from(12340000u128);
+        let burn = Uint128::from(76543u128);
+        let too_much = Uint128::from(12340321u128);
+
+        do_instantiate(deps.as_mut(), &addr1, amount1);
+
+        // cannot burn nothing
+        let info = mock_info(addr1.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::Burn {
+            amount: Uint128::zero(),
+        };
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert_eq!(err, ContractError::InvalidZeroAmount {});
+        assert_eq!(
+            query_token_info(deps.as_ref()).unwrap().total_supply,
+            amount1
+        );
+
+        // cannot burn more than we have
+        let info = mock_info(addr1.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::Burn { amount: too_much };
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert!(matches!(err, ContractError::Std(StdError::Overflow { .. })));
+        assert_eq!(
+            query_token_info(deps.as_ref()).unwrap().total_supply,
+            amount1
+        );
+
+        // valid burn reduces total supply
+        let info = mock_info(addr1.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::Burn { amount: burn };
+        let res = execute(deps.as_mut(), env, info, msg).unwrap();
+        assert_eq!(res.messages.len(), 0);
+
+        let remainder = amount1.checked_sub(burn).unwrap();
+        assert_eq!(get_balance(deps.as_ref(), addr1), remainder);
+        assert_eq!(
+            query_token_info(deps.as_ref()).unwrap().total_supply,
+            remainder
+        );
+    }
+
+    #[test]
+    fn send() {
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
+        let addr1 = String::from("addr0001");
+        let contract = String::from("addr0002");
+        let amount1 = Uint128::from(12340000u128);
+        let transfer = Uint128::from(76543u128);
+        let too_much = Uint128::from(12340321u128);
+        let send_msg = Binary::from(r#"{"some":123}"#.as_bytes());
+
+        do_instantiate(deps.as_mut(), &addr1, amount1);
+
+        // cannot send nothing
+        let info = mock_info(addr1.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::Send {
+            contract: contract.clone(),
+            amount: Uint128::zero(),
+            msg: send_msg.clone(),
+        };
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert_eq!(err, ContractError::InvalidZeroAmount {});
+
+        // cannot send more than we have
+        let info = mock_info(addr1.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::Send {
+            contract: contract.clone(),
+            amount: too_much,
+            msg: send_msg.clone(),
+        };
+        let err = execute(deps.as_mut(), env, info, msg).unwrap_err();
+        assert!(matches!(err, ContractError::Std(StdError::Overflow { .. })));
+
+        // valid transfer
+        let info = mock_info(addr1.as_ref(), &[]);
+        let env = mock_env();
+        let msg = ExecuteMsg::Send {
+            contract: contract.clone(),
+            amount: transfer,
+            msg: send_msg.clone(),
+        };
+        let res = execute(deps.as_mut(), env, info, msg).unwrap();
+        assert_eq!(res.messages.len(), 1);
+
+        // ensure proper send message sent
+        // this is the message we want delivered to the other side
+        let binary_msg = Cw20ReceiveMsg {
+            sender: addr1.clone(),
+            amount: transfer,
+            msg: send_msg,
+        }
+        .into_binary()
+        .unwrap();
+        // and this is how it must be wrapped for the vm to process it
+        assert_eq!(
+            res.messages[0],
+            SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
+                contract_addr: contract.clone(),
+                msg: binary_msg,
+                funds: vec![],
+            }))
+        );
+
+        // ensure balance is properly transferred
+        let remainder = amount1.checked_sub(transfer).unwrap();
+        assert_eq!(get_balance(deps.as_ref(), addr1), remainder);
+        assert_eq!(get_balance(deps.as_ref(), contract), transfer);
+        assert_eq!(
+            query_token_info(deps.as_ref()).unwrap().total_supply,
+            amount1
+        );
+    }
+
+    mod marketing {
+        use super::*;
+
+        #[test]
+        fn update_unauthorised() {
+            let mut deps = mock_dependencies();
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![],
+                mint: None,
+                marketing: Some(InstantiateMarketingInfo {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some("marketing".to_owned()),
+                    logo: Some(Logo::Url("url".to_owned())),
+                }),
+            };
+
+            let info = mock_info("creator", &[]);
+
+            instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
+
+            let err = execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::UpdateMarketing {
+                    project: Some("New project".to_owned()),
+                    description: Some("Better description".to_owned()),
+                    marketing: Some("creator".to_owned()),
+                },
+            )
+            .unwrap_err();
+
+            assert_eq!(err, ContractError::Unauthorized {});
+
+            // Ensure marketing didn't change
+            assert_eq!(
+                query_marketing_info(deps.as_ref()).unwrap(),
+                MarketingInfoResponse {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some(Addr::unchecked("marketing")),
+                    logo: Some(LogoInfo::Url("url".to_owned())),
+                }
+            );
+
+            let err = query_download_logo(deps.as_ref()).unwrap_err();
+            assert!(
+                matches!(err, StdError::NotFound { .. }),
+                "Expected StdError::NotFound, received {}",
+                err
+            );
+        }
+
+        #[test]
+        fn update_project() {
+            let mut deps = mock_dependencies();
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![],
+                mint: None,
+                marketing: Some(InstantiateMarketingInfo {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some("creator".to_owned()),
+                    logo: Some(Logo::Url("url".to_owned())),
+                }),
+            };
+
+            let info = mock_info("creator", &[]);
+
+            instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
+
+            let res = execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::UpdateMarketing {
+                    project: Some("New project".to_owned()),
+                    description: None,
+                    marketing: None,
+                },
+            )
+            .unwrap();
+
+            assert_eq!(res.messages, vec![]);
+
+            assert_eq!(
+                query_marketing_info(deps.as_ref()).unwrap(),
+                MarketingInfoResponse {
+                    project: Some("New project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some(Addr::unchecked("creator")),
+                    logo: Some(LogoInfo::Url("url".to_owned())),
+                }
+            );
+
+            let err = query_download_logo(deps.as_ref()).unwrap_err();
+            assert!(
+                matches!(err, StdError::NotFound { .. }),
+                "Expected StdError::NotFound, received {}",
+                err
+            );
+        }
+
+        #[test]
+        fn clear_project() {
+            let mut deps = mock_dependencies();
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![],
+                mint: None,
+                marketing: Some(InstantiateMarketingInfo {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some("creator".to_owned()),
+                    logo: Some(Logo::Url("url".to_owned())),
+                }),
+            };
+
+            let info = mock_info("creator", &[]);
+
+            instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
+
+            let res = execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::UpdateMarketing {
+                    project: Some("".to_owned()),
+                    description: None,
+                    marketing: None,
+                },
+            )
+            .unwrap();
+
+            assert_eq!(res.messages, vec![]);
+
+            assert_eq!(
+                query_marketing_info(deps.as_ref()).unwrap(),
+                MarketingInfoResponse {
+                    project: None,
+                    description: Some("Description".to_owned()),
+                    marketing: Some(Addr::unchecked("creator")),
+                    logo: Some(LogoInfo::Url("url".to_owned())),
+                }
+            );
+
+            let err = query_download_logo(deps.as_ref()).unwrap_err();
+            assert!(
+                matches!(err, StdError::NotFound { .. }),
+                "Expected StdError::NotFound, received {}",
+                err
+            );
+        }
+
+        #[test]
+        fn update_description() {
+            let mut deps = mock_dependencies();
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![],
+                mint: None,
+                marketing: Some(InstantiateMarketingInfo {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some("creator".to_owned()),
+                    logo: Some(Logo::Url("url".to_owned())),
+                }),
+            };
+
+            let info = mock_info("creator", &[]);
+
+            instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
+
+            let res = execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::UpdateMarketing {
+                    project: None,
+                    description: Some("Better description".to_owned()),
+                    marketing: None,
+                },
+            )
+            .unwrap();
+
+            assert_eq!(res.messages, vec![]);
+
+            assert_eq!(
+                query_marketing_info(deps.as_ref()).unwrap(),
+                MarketingInfoResponse {
+                    project: Some("Project".to_owned()),
+                    description: Some("Better description".to_owned()),
+                    marketing: Some(Addr::unchecked("creator")),
+                    logo: Some(LogoInfo::Url("url".to_owned())),
+                }
+            );
+
+            let err = query_download_logo(deps.as_ref()).unwrap_err();
+            assert!(
+                matches!(err, StdError::NotFound { .. }),
+                "Expected StdError::NotFound, received {}",
+                err
+            );
+        }
+
+        #[test]
+        fn clear_description() {
+            let mut deps = mock_dependencies();
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![],
+                mint: None,
+                marketing: Some(InstantiateMarketingInfo {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some("creator".to_owned()),
+                    logo: Some(Logo::Url("url".to_owned())),
+                }),
+            };
+
+            let info = mock_info("creator", &[]);
+
+            instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
+
+            let res = execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::UpdateMarketing {
+                    project: None,
+                    description: Some("".to_owned()),
+                    marketing: None,
+                },
+            )
+            .unwrap();
+
+            assert_eq!(res.messages, vec![]);
+
+            assert_eq!(
+                query_marketing_info(deps.as_ref()).unwrap(),
+                MarketingInfoResponse {
+                    project: Some("Project".to_owned()),
+                    description: None,
+                    marketing: Some(Addr::unchecked("creator")),
+                    logo: Some(LogoInfo::Url("url".to_owned())),
+                }
+            );
+
+            let err = query_download_logo(deps.as_ref()).unwrap_err();
+            assert!(
+                matches!(err, StdError::NotFound { .. }),
+                "Expected StdError::NotFound, received {}",
+                err
+            );
+        }
+
+        #[test]
+        fn update_marketing() {
+            let mut deps = mock_dependencies();
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![],
+                mint: None,
+                marketing: Some(InstantiateMarketingInfo {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some("creator".to_owned()),
+                    logo: Some(Logo::Url("url".to_owned())),
+                }),
+            };
+
+            let info = mock_info("creator", &[]);
+
+            instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
+
+            let res = execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::UpdateMarketing {
+                    project: None,
+                    description: None,
+                    marketing: Some("marketing".to_owned()),
+                },
+            )
+            .unwrap();
+
+            assert_eq!(res.messages, vec![]);
+
+            assert_eq!(
+                query_marketing_info(deps.as_ref()).unwrap(),
+                MarketingInfoResponse {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some(Addr::unchecked("marketing")),
+                    logo: Some(LogoInfo::Url("url".to_owned())),
+                }
+            );
+
+            let err = query_download_logo(deps.as_ref()).unwrap_err();
+            assert!(
+                matches!(err, StdError::NotFound { .. }),
+                "Expected StdError::NotFound, received {}",
+                err
+            );
+        }
+
+        #[test]
+        fn update_marketing_invalid() {
+            let mut deps = mock_dependencies();
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![],
+                mint: None,
+                marketing: Some(InstantiateMarketingInfo {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some("creator".to_owned()),
+                    logo: Some(Logo::Url("url".to_owned())),
+                }),
+            };
+
+            let info = mock_info("creator", &[]);
+
+            instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
+
+            let err = execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::UpdateMarketing {
+                    project: None,
+                    description: None,
+                    marketing: Some("m".to_owned()),
+                },
+            )
+            .unwrap_err();
+
+            assert!(
+                matches!(err, ContractError::Std(_)),
+                "Expected Std error, received: {}",
+                err
+            );
+
+            assert_eq!(
+                query_marketing_info(deps.as_ref()).unwrap(),
+                MarketingInfoResponse {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some(Addr::unchecked("creator")),
+                    logo: Some(LogoInfo::Url("url".to_owned())),
+                }
+            );
+
+            let err = query_download_logo(deps.as_ref()).unwrap_err();
+            assert!(
+                matches!(err, StdError::NotFound { .. }),
+                "Expected StdError::NotFound, received {}",
+                err
+            );
+        }
+
+        #[test]
+        fn clear_marketing() {
+            let mut deps = mock_dependencies();
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![],
+                mint: None,
+                marketing: Some(InstantiateMarketingInfo {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some("creator".to_owned()),
+                    logo: Some(Logo::Url("url".to_owned())),
+                }),
+            };
+
+            let info = mock_info("creator", &[]);
+
+            instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
+
+            let res = execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::UpdateMarketing {
+                    project: None,
+                    description: None,
+                    marketing: Some("".to_owned()),
+                },
+            )
+            .unwrap();
+
+            assert_eq!(res.messages, vec![]);
+
+            assert_eq!(
+                query_marketing_info(deps.as_ref()).unwrap(),
+                MarketingInfoResponse {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: None,
+                    logo: Some(LogoInfo::Url("url".to_owned())),
+                }
+            );
+
+            let err = query_download_logo(deps.as_ref()).unwrap_err();
+            assert!(
+                matches!(err, StdError::NotFound { .. }),
+                "Expected StdError::NotFound, received {}",
+                err
+            );
+        }
+
+        #[test]
+        fn update_logo_url() {
+            let mut deps = mock_dependencies();
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![],
+                mint: None,
+                marketing: Some(InstantiateMarketingInfo {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some("creator".to_owned()),
+                    logo: Some(Logo::Url("url".to_owned())),
+                }),
+            };
+
+            let info = mock_info("creator", &[]);
+
+            instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
+
+            let res = execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::UploadLogo(Logo::Url("new_url".to_owned())),
+            )
+            .unwrap();
+
+            assert_eq!(res.messages, vec![]);
+
+            assert_eq!(
+                query_marketing_info(deps.as_ref()).unwrap(),
+                MarketingInfoResponse {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some(Addr::unchecked("creator")),
+                    logo: Some(LogoInfo::Url("new_url".to_owned())),
+                }
+            );
+
+            let err = query_download_logo(deps.as_ref()).unwrap_err();
+            assert!(
+                matches!(err, StdError::NotFound { .. }),
+                "Expected StdError::NotFound, received {}",
+                err
+            );
+        }
+
+        #[test]
+        fn update_logo_png() {
+            let mut deps = mock_dependencies();
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![],
+                mint: None,
+                marketing: Some(InstantiateMarketingInfo {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some("creator".to_owned()),
+                    logo: Some(Logo::Url("url".to_owned())),
+                }),
+            };
+
+            let info = mock_info("creator", &[]);
+
+            instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
+
+            let res = execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::UploadLogo(Logo::Embedded(EmbeddedLogo::Png(PNG_HEADER.into()))),
+            )
+            .unwrap();
+
+            assert_eq!(res.messages, vec![]);
+
+            assert_eq!(
+                query_marketing_info(deps.as_ref()).unwrap(),
+                MarketingInfoResponse {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some(Addr::unchecked("creator")),
+                    logo: Some(LogoInfo::Embedded),
+                }
+            );
+
+            assert_eq!(
+                query_download_logo(deps.as_ref()).unwrap(),
+                DownloadLogoResponse {
+                    mime_type: "image/png".to_owned(),
+                    data: PNG_HEADER.into(),
+                }
+            );
+        }
+
+        #[test]
+        fn update_logo_svg() {
+            let mut deps = mock_dependencies();
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![],
+                mint: None,
+                marketing: Some(InstantiateMarketingInfo {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some("creator".to_owned()),
+                    logo: Some(Logo::Url("url".to_owned())),
+                }),
+            };
+
+            let info = mock_info("creator", &[]);
+
+            instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
+
+            let img = "<?xml version=\"1.0\"?><svg></svg>".as_bytes();
+            let res = execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::UploadLogo(Logo::Embedded(EmbeddedLogo::Svg(img.into()))),
+            )
+            .unwrap();
+
+            assert_eq!(res.messages, vec![]);
+
+            assert_eq!(
+                query_marketing_info(deps.as_ref()).unwrap(),
+                MarketingInfoResponse {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some(Addr::unchecked("creator")),
+                    logo: Some(LogoInfo::Embedded),
+                }
+            );
+
+            assert_eq!(
+                query_download_logo(deps.as_ref()).unwrap(),
+                DownloadLogoResponse {
+                    mime_type: "image/svg+xml".to_owned(),
+                    data: img.into(),
+                }
+            );
+        }
+
+        #[test]
+        fn update_logo_png_oversized() {
+            let mut deps = mock_dependencies();
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![],
+                mint: None,
+                marketing: Some(InstantiateMarketingInfo {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some("creator".to_owned()),
+                    logo: Some(Logo::Url("url".to_owned())),
+                }),
+            };
+
+            let info = mock_info("creator", &[]);
+
+            instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
+
+            let img = [&PNG_HEADER[..], &[1; 6000][..]].concat();
+            let err = execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::UploadLogo(Logo::Embedded(EmbeddedLogo::Png(img.into()))),
+            )
+            .unwrap_err();
+
+            assert_eq!(err, ContractError::LogoTooBig {});
+
+            assert_eq!(
+                query_marketing_info(deps.as_ref()).unwrap(),
+                MarketingInfoResponse {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some(Addr::unchecked("creator")),
+                    logo: Some(LogoInfo::Url("url".to_owned())),
+                }
+            );
+
+            let err = query_download_logo(deps.as_ref()).unwrap_err();
+            assert!(
+                matches!(err, StdError::NotFound { .. }),
+                "Expected StdError::NotFound, received {}",
+                err
+            );
+        }
+
+        #[test]
+        fn update_logo_svg_oversized() {
+            let mut deps = mock_dependencies();
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![],
+                mint: None,
+                marketing: Some(InstantiateMarketingInfo {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some("creator".to_owned()),
+                    logo: Some(Logo::Url("url".to_owned())),
+                }),
+            };
+
+            let info = mock_info("creator", &[]);
+
+            instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
+
+            let img = [
+                "<?xml version=\"1.0\"?><svg>",
+                std::str::from_utf8(&[b'x'; 6000]).unwrap(),
+                "</svg>",
+            ]
+            .concat()
+            .into_bytes();
+
+            let err = execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::UploadLogo(Logo::Embedded(EmbeddedLogo::Svg(img.into()))),
+            )
+            .unwrap_err();
+
+            assert_eq!(err, ContractError::LogoTooBig {});
+
+            assert_eq!(
+                query_marketing_info(deps.as_ref()).unwrap(),
+                MarketingInfoResponse {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some(Addr::unchecked("creator")),
+                    logo: Some(LogoInfo::Url("url".to_owned())),
+                }
+            );
+
+            let err = query_download_logo(deps.as_ref()).unwrap_err();
+            assert!(
+                matches!(err, StdError::NotFound { .. }),
+                "Expected StdError::NotFound, received {}",
+                err
+            );
+        }
+
+        #[test]
+        fn update_logo_png_invalid() {
+            let mut deps = mock_dependencies();
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![],
+                mint: None,
+                marketing: Some(InstantiateMarketingInfo {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some("creator".to_owned()),
+                    logo: Some(Logo::Url("url".to_owned())),
+                }),
+            };
+
+            let info = mock_info("creator", &[]);
+
+            instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
+
+            let img = &[1];
+            let err = execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::UploadLogo(Logo::Embedded(EmbeddedLogo::Png(img.into()))),
+            )
+            .unwrap_err();
+
+            assert_eq!(err, ContractError::InvalidPngHeader {});
+
+            assert_eq!(
+                query_marketing_info(deps.as_ref()).unwrap(),
+                MarketingInfoResponse {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some(Addr::unchecked("creator")),
+                    logo: Some(LogoInfo::Url("url".to_owned())),
+                }
+            );
+
+            let err = query_download_logo(deps.as_ref()).unwrap_err();
+            assert!(
+                matches!(err, StdError::NotFound { .. }),
+                "Expected StdError::NotFound, received {}",
+                err
+            );
+        }
+
+        #[test]
+        fn update_logo_svg_invalid() {
+            let mut deps = mock_dependencies();
+            let instantiate_msg = InstantiateMsg {
+                name: "Cash Token".to_string(),
+                symbol: "CASH".to_string(),
+                decimals: 9,
+                initial_balances: vec![],
+                mint: None,
+                marketing: Some(InstantiateMarketingInfo {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some("creator".to_owned()),
+                    logo: Some(Logo::Url("url".to_owned())),
+                }),
+            };
+
+            let info = mock_info("creator", &[]);
+
+            instantiate(deps.as_mut(), mock_env(), info.clone(), instantiate_msg).unwrap();
+
+            let img = &[1];
+
+            let err = execute(
+                deps.as_mut(),
+                mock_env(),
+                info,
+                ExecuteMsg::UploadLogo(Logo::Embedded(EmbeddedLogo::Svg(img.into()))),
+            )
+            .unwrap_err();
+
+            assert_eq!(err, ContractError::InvalidXmlPreamble {});
+
+            assert_eq!(
+                query_marketing_info(deps.as_ref()).unwrap(),
+                MarketingInfoResponse {
+                    project: Some("Project".to_owned()),
+                    description: Some("Description".to_owned()),
+                    marketing: Some(Addr::unchecked("creator")),
+                    logo: Some(LogoInfo::Url("url".to_owned())),
+                }
+            );
+
+            let err = query_download_logo(deps.as_ref()).unwrap_err();
+            assert!(
+                matches!(err, StdError::NotFound { .. }),
+                "Expected StdError::NotFound, received {}",
+                err
+            );
+        }
+    }
+}

--- a/contracts/cw20-base/src/enumerable.rs
+++ b/contracts/cw20-base/src/enumerable.rs
@@ -1,0 +1,210 @@
+use cosmwasm_std::{Deps, Order, StdResult};
+use cw20::{AllAccountsResponse, AllAllowancesResponse, AllowanceInfo};
+
+use crate::state::{ALLOWANCES, BALANCES};
+use cw_storage_plus::Bound;
+
+// settings for pagination
+const MAX_LIMIT: u32 = 30;
+const DEFAULT_LIMIT: u32 = 10;
+
+pub fn query_all_allowances(
+    deps: Deps,
+    owner: String,
+    start_after: Option<String>,
+    limit: Option<u32>,
+) -> StdResult<AllAllowancesResponse> {
+    let owner_addr = deps.api.addr_validate(&owner)?;
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    let start = start_after.map(Bound::exclusive);
+
+    let allowances = ALLOWANCES
+        .prefix(&owner_addr)
+        .range(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .map(|item| {
+            item.map(|(addr, allow)| AllowanceInfo {
+                spender: addr.into(),
+                allowance: allow.allowance,
+                expires: allow.expires,
+            })
+        })
+        .collect::<StdResult<_>>()?;
+    Ok(AllAllowancesResponse { allowances })
+}
+
+pub fn query_all_accounts(
+    deps: Deps,
+    start_after: Option<String>,
+    limit: Option<u32>,
+) -> StdResult<AllAccountsResponse> {
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+    let start = start_after.map(Bound::exclusive);
+
+    let accounts = BALANCES
+        .keys(deps.storage, start, None, Order::Ascending)
+        .take(limit)
+        .map(|item| item.map(Into::into))
+        .collect::<StdResult<_>>()?;
+
+    Ok(AllAccountsResponse { accounts })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use cosmwasm_std::testing::{mock_dependencies_with_balance, mock_env, mock_info};
+    use cosmwasm_std::{coins, DepsMut, Uint128};
+    use cw20::{Cw20Coin, Expiration, TokenInfoResponse};
+
+    use crate::contract::{execute, instantiate, query_token_info};
+    use crate::msg::{ExecuteMsg, InstantiateMsg};
+
+    // this will set up the instantiation for other tests
+    fn do_instantiate(mut deps: DepsMut, addr: &str, amount: Uint128) -> TokenInfoResponse {
+        let instantiate_msg = InstantiateMsg {
+            name: "Auto Gen".to_string(),
+            symbol: "AUTO".to_string(),
+            decimals: 3,
+            initial_balances: vec![Cw20Coin {
+                address: addr.into(),
+                amount,
+            }],
+            mint: None,
+            marketing: None,
+        };
+        let info = mock_info("creator", &[]);
+        let env = mock_env();
+        instantiate(deps.branch(), env, info, instantiate_msg).unwrap();
+        query_token_info(deps.as_ref()).unwrap()
+    }
+
+    #[test]
+    fn query_all_allowances_works() {
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
+
+        let owner = String::from("owner");
+        // these are in alphabetical order same than insert order
+        let spender1 = String::from("earlier");
+        let spender2 = String::from("later");
+
+        let info = mock_info(owner.as_ref(), &[]);
+        let env = mock_env();
+        do_instantiate(deps.as_mut(), &owner, Uint128::new(12340000));
+
+        // no allowance to start
+        let allowances = query_all_allowances(deps.as_ref(), owner.clone(), None, None).unwrap();
+        assert_eq!(allowances.allowances, vec![]);
+
+        // set allowance with height expiration
+        let allow1 = Uint128::new(7777);
+        let expires = Expiration::AtHeight(5432);
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: spender1.clone(),
+            amount: allow1,
+            expires: Some(expires),
+        };
+        execute(deps.as_mut(), env.clone(), info.clone(), msg).unwrap();
+
+        // set allowance with no expiration
+        let allow2 = Uint128::new(54321);
+        let msg = ExecuteMsg::IncreaseAllowance {
+            spender: spender2.clone(),
+            amount: allow2,
+            expires: None,
+        };
+        execute(deps.as_mut(), env, info, msg).unwrap();
+
+        // query list gets 2
+        let allowances = query_all_allowances(deps.as_ref(), owner.clone(), None, None).unwrap();
+        assert_eq!(allowances.allowances.len(), 2);
+
+        // first one is spender1 (order of CanonicalAddr uncorrelated with String)
+        let allowances = query_all_allowances(deps.as_ref(), owner.clone(), None, Some(1)).unwrap();
+        assert_eq!(allowances.allowances.len(), 1);
+        let allow = &allowances.allowances[0];
+        assert_eq!(&allow.spender, &spender1);
+        assert_eq!(&allow.expires, &expires);
+        assert_eq!(&allow.allowance, &allow1);
+
+        // next one is spender2
+        let allowances = query_all_allowances(
+            deps.as_ref(),
+            owner,
+            Some(allow.spender.clone()),
+            Some(10000),
+        )
+        .unwrap();
+        assert_eq!(allowances.allowances.len(), 1);
+        let allow = &allowances.allowances[0];
+        assert_eq!(&allow.spender, &spender2);
+        assert_eq!(&allow.expires, &Expiration::Never {});
+        assert_eq!(&allow.allowance, &allow2);
+    }
+
+    #[test]
+    fn query_all_accounts_works() {
+        let mut deps = mock_dependencies_with_balance(&coins(2, "token"));
+
+        // insert order and lexicographical order are different
+        let acct1 = String::from("acct01");
+        let acct2 = String::from("zebra");
+        let acct3 = String::from("nice");
+        let acct4 = String::from("aaaardvark");
+        let expected_order = [acct4.clone(), acct1.clone(), acct3.clone(), acct2.clone()];
+
+        do_instantiate(deps.as_mut(), &acct1, Uint128::new(12340000));
+
+        // put money everywhere (to create balanaces)
+        let info = mock_info(acct1.as_ref(), &[]);
+        let env = mock_env();
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            ExecuteMsg::Transfer {
+                recipient: acct2,
+                amount: Uint128::new(222222),
+            },
+        )
+        .unwrap();
+        execute(
+            deps.as_mut(),
+            env.clone(),
+            info.clone(),
+            ExecuteMsg::Transfer {
+                recipient: acct3,
+                amount: Uint128::new(333333),
+            },
+        )
+        .unwrap();
+        execute(
+            deps.as_mut(),
+            env,
+            info,
+            ExecuteMsg::Transfer {
+                recipient: acct4,
+                amount: Uint128::new(444444),
+            },
+        )
+        .unwrap();
+
+        // make sure we get the proper results
+        let accounts = query_all_accounts(deps.as_ref(), None, None).unwrap();
+        assert_eq!(accounts.accounts, expected_order);
+
+        // let's do pagination
+        let accounts = query_all_accounts(deps.as_ref(), None, Some(2)).unwrap();
+        assert_eq!(accounts.accounts, expected_order[0..2].to_vec());
+
+        let accounts =
+            query_all_accounts(deps.as_ref(), Some(accounts.accounts[1].clone()), Some(1)).unwrap();
+        assert_eq!(accounts.accounts, expected_order[2..3].to_vec());
+
+        let accounts =
+            query_all_accounts(deps.as_ref(), Some(accounts.accounts[0].clone()), Some(777))
+                .unwrap();
+        assert_eq!(accounts.accounts, expected_order[3..].to_vec());
+    }
+}

--- a/contracts/cw20-base/src/error.rs
+++ b/contracts/cw20-base/src/error.rs
@@ -1,0 +1,35 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+
+    #[error("Unauthorized")]
+    Unauthorized {},
+
+    #[error("Cannot set to own account")]
+    CannotSetOwnAccount {},
+
+    #[error("Invalid zero amount")]
+    InvalidZeroAmount {},
+
+    #[error("Allowance is expired")]
+    Expired {},
+
+    #[error("No allowance for this account")]
+    NoAllowance {},
+
+    #[error("Minting cannot exceed the cap")]
+    CannotExceedCap {},
+
+    #[error("Logo binary data exceeds 5KB limit")]
+    LogoTooBig {},
+
+    #[error("Invalid xml preamble for SVG")]
+    InvalidXmlPreamble {},
+
+    #[error("Invalid png header")]
+    InvalidPngHeader {},
+}

--- a/contracts/cw20-base/src/lib.rs
+++ b/contracts/cw20-base/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod allowances;
+pub mod contract;
+pub mod enumerable;
+mod error;
+pub mod msg;
+pub mod state;
+
+pub use crate::error::ContractError;

--- a/contracts/cw20-base/src/msg.rs
+++ b/contracts/cw20-base/src/msg.rs
@@ -1,0 +1,113 @@
+use cosmwasm_std::{StdError, StdResult, Uint128};
+use cw20::{Cw20Coin, Logo, MinterResponse};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+pub use cw20::Cw20ExecuteMsg as ExecuteMsg;
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
+pub struct InstantiateMarketingInfo {
+    pub project: Option<String>,
+    pub description: Option<String>,
+    pub marketing: Option<String>,
+    pub logo: Option<Logo>,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
+pub struct InstantiateMsg {
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+    pub initial_balances: Vec<Cw20Coin>,
+    pub mint: Option<MinterResponse>,
+    pub marketing: Option<InstantiateMarketingInfo>,
+}
+
+impl InstantiateMsg {
+    pub fn get_cap(&self) -> Option<Uint128> {
+        self.mint.as_ref().and_then(|v| v.cap)
+    }
+
+    pub fn validate(&self) -> StdResult<()> {
+        // Check name, symbol, decimals
+        if !is_valid_name(&self.name) {
+            return Err(StdError::generic_err(
+                "Name is not in the expected format (3-50 UTF-8 bytes)",
+            ));
+        }
+        if !is_valid_symbol(&self.symbol) {
+            return Err(StdError::generic_err(
+                "Ticker symbol is not in expected format [a-zA-Z\\-]{3,12}",
+            ));
+        }
+        if self.decimals > 18 {
+            return Err(StdError::generic_err("Decimals must not exceed 18"));
+        }
+        Ok(())
+    }
+}
+
+fn is_valid_name(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    if bytes.len() < 3 || bytes.len() > 50 {
+        return false;
+    }
+    true
+}
+
+fn is_valid_symbol(symbol: &str) -> bool {
+    let bytes = symbol.as_bytes();
+    if bytes.len() < 3 || bytes.len() > 12 {
+        return false;
+    }
+    for byte in bytes.iter() {
+        if (*byte != 45) && (*byte < 65 || *byte > 90) && (*byte < 97 || *byte > 122) {
+            return false;
+        }
+    }
+    true
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    /// Returns the current balance of the given address, 0 if unset.
+    /// Return type: BalanceResponse.
+    Balance { address: String },
+    /// Returns metadata on the contract - name, decimals, supply, etc.
+    /// Return type: TokenInfoResponse.
+    TokenInfo {},
+    /// Only with "mintable" extension.
+    /// Returns who can mint and the hard cap on maximum tokens after minting.
+    /// Return type: MinterResponse.
+    Minter {},
+    /// Only with "allowance" extension.
+    /// Returns how much spender can use from owner account, 0 if unset.
+    /// Return type: AllowanceResponse.
+    Allowance { owner: String, spender: String },
+    /// Only with "enumerable" extension (and "allowances")
+    /// Returns all allowances this owner has approved. Supports pagination.
+    /// Return type: AllAllowancesResponse.
+    AllAllowances {
+        owner: String,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+    /// Only with "enumerable" extension
+    /// Returns all accounts that have balances. Supports pagination.
+    /// Return type: AllAccountsResponse.
+    AllAccounts {
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+    /// Only with "marketing" extension
+    /// Returns more metadata on the contract to display in the client:
+    /// - description, logo, project url, etc.
+    /// Return type: MarketingInfoResponse
+    MarketingInfo {},
+    /// Only with "marketing" extension
+    /// Downloads the mbeded logo data (if stored on chain). Errors if no logo data ftored for this
+    /// contract.
+    /// Return type: DownloadLogoResponse.
+    DownloadLogo {},
+}

--- a/contracts/cw20-base/src/state.rs
+++ b/contracts/cw20-base/src/state.rs
@@ -1,0 +1,36 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::{Addr, Uint128};
+use cw_storage_plus::{Item, Map};
+
+use cw20::{AllowanceResponse, Logo, MarketingInfoResponse};
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub struct TokenInfo {
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+    pub total_supply: Uint128,
+    pub mint: Option<MinterData>,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct MinterData {
+    pub minter: Addr,
+    /// cap is how many more tokens can be issued by the minter
+    pub cap: Option<Uint128>,
+}
+
+impl TokenInfo {
+    pub fn get_cap(&self) -> Option<Uint128> {
+        self.mint.as_ref().and_then(|v| v.cap)
+    }
+}
+
+pub const TOKEN_INFO: Item<TokenInfo> = Item::new("token_info");
+pub const MARKETING_INFO: Item<MarketingInfoResponse> = Item::new("marketing_info");
+pub const LOGO: Item<Logo> = Item::new("logo");
+pub const BALANCES: Map<&Addr, Uint128> = Map::new("balance");
+pub const ALLOWANCES: Map<(&Addr, &Addr), AllowanceResponse> = Map::new("allowance");


### PR DESCRIPTION
This updates the deploy_local script to use a regular cw20 token and the staking contract. Rather than clone the cw20-base contract every time this maintains our own copy of the contract in `contracts/cw20-base`. imho this makes our local deployment process a little simpler as we don't have to worry about changes upstream causing trouble and can re-sync as needed.