### PR TITLE
Add a majority passing threshold option.

### DIFF
--- a/contracts/cw-govmod-single/src/threshold.rs
+++ b/contracts/cw-govmod-single/src/threshold.rs
@@ -4,6 +4,39 @@ use serde::{Deserialize, Serialize};
 
 use crate::ContractError;
 
+/// A percentage of voting power that must vote yes for a proposal to
+/// pass. An example of why this is needed:
+///
+/// If a user specifies a 60% passing threshold, and there are 10
+/// voters they likely expect that proposal to pass when there are 6
+/// yes votes. This implies that the condition for passing should be
+/// `yes_votes >= total_votes * threshold`.
+///
+/// With this in mind, how should a user specify that they would like
+/// proposals to pass if the majority of voters choose yes? Selecting
+/// a 50% passing threshold with those rules doesn't properly cover
+/// that case as 5 voters voting yes out of 10 would pass the
+/// proposal. Selecting 50.0001% or or some variation of that also
+/// does not work as a very small yes vote which technically makes the
+/// majority yes may not reach that threshold.
+///
+/// To handle these cases we provide both a majority and percent
+/// option for all percentages. If majority is selected passing will
+/// be determined by `yes > total_votes * 0.5`. If percent is selected
+/// passing is determined by `yes >= total_votes * percent`.
+///
+/// In both of these cases a proposal with only abstain votes must
+/// fail. This requires a special case passing logic.
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum PercentageThreshold {
+    /// The majority of voters must vote yes for the proposal to pass.
+    Majority {},
+    /// A percentage of voting power >= percent must vote yes for the
+    /// proposal to pass.
+    Percent(Decimal),
+}
+
 /// The ways a proposal may reach its passing / failing threshold.
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
@@ -12,30 +45,41 @@ pub enum Threshold {
     /// votes in order for a proposal to pass.  See
     /// `ThresholdResponse::AbsolutePercentage` in the cw3 spec for
     /// details.
-    AbsolutePercentage { percentage: Decimal },
+    AbsolutePercentage { percentage: PercentageThreshold },
 
     /// Declares a `quorum` of the total votes that must participate
     /// in the election in order for the vote to be considered at all.
     /// See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for
     /// details.
-    ThresholdQuorum { threshold: Decimal, quorum: Decimal },
+    ThresholdQuorum {
+        threshold: PercentageThreshold,
+        quorum: PercentageThreshold,
+    },
 }
 
 /// Asserts that the 0.0 < percent <= 1.0
-fn validate_percentage(percent: &Decimal) -> Result<(), ContractError> {
-    if percent.is_zero() {
-        Err(ContractError::ZeroThreshold {})
-    } else if *percent > Decimal::one() {
-        Err(ContractError::UnreachableThreshold {})
+fn validate_percentage(percent: &PercentageThreshold) -> Result<(), ContractError> {
+    if let PercentageThreshold::Percent(percent) = percent {
+        if percent.is_zero() {
+            Err(ContractError::ZeroThreshold {})
+        } else if *percent > Decimal::one() {
+            Err(ContractError::UnreachableThreshold {})
+        } else {
+            Ok(())
+        }
     } else {
         Ok(())
     }
 }
 
 /// Asserts that a quorum <= 1. Quorums may be zero.
-fn validate_quorum(quorum: &Decimal) -> Result<(), ContractError> {
-    if *quorum > Decimal::one() {
-        Err(ContractError::UnreachableThreshold {})
+fn validate_quorum(quorum: &PercentageThreshold) -> Result<(), ContractError> {
+    if let PercentageThreshold::Percent(quorum) = quorum {
+        if *quorum > Decimal::one() {
+            Err(ContractError::UnreachableThreshold {})
+        } else {
+            Ok(())
+        }
     } else {
         Ok(())
     }


### PR DESCRIPTION
The majority threshold option allows the creator to specify that they
would like a proposal to pass if the majority of votes for that
proposal are yes. Otherwise, a proposal will pass if the yes votes are
greater than or equal to the number of votes required for passing.

Why this is needed:

If the passing threshold is 60% folks likely expect that if 6 out of
10 members vote yes that proposal will pass. This implies that yes >=
threshold.

On the other hand, this makes it difficult to specify that users would
like a majority of votes to be the passing threshold as specifying a
50% passing threshold will allow a vote with 5 yes and 5 no votes to
pass. The majority option addresses this by comparing yes > threshold
for that case.

This PR also adds a special case so if all the votes for a proposal are
abstain the proposal fails.