### PR TITLE
Add `ReverseProposals` query to cw-govmod-single.

### DIFF
--- a/contracts/cw-govmod-single/src/msg.rs
+++ b/contracts/cw-govmod-single/src/msg.rs
@@ -126,6 +126,10 @@ pub enum QueryMsg {
         start_after: Option<u64>,
         limit: Option<u64>,
     },
+    ReverseProposals {
+        start_before: Option<u64>,
+        limit: Option<u64>,
+    },
     ProposalCount {},
     Vote {
         proposal_id: u64,

--- a/contracts/cw-govmod-single/src/query.rs
+++ b/contracts/cw-govmod-single/src/query.rs
@@ -36,3 +36,10 @@ pub struct VoteResponse {
 pub struct VoteListResponse {
     pub votes: Vec<VoteInfo>,
 }
+
+/// A list of proposals returned by `ListProposals` and
+/// `ReverseProposals`.
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
+pub struct ProposalListResponse {
+    pub proposals: Vec<ProposalResponse>,
+}

--- a/contracts/cw-govmod-single/src/threshold.rs
+++ b/contracts/cw-govmod-single/src/threshold.rs
@@ -32,6 +32,15 @@ fn validate_percentage(percent: &Decimal) -> Result<(), ContractError> {
     }
 }
 
+/// Asserts that a quorum <= 1. Quorums may be zero.
+fn validate_quorum(quorum: &Decimal) -> Result<(), ContractError> {
+    if *quorum > Decimal::one() {
+        Err(ContractError::UnreachableThreshold {})
+    } else {
+        Ok(())
+    }
+}
+
 impl Threshold {
     /// returns error if this is an unreachable value,
     /// given a total weight of all members in the group
@@ -42,7 +51,7 @@ impl Threshold {
             } => validate_percentage(percentage_needed),
             Threshold::ThresholdQuorum { threshold, quorum } => {
                 validate_percentage(threshold)?;
-                validate_percentage(quorum)
+                validate_quorum(quorum)
             }
         }
     }

--- a/contracts/cw20-staked-balance-voting/Cargo.toml
+++ b/contracts/cw20-staked-balance-voting/Cargo.toml
@@ -38,8 +38,8 @@ cw-utils = "0.11"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
-cw-governance-macros = { version = "0.1.0", path = "../cw-governance-macros" }
-cw-governance-interface = { version = "0.1.0", path = "../cw-governance-interface" }
+cw-governance-macros = { version = "0.1.0", path = "../../packages/cw-governance-macros" }
+cw-governance-interface = { version = "0.1.0", path = "../../packages/cw-governance-interface" } 
 stake-cw20 = { path = "../stake-cw20" }
 cw20-base = {  version = "0.12", features = ["library"] }
 

--- a/contracts/cw4-voting/Cargo.toml
+++ b/contracts/cw4-voting/Cargo.toml
@@ -37,8 +37,8 @@ cw-utils = "0.12"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
-cw-governance-macros = { version = "0.1.0", path = "../cw-governance-macros" }
-cw-governance-interface = { version = "0.1.0", path = "../cw-governance-interface" }
+cw-governance-macros = { version = "0.1.0", path = "../../packages/cw-governance-macros" }
+cw-governance-interface = { version = "0.1.0", path = "../../packages/cw-governance-interface" } 
 cw4-group = "0.11"
 cw4 = "0.11"
 


### PR DESCRIPTION
Resolves #213 

This adds the `ReverseProposals` query to `cw-govmod-single`. It does not add the `Tally` query as in the new design that query is strictly a subset of the `Proposal` query with a little extra work to compute the current turnout percent on the contract side.

Where possible we want to limit the amount of contract side compute happening and limit complexity in the contracts so I'm in favor of just not adding it.