### PR TITLE
Don't allow creation of claims if >= 100 are outstanding

### DIFF
--- a/contracts/stake-cw20/src/error.rs
+++ b/contracts/stake-cw20/src/error.rs
@@ -13,4 +13,6 @@ pub enum ContractError {
     InvalidToken { received: Addr, expected: Addr },
     #[error("Unauthorized")]
     Unauthorized { received: Addr, expected: Addr },
+    #[error("Too many outstanding claims. Claim some tokens before unstaking more.")]
+    TooManyClaims {},
 }

--- a/contracts/stake-cw20/src/state.rs
+++ b/contracts/stake-cw20/src/state.rs
@@ -29,6 +29,9 @@ pub const STAKED_TOTAL: SnapshotItem<Uint128> = SnapshotItem::new(
     Strategy::EveryBlock,
 );
 
+/// The maximum number of claims that may be outstanding.
+pub const MAX_CLAIMS: u64 = 100;
+
 pub const CLAIMS: Claims = Claims::new("claims");
 
 pub const BALANCE: Item<Uint128> = Item::new("balance");


### PR DESCRIPTION
There exists a world wherein a user of the staking contract creates so many claims that the process of iterating over them to redeem them causes an out of gas error.

Ideally, we'd sidestep this issue by adding the ability to redeem a single claim to the contracts. Sadly, cw-controllers has [no such](https://docs.rs/cw-controllers/latest/cw_controllers/struct.Claims.html) method and the fields of `Claims` are private. Short of submitting a change there we can limit the number of outstanding claims allowed.

Open to thoughts on if this is the approach we'd like to take. Ideal one is certainly to modify cw-controllers to allow this sort of behavior.

## Testing

Want to verify that 100 claims is a conservative enough threshold that one can still submit a claim that that point.

1. Spin up contracts in docker.
2. Import default account into docker container keyring.
2. Create a staking contract with a one second unstaking duration
3. Create 100 claims:
    ```
    for i in {0..100}; do docker exec -it cosmwasm junod tx wasm execute juno1j08452mqwadp8xu25kn9rleyl2gufgfjnv0sn8dvynynakkjukcqkfwuqa '{"unstake":{"amount":"1"}}' --from default --fees 20000ujunox --chain-id testing --gas auto --gas-adjustment 2 -y; sleep 6; done
    ```
4. Verify those claims have been created and are pending:
    ```
    docker exec -it cosmwasm junod query wasm contract-state smart juno1j08452mqwadp8xu25kn9rleyl2gufgfjnv0sn8dvynynakkjukcqkfwuqa '{"claims": {"address":"juno10j9gpw9t4jsz47qgnkvl5n3zlm2fz72k67rxsg"}}' --output json | jq '.data.claims | length'
    ```
5. Claim yo tokens:
    ```
    docker exec -it cosmwasm junod tx wasm execute juno1j08452mqwadp8xu25kn9rleyl2gufgfjnv0sn8dvynynakkjukcqkfwuqa '{"claim":{}}' --from default --fees 20000ujunox --chain-id testing --gas auto --gas-adjustment 2 -y
    ```