### PR TITLE
add stake-cw20-external-rewards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ incremental = false
 codegen-units = 1
 incremental = false
 
+[profile.release.package.stake-cw20-external-rewards]
+codegen-units = 1
+incremental = false
+
 [profile.release.package.cw-distribution]
 codegen-units = 1
 incremental = false

--- a/contracts/stake-cw20-external-rewards/.cargo/config
+++ b/contracts/stake-cw20-external-rewards/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+schema = "run --example schema"

--- a/contracts/stake-cw20-external-rewards/Cargo.lock
+++ b/contracts/stake-cw20-external-rewards/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,9 +43,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.6.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
+checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
 
 [[package]]
 name = "cosmwasm-crypto"
@@ -77,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.0.0-beta4"
+version = "1.0.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5de9749a4a933c34c59db83a77935a79cd705f93ae2b1cfbe40821f32751f75"
+checksum = "22e4b3f6933f94acdd3ddb931af4870c2002e3331a4a8b247a4ef070dd31ccb0"
 dependencies = [
  "schemars",
  "serde_json",
@@ -103,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.0.0-beta4"
+version = "1.0.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f472c0bfd584a4510702537d0b65c5331095e76099586a12f749fd69afda9c5e"
+checksum = "665cf97ad42be46936f6e6739711824a9bf21c440a6c98e185a3404aef0c3b81"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -113,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
 ]
@@ -128,9 +122,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+checksum = "b32a398eb1ccfbe7e4f452bc749c44d38dd732e9a253f19da224c416f00ee7f4"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -176,27 +170,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "cw-distribution"
-version = "0.2.5"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-multi-test 0.11.1",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "cw-multi-test"
-version = "0.10.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89a6191b839adef794f9bb8610d6d99857188517cca378b694e670bd1be614f"
+checksum = "670f079c08ee111664b4d01f845ab11aa1f722a51013bd71bfe9d930f323406d"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus 0.10.3",
+ "cw-storage-plus 0.10.0",
  "cw0",
  "derivative",
  "itertools",
@@ -207,29 +189,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cw-multi-test"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b44e3ccc6ead7e8c0ecc682e8ab634ce1dec8a2ac97b7b44e84477695adc55"
-dependencies = [
- "anyhow",
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw-storage-plus 0.11.1",
- "cw-utils",
- "derivative",
- "itertools",
- "prost",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "cw-storage-plus"
-version = "0.10.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b8b840947313c1a1cccf056836cd79a60b4526bdcd6582995be37dc97be4ae"
+checksum = "bbae8575a3517f88581f0a48f7021f01a0ebde1b65d47d33b54d1cba3bd9028f"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -261,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "cw0"
-version = "0.10.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae676b6cced78a3d38ad4b01ab4ed66fc78ac191c3c0d6bfd5372cb2efd473b"
+checksum = "fc7328a0b49764fb13e4c67fbe1e5527db1f33ed8c398b55efa6c0597fee5a58"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -273,12 +236,12 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "0.10.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7002e6f9c1a1ef3915dca704a6306ba00c39495efd928551d6077c734f9a3d8"
+checksum = "f4dc7be3e594753983f9c0a3ef23a1a3fb3afc2155f65ea8522c66703c8bd90f"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.10.3",
+ "cw-storage-plus 0.10.0",
  "schemars",
  "serde",
 ]
@@ -297,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "cw20"
-version = "0.10.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56fc9d54b9b365801beb101a5c0375dceaa5a285bfc14438a7b6007f9d362142"
+checksum = "d1f78c56916b79959930645446abdf29cd55df464e6057ba92252410f00c8ddb"
 dependencies = [
  "cosmwasm-std",
  "cw0",
@@ -321,15 +284,15 @@ dependencies = [
 
 [[package]]
 name = "cw20-base"
-version = "0.10.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5df0a946a4a58dd4fdb158ff1595c55774beeef76d09f108b547bce572dcf"
+checksum = "30b9c237cb0713816588c0cc6fb49dbdaf2688b184d441518436b0c986fb45dd"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.10.3",
+ "cw-storage-plus 0.10.0",
  "cw0",
- "cw2 0.10.3",
- "cw20 0.10.3",
+ "cw2 0.10.0",
+ "cw20 0.10.2",
  "schemars",
  "serde",
  "thiserror",
@@ -352,110 +315,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cw3"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c82e63276f517fe9bafc1ddca19d091367d715d54199708c4ea3c8c58c51936"
-dependencies = [
- "cosmwasm-std",
- "cw-utils",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw3-dao"
-version = "0.2.6"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-multi-test 0.11.1",
- "cw-storage-plus 0.11.1",
- "cw-utils",
- "cw2 0.11.1",
- "cw20 0.11.1",
- "cw20-base 0.11.1",
- "cw3",
- "schemars",
- "serde",
- "stake-cw20 0.2.6",
- "thiserror",
-]
-
-[[package]]
-name = "cw3-multisig"
-version = "0.2.5"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-multi-test 0.11.1",
- "cw-storage-plus 0.11.1",
- "cw-utils",
- "cw2 0.11.1",
- "cw20 0.11.1",
- "cw20-base 0.11.1",
- "cw3",
- "cw4",
- "cw4-group",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw4"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41445666e3f6284c72f569b2240bb52d0add94bb448e169d30ae28fe000cfaeb"
-dependencies = [
- "cosmwasm-std",
- "cw-storage-plus 0.11.1",
- "schemars",
- "serde",
-]
-
-[[package]]
-name = "cw4-group"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3389be9a6d350cc5ed9918af4070007c9acc360e515788a10885536b972764"
-dependencies = [
- "cosmwasm-std",
- "cw-controllers",
- "cw-storage-plus 0.11.1",
- "cw-utils",
- "cw2 0.11.1",
- "cw4",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "cw4-registry"
-version = "0.2.5"
-dependencies = [
- "anyhow",
- "assert_matches",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw-multi-test 0.11.1",
- "cw-storage-plus 0.11.1",
- "cw-utils",
- "cw2 0.11.1",
- "cw4",
- "cw4-group",
- "schemars",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "der"
-version = "0.4.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
+checksum = "31e21d2d0f22cde6e88694108429775c0219760a07779bf96503b434a03d7412"
 dependencies = [
  "const-oid",
 ]
@@ -488,9 +351,9 @@ checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "ecdsa"
-version = "0.12.4"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
+checksum = "713c32426287891008edb98f8b5c6abb2130aa043c93a818728fcda78606f274"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -520,9 +383,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.6"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
+checksum = "069397e10739989e400628cbc0556a817a8a64119d7a2315767f4456e1332c23"
 dependencies = [
  "crypto-bigint",
  "ff",
@@ -536,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
+checksum = "63eec06c61e487eecf0f7e6e6372e596a81922c28d33e645d6983ca6493a1af0"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -546,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
@@ -567,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
  "libc",
@@ -605,18 +468,18 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "k256"
@@ -632,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "opaque-debug"
@@ -644,9 +507,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "pkcs8"
-version = "0.7.6"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
+checksum = "fbee84ed13e44dd82689fa18348a49934fa79cc774a344c42fc9b301c71b140a"
 dependencies = [
  "der",
  "spki",
@@ -654,18 +517,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "prost"
-version = "0.9.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -673,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.9.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
  "itertools",
@@ -686,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -708,14 +571,14 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.4",
+ "getrandom 0.2.3",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "schemars"
@@ -783,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -794,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer",
  "cfg-if",
@@ -807,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.2"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
+checksum = "c19772be3c4dd2ceaacf03cb41d5885f2a02c4d8804884918e3a258480803335"
 dependencies = [
  "digest",
  "rand_core 0.6.3",
@@ -817,31 +680,11 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
+checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
 dependencies = [
  "der",
-]
-
-[[package]]
-name = "stake-cw20"
-version = "0.2.6"
-dependencies = [
- "anyhow",
- "cosmwasm-schema",
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw-controllers",
- "cw-multi-test 0.11.1",
- "cw-storage-plus 0.11.1",
- "cw-utils",
- "cw2 0.11.1",
- "cw20 0.11.1",
- "cw20-base 0.11.1",
- "schemars",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -871,14 +714,14 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.10.3",
- "cw-storage-plus 0.10.3",
- "cw2 0.10.3",
- "cw20 0.10.3",
- "cw20-base 0.10.3",
+ "cw-multi-test",
+ "cw-storage-plus 0.10.0",
+ "cw2 0.10.0",
+ "cw20 0.10.2",
+ "cw20-base 0.10.0",
  "schemars",
  "serde",
- "stake-cw20 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stake-cw20",
  "thiserror",
 ]
 
@@ -896,9 +739,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -927,15 +770,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "uint"
-version = "0.9.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1b413ebfe8c2c74a69ff124699dd156a7fa41cb1d09ba6df94aa2f2b0a4a3a"
+checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -951,9 +794,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wasi"
@@ -969,6 +812,6 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"

--- a/contracts/stake-cw20-external-rewards/Cargo.toml
+++ b/contracts/stake-cw20-external-rewards/Cargo.toml
@@ -15,16 +15,6 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-opt-level = 3
-debug = false
-rpath = false
-lto = true
-debug-assertions = false
-codegen-units = 1
-panic = 'abort'
-incremental = false
-overflow-checks = true
 
 [features]
 # for more explicit tests, cargo test --features=backtraces

--- a/contracts/stake-cw20-external-rewards/Cargo.toml
+++ b/contracts/stake-cw20-external-rewards/Cargo.toml
@@ -1,0 +1,57 @@
+[package]
+name = "stake-cw20-external-rewards"
+version = "0.1.0"
+authors = ["ben2x4 <ben2x4@tutanota.com>"]
+edition = "2018"
+
+exclude = [
+  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
+  "contract.wasm",
+  "hash.txt",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[profile.release]
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+codegen-units = 1
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[package.metadata.scripts]
+optimize = """docker run --rm -v "$(pwd)":/code \
+  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  cosmwasm/rust-optimizer:0.12.3
+"""
+
+[dependencies]
+cosmwasm-std = { version = "1.0.0-beta" }
+cosmwasm-storage = { version = "1.0.0-beta" }
+cw-storage-plus = "0.10"
+cw2 = "0.10"
+cw20 = "0.10"
+cw20-base = {  version = "0.10.0", features = ["library"] }
+stake-cw20 = { version = "0.2.6", features = ["library"] }
+schemars = "0.8.3"
+serde = { version = "1.0.127", default-features = false, features = ["derive"] }
+thiserror = { version = "1.0.26" }
+
+[dev-dependencies]
+cosmwasm-schema = { version = "1.0.0-beta" }
+cw-multi-test = {  version = "0.10.0" }
+anyhow = { version = "1.0.51"}

--- a/contracts/stake-cw20-external-rewards/LICENSE
+++ b/contracts/stake-cw20-external-rewards/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/contracts/stake-cw20-external-rewards/NOTICE
+++ b/contracts/stake-cw20-external-rewards/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2021 ben2x4 <ben2x4@tutanota.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/contracts/stake-cw20-external-rewards/README.md
+++ b/contracts/stake-cw20-external-rewards/README.md
@@ -1,0 +1,108 @@
+# CosmWasm Starter Pack
+
+This is a template to build smart contracts in Rust to run inside a
+[Cosmos SDK](https://github.com/cosmos/cosmos-sdk) module on all chains that enable it.
+To understand the framework better, please read the overview in the
+[cosmwasm repo](https://github.com/CosmWasm/cosmwasm/blob/master/README.md),
+and dig into the [cosmwasm docs](https://www.cosmwasm.com).
+This assumes you understand the theory and just want to get coding.
+
+## Creating a new repo from template
+
+Assuming you have a recent version of rust and cargo (v1.55.0+) installed
+(via [rustup](https://rustup.rs/)),
+then the following should get you a new repo to start a contract:
+
+(Note that recent cargo-generate requires Rust 1.55 features or produces a compile error)
+
+Install [cargo-generate](https://github.com/ashleygwilliams/cargo-generate) and cargo-run-script.
+Unless you did that before, run this line now:
+
+```sh
+cargo install cargo-generate --features vendored-openssl
+cargo install cargo-run-script
+```
+
+Now, use it to create your new contract.
+Go to the folder in which you want to place it and run:
+
+
+**Latest: 1.0.0-beta**
+
+```sh
+cargo generate --git https://github.com/CosmWasm/cw-template.git --name PROJECT_NAME
+````
+
+**Older Version**
+
+Pass version as branch flag:
+
+```sh
+cargo generate --git https://github.com/CosmWasm/cw-template.git --branch <version> --name PROJECT_NAME
+````
+
+Example:
+
+```sh
+cargo generate --git https://github.com/CosmWasm/cw-template.git --branch 0.16 --name PROJECT_NAME
+```
+
+You will now have a new folder called `PROJECT_NAME` (I hope you changed that to something else)
+containing a simple working contract and build system that you can customize.
+
+## Create a Repo
+
+After generating, you have a initialized local git repo, but no commits, and no remote.
+Go to a server (eg. github) and create a new upstream repo (called `YOUR-GIT-URL` below).
+Then run the following:
+
+```sh
+# this is needed to create a valid Cargo.lock file (see below)
+cargo check
+git branch -M main
+git add .
+git commit -m 'Initial Commit'
+git remote add origin YOUR-GIT-URL
+git push -u origin main
+```
+
+## CI Support
+
+We have template configurations for both [GitHub Actions](.github/workflows/Basic.yml)
+and [Circle CI](.circleci/config.yml) in the generated project, so you can
+get up and running with CI right away.
+
+One note is that the CI runs all `cargo` commands
+with `--locked` to ensure it uses the exact same versions as you have locally. This also means
+you must have an up-to-date `Cargo.lock` file, which is not auto-generated.
+The first time you set up the project (or after adding any dep), you should ensure the
+`Cargo.lock` file is updated, so the CI will test properly. This can be done simply by
+running `cargo check` or `cargo unit-test`.
+
+## Using your project
+
+Once you have your custom repo, you should check out [Developing](./Developing.md) to explain
+more on how to run tests and develop code. Or go through the
+[online tutorial](https://docs.cosmwasm.com/) to get a better feel
+of how to develop.
+
+[Publishing](./Publishing.md) contains useful information on how to publish your contract
+to the world, once you are ready to deploy it on a running blockchain. And
+[Importing](./Importing.md) contains information about pulling in other contracts or crates
+that have been published.
+
+Please replace this README file with information about your specific project. You can keep
+the `Developing.md` and `Publishing.md` files as useful referenced, but please set some
+proper description in the README.
+
+## Gitpod integration
+
+[Gitpod](https://www.gitpod.io/) container-based development platform will be enabled on your project by default.
+
+Workspace contains:
+ - **rust**: for builds
+ - [wasmd](https://github.com/CosmWasm/wasmd): for local node setup and client
+ - **jq**: shell JSON manipulation tool
+
+Follow [Gitpod Getting Started](https://www.gitpod.io/docs/getting-started) and launch your workspace.
+

--- a/contracts/stake-cw20-external-rewards/examples/schema.rs
+++ b/contracts/stake-cw20-external-rewards/examples/schema.rs
@@ -1,0 +1,24 @@
+use std::env::current_dir;
+use std::fs::create_dir_all;
+
+use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
+
+use stake_cw20_external_rewards::msg::{
+    ClaimableRewardsResponse, ExecuteMsg, InfoResponse, InstantiateMsg, QueryMsg,
+};
+use stake_cw20_external_rewards::state::{Config, LastClaim};
+
+fn main() {
+    let mut out_dir = current_dir().unwrap();
+    out_dir.push("schema");
+    create_dir_all(&out_dir).unwrap();
+    remove_schemas(&out_dir).unwrap();
+
+    export_schema(&schema_for!(InstantiateMsg), &out_dir);
+    export_schema(&schema_for!(ExecuteMsg), &out_dir);
+    export_schema(&schema_for!(QueryMsg), &out_dir);
+    export_schema(&schema_for!(Config), &out_dir);
+    export_schema(&schema_for!(LastClaim), &out_dir);
+    export_schema(&schema_for!(InfoResponse), &out_dir);
+    export_schema(&schema_for!(ClaimableRewardsResponse), &out_dir);
+}

--- a/contracts/stake-cw20-external-rewards/schema/claimable_rewards_response.json
+++ b/contracts/stake-cw20-external-rewards/schema/claimable_rewards_response.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ClaimableRewardsResponse",
+  "type": "object",
+  "required": [
+    "amount"
+  ],
+  "properties": {
+    "amount": {
+      "$ref": "#/definitions/Uint128"
+    }
+  },
+  "definitions": {
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/stake-cw20-external-rewards/schema/config.json
+++ b/contracts/stake-cw20-external-rewards/schema/config.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Config",
+  "type": "object",
+  "required": [
+    "denom",
+    "end_block",
+    "funded",
+    "payment_block_delta",
+    "payment_per_block",
+    "staking_contract",
+    "start_block",
+    "total_amount"
+  ],
+  "properties": {
+    "denom": {
+      "$ref": "#/definitions/Denom"
+    },
+    "end_block": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "funded": {
+      "type": "boolean"
+    },
+    "payment_block_delta": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "payment_per_block": {
+      "$ref": "#/definitions/Uint128"
+    },
+    "staking_contract": {
+      "$ref": "#/definitions/Addr"
+    },
+    "start_block": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "total_amount": {
+      "$ref": "#/definitions/Uint128"
+    }
+  },
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Denom": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "native"
+          ],
+          "properties": {
+            "native": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "cw20"
+          ],
+          "properties": {
+            "cw20": {
+              "$ref": "#/definitions/Addr"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/stake-cw20-external-rewards/schema/config.json
+++ b/contracts/stake-cw20-external-rewards/schema/config.json
@@ -3,16 +3,21 @@
   "title": "Config",
   "type": "object",
   "required": [
+    "blocks_between_payments",
     "denom",
     "end_block",
     "funded",
-    "payment_block_delta",
     "payment_per_block",
     "staking_contract",
     "start_block",
     "total_amount"
   ],
   "properties": {
+    "blocks_between_payments": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
     "denom": {
       "$ref": "#/definitions/Denom"
     },
@@ -23,11 +28,6 @@
     },
     "funded": {
       "type": "boolean"
-    },
-    "payment_block_delta": {
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
     },
     "payment_per_block": {
       "$ref": "#/definitions/Uint128"

--- a/contracts/stake-cw20-external-rewards/schema/execute_msg.json
+++ b/contracts/stake-cw20-external-rewards/schema/execute_msg.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ExecuteMsg",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "claim"
+      ],
+      "properties": {
+        "claim": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "receive"
+      ],
+      "properties": {
+        "receive": {
+          "$ref": "#/definitions/Cw20ReceiveMsg"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "claim_up_to_block"
+      ],
+      "properties": {
+        "claim_up_to_block": {
+          "type": "object",
+          "required": [
+            "block"
+          ],
+          "properties": {
+            "block": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "Binary": {
+      "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
+      "type": "string"
+    },
+    "Cw20ReceiveMsg": {
+      "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
+      "type": "object",
+      "required": [
+        "amount",
+        "msg",
+        "sender"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "msg": {
+          "$ref": "#/definitions/Binary"
+        },
+        "sender": {
+          "type": "string"
+        }
+      }
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/stake-cw20-external-rewards/schema/info_response.json
+++ b/contracts/stake-cw20-external-rewards/schema/info_response.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InfoResponse",
+  "type": "object",
+  "required": [
+    "denom",
+    "end_block",
+    "payment_block_delta",
+    "payment_per_block",
+    "staking_contract",
+    "start_block",
+    "total_amount"
+  ],
+  "properties": {
+    "denom": {
+      "$ref": "#/definitions/Denom"
+    },
+    "end_block": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "payment_block_delta": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "payment_per_block": {
+      "$ref": "#/definitions/Uint128"
+    },
+    "staking_contract": {
+      "type": "string"
+    },
+    "start_block": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "total_amount": {
+      "$ref": "#/definitions/Uint128"
+    }
+  },
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Denom": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "native"
+          ],
+          "properties": {
+            "native": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "cw20"
+          ],
+          "properties": {
+            "cw20": {
+              "$ref": "#/definitions/Addr"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/stake-cw20-external-rewards/schema/info_response.json
+++ b/contracts/stake-cw20-external-rewards/schema/info_response.json
@@ -3,15 +3,21 @@
   "title": "InfoResponse",
   "type": "object",
   "required": [
+    "blocks_between_payments",
     "denom",
     "end_block",
-    "payment_block_delta",
+    "funded",
     "payment_per_block",
     "staking_contract",
     "start_block",
     "total_amount"
   ],
   "properties": {
+    "blocks_between_payments": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
     "denom": {
       "$ref": "#/definitions/Denom"
     },
@@ -20,10 +26,8 @@
       "format": "uint64",
       "minimum": 0.0
     },
-    "payment_block_delta": {
-      "type": "integer",
-      "format": "uint64",
-      "minimum": 0.0
+    "funded": {
+      "type": "boolean"
     },
     "payment_per_block": {
       "$ref": "#/definitions/Uint128"

--- a/contracts/stake-cw20-external-rewards/schema/instantiate_msg.json
+++ b/contracts/stake-cw20-external-rewards/schema/instantiate_msg.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "InstantiateMsg",
+  "type": "object",
+  "required": [
+    "denom",
+    "distribution_token",
+    "end_block",
+    "payment_block_delta",
+    "payment_per_block",
+    "start_block",
+    "total_amount"
+  ],
+  "properties": {
+    "denom": {
+      "$ref": "#/definitions/Denom"
+    },
+    "distribution_token": {
+      "type": "string"
+    },
+    "end_block": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "payment_block_delta": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "payment_per_block": {
+      "$ref": "#/definitions/Uint128"
+    },
+    "start_block": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "total_amount": {
+      "$ref": "#/definitions/Uint128"
+    }
+  },
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Denom": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "native"
+          ],
+          "properties": {
+            "native": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "cw20"
+          ],
+          "properties": {
+            "cw20": {
+              "$ref": "#/definitions/Addr"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/stake-cw20-external-rewards/schema/last_claim.json
+++ b/contracts/stake-cw20-external-rewards/schema/last_claim.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "LastClaim",
+  "type": "object",
+  "required": [
+    "block_height",
+    "time"
+  ],
+  "properties": {
+    "block_height": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "time": {
+      "$ref": "#/definitions/Timestamp"
+    }
+  },
+  "definitions": {
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/stake-cw20-external-rewards/schema/query_msg.json
+++ b/contracts/stake-cw20-external-rewards/schema/query_msg.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "QueryMsg",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "info"
+      ],
+      "properties": {
+        "info": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "claimable_rewards"
+      ],
+      "properties": {
+        "claimable_rewards": {
+          "type": "object",
+          "required": [
+            "address"
+          ],
+          "properties": {
+            "address": {
+              "$ref": "#/definitions/Addr"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/stake-cw20-external-rewards/src/contract.rs
+++ b/contracts/stake-cw20-external-rewards/src/contract.rs
@@ -258,7 +258,7 @@ pub fn query_info(deps: Deps) -> StdResult<InfoResponse> {
         denom: config.denom,
         staking_contract: config.staking_contract.to_string(),
         blocks_between_payments: config.blocks_between_payments,
-        funded: config.funded
+        funded: config.funded,
     })
 }
 
@@ -1283,7 +1283,10 @@ mod tests {
             .unwrap_err()
             .downcast()
             .unwrap();
-        assert_eq!(err, ContractError::StartAndEndBlocksNotDivisibleByBlocksBetweenPayments {});
+        assert_eq!(
+            err,
+            ContractError::StartAndEndBlocksNotDivisibleByBlocksBetweenPayments {}
+        );
 
         app.borrow_mut().update_block(|b| b.height = 0);
         let stakeable_token = instantiate_cw20(&mut app);
@@ -1300,7 +1303,10 @@ mod tests {
             .unwrap_err()
             .downcast()
             .unwrap();
-        assert_eq!(err, ContractError::StartAndEndBlocksNotDivisibleByBlocksBetweenPayments {});
+        assert_eq!(
+            err,
+            ContractError::StartAndEndBlocksNotDivisibleByBlocksBetweenPayments {}
+        );
 
         app.borrow_mut().update_block(|b| b.height = 0);
         let stakeable_token = instantiate_cw20(&mut app);

--- a/contracts/stake-cw20-external-rewards/src/contract.rs
+++ b/contracts/stake-cw20-external-rewards/src/contract.rs
@@ -1,0 +1,1329 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{
+    from_binary, to_binary, Addr, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env,
+    MessageInfo, QuerierWrapper, Response, StdResult, Timestamp, Uint128, WasmMsg,
+};
+use cw20::{Cw20ExecuteMsg, Cw20ReceiveMsg, Denom};
+use std::cmp::min;
+
+use crate::error::ContractError;
+use crate::error::ContractError::RewardsNotStarted;
+use crate::msg::{
+    ClaimableRewardsResponse, ExecuteMsg, InfoResponse, InstantiateMsg, QueryMsg, ReceiveMsg,
+};
+use crate::state::{Config, LastClaim, CONFIG, LAST_CLAIMED};
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    validate_instantiate_msg(&env, &msg)?;
+    let config = Config {
+        start_block: msg.start_block,
+        end_block: msg.end_block,
+        payment_per_block: msg.payment_per_block,
+        total_amount: msg.total_amount,
+        denom: msg.denom.clone(),
+        staking_contract: deps.api.addr_validate(&*msg.distribution_token)?,
+        funded: match msg.denom {
+            Denom::Native(_) => true,
+            Denom::Cw20(_) => false,
+        },
+        payment_block_delta: msg.payment_block_delta,
+    };
+    CONFIG.save(deps.storage, &config)?;
+    Ok(Response::default())
+}
+
+pub fn validate_instantiate_msg(env: &Env, msg: &InstantiateMsg) -> Result<(), ContractError> {
+    if env.block.height > msg.start_block {
+        return Err(ContractError::StartBlockAlreadyOccurred {});
+    }
+    if msg.start_block > msg.end_block {
+        return Err(ContractError::StartBlockAfterEndBlock {});
+    }
+    if msg.start_block % msg.payment_block_delta != 0 {
+        return Err(ContractError::StartBlockNotDivisibleByPaymentDelta {});
+    }
+    if msg.end_block % msg.payment_block_delta != 0 {
+        return Err(ContractError::EndBlockNotDivisibleByPaymentDelta {});
+    }
+    let duration = Uint128::from(((msg.end_block - msg.start_block) / msg.payment_block_delta) + 1);
+    let calculated_total = duration
+        .checked_mul(msg.payment_per_block)
+        .map_err(cosmwasm_std::StdError::overflow)?
+        .checked_mul(Uint128::from(msg.payment_block_delta))
+        .map_err(cosmwasm_std::StdError::overflow)?;
+    if calculated_total != msg.total_amount {
+        return Err(ContractError::InvalidTotalAmount {});
+    }
+    Ok(())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::Claim {} => try_claim(deps, _env.clone(), info, _env.block.height),
+        ExecuteMsg::Receive(msg) => try_receive(deps, _env, info, msg),
+        ExecuteMsg::ClaimUpToBlock { block } => try_claim(deps, _env, info, block),
+    }
+}
+
+pub fn try_receive(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    wrapper: Cw20ReceiveMsg,
+) -> Result<Response, ContractError> {
+    let msg: ReceiveMsg = from_binary(&wrapper.msg)?;
+    match msg {
+        ReceiveMsg::Fund {} => try_fund(deps, env, info, wrapper.amount),
+    }
+}
+
+pub fn try_fund(
+    deps: DepsMut,
+    _env: Env,
+    info: MessageInfo,
+    amount: Uint128,
+) -> Result<Response, ContractError> {
+    let mut config = CONFIG.load(deps.storage)?;
+    if config.funded {
+        return Err(ContractError::AlreadyFunded {});
+    }
+    if config.denom != Denom::Cw20(info.sender) {
+        return Err(ContractError::IncorrectDenom {});
+    }
+    if amount != config.total_amount {
+        return Err(ContractError::IncorrectFundingAmount {
+            received: amount,
+            expected: config.total_amount,
+        });
+    }
+    config.funded = true;
+    CONFIG.save(deps.storage, &config)?;
+    Ok(Response::new()
+        .add_attribute("action", "fund")
+        .add_attribute("amount", amount))
+}
+
+pub fn try_claim(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    up_to_block: u64,
+) -> Result<Response, ContractError> {
+    if up_to_block > env.block.height {
+        return Err(ContractError::InvalidFutureBlock {});
+    }
+    let config = CONFIG.load(deps.storage)?;
+    if !config.funded {
+        return Err(ContractError::NotFunded {});
+    };
+    if env.block.height < config.start_block {
+        return Err(RewardsNotStarted {
+            current_block: env.block.height,
+            start_block: config.start_block,
+        });
+    }
+    let last_claimed = LAST_CLAIMED
+        .may_load(deps.storage, info.sender.clone())?
+        .unwrap_or(LastClaim {
+            block_height: config.start_block,
+            time: Timestamp::default(),
+        });
+    let (amount_owed, new_claim_height) = get_amount_owed(
+        deps.as_ref(),
+        &info.sender,
+        &config,
+        last_claimed.block_height,
+        up_to_block,
+    )?;
+
+    if amount_owed == Uint128::zero() {
+        return Err(ContractError::ZeroClaimable {});
+    }
+
+    let new_claim = LastClaim {
+        block_height: new_claim_height,
+        time: env.block.time,
+    };
+    LAST_CLAIMED.save(deps.storage, info.sender.clone(), &new_claim)?;
+
+    let payment_msg = get_payment_msg(&env, &config, &info, amount_owed)?;
+
+    Ok(Response::new()
+        .add_message(payment_msg)
+        .add_attribute("action", "claim")
+        .add_attribute("amount", amount_owed))
+}
+
+fn get_amount_owed(
+    deps: Deps,
+    address: &Addr,
+    config: &Config,
+    last_claimed: u64,
+    up_to_block: u64,
+) -> StdResult<(Uint128, u64)> {
+    let delta = config.payment_block_delta;
+    let mut current_block = last_claimed;
+    let mut amount = Uint128::zero();
+    while current_block <= min(up_to_block, config.end_block) {
+        let stake_info = get_stake_info_at_height(deps.querier, config, address, current_block)?;
+        if stake_info.balance > Uint128::zero() {
+            amount += ((Uint128::from(delta) * config.payment_per_block) * stake_info.balance)
+                .checked_div(stake_info.total)?
+        }
+        current_block += delta;
+    }
+    Ok((amount, current_block))
+}
+
+fn get_payment_msg(
+    _env: &Env,
+    config: &Config,
+    info: &MessageInfo,
+    amount: Uint128,
+) -> StdResult<CosmosMsg> {
+    Ok(match config.clone().denom {
+        Denom::Native(denom) => BankMsg::Send {
+            to_address: info.sender.to_string(),
+            amount: vec![Coin { amount, denom }],
+        }
+        .into(),
+        Denom::Cw20(address) => {
+            let transfer = Cw20ExecuteMsg::Transfer {
+                recipient: info.sender.to_string(),
+                amount,
+            };
+            WasmMsg::Execute {
+                contract_addr: address.to_string(),
+                msg: to_binary(&transfer)?,
+                funds: vec![],
+            }
+            .into()
+        }
+    })
+}
+
+struct StakeInfo {
+    pub balance: Uint128,
+    pub total: Uint128,
+}
+fn get_stake_info_at_height(
+    deps: QuerierWrapper,
+    config: &Config,
+    address: &Addr,
+    height: u64,
+) -> StdResult<StakeInfo> {
+    let balance_query = stake_cw20::msg::QueryMsg::StakedBalanceAtHeight {
+        address: address.to_string(),
+        height: Some(height),
+    };
+    let balance_response: stake_cw20::msg::StakedBalanceAtHeightResponse =
+        deps.query_wasm_smart(config.staking_contract.to_string(), &balance_query)?;
+    let total_query = stake_cw20::msg::QueryMsg::TotalStakedAtHeight {
+        height: Some(height),
+    };
+    let total_response: stake_cw20::msg::TotalStakedAtHeightResponse =
+        deps.query_wasm_smart(config.staking_contract.to_string(), &total_query)?;
+    Ok(StakeInfo {
+        balance: balance_response.balance,
+        total: total_response.total,
+    })
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::Info {} => to_binary(&query_info(deps)?),
+        QueryMsg::ClaimableRewards { address } => {
+            to_binary(&query_claimable_rewards(deps, env, address)?)
+        }
+    }
+}
+
+pub fn query_info(deps: Deps) -> StdResult<InfoResponse> {
+    let config = CONFIG.load(deps.storage)?;
+    Ok(InfoResponse {
+        start_block: config.start_block,
+        end_block: config.end_block,
+        payment_per_block: config.payment_per_block,
+        total_amount: config.total_amount,
+        denom: config.denom,
+        staking_contract: config.staking_contract.to_string(),
+        payment_block_delta: config.payment_block_delta,
+    })
+}
+
+pub fn query_claimable_rewards(
+    deps: Deps,
+    env: Env,
+    address: Addr,
+) -> StdResult<ClaimableRewardsResponse> {
+    let config = CONFIG.load(deps.storage)?;
+    let last_claimed = LAST_CLAIMED
+        .may_load(deps.storage, address.clone())?
+        .unwrap_or(LastClaim {
+            block_height: config.start_block,
+            time: Timestamp::default(),
+        });
+    let (amount, _) = get_amount_owed(
+        deps,
+        &address,
+        &config,
+        last_claimed.block_height,
+        env.block.height,
+    )?;
+    Ok(ClaimableRewardsResponse { amount })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::borrow::BorrowMut;
+
+    use crate::msg::ExecuteMsg::{Claim, ClaimUpToBlock};
+    use crate::msg::QueryMsg::{ClaimableRewards, Info};
+    use cosmwasm_std::Empty;
+    use cw20::{Cw20Coin, Cw20Contract};
+    use cw_multi_test::{next_block, App, Contract, ContractWrapper, Executor};
+
+    const OWNER: &str = "owner0001";
+    const ADDR1: &str = "addr0001";
+    const ADDR2: &str = "addr0002";
+    const ADDR3: &str = "addr0003";
+    const ADDR4: &str = "addr0004";
+    const INITIAL_BALANCE: u32 = 1000;
+
+    pub fn contract_rewards() -> Box<dyn Contract<Empty>> {
+        let contract = ContractWrapper::new(
+            crate::contract::execute,
+            crate::contract::instantiate,
+            crate::contract::query,
+        );
+        Box::new(contract)
+    }
+
+    pub fn contract_cw20() -> Box<dyn Contract<Empty>> {
+        let contract = ContractWrapper::new(
+            cw20_base::contract::execute,
+            cw20_base::contract::instantiate,
+            cw20_base::contract::query,
+        );
+        Box::new(contract)
+    }
+
+    pub fn contract_stake_cw20() -> Box<dyn Contract<Empty>> {
+        let contract = ContractWrapper::new(
+            stake_cw20::contract::execute,
+            stake_cw20::contract::instantiate,
+            stake_cw20::contract::query,
+        );
+        Box::new(contract)
+    }
+
+    fn mock_app() -> App {
+        App::default()
+    }
+
+    // uploads code and returns address of cw20 contract
+    fn instantiate_cw20(app: &mut App) -> Addr {
+        let cw20_id = app.store_code(contract_cw20());
+        let msg = cw20_base::msg::InstantiateMsg {
+            name: "test".to_string(),
+            symbol: "STAKE".to_string(),
+            decimals: 0,
+            initial_balances: vec![
+                Cw20Coin {
+                    address: Addr::unchecked(ADDR1).to_string(),
+                    amount: Uint128::from(INITIAL_BALANCE),
+                },
+                Cw20Coin {
+                    address: Addr::unchecked(ADDR2).to_string(),
+                    amount: Uint128::from(INITIAL_BALANCE),
+                },
+                Cw20Coin {
+                    address: Addr::unchecked(ADDR3).to_string(),
+                    amount: Uint128::from(INITIAL_BALANCE),
+                },
+                Cw20Coin {
+                    address: Addr::unchecked(ADDR4).to_string(),
+                    amount: Uint128::from(INITIAL_BALANCE),
+                },
+            ],
+            mint: None,
+            marketing: None,
+        };
+        let token_contract = app
+            .instantiate_contract(cw20_id, Addr::unchecked(OWNER), &msg, &[], "cw20", None)
+            .unwrap();
+
+        let stake_cw20_id = app.store_code(contract_stake_cw20());
+        let msg = stake_cw20::msg::InstantiateMsg {
+            admin: None,
+            token_address: token_contract.clone(),
+            unstaking_duration: None,
+        };
+
+        let stake_contract = app
+            .instantiate_contract(
+                stake_cw20_id,
+                Addr::unchecked(OWNER),
+                &msg,
+                &[],
+                "cw20",
+                None,
+            )
+            .unwrap();
+
+        app.execute_contract(
+            Addr::unchecked(ADDR1),
+            token_contract.clone(),
+            &cw20::Cw20ExecuteMsg::Send {
+                contract: stake_contract.to_string(),
+                amount: Uint128::from(INITIAL_BALANCE),
+                msg: to_binary(&stake_cw20::msg::ReceiveMsg::Stake {}).unwrap(),
+            },
+            &[],
+        )
+        .unwrap();
+        app.execute_contract(
+            Addr::unchecked(ADDR2),
+            token_contract.clone(),
+            &cw20::Cw20ExecuteMsg::Send {
+                contract: stake_contract.to_string(),
+                amount: Uint128::from(INITIAL_BALANCE),
+                msg: to_binary(&stake_cw20::msg::ReceiveMsg::Stake {}).unwrap(),
+            },
+            &[],
+        )
+        .unwrap();
+        app.execute_contract(
+            Addr::unchecked(ADDR3),
+            token_contract.clone(),
+            &cw20::Cw20ExecuteMsg::Send {
+                contract: stake_contract.to_string(),
+                amount: Uint128::from(INITIAL_BALANCE),
+                msg: to_binary(&stake_cw20::msg::ReceiveMsg::Stake {}).unwrap(),
+            },
+            &[],
+        )
+        .unwrap();
+        app.execute_contract(
+            Addr::unchecked(ADDR4),
+            token_contract,
+            &cw20::Cw20ExecuteMsg::Send {
+                contract: stake_contract.to_string(),
+                amount: Uint128::from(INITIAL_BALANCE),
+                msg: to_binary(&stake_cw20::msg::ReceiveMsg::Stake {}).unwrap(),
+            },
+            &[],
+        )
+        .unwrap();
+
+        stake_contract
+    }
+
+    fn instantiate_rewards(
+        app: &mut App,
+        msg: InstantiateMsg,
+        funds: &[Coin],
+    ) -> anyhow::Result<Addr> {
+        let contract_id = app.store_code(contract_rewards());
+        app.instantiate_contract(
+            contract_id,
+            Addr::unchecked(OWNER),
+            &msg,
+            funds,
+            "rewards",
+            None,
+        )
+    }
+
+    #[test]
+    fn proper_initialization() {
+        let mut app = mock_app();
+        app.borrow_mut().update_block(|b| b.height = 0);
+        let stakeable_token = instantiate_cw20(&mut app);
+        let instantiate_msg = InstantiateMsg {
+            start_block: 1000,
+            end_block: 4000,
+            payment_per_block: Uint128::new(4),
+            total_amount: Uint128::new(16000),
+            denom: Denom::Native("utest".to_string()),
+            distribution_token: stakeable_token.to_string(),
+            payment_block_delta: 1000,
+        };
+        let _reward = instantiate_rewards(&mut app, instantiate_msg, &[]).unwrap();
+    }
+
+    #[test]
+    fn basic_native_distribution() {
+        let mut app = mock_app();
+        app.borrow_mut().update_block(|block| block.height = 0);
+        let denom = "utest".to_string();
+        let owner = Addr::unchecked(OWNER);
+
+        let init_funds = vec![Coin {
+            denom: denom.clone(),
+            amount: Uint128::new(16000),
+        }];
+        app.borrow_mut().init_modules(|router, _, storage| {
+            router
+                .bank
+                .init_balance(storage, &owner, init_funds.clone())
+                .unwrap()
+        });
+
+        println!(
+            "native balance: {}",
+            app.wrap()
+                .query_balance(owner, denom.clone())
+                .unwrap()
+                .amount
+        );
+        let stakeable_token = instantiate_cw20(&mut app.borrow_mut());
+        let instantiate_msg = InstantiateMsg {
+            start_block: 1000,
+            end_block: 4000,
+            payment_per_block: Uint128::new(4),
+            total_amount: Uint128::new(16000),
+            denom: Denom::Native(denom.clone()),
+            distribution_token: stakeable_token.to_string(),
+            payment_block_delta: 1000,
+        };
+        app.borrow_mut().update_block(next_block);
+
+        let reward =
+            instantiate_rewards(&mut app.borrow_mut(), instantiate_msg, &init_funds).unwrap();
+
+        let res: stake_cw20::msg::StakedBalanceAtHeightResponse = app
+            .wrap()
+            .query_wasm_smart(
+                stakeable_token,
+                &stake_cw20::msg::QueryMsg::StakedBalanceAtHeight {
+                    address: ADDR1.to_string(),
+                    height: None,
+                },
+            )
+            .unwrap();
+        assert_eq!(res.balance, Uint128::new(1000));
+
+        // No claim before start block
+        app.borrow_mut().update_block(|block| block.height = 500);
+        let err: ContractError = app
+            .execute_contract(Addr::unchecked(ADDR1), reward.clone(), &Claim {}, &[])
+            .unwrap_err()
+            .downcast()
+            .unwrap();
+        assert_eq!(
+            err,
+            RewardsNotStarted {
+                current_block: 500,
+                start_block: 1000
+            }
+        );
+
+        let native_balance = app
+            .wrap()
+            .query_balance(Addr::unchecked(ADDR1), denom.clone())
+            .unwrap()
+            .amount;
+        assert_eq!(native_balance, Uint128::zero());
+
+        // Fist claim
+        app.borrow_mut().update_block(|block| block.height = 1001);
+        // Test query works
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR1),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(1000));
+        let _res = app
+            .execute_contract(Addr::unchecked(ADDR1), reward.clone(), &Claim {}, &[])
+            .unwrap();
+        let native_balance = app
+            .wrap()
+            .query_balance(Addr::unchecked(ADDR1), denom.clone())
+            .unwrap()
+            .amount;
+        assert_eq!(native_balance, Uint128::new(1000));
+
+        // Can't claim twice
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR1),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(0));
+        app.borrow_mut().update_block(|block| block.height = 1020);
+        let err = app
+            .execute_contract(Addr::unchecked(ADDR1), reward.clone(), &Claim {}, &[])
+            .unwrap_err();
+        assert_eq!(ContractError::ZeroClaimable {}, err.downcast().unwrap());
+
+        // Second claim
+        app.borrow_mut().update_block(|block| block.height = 2011);
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR1),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(1000));
+        let _res = app
+            .execute_contract(Addr::unchecked(ADDR1), reward.clone(), &Claim {}, &[])
+            .unwrap();
+        let native_balance = app
+            .wrap()
+            .query_balance(Addr::unchecked(ADDR1), denom.clone())
+            .unwrap()
+            .amount;
+        assert_eq!(native_balance, Uint128::new(2000));
+
+        // Addr2 claims two epochs at once
+        let native_balance = app
+            .wrap()
+            .query_balance(Addr::unchecked(ADDR2), denom.clone())
+            .unwrap()
+            .amount;
+        assert_eq!(native_balance, Uint128::zero());
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR2),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(2000));
+        let _res = app
+            .execute_contract(Addr::unchecked(ADDR2), reward.clone(), &Claim {}, &[])
+            .unwrap();
+        let native_balance = app
+            .wrap()
+            .query_balance(Addr::unchecked(ADDR2), denom.clone())
+            .unwrap()
+            .amount;
+        assert_eq!(native_balance, Uint128::new(2000));
+
+        // Third claim
+        app.borrow_mut().update_block(|block| block.height = 3001);
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR1),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(1000));
+        let _res = app
+            .execute_contract(Addr::unchecked(ADDR1), reward.clone(), &Claim {}, &[])
+            .unwrap();
+        let native_balance = app
+            .wrap()
+            .query_balance(Addr::unchecked(ADDR1), denom.clone())
+            .unwrap()
+            .amount;
+        assert_eq!(native_balance, Uint128::new(3000));
+
+        // 4th claim
+        app.borrow_mut().update_block(|block| block.height = 4001);
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR1),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(1000));
+        let _res = app
+            .execute_contract(Addr::unchecked(ADDR1), reward.clone(), &Claim {}, &[])
+            .unwrap();
+        let native_balance = app
+            .wrap()
+            .query_balance(Addr::unchecked(ADDR1), denom.clone())
+            .unwrap()
+            .amount;
+        assert_eq!(native_balance, Uint128::new(4000));
+
+        // Rewards finished
+        app.borrow_mut().update_block(|block| block.height = 5001);
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR1),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(0));
+        let err = app
+            .execute_contract(Addr::unchecked(ADDR1), reward.clone(), &Claim {}, &[])
+            .unwrap_err();
+        assert_eq!(ContractError::ZeroClaimable {}, err.downcast().unwrap());
+
+        // Other addresses claim rewards
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR2),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(2000));
+        let _res = app
+            .execute_contract(Addr::unchecked(ADDR2), reward.clone(), &Claim {}, &[])
+            .unwrap();
+        let native_balance = app
+            .wrap()
+            .query_balance(Addr::unchecked(ADDR2), denom.clone())
+            .unwrap()
+            .amount;
+        assert_eq!(native_balance, Uint128::new(4000));
+
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR3),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(4000));
+        let _res = app
+            .execute_contract(Addr::unchecked(ADDR3), reward.clone(), &Claim {}, &[])
+            .unwrap();
+        let native_balance = app
+            .wrap()
+            .query_balance(Addr::unchecked(ADDR3), denom)
+            .unwrap()
+            .amount;
+        assert_eq!(native_balance, Uint128::new(4000));
+
+        let err = app
+            .execute_contract(Addr::unchecked(ADDR3), reward, &Claim {}, &[])
+            .unwrap_err();
+        assert_eq!(ContractError::ZeroClaimable {}, err.downcast().unwrap());
+    }
+
+    #[test]
+    fn basic_cw20_distribution() {
+        let mut app = mock_app();
+        app.borrow_mut().update_block(|block| block.height = 0);
+        let denom = "utest".to_string();
+        let owner = Addr::unchecked(OWNER);
+
+        let init_funds = vec![Coin {
+            denom: denom.clone(),
+            amount: Uint128::new(16000),
+        }];
+        app.borrow_mut().init_modules(|router, _, storage| {
+            router
+                .bank
+                .init_balance(storage, &owner, init_funds.clone())
+                .unwrap()
+        });
+
+        println!(
+            "native balance: {}",
+            app.wrap().query_balance(owner, denom).unwrap().amount
+        );
+        let stakeable_token = instantiate_cw20(&mut app.borrow_mut());
+
+        // Instantiate reward token
+        let cw20_id = app.store_code(contract_cw20());
+        let msg = cw20_base::msg::InstantiateMsg {
+            name: "test".to_string(),
+            symbol: "STAKE".to_string(),
+            decimals: 0,
+            initial_balances: vec![Cw20Coin {
+                address: Addr::unchecked(OWNER).to_string(),
+                amount: Uint128::new(16000),
+            }],
+            mint: None,
+            marketing: None,
+        };
+        let reward_contract_addr = app
+            .instantiate_contract(
+                cw20_id,
+                Addr::unchecked(OWNER),
+                &msg,
+                &[],
+                "cw20_reward",
+                None,
+            )
+            .unwrap();
+        let reward_contract = Cw20Contract(reward_contract_addr);
+        app.borrow_mut().update_block(next_block);
+
+        let instantiate_msg = InstantiateMsg {
+            start_block: 1000,
+            end_block: 4000,
+            payment_per_block: Uint128::new(4),
+            total_amount: Uint128::new(16000),
+            denom: Denom::Cw20(reward_contract.addr()),
+            distribution_token: stakeable_token.to_string(),
+            payment_block_delta: 1000,
+        };
+        app.borrow_mut().update_block(next_block);
+
+        let reward =
+            instantiate_rewards(&mut app.borrow_mut(), instantiate_msg, &init_funds).unwrap();
+
+        let res: stake_cw20::msg::StakedBalanceAtHeightResponse = app
+            .wrap()
+            .query_wasm_smart(
+                stakeable_token,
+                &stake_cw20::msg::QueryMsg::StakedBalanceAtHeight {
+                    address: ADDR1.to_string(),
+                    height: None,
+                },
+            )
+            .unwrap();
+        assert_eq!(res.balance, Uint128::new(1000));
+
+        // Fund Contract
+        let cw20_send = Cw20ExecuteMsg::Send {
+            contract: reward.to_string(),
+            amount: Uint128::new(16000),
+            msg: to_binary(&ReceiveMsg::Fund {}).unwrap(),
+        };
+        let _res = app
+            .execute_contract(
+                Addr::unchecked(OWNER),
+                reward_contract.addr(),
+                &cw20_send,
+                &[],
+            )
+            .unwrap();
+
+        // No claim before start block
+        app.borrow_mut().update_block(|block| block.height = 500);
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR1),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(0));
+        let err: ContractError = app
+            .execute_contract(Addr::unchecked(ADDR1), reward.clone(), &Claim {}, &[])
+            .unwrap_err()
+            .downcast()
+            .unwrap();
+        assert_eq!(
+            err,
+            RewardsNotStarted {
+                current_block: 500,
+                start_block: 1000
+            }
+        );
+
+        let cw20_balance = reward_contract
+            .balance(&app, Addr::unchecked(ADDR1))
+            .unwrap();
+        assert_eq!(cw20_balance, Uint128::zero());
+
+        // Fist claim
+        app.borrow_mut().update_block(|block| block.height = 1001);
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR1),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(1000));
+        let _res = app
+            .execute_contract(Addr::unchecked(ADDR1), reward.clone(), &Claim {}, &[])
+            .unwrap();
+        let cw20_balance = reward_contract
+            .balance(&app, Addr::unchecked(ADDR1))
+            .unwrap();
+        assert_eq!(cw20_balance, Uint128::new(1000));
+
+        // Can't claim twice
+        app.borrow_mut().update_block(|block| block.height = 1020);
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR1),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(0));
+        let err = app
+            .execute_contract(Addr::unchecked(ADDR1), reward.clone(), &Claim {}, &[])
+            .unwrap_err();
+        assert_eq!(ContractError::ZeroClaimable {}, err.downcast().unwrap());
+
+        // Second claim
+        app.borrow_mut().update_block(|block| block.height = 2011);
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR1),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(1000));
+        let _res = app
+            .execute_contract(Addr::unchecked(ADDR1), reward.clone(), &Claim {}, &[])
+            .unwrap();
+        let cw20_balance = reward_contract
+            .balance(&app, Addr::unchecked(ADDR1))
+            .unwrap();
+        assert_eq!(cw20_balance, Uint128::new(2000));
+
+        // Addr2 claims two epochs at once
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR2),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(2000));
+        let cw20_balance = reward_contract
+            .balance(&app, Addr::unchecked(ADDR2))
+            .unwrap();
+        assert_eq!(cw20_balance, Uint128::zero());
+        let _res = app
+            .execute_contract(Addr::unchecked(ADDR2), reward.clone(), &Claim {}, &[])
+            .unwrap();
+        let cw20_balance = reward_contract
+            .balance(&app, Addr::unchecked(ADDR2))
+            .unwrap();
+        assert_eq!(cw20_balance, Uint128::new(2000));
+
+        // Third claim
+        app.borrow_mut().update_block(|block| block.height = 3001);
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR1),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(1000));
+        let _res = app
+            .execute_contract(Addr::unchecked(ADDR1), reward.clone(), &Claim {}, &[])
+            .unwrap();
+        let cw20_balance = reward_contract
+            .balance(&app, Addr::unchecked(ADDR1))
+            .unwrap();
+        assert_eq!(cw20_balance, Uint128::new(3000));
+
+        // 4th claim
+        app.borrow_mut().update_block(|block| block.height = 4001);
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR1),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(1000));
+        let _res = app
+            .execute_contract(Addr::unchecked(ADDR1), reward.clone(), &Claim {}, &[])
+            .unwrap();
+        let cw20_balance = reward_contract
+            .balance(&app, Addr::unchecked(ADDR1))
+            .unwrap();
+        assert_eq!(cw20_balance, Uint128::new(4000));
+
+        // Rewards finished
+        app.borrow_mut().update_block(|block| block.height = 5001);
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR1),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(0));
+        let err = app
+            .execute_contract(Addr::unchecked(ADDR1), reward.clone(), &Claim {}, &[])
+            .unwrap_err();
+        assert_eq!(ContractError::ZeroClaimable {}, err.downcast().unwrap());
+
+        // Other addresses claim rewards
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR2),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(2000));
+        let _res = app
+            .execute_contract(Addr::unchecked(ADDR2), reward.clone(), &Claim {}, &[])
+            .unwrap();
+        let cw20_balance = reward_contract
+            .balance(&app, Addr::unchecked(ADDR2))
+            .unwrap();
+        assert_eq!(cw20_balance, Uint128::new(4000));
+
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR3),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(4000));
+        let _res = app
+            .execute_contract(Addr::unchecked(ADDR3), reward.clone(), &Claim {}, &[])
+            .unwrap();
+        let cw20_balance = reward_contract
+            .balance(&app, Addr::unchecked(ADDR3))
+            .unwrap();
+        assert_eq!(cw20_balance, Uint128::new(4000));
+
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR3),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(0));
+        let err = app
+            .execute_contract(Addr::unchecked(ADDR3), reward, &Claim {}, &[])
+            .unwrap_err();
+        assert_eq!(ContractError::ZeroClaimable {}, err.downcast().unwrap());
+    }
+
+    #[test]
+    fn info_query() {
+        let mut app = mock_app();
+        app.borrow_mut().update_block(|block| block.height = 0);
+        let denom = "utest".to_string();
+        let owner = Addr::unchecked(OWNER);
+
+        let init_funds = vec![Coin {
+            denom: denom.clone(),
+            amount: Uint128::new(16000),
+        }];
+        app.borrow_mut().init_modules(|router, _, storage| {
+            router
+                .bank
+                .init_balance(storage, &owner, init_funds.clone())
+                .unwrap()
+        });
+
+        println!(
+            "native balance: {}",
+            app.wrap()
+                .query_balance(owner, denom.clone())
+                .unwrap()
+                .amount
+        );
+        let stakeable_token = instantiate_cw20(&mut app.borrow_mut());
+        let instantiate_msg = InstantiateMsg {
+            start_block: 1000,
+            end_block: 4000,
+            payment_per_block: Uint128::new(4),
+            total_amount: Uint128::new(16000),
+            denom: Denom::Native(denom),
+            distribution_token: stakeable_token.to_string(),
+            payment_block_delta: 1000,
+        };
+        app.borrow_mut().update_block(next_block);
+
+        let reward =
+            instantiate_rewards(&mut app.borrow_mut(), instantiate_msg.clone(), &init_funds)
+                .unwrap();
+
+        let expected_response = InfoResponse {
+            start_block: instantiate_msg.start_block,
+            end_block: instantiate_msg.end_block,
+            payment_per_block: instantiate_msg.payment_per_block,
+            total_amount: instantiate_msg.total_amount,
+            denom: instantiate_msg.denom,
+            staking_contract: instantiate_msg.distribution_token,
+            payment_block_delta: 1000,
+        };
+
+        let res: InfoResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(reward, &Info {})
+            .unwrap();
+        assert_eq!(res, expected_response)
+    }
+
+    #[test]
+    fn claim_up_to() {
+        let mut app = mock_app();
+        app.borrow_mut().update_block(|block| block.height = 0);
+        let denom = "utest".to_string();
+        let owner = Addr::unchecked(OWNER);
+
+        let init_funds = vec![Coin {
+            denom: denom.clone(),
+            amount: Uint128::new(16000),
+        }];
+        app.borrow_mut().init_modules(|router, _, storage| {
+            router
+                .bank
+                .init_balance(storage, &owner, init_funds.clone())
+                .unwrap()
+        });
+
+        println!(
+            "native balance: {}",
+            app.wrap()
+                .query_balance(owner, denom.clone())
+                .unwrap()
+                .amount
+        );
+        let stakeable_token = instantiate_cw20(&mut app.borrow_mut());
+        let instantiate_msg = InstantiateMsg {
+            start_block: 1000,
+            end_block: 4000,
+            payment_per_block: Uint128::new(4),
+            total_amount: Uint128::new(16000),
+            denom: Denom::Native(denom.clone()),
+            distribution_token: stakeable_token.to_string(),
+            payment_block_delta: 1000,
+        };
+        app.borrow_mut().update_block(next_block);
+
+        let reward =
+            instantiate_rewards(&mut app.borrow_mut(), instantiate_msg, &init_funds).unwrap();
+
+        let res: stake_cw20::msg::StakedBalanceAtHeightResponse = app
+            .wrap()
+            .query_wasm_smart(
+                stakeable_token,
+                &stake_cw20::msg::QueryMsg::StakedBalanceAtHeight {
+                    address: ADDR1.to_string(),
+                    height: None,
+                },
+            )
+            .unwrap();
+        assert_eq!(res.balance, Uint128::new(1000));
+
+        // Cannont claim up to blocks in the future
+        let err: ContractError = app
+            .execute_contract(
+                Addr::unchecked(ADDR1),
+                reward.clone(),
+                &ClaimUpToBlock { block: 3001 },
+                &[],
+            )
+            .unwrap_err()
+            .downcast()
+            .unwrap();
+        assert_eq!(err, ContractError::InvalidFutureBlock {});
+
+        // Claim Two blocks
+        app.borrow_mut().update_block(|block| block.height = 3001);
+        // Test query works
+        let res: ClaimableRewardsResponse = app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                reward.clone(),
+                &ClaimableRewards {
+                    address: Addr::unchecked(ADDR1),
+                },
+            )
+            .unwrap();
+        assert_eq!(res.amount, Uint128::new(3000));
+        let _res = app
+            .execute_contract(
+                Addr::unchecked(ADDR1),
+                reward.clone(),
+                &ClaimUpToBlock { block: 2001 },
+                &[],
+            )
+            .unwrap();
+        let native_balance = app
+            .wrap()
+            .query_balance(Addr::unchecked(ADDR1), denom.clone())
+            .unwrap()
+            .amount;
+        assert_eq!(native_balance, Uint128::new(2000));
+
+        let _res = app
+            .execute_contract(
+                Addr::unchecked(ADDR1),
+                reward,
+                &ClaimUpToBlock { block: 3001 },
+                &[],
+            )
+            .unwrap();
+        let native_balance = app
+            .wrap()
+            .query_balance(Addr::unchecked(ADDR1), denom)
+            .unwrap()
+            .amount;
+        assert_eq!(native_balance, Uint128::new(3000));
+    }
+
+    #[test]
+    fn validate_instantiate_msg() {
+        let mut app = mock_app();
+        app.borrow_mut().update_block(|b| b.height = 5000);
+        let stakeable_token = instantiate_cw20(&mut app);
+        let instantiate_msg = InstantiateMsg {
+            start_block: 1000,
+            end_block: 4000,
+            payment_per_block: Uint128::new(4),
+            total_amount: Uint128::new(16000),
+            denom: Denom::Native("utest".to_string()),
+            distribution_token: stakeable_token.to_string(),
+            payment_block_delta: 1000,
+        };
+        let err: ContractError = instantiate_rewards(&mut app, instantiate_msg, &[])
+            .unwrap_err()
+            .downcast()
+            .unwrap();
+        assert_eq!(err, ContractError::StartBlockAlreadyOccurred {});
+
+        app.borrow_mut().update_block(|b| b.height = 0);
+        let stakeable_token = instantiate_cw20(&mut app);
+        let instantiate_msg = InstantiateMsg {
+            start_block: 5000,
+            end_block: 4000,
+            payment_per_block: Uint128::new(4),
+            total_amount: Uint128::new(16000),
+            denom: Denom::Native("utest".to_string()),
+            distribution_token: stakeable_token.to_string(),
+            payment_block_delta: 1000,
+        };
+        let err: ContractError = instantiate_rewards(&mut app, instantiate_msg, &[])
+            .unwrap_err()
+            .downcast()
+            .unwrap();
+        assert_eq!(err, ContractError::StartBlockAfterEndBlock {});
+
+        app.borrow_mut().update_block(|b| b.height = 0);
+        let stakeable_token = instantiate_cw20(&mut app);
+        let instantiate_msg = InstantiateMsg {
+            start_block: 1050,
+            end_block: 4000,
+            payment_per_block: Uint128::new(4),
+            total_amount: Uint128::new(16000),
+            denom: Denom::Native("utest".to_string()),
+            distribution_token: stakeable_token.to_string(),
+            payment_block_delta: 1000,
+        };
+        let err: ContractError = instantiate_rewards(&mut app, instantiate_msg, &[])
+            .unwrap_err()
+            .downcast()
+            .unwrap();
+        assert_eq!(err, ContractError::StartBlockNotDivisibleByPaymentDelta {});
+
+        app.borrow_mut().update_block(|b| b.height = 0);
+        let stakeable_token = instantiate_cw20(&mut app);
+        let instantiate_msg = InstantiateMsg {
+            start_block: 1000,
+            end_block: 3999,
+            payment_per_block: Uint128::new(4),
+            total_amount: Uint128::new(16000),
+            denom: Denom::Native("utest".to_string()),
+            distribution_token: stakeable_token.to_string(),
+            payment_block_delta: 1000,
+        };
+        let err: ContractError = instantiate_rewards(&mut app, instantiate_msg, &[])
+            .unwrap_err()
+            .downcast()
+            .unwrap();
+        assert_eq!(err, ContractError::EndBlockNotDivisibleByPaymentDelta {});
+
+        app.borrow_mut().update_block(|b| b.height = 0);
+        let stakeable_token = instantiate_cw20(&mut app);
+        let instantiate_msg = InstantiateMsg {
+            start_block: 1000,
+            end_block: 4000,
+            payment_per_block: Uint128::new(4),
+            total_amount: Uint128::new(16001),
+            denom: Denom::Native("utest".to_string()),
+            distribution_token: stakeable_token.to_string(),
+            payment_block_delta: 1000,
+        };
+        let err: ContractError = instantiate_rewards(&mut app, instantiate_msg, &[])
+            .unwrap_err()
+            .downcast()
+            .unwrap();
+        assert_eq!(err, ContractError::InvalidTotalAmount {});
+    }
+}

--- a/contracts/stake-cw20-external-rewards/src/contract.rs
+++ b/contracts/stake-cw20-external-rewards/src/contract.rs
@@ -492,7 +492,7 @@ mod tests {
                 .unwrap()
                 .amount
         );
-        let stakeable_token = instantiate_cw20(&mut app.borrow_mut());
+        let stakeable_token = instantiate_cw20(&mut app);
         let instantiate_msg = InstantiateMsg {
             start_block: 1000,
             end_block: 4000,
@@ -505,7 +505,7 @@ mod tests {
         app.borrow_mut().update_block(next_block);
 
         let reward =
-            instantiate_rewards(&mut app.borrow_mut(), instantiate_msg, &init_funds).unwrap();
+            instantiate_rewards(&mut app, instantiate_msg, &init_funds).unwrap();
 
         let res: stake_cw20::msg::StakedBalanceAtHeightResponse = app
             .wrap()
@@ -769,7 +769,7 @@ mod tests {
             "native balance: {}",
             app.wrap().query_balance(owner, denom).unwrap().amount
         );
-        let stakeable_token = instantiate_cw20(&mut app.borrow_mut());
+        let stakeable_token = instantiate_cw20(&mut app);
 
         // Instantiate reward token
         let cw20_id = app.store_code(contract_cw20());
@@ -809,7 +809,7 @@ mod tests {
         app.borrow_mut().update_block(next_block);
 
         let reward =
-            instantiate_rewards(&mut app.borrow_mut(), instantiate_msg, &init_funds).unwrap();
+            instantiate_rewards(&mut app, instantiate_msg, &init_funds).unwrap();
 
         let res: stake_cw20::msg::StakedBalanceAtHeightResponse = app
             .wrap()
@@ -1094,7 +1094,7 @@ mod tests {
                 .unwrap()
                 .amount
         );
-        let stakeable_token = instantiate_cw20(&mut app.borrow_mut());
+        let stakeable_token = instantiate_cw20(&mut app);
         let instantiate_msg = InstantiateMsg {
             start_block: 1000,
             end_block: 4000,
@@ -1107,7 +1107,7 @@ mod tests {
         app.borrow_mut().update_block(next_block);
 
         let reward =
-            instantiate_rewards(&mut app.borrow_mut(), instantiate_msg.clone(), &init_funds)
+            instantiate_rewards(&mut app, instantiate_msg.clone(), &init_funds)
                 .unwrap();
 
         let expected_response = InfoResponse {
@@ -1153,7 +1153,7 @@ mod tests {
                 .unwrap()
                 .amount
         );
-        let stakeable_token = instantiate_cw20(&mut app.borrow_mut());
+        let stakeable_token = instantiate_cw20(&mut app);
         let instantiate_msg = InstantiateMsg {
             start_block: 1000,
             end_block: 4000,
@@ -1166,7 +1166,7 @@ mod tests {
         app.borrow_mut().update_block(next_block);
 
         let reward =
-            instantiate_rewards(&mut app.borrow_mut(), instantiate_msg, &init_funds).unwrap();
+            instantiate_rewards(&mut app, instantiate_msg, &init_funds).unwrap();
 
         let res: stake_cw20::msg::StakedBalanceAtHeightResponse = app
             .wrap()

--- a/contracts/stake-cw20-external-rewards/src/contract.rs
+++ b/contracts/stake-cw20-external-rewards/src/contract.rs
@@ -504,8 +504,7 @@ mod tests {
         };
         app.borrow_mut().update_block(next_block);
 
-        let reward =
-            instantiate_rewards(&mut app, instantiate_msg, &init_funds).unwrap();
+        let reward = instantiate_rewards(&mut app, instantiate_msg, &init_funds).unwrap();
 
         let res: stake_cw20::msg::StakedBalanceAtHeightResponse = app
             .wrap()
@@ -808,8 +807,7 @@ mod tests {
         };
         app.borrow_mut().update_block(next_block);
 
-        let reward =
-            instantiate_rewards(&mut app, instantiate_msg, &init_funds).unwrap();
+        let reward = instantiate_rewards(&mut app, instantiate_msg, &init_funds).unwrap();
 
         let res: stake_cw20::msg::StakedBalanceAtHeightResponse = app
             .wrap()
@@ -1106,9 +1104,7 @@ mod tests {
         };
         app.borrow_mut().update_block(next_block);
 
-        let reward =
-            instantiate_rewards(&mut app, instantiate_msg.clone(), &init_funds)
-                .unwrap();
+        let reward = instantiate_rewards(&mut app, instantiate_msg.clone(), &init_funds).unwrap();
 
         let expected_response = InfoResponse {
             start_block: instantiate_msg.start_block,
@@ -1165,8 +1161,7 @@ mod tests {
         };
         app.borrow_mut().update_block(next_block);
 
-        let reward =
-            instantiate_rewards(&mut app, instantiate_msg, &init_funds).unwrap();
+        let reward = instantiate_rewards(&mut app, instantiate_msg, &init_funds).unwrap();
 
         let res: stake_cw20::msg::StakedBalanceAtHeightResponse = app
             .wrap()

--- a/contracts/stake-cw20-external-rewards/src/error.rs
+++ b/contracts/stake-cw20-external-rewards/src/error.rs
@@ -35,10 +35,8 @@ pub enum ContractError {
     StartBlockAlreadyOccurred {},
     #[error("Start block later then end block")]
     StartBlockAfterEndBlock {},
-    #[error("Start block is not divisible by payment delta")]
-    StartBlockNotDivisibleByPaymentDelta {},
-    #[error("End block is not divisible by payment delta")]
-    EndBlockNotDivisibleByPaymentDelta {},
+    #[error("Start block is not divisible by blocks between payments")]
+    StartAndEndBlocksNotDivisibleByBlocksBetweenPayments {},
     #[error("Total amount is not equal to total payments")]
     InvalidTotalAmount {},
 }

--- a/contracts/stake-cw20-external-rewards/src/error.rs
+++ b/contracts/stake-cw20-external-rewards/src/error.rs
@@ -1,0 +1,44 @@
+use cosmwasm_std::{StdError, Uint128};
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error("{0}")]
+    Std(#[from] StdError),
+    #[error("DivideByZero")]
+    DivideByZero {},
+    #[error("Unauthorized")]
+    Unauthorized {},
+    #[error("NotFunded")]
+    NotFunded {},
+    #[error("AlreadyFunded")]
+    AlreadyFunded {},
+    #[error("IncorrectDenom")]
+    IncorrectDenom {},
+    #[error("IncorrectFundingAmount")]
+    IncorrectFundingAmount {
+        received: Uint128,
+        expected: Uint128,
+    },
+    #[error("RewardsNotStarted")]
+    RewardsNotStarted {
+        current_block: u64,
+        start_block: u64,
+    },
+    #[error("ZeroClaimable")]
+    ZeroClaimable {},
+    // Add any other custom errors you like here.
+    // Look at https://docs.rs/thiserror/1.0.21/thiserror/ for details.
+    #[error("BlockInFuture")]
+    InvalidFutureBlock {},
+    #[error("Start block already occurred")]
+    StartBlockAlreadyOccurred {},
+    #[error("Start block later then end block")]
+    StartBlockAfterEndBlock {},
+    #[error("Start block is not divisible by payment delta")]
+    StartBlockNotDivisibleByPaymentDelta {},
+    #[error("End block is not divisible by payment delta")]
+    EndBlockNotDivisibleByPaymentDelta {},
+    #[error("Total amount is not equal to total payments")]
+    InvalidTotalAmount {},
+}

--- a/contracts/stake-cw20-external-rewards/src/lib.rs
+++ b/contracts/stake-cw20-external-rewards/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod contract;
+mod error;
+pub mod msg;
+pub mod state;
+
+pub use crate::error::ContractError;

--- a/contracts/stake-cw20-external-rewards/src/msg.rs
+++ b/contracts/stake-cw20-external-rewards/src/msg.rs
@@ -1,0 +1,57 @@
+use cosmwasm_std::{Addr, Uint128};
+use cw20::Cw20ReceiveMsg;
+use cw20::Denom;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InstantiateMsg {
+    pub start_block: u64,
+    pub end_block: u64,
+    pub payment_per_block: Uint128,
+    pub total_amount: Uint128,
+    pub denom: Denom,
+    pub distribution_token: String,
+    pub payment_block_delta: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    Claim {},
+    Receive(Cw20ReceiveMsg),
+    ClaimUpToBlock { block: u64 },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReceiveMsg {
+    /// Adds all sent native tokens to the contract
+    Fund {},
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    // GetCount returns the current count as a json-encoded number
+    Info {},
+    ClaimableRewards { address: Addr },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct InfoResponse {
+    pub start_block: u64,
+    pub end_block: u64,
+    pub payment_per_block: Uint128,
+    pub total_amount: Uint128,
+    pub denom: Denom,
+    pub staking_contract: String,
+    pub payment_block_delta: u64,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct ClaimableRewardsResponse {
+    pub amount: Uint128,
+}

--- a/contracts/stake-cw20-external-rewards/src/msg.rs
+++ b/contracts/stake-cw20-external-rewards/src/msg.rs
@@ -47,7 +47,8 @@ pub struct InfoResponse {
     pub total_amount: Uint128,
     pub denom: Denom,
     pub staking_contract: String,
-    pub payment_block_delta: u64,
+    pub blocks_between_payments: u64,
+    pub funded: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/stake-cw20-external-rewards/src/state.rs
+++ b/contracts/stake-cw20-external-rewards/src/state.rs
@@ -1,0 +1,27 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use cosmwasm_std::{Addr, Uint128};
+use cw20::Denom;
+use cw_storage_plus::{Item, Map};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Config {
+    pub start_block: u64,
+    pub end_block: u64,
+    pub payment_per_block: Uint128,
+    pub total_amount: Uint128,
+    pub denom: Denom,
+    pub staking_contract: Addr,
+    pub funded: bool,
+    pub payment_block_delta: u64,
+}
+
+pub const CONFIG: Item<Config> = Item::new("config");
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct LastClaim {
+    pub block_height: u64,
+    pub time: cosmwasm_std::Timestamp,
+}
+pub const LAST_CLAIMED: Map<Addr, LastClaim> = Map::new("last_claimed");

--- a/contracts/stake-cw20-external-rewards/src/state.rs
+++ b/contracts/stake-cw20-external-rewards/src/state.rs
@@ -14,7 +14,7 @@ pub struct Config {
     pub denom: Denom,
     pub staking_contract: Addr,
     pub funded: bool,
-    pub payment_block_delta: u64,
+    pub blocks_between_payments: u64,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");


### PR DESCRIPTION
This contract distributes external staking rewards to stakers in the `stake-cw20` contract. External means the rewards is either a native or cw20 that is not the same as the cw20 being staked. 

The contract calculates rewards based on blocks but only distributes them at predefined epochs. This is all configurable in the instatiation message.