### PR TITLE
Add cw-governance functionality for managing cw20 and cw721 assets.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,8 @@ dependencies = [
  "cw20 0.12.1",
  "cw20-balance-voting",
  "cw20-base 0.12.1",
+ "cw721",
+ "cw721-base",
  "schemars",
  "serde",
  "thiserror",
@@ -596,6 +598,34 @@ dependencies = [
  "cw2 0.12.1",
  "cw4",
  "cw4-group",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw721"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5bb00baf493fc48bf05831edc3ed074731da7c1944c8521ead3df4ff08d9c7"
+dependencies = [
+ "cosmwasm-std",
+ "cw-utils 0.12.1",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw721-base"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da773ac93cae5a01a052772d65a2f377dd22933f583ef8f739d67f32ffce1b6b"
+dependencies = [
+ "cosmwasm-std",
+ "cw-storage-plus 0.12.1",
+ "cw-utils 0.12.1",
+ "cw2 0.12.1",
+ "cw721",
  "schemars",
  "serde",
  "thiserror",

--- a/contracts/cw-governance/Cargo.toml
+++ b/contracts/cw-governance/Cargo.toml
@@ -34,6 +34,8 @@ cosmwasm-storage = { version = "1.0.0-beta5" }
 cw-storage-plus = "0.12"
 cw2 = "0.12"
 cw-utils = "0.12"
+cw20 = "0.12"
+cw721 = "0.12"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
@@ -44,6 +46,6 @@ cw-governance-macros = { version = "0.1.0", path = "../../packages/cw-governance
 cosmwasm-schema = { version = "1.0.0-beta5" }
 cw-multi-test = "0.12"
 cw20-base = "0.12"
+cw721-base = "0.12"
 cw-govmod-sudo = { version = "0.1.0", path = "../cw-govmod-sudo"}
 cw20-balance-voting = { version = "0.1.0", path = "../cw20-balance-voting"}
-cw20 = "0.12"

--- a/contracts/cw-governance/src/msg.rs
+++ b/contracts/cw-governance/src/msg.rs
@@ -57,6 +57,13 @@ pub struct InstantiateMsg {
     /// An image URL to describe the governance module contract.
     pub image_url: Option<String>,
 
+    /// If true the contract will automatically add received cw20
+    /// tokens to its treasury.
+    pub automatically_add_cw20s: bool,
+    /// If true the contract will automatically add received cw721
+    /// tokens to its treasury.
+    pub automatically_add_cw721s: bool,
+
     /// Instantiate information for the governance contract's voting
     /// power module.
     pub voting_module_instantiate_info: ModuleInstantiateInfo,
@@ -97,6 +104,24 @@ pub enum ExecuteMsg {
     SetItem { key: String, addr: String },
     /// Removes an item from the governance contract's item map.
     RemoveItem { key: String },
+    /// Executed when the contract receives a cw20 token. Depending on
+    /// the contract's configuration the contract will automatically
+    /// add the token to its treasury.
+    Receive(cw20::Cw20ReceiveMsg),
+    /// Executed when the contract receives a cw721 token. Depending
+    /// on the contract's configuration the contract will
+    /// automatically add the token to its treasury.
+    ReceiveNft(cw721::Cw721ReceiveMsg),
+    /// Updates the list of cw20 tokens this contract has registered.
+    UpdateCw20List {
+        to_add: Vec<String>,
+        to_remove: Vec<String>,
+    },
+    /// Updates the list of cw721 tokens this contract has registered.
+    UpdateCw721List {
+        to_add: Vec<String>,
+        to_remove: Vec<String>,
+    },
 }
 
 #[voting_query]
@@ -118,10 +143,30 @@ pub enum QueryMsg {
     /// limited by network times than compute times. Returns
     /// `DumpStateResponse`.
     DumpState {},
-    GetItem {
-        key: String,
-    },
+    /// Gets the address associated with an item key.
+    GetItem { key: String },
+    /// Lists all of the item keys associted with the contract. For
+    /// example, given the items `{ "group": "...", "subdao": "..."}`
+    /// this query would return `["group", "subdao"]`.
     ListItems {
+        start_at: Option<String>,
+        limit: Option<u64>,
+    },
+    /// Lists the addresses of the cw20 tokens in this contract's
+    /// treasury.
+    Cw20TokenList {
+        start_at: Option<String>,
+        limit: Option<u64>,
+    },
+    /// Lists the addresses of the cw721 tokens in this contract's
+    /// treasury.
+    Cw721TokenList {
+        start_at: Option<String>,
+        limit: Option<u64>,
+    },
+    /// Gets the token balance for each cw20 registered with the
+    /// contract.
+    Cw20Balances {
         start_at: Option<String>,
         limit: Option<u64>,
     },

--- a/contracts/cw-governance/src/query.rs
+++ b/contracts/cw-governance/src/query.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::Addr;
+use cosmwasm_std::{Addr, Uint128};
 use cw2::ContractVersion;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -26,4 +26,13 @@ pub struct GetItemResponse {
     /// `None` if no item with the provided key was found, `Some`
     /// otherwise.
     pub item: Option<Addr>,
+}
+
+/// Returned by Cw20Balances query.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Cw20BalanceResponse {
+    /// The address of the token.
+    pub addr: Addr,
+    /// The contract's balance.
+    pub balance: Uint128,
 }

--- a/contracts/cw-governance/src/state.rs
+++ b/contracts/cw-governance/src/state.rs
@@ -6,9 +6,19 @@ use cw_storage_plus::{Item, Map};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
+    /// The name of the contract.
     pub name: String,
+    /// A description of the contract.
     pub description: String,
+    /// An optional image URL for displaying alongside the contract.
     pub image_url: Option<String>,
+
+    /// If true the contract will automatically add received cw20
+    /// tokens to its treasury.
+    pub automatically_add_cw20s: bool,
+    /// If true the contract will automatically add received cw721
+    /// tokens to its treasury.
+    pub automatically_add_cw721s: bool,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");
@@ -17,6 +27,13 @@ pub const GOVERNANCE_MODULES: Map<Addr, Empty> = Map::new("governance_modules");
 pub const ITEMS: Map<String, Addr> = Map::new("items");
 pub const PENDING_ITEM_INSTANTIATION_NAMES: Map<u64, String> =
     Map::new("pending_item_instantiations");
+
+/// Set of cw20 tokens that have been registered with this contract's
+/// treasury.
+pub const CW20_LIST: Map<Addr, Empty> = Map::new("cw20s");
+/// Set of cw721 tokens that have been registered with this contract's
+/// treasury.
+pub const CW721_LIST: Map<Addr, Empty> = Map::new("cw721s");
 
 /// Stores the number of governance modules present in the governance
 /// contract. This information is avaliable from the governance

--- a/contracts/cw-govmod-single/src/tests.rs
+++ b/contracts/cw-govmod-single/src/tests.rs
@@ -91,6 +91,8 @@ fn instantiate_with_default_governance(
         name: "DAO DAO".to_string(),
         description: "A DAO that builds DAOs".to_string(),
         image_url: None,
+        automatically_add_cw20s: true,
+        automatically_add_cw721s: true,
         voting_module_instantiate_info: cw_governance::msg::ModuleInstantiateInfo {
             code_id: votemod_id,
             msg: to_binary(&cw20_balance_voting::msg::InstantiateMsg {


### PR DESCRIPTION
Adds:
    
1. Management of cw20 and cw721 token lists.
2. Automatic addition of received cw20 and cw721 assets to list.
3. Toggling on / off of automatic addition.
4. Associated queries for listing assets and listing asset balances.

After some thinking I've opted to implement this functionality inside
of the core contract instead of inside separate treasury
modules. Implementing treasury modules is nice because it makes us
flexible in the event that a new token / NFT / unknown asset standard
comes out and we would like to support it. It adds a fair amount of
complexity though:

1. Someone wanting to send tokens to a DAO must send those tokens to
   the appropriate treasury contract.
2. Queries on the frontend for asset lists require two additional
   queries (what are treasury contracts, what is address of treasury
   contract I care about).

We can always add new treasury contracts later down the line.