### PR TITLE
Initial items on DAO Instantiation

### DIFF
--- a/contracts/cw-governance/schema/dump_state_response.json
+++ b/contracts/cw-governance/schema/dump_state_response.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "DumpStateResponse",
-  "description": "Relevant state for the governance module.",
+  "description": "Relevant state for the governance module. Returned by the `DumpState` query.",
   "type": "object",
   "required": [
     "config",

--- a/contracts/cw-governance/schema/execute_msg.json
+++ b/contracts/cw-governance/schema/execute_msg.json
@@ -98,18 +98,58 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "description": "Adds an item to the governance contract's item map. If the item already exists the existing value is overriden. If the item does not exist a new item is added.",
+      "type": "object",
+      "required": [
+        "set_item"
+      ],
+      "properties": {
+        "set_item": {
+          "type": "object",
+          "required": [
+            "addr",
+            "key"
+          ],
+          "properties": {
+            "addr": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Removes an item from the governance contract's item map.",
+      "type": "object",
+      "required": [
+        "remove_item"
+      ],
+      "properties": {
+        "remove_item": {
+          "type": "object",
+          "required": [
+            "key"
+          ],
+          "properties": {
+            "key": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {
     "Admin": {
       "description": "Information about the admin of a contract.",
       "oneOf": [
-        {
-          "type": "string",
-          "enum": [
-            "none"
-          ]
-        },
         {
           "description": "A specific address.",
           "type": "object",
@@ -139,6 +179,19 @@
           ],
           "properties": {
             "governance_contract": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "No admin.",
+          "type": "object",
+          "required": [
+            "none"
+          ],
+          "properties": {
+            "none": {
               "type": "object"
             }
           },

--- a/contracts/cw-governance/schema/instantiate_msg.json
+++ b/contracts/cw-governance/schema/instantiate_msg.json
@@ -27,6 +27,16 @@
         "null"
       ]
     },
+    "initial_items": {
+      "description": "Initial information for arbitrary contract addresses to be added to the items map. The key is the name of the item in the items map. The value is an enum that either uses an existing address or instantiates a new contract.",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/InitialItem"
+      }
+    },
     "name": {
       "description": "The name of the governance contract.",
       "type": "string"
@@ -44,12 +54,6 @@
     "Admin": {
       "description": "Information about the admin of a contract.",
       "oneOf": [
-        {
-          "type": "string",
-          "enum": [
-            "none"
-          ]
-        },
         {
           "description": "A specific address.",
           "type": "object",
@@ -83,12 +87,92 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "description": "No admin.",
+          "type": "object",
+          "required": [
+            "none"
+          ],
+          "properties": {
+            "none": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },
     "Binary": {
       "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>",
       "type": "string"
+    },
+    "InitialItem": {
+      "type": "object",
+      "required": [
+        "info",
+        "name"
+      ],
+      "properties": {
+        "info": {
+          "description": "The info from which to derive the address.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InitialItemInfo"
+            }
+          ]
+        },
+        "name": {
+          "description": "The name of the item.",
+          "type": "string"
+        }
+      }
+    },
+    "InitialItemInfo": {
+      "oneOf": [
+        {
+          "description": "An existing contract address.",
+          "type": "object",
+          "required": [
+            "Existing"
+          ],
+          "properties": {
+            "Existing": {
+              "type": "object",
+              "required": [
+                "address"
+              ],
+              "properties": {
+                "address": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Info for instantiating a new contract.",
+          "type": "object",
+          "required": [
+            "Instantiate"
+          ],
+          "properties": {
+            "Instantiate": {
+              "type": "object",
+              "required": [
+                "info"
+              ],
+              "properties": {
+                "info": {
+                  "$ref": "#/definitions/ModuleInstantiateInfo"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     },
     "ModuleInstantiateInfo": {
       "description": "Information needed to instantiate a governance or voting module.",

--- a/contracts/cw-governance/schema/query_msg.json
+++ b/contracts/cw-governance/schema/query_msg.json
@@ -69,6 +69,116 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "get_item"
+      ],
+      "properties": {
+        "get_item": {
+          "type": "object",
+          "required": [
+            "key"
+          ],
+          "properties": {
+            "key": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "list_items"
+      ],
+      "properties": {
+        "list_items": {
+          "type": "object",
+          "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "start_at": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "voting_power_at_height"
+      ],
+      "properties": {
+        "voting_power_at_height": {
+          "type": "object",
+          "required": [
+            "address"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "height": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "total_power_at_height"
+      ],
+      "properties": {
+        "total_power_at_height": {
+          "type": "object",
+          "properties": {
+            "height": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "info"
+      ],
+      "properties": {
+        "info": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/contracts/cw-governance/src/error.rs
+++ b/contracts/cw-governance/src/error.rs
@@ -27,4 +27,7 @@ pub enum ContractError {
 
     #[error("Unsigned integer overflow.")]
     Overflow {},
+
+    #[error("You can only instantiate {0} items during instantiation, but you tried to instantiate {1}.")]
+    TooManyItems(u64, usize),
 }

--- a/contracts/cw-governance/src/msg.rs
+++ b/contracts/cw-governance/src/msg.rs
@@ -33,6 +33,22 @@ pub struct ModuleInstantiateInfo {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub enum InitialItemInfo {
+    /// An existing contract address.
+    Existing { address: String },
+    /// Info for instantiating a new contract.
+    Instantiate { info: ModuleInstantiateInfo },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InitialItem {
+    /// The name of the item.
+    pub name: String,
+    /// The info from which to derive the address.
+    pub info: InitialItemInfo,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
     /// The name of the governance contract.
     pub name: String,
@@ -47,6 +63,12 @@ pub struct InstantiateMsg {
     /// Instantiate information for the governance contract's
     /// governance modules.
     pub governance_modules_instantiate_info: Vec<ModuleInstantiateInfo>,
+
+    /// Initial information for arbitrary contract addresses to be
+    /// added to the items map. The key is the name of the item in the
+    /// items map. The value is an enum that either uses an existing
+    /// address or instantiates a new contract.
+    pub initial_items: Option<Vec<InitialItem>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/cw-governance/src/state.rs
+++ b/contracts/cw-governance/src/state.rs
@@ -15,6 +15,7 @@ pub const CONFIG: Item<Config> = Item::new("config");
 pub const VOTING_MODULE: Item<Addr> = Item::new("voting_module");
 pub const GOVERNANCE_MODULES: Map<Addr, Empty> = Map::new("governance_modules");
 pub const ITEMS: Map<String, Addr> = Map::new("items");
+pub const PENDING_ITEM_INSTANTIATION_NAMES: Map<u64, String> = Map::new("pending_item_instantiations");
 
 /// Stores the number of governance modules present in the governance
 /// contract. This information is avaliable from the governance

--- a/contracts/cw-governance/src/state.rs
+++ b/contracts/cw-governance/src/state.rs
@@ -15,7 +15,8 @@ pub const CONFIG: Item<Config> = Item::new("config");
 pub const VOTING_MODULE: Item<Addr> = Item::new("voting_module");
 pub const GOVERNANCE_MODULES: Map<Addr, Empty> = Map::new("governance_modules");
 pub const ITEMS: Map<String, Addr> = Map::new("items");
-pub const PENDING_ITEM_INSTANTIATION_NAMES: Map<u64, String> = Map::new("pending_item_instantiations");
+pub const PENDING_ITEM_INSTANTIATION_NAMES: Map<u64, String> =
+    Map::new("pending_item_instantiations");
 
 /// Stores the number of governance modules present in the governance
 /// contract. This information is avaliable from the governance

--- a/contracts/cw-govmod-single/src/tests.rs
+++ b/contracts/cw-govmod-single/src/tests.rs
@@ -114,6 +114,7 @@ fn instantiate_with_default_governance(
             admin: cw_governance::msg::Admin::GovernanceContract {},
             label: "DAO DAO governance module".to_string(),
         }],
+        initial_items: None,
     };
 
     instantiate_governance(app, governance_id, governance_instantiate)


### PR DESCRIPTION
Part 2 of #214

Allow the DAO to set an initial list of items on instantiation. These items can be:
- already existing addresses
- info used to instantiate a new contract, storing the corresponding address automatically
