### PR TITLE
Add `start_height` field to proposal queries

### DIFF
--- a/contracts/cw3-dao/src/contract.rs
+++ b/contracts/cw3-dao/src/contract.rs
@@ -542,6 +542,7 @@ fn query_proposal(deps: Deps, env: Env, id: u64) -> StdResult<ProposalResponse> 
         expires: prop.expires,
         threshold,
         deposit_amount: prop.deposit,
+        start_height: prop.start_height,
     })
 }
 

--- a/contracts/cw3-dao/src/helpers.rs
+++ b/contracts/cw3-dao/src/helpers.rs
@@ -114,6 +114,7 @@ pub fn map_proposal(
         expires: prop.expires,
         threshold,
         deposit_amount: prop.deposit,
+        start_height: prop.start_height,
     })
 }
 

--- a/contracts/cw3-dao/src/query.rs
+++ b/contracts/cw3-dao/src/query.rs
@@ -99,6 +99,10 @@ where
     /// that the generic `Threshold{}` query does not provide valid information for existing proposals.
     pub threshold: ThresholdResponse,
     pub deposit_amount: Uint128,
+    /// The block height the proposal was created at. This can be
+    /// cross referenced with staked_balance_at_height queries to
+    /// determine an addresses's voting power for this proposal.
+    pub start_height: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/contracts/cw3-dao/src/tests.rs
+++ b/contracts/cw3-dao/src/tests.rs
@@ -698,6 +698,9 @@ fn test_proposal_queries() {
         .unwrap();
     assert_eq!(prop_count, 1);
 
+    // Proposal is open on the next block.
+    let first_proposal_start_block = app.block_info().height + 1;
+
     // another proposal
     app.update_block(next_block);
     let proposal = pay_somebody_proposal();
@@ -780,6 +783,7 @@ fn test_proposal_queries() {
             total_weight: Uint128::new(20000000),
         },
         deposit_amount: Uint128::zero(),
+        start_height: first_proposal_start_block,
     };
     assert_eq!(&expected, &res.proposals[0]);
 }


### PR DESCRIPTION
The amount of voting power a given address has in a proposal is determined by their voting power on the block when the proposal as started. We currently do not expose this information via proposal queries which makes it quite the detective operation to determine if a given address can vote in a proposal.