### PR TITLE
Instantiate DAO with existing staking contract

### DIFF
--- a/contracts/cw3-dao/src/error.rs
+++ b/contracts/cw3-dao/src/error.rs
@@ -53,4 +53,10 @@ pub enum ContractError {
 
     #[error("DAO is paused")]
     Paused {},
+
+    #[error("Cannot use an existing staking contract with a new CW20")]
+    CannotUseExistingStakingContract {},
+
+    #[error("Staking contract CW20 and DAO CW20 do not match")]
+    StakingContractMismatch {},
 }

--- a/contracts/cw3-dao/src/msg.rs
+++ b/contracts/cw3-dao/src/msg.rs
@@ -17,6 +17,8 @@ pub struct InstantiateMsg {
     pub description: String,
     /// Set an existing governance token or launch a new one
     pub gov_token: GovTokenMsg,
+    /// Set an existing staking contract or instantiate an new one
+    pub staking_contract: StakingContractMsg,
     /// Voting params configuration
     pub threshold: Threshold,
     /// The amount of time a proposal can be voted on before expiring
@@ -38,19 +40,25 @@ pub enum GovTokenMsg {
     // Instantiate a new cw20 token with the DAO as minter
     InstantiateNewCw20 {
         cw20_code_id: u64,
-        stake_contract_code_id: u64,
         label: String,
         initial_dao_balance: Option<Uint128>,
         msg: GovTokenInstantiateMsg,
-        unstaking_duration: Option<Duration>,
     },
     /// Use an existing cw20 token
-    UseExistingCw20 {
-        addr: String,
-        label: String,
-        stake_contract_code_id: u64,
+    UseExistingCw20 { addr: String, label: String },
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
+pub enum StakingContractMsg {
+    /// Create a new staking contract
+    InstantiateNewStakingContract {
+        staking_contract_code_id: u64,
         unstaking_duration: Option<Duration>,
     },
+    /// Use an existing already instantiated staking contract
+    UseExistingStakingContract { addr: String },
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]

--- a/contracts/cw3-dao/src/state.rs
+++ b/contracts/cw3-dao/src/state.rs
@@ -1,4 +1,4 @@
-use crate::msg::Threshold;
+use crate::msg::{StakingContractMsg, Threshold};
 use cosmwasm_std::{
     Addr, BlockInfo, CosmosMsg, Decimal, Empty, StdError, StdResult, Storage, Uint128,
 };
@@ -180,9 +180,8 @@ pub const STAKING_CONTRACT: Item<Addr> = Item::new("staking_contract");
 pub const GOV_TOKEN: Item<Addr> = Item::new("gov_token");
 
 // Stores staking contract CODE ID and Unbonding time for use in a reply
-pub const STAKING_CONTRACT_CODE_ID: Item<u64> = Item::new("staking_contract_code_id");
-pub const STAKING_CONTRACT_UNSTAKING_DURATION: Item<Option<Duration>> =
-    Item::new("staking_contract_unstaking_duration");
+pub const STAKING_CONTRACT_DETAILS: Item<StakingContractMsg> =
+    Item::new("staking_contract_details");
 
 // Multiple-item map
 pub const BALLOTS: Map<(u64, &Addr), Ballot> = Map::new("votes");


### PR DESCRIPTION
We now have an added enum in instantiate to create a DAO with an existing staking contract.

- Similar to how we handle CW20s.
- If we instantiate a new CW20 the contract will error if the user specifies to use an existing staking contract. As this action is invalid
- Existing CW20s can use both a new staking contract or an older one
- Test cases cover all possible combinations

Feedback appreciated.