### PR TITLE
Make admin optional stake cw20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "cw3-dao"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "stake-cw20"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/contracts/cw3-dao/Cargo.toml
+++ b/contracts/cw3-dao/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw3-dao"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Jake Hartnell <jake@stargaze.zone>", "Ben2x4 <Ben2x4@tutanota.com>", "Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "Implements a cw20 token governed DAO with multiple voting patterns."

--- a/contracts/cw3-dao/src/contract.rs
+++ b/contracts/cw3-dao/src/contract.rs
@@ -140,7 +140,7 @@ pub fn instantiate(
                 admin: Some(env.contract.address.to_string()),
                 label,
                 msg: to_binary(&stake_cw20::msg::InstantiateMsg {
-                    admin: env.contract.address,
+                    admin: Some(env.contract.address),
                     unstaking_duration,
                     token_address: cw20_addr.addr(),
                 })?,
@@ -740,7 +740,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                         admin: Some(env.contract.address.to_string()),
                         label: env.contract.address.to_string(),
                         msg: to_binary(&stake_cw20::msg::InstantiateMsg {
-                            admin: env.contract.address,
+                            admin: Some(env.contract.address),
                             unstaking_duration,
                             token_address: cw20_addr,
                         })?,

--- a/contracts/stake-cw20/Cargo.toml
+++ b/contracts/stake-cw20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stake-cw20"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Ben2x4 <Ben2x4@tutanota.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/contracts/stake-cw20/schema/execute_msg.json
+++ b/contracts/stake-cw20/schema/execute_msg.json
@@ -54,12 +54,16 @@
       "properties": {
         "update_config": {
           "type": "object",
-          "required": [
-            "admin"
-          ],
           "properties": {
             "admin": {
-              "$ref": "#/definitions/Addr"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "duration": {
               "anyOf": [

--- a/contracts/stake-cw20/schema/get_config_response.json
+++ b/contracts/stake-cw20/schema/get_config_response.json
@@ -3,12 +3,18 @@
   "title": "GetConfigResponse",
   "type": "object",
   "required": [
-    "admin",
     "token_address"
   ],
   "properties": {
     "admin": {
-      "$ref": "#/definitions/Addr"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Addr"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "token_address": {
       "$ref": "#/definitions/Addr"

--- a/contracts/stake-cw20/schema/instantiate_msg.json
+++ b/contracts/stake-cw20/schema/instantiate_msg.json
@@ -3,12 +3,18 @@
   "title": "InstantiateMsg",
   "type": "object",
   "required": [
-    "admin",
     "token_address"
   ],
   "properties": {
     "admin": {
-      "$ref": "#/definitions/Addr"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Addr"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "token_address": {
       "$ref": "#/definitions/Addr"

--- a/contracts/stake-cw20/src/contract.rs
+++ b/contracts/stake-cw20/src/contract.rs
@@ -553,10 +553,7 @@ mod tests {
         admin: Option<Addr>,
         duration: Option<Duration>,
     ) -> AnyResult<AppResponse> {
-        let msg = ExecuteMsg::UpdateConfig {
-            admin,
-            duration,
-        };
+        let msg = ExecuteMsg::UpdateConfig { admin, duration };
         app.execute_contract(info.sender, staking_addr.clone(), &msg, &[])
     }
 

--- a/contracts/stake-cw20/src/contract.rs
+++ b/contracts/stake-cw20/src/contract.rs
@@ -39,7 +39,10 @@ pub fn instantiate(
     _info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response<Empty>, ContractError> {
-    let admin = deps.api.addr_validate(msg.admin.as_str())?;
+    let admin = match msg.admin {
+        Some(admin) => Some(deps.api.addr_validate(admin.as_str())?),
+        None => None
+    };
 
     let config = Config {
         admin,
@@ -72,22 +75,27 @@ pub fn execute(
 pub fn execute_update_config(
     info: MessageInfo,
     deps: DepsMut,
-    admin: Addr,
+    new_admin: Option<Addr>,
     duration: Option<Duration>,
 ) -> Result<Response, ContractError> {
     let mut config: Config = CONFIG.load(deps.storage)?;
-    if info.sender != config.admin {
-        return Err(ContractError::Unauthorized {
-            expected: config.admin,
-            received: info.sender,
-        });
+    match config.admin {
+        None => Err(ContractError::NoAdminConfigured {}),
+        Some(current_admin) => {
+            if info.sender != current_admin {
+                return Err(ContractError::Unauthorized {
+                    expected: current_admin,
+                    received: info.sender,
+                });
+            }
+
+            config.admin = new_admin;
+            config.unstaking_duration = duration;
+
+            CONFIG.save(deps.storage, &config)?;
+            Ok(Response::new().add_attribute("admin", config.admin.map(|a|a.to_string()).unwrap_or("None".to_string())))
+        }
     }
-
-    config.admin = admin;
-    config.unstaking_duration = duration;
-
-    CONFIG.save(deps.storage, &config)?;
-    Ok(Response::new().add_attribute("owner", config.admin.to_string()))
 }
 
 pub fn execute_receive(
@@ -432,7 +440,7 @@ mod tests {
     ) -> Addr {
         let staking_code_id = app.store_code(contract_staking());
         let msg = crate::msg::InstantiateMsg {
-            admin: Addr::unchecked("owner"),
+            admin: Some(Addr::unchecked("owner")),
             token_address: cw20,
             unstaking_duration,
         };
@@ -536,10 +544,10 @@ mod tests {
         app: &mut App,
         staking_addr: &Addr,
         info: MessageInfo,
-        admin: Addr,
+        admin: Option<Addr>,
         duration: Option<Duration>,
     ) -> AnyResult<AppResponse> {
-        let msg = ExecuteMsg::UpdateConfig { admin, duration };
+        let msg = ExecuteMsg::UpdateConfig { admin: admin, duration };
         app.execute_contract(info.sender, staking_addr.clone(), &msg, &[])
     }
 
@@ -582,13 +590,13 @@ mod tests {
             &mut app,
             &staking_addr,
             info,
-            Addr::unchecked("owner2"),
+            Some(Addr::unchecked("owner2")),
             Some(Duration::Height(100)),
         )
         .unwrap();
 
         let config = query_config(&app, &staking_addr);
-        assert_eq!(config.admin, Addr::unchecked("owner2"));
+        assert_eq!(config.admin, Some(Addr::unchecked("owner2")));
         assert_eq!(config.unstaking_duration, Some(Duration::Height(100)));
 
         // Try updating admin with original owner, which is now invalid
@@ -597,10 +605,36 @@ mod tests {
             &mut app,
             &staking_addr,
             info,
-            Addr::unchecked("owner3"),
+            Some(Addr::unchecked("owner3")),
             Some(Duration::Height(100)),
         )
         .unwrap_err();
+
+        // Remove admin
+        let info = mock_info("owner2", &[]);
+        let _env = mock_env();
+        // Test update admin
+        update_config(
+            &mut app,
+            &staking_addr,
+            info,
+            None,
+            Some(Duration::Height(100)),
+        ).unwrap();
+
+        // Assert no further updates can be made
+        let info = mock_info("owner2", &[]);
+        let _env = mock_env();
+        // Test update admin
+        let err: ContractError = update_config(
+            &mut app,
+            &staking_addr,
+            info,
+            None,
+            Some(Duration::Height(100)),
+        ).unwrap_err().downcast().unwrap();
+        assert_eq!(err,ContractError::NoAdminConfigured {})
+
     }
 
     #[test]

--- a/contracts/stake-cw20/src/error.rs
+++ b/contracts/stake-cw20/src/error.rs
@@ -15,4 +15,6 @@ pub enum ContractError {
     Unauthorized { received: Addr, expected: Addr },
     #[error("Too many outstanding claims. Claim some tokens before unstaking more.")]
     TooManyClaims {},
+    #[error("No admin configured")]
+    NoAdminConfigured {},
 }

--- a/contracts/stake-cw20/src/msg.rs
+++ b/contracts/stake-cw20/src/msg.rs
@@ -9,7 +9,7 @@ pub use cw_controllers::ClaimsResponse;
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
 pub struct InstantiateMsg {
-    pub admin: Addr,
+    pub admin: Option<Addr>,
     pub token_address: Addr,
     pub unstaking_duration: Option<Duration>,
 }
@@ -23,7 +23,7 @@ pub enum ExecuteMsg {
     },
     Claim {},
     UpdateConfig {
-        admin: Addr,
+        admin: Option<Addr>,
         duration: Option<Duration>,
     },
 }
@@ -83,7 +83,7 @@ pub struct TotalValueResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct GetConfigResponse {
-    pub admin: Addr,
+    pub admin: Option<Addr>,
     pub token_address: Addr,
     pub unstaking_duration: Option<Duration>,
 }

--- a/contracts/stake-cw20/src/state.rs
+++ b/contracts/stake-cw20/src/state.rs
@@ -8,7 +8,7 @@ use cw_utils::Duration;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 pub struct Config {
-    pub admin: Addr,
+    pub admin: Option<Addr>,
     pub token_address: Addr,
     pub unstaking_duration: Option<Duration>,
 }


### PR DESCRIPTION
This contract is more widely useful then just DAO's and therefore I think it is best if admin is optional. When an admin is not set the staking configs are immutable. This is an important user safeguard as the admin can lock the users funds forever and it could be quite dangerous if the admin was malicious.