### PR TITLE
Automatically add cw20s to balance list

### DIFF
--- a/contracts/cw3-dao/src/msg.rs
+++ b/contracts/cw3-dao/src/msg.rs
@@ -2,7 +2,7 @@ use crate::error::ContractError;
 use crate::query::ThresholdResponse;
 use crate::state::Config;
 use cosmwasm_std::{Addr, CosmosMsg, Decimal, Empty, Uint128};
-use cw20::Cw20Coin;
+use cw20::{Cw20Coin, Cw20ReceiveMsg};
 use cw20_base::msg::InstantiateMarketingInfo;
 use cw3::Vote;
 use cw_utils::{Duration, Expiration};
@@ -28,6 +28,7 @@ pub struct InstantiateMsg {
     /// Optional Image URL that is used by the contract
     pub image_url: Option<String>,
     pub only_members_execute: bool,
+    pub automatically_add_cw20s: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -168,6 +169,9 @@ pub enum ExecuteMsg {
     /// Update Staking Contract (can only be called by DAO contract)
     /// WARNING: this changes the contract controlling voting
     UpdateStakingContract { new_staking_contract: Addr },
+    /// Wrapper called for automatically adding cw20s
+    /// to our tracked balances
+    Receive(Cw20ReceiveMsg),
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/contracts/cw3-dao/src/state.rs
+++ b/contracts/cw3-dao/src/state.rs
@@ -23,6 +23,7 @@ pub struct Config {
     pub refund_failed_proposals: Option<bool>,
     pub image_url: Option<String>,
     pub only_members_execute: bool,
+    pub automatically_add_cw20s: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]

--- a/contracts/cw3-multisig/src/msg.rs
+++ b/contracts/cw3-multisig/src/msg.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{error::ContractError, state::Config};
 use cosmwasm_std::{Addr, CosmosMsg, Decimal, Empty};
+use cw20::Cw20ReceiveMsg;
 use cw3::Vote;
 use cw4::{Member, MemberChangedHookMsg};
 use cw_utils::{Duration, Expiration, ThresholdResponse};
@@ -19,6 +20,7 @@ pub struct InstantiateMsg {
     pub max_voting_period: Duration,
     pub image_url: Option<String>,
     pub only_members_execute: bool,
+    pub automatically_add_cw20s: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -160,6 +162,9 @@ pub enum ExecuteMsg {
         to_add: Vec<Addr>,
         to_remove: Vec<Addr>,
     },
+    /// Wrapper called for automatically adding cw20s
+    /// to our tracked balances
+    Receive(Cw20ReceiveMsg),
 }
 
 // We can also add this as a cw3 extension

--- a/contracts/cw3-multisig/src/state.rs
+++ b/contracts/cw3-multisig/src/state.rs
@@ -28,6 +28,7 @@ pub struct Config {
     /// Optional Image URL that is used by the contract
     pub image_url: Option<String>,
     pub only_members_execute: bool,
+    pub automatically_add_cw20s: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]


### PR DESCRIPTION
Addresses #176 

Allows DAOs/multisigs to automatically list CW20s sent to them.
- Both DAOs and multisigs can have a config flag to disable/enable this feature e.g. big DAOs may not want to be spammed with CW20s.
- Automatically adding to the tracked balances state.

Feedback appreciated!