### PR TITLE
Remove division when computing if majority threshold is reached.

### DIFF
--- a/packages/voting/src/lib.rs
+++ b/packages/voting/src/lib.rs
@@ -34,6 +34,37 @@ pub enum VoteCmp {
 /// Compares `votes` with `total_power * passing_percentage`. The
 /// comparason function used depends on the `VoteCmp` variation
 /// selected.
+///
+/// !!NOTE!! THIS FUNCTION DOES NOT ROUND UP.
+///
+/// For example, the following assertion will succede:
+///
+/// ```rust
+/// use voting::{compare_vote_count, VoteCmp};
+/// use cosmwasm_std::{Uint128, Decimal};
+/// fn test() {
+///     assert!(compare_vote_count(
+///         Uint128::new(7),
+///         VoteCmp::Greater,
+///         Uint128::new(13),
+///         Decimal::from_ratio(7u64, 13u64)
+///     ));
+/// }
+/// ```
+///
+/// This is because `7 * (7/13)` is `6.999...` after rounding. You
+/// MUST ensure this is the behavior you want when calling this
+/// function.
+///
+/// For our current purposes this is OK as the only place we use the
+/// `Greater` comparason is when looking to see if no votes have
+/// reached `> (1 - threshold)` and thus made the proposal
+/// unpassable. As threshold will be a rounded down version of the
+/// infinite percision real version `1 - threshold` will actually be a
+/// higher magnitured than the real one meaning that we won't ever be
+/// in the position of simeltaniously reporting a proposal as both
+/// rejected and passed.
+///
 pub fn compare_vote_count(
     votes: Uint128,
     cmp: VoteCmp,
@@ -50,60 +81,6 @@ pub fn compare_vote_count(
         VoteCmp::Greater => votes > threshold,
         VoteCmp::Geq => votes >= threshold,
     }
-}
-
-/// Computes the number of votes needed for a proposal to pass. This
-/// must round up. For example, with a 50% passing percentage and 15
-/// total votes 8 votes are required, not 7.
-///
-/// Note that it is possible, though unlikely, that no number of votes
-/// will ever meet the threshold. This happens if the total power is
-/// zero. For example, this may happen if all votes are abstain.
-pub fn votes_needed(total_power: Uint128, passing_percentage: Decimal) -> Uint128 {
-    // Voting power is counted with a Uint128. In order to avoid an
-    // overflow while multiplying by the percision factor we need to
-    // do a full mul which results in a Uint256.
-    //
-    // Percision factor here ensures that any rounding down here that
-    // happens in the VM happens in the 9th decimal place. This makes
-    // it reasonably likely that we successfully round up.
-    let total_power = total_power.full_mul(PRECISION_FACTOR);
-    // Multiplication of a Uint256 and a Decimal is not implemented so
-    // we first multiply by the decimal's raw form and then divide by
-    // the number of decimal places in the decimal. This is the same
-    // thing that happens under the hood when a Uint128 is multiplied
-    // by Decimal.
-    //
-    // This multiplication will round down but because we have
-    // multiplied by `PERCISION_FACTOR` above that rounding ought to
-    // occur in the 9th decimal place.
-    let applied = total_power.multiply_ratio(
-        passing_percentage.atomics(),
-        Uint256::from(10u64).pow(passing_percentage.decimal_places()),
-    );
-    // The maximum possible value for applied occurs if `total_power`
-    // is 2^128. Given a percision factor of 10^9 we confirm that the
-    // numerator value will not overflow as:
-    //
-    // 2^128 * 10^9 + 10^9 < 2^256
-    //
-    // In the interest of being percise, this will not overflow so
-    // long as our percision factor is less than `3.4*10^38`. We don't
-    // have to worry about this because that value won't even fit into
-    // a u128 (the type of PERCISION_FACTOR).
-    let rounded = (applied + Uint256::from(PRECISION_FACTOR) - Uint256::from(1u128))
-        / Uint256::from(PRECISION_FACTOR);
-    // Truncated should be strictly <= than the largest possible
-    // Uint128. Imagine the pathalogical case where the passing
-    // threshold is 100% and there are 2^128 total votes. In this case
-    // rounded is:
-    //
-    // Floor[(2^128 * 10^9 - 1) / 10^9 + 1]
-    //
-    // This number is 2^128 which will fit into a 128 bit
-    // integer. Note: if we didn't floor here this would not be the
-    // case, happily unsigned integer division does indeed do that.
-    rounded.try_into().unwrap()
 }
 
 impl Votes {
@@ -162,16 +139,6 @@ impl std::fmt::Display for Vote {
 mod test {
     use super::*;
 
-    /// Determines if a number of votes meets the provided threshold given
-    /// the total number of votes outstanding.
-    fn votes_meet_threshold(
-        votes: Uint128,
-        total_power: Uint128,
-        passing_percentage: Decimal,
-    ) -> bool {
-        votes >= votes_needed(total_power, passing_percentage)
-    }
-
     #[test]
     fn count_votes() {
         let mut votes = Votes::with_yes(Uint128::new(5));
@@ -186,83 +153,197 @@ mod test {
     }
 
     #[test]
-    fn votes_needed_rounds_properly() {
-        // round up right below 1
-        assert_eq!(
-            Uint128::new(1),
-            votes_needed(Uint128::new(3), Decimal::permille(333))
-        );
-        // round up right over 1
-        assert_eq!(
-            Uint128::new(2),
-            votes_needed(Uint128::new(3), Decimal::permille(334))
-        );
-        assert_eq!(
-            Uint128::new(11),
-            votes_needed(Uint128::new(30), Decimal::permille(334))
-        );
-
-        // exact matches don't round
-        assert_eq!(
-            Uint128::new(17),
-            votes_needed(Uint128::new(34), Decimal::percent(50))
-        );
-        assert_eq!(
-            Uint128::new(12),
-            votes_needed(Uint128::new(48), Decimal::percent(25))
-        );
-
-        assert_eq!(
+    fn vote_comparasons() {
+        assert!(!compare_vote_count(
             Uint128::new(7),
-            votes_needed(Uint128::new(13), Decimal::percent(50))
-        );
+            VoteCmp::Geq,
+            Uint128::new(15),
+            Decimal::percent(50)
+        ));
+        assert!(!compare_vote_count(
+            Uint128::new(7),
+            VoteCmp::Greater,
+            Uint128::new(15),
+            Decimal::percent(50)
+        ));
 
-        assert_eq!(
-            Uint128::zero(),
-            votes_needed(Uint128::zero(), Decimal::percent(50))
-        );
+        assert!(compare_vote_count(
+            Uint128::new(7),
+            VoteCmp::Geq,
+            Uint128::new(14),
+            Decimal::percent(50)
+        ));
+        assert!(!compare_vote_count(
+            Uint128::new(7),
+            VoteCmp::Greater,
+            Uint128::new(14),
+            Decimal::percent(50)
+        ));
 
-        assert_eq!(
+        assert!(compare_vote_count(
+            Uint128::new(7),
+            VoteCmp::Geq,
+            Uint128::new(13),
+            Decimal::from_ratio(7u64, 13u64)
+        ));
+
+        assert!(!compare_vote_count(
+            Uint128::new(6),
+            VoteCmp::Greater,
+            Uint128::new(13),
+            Decimal::one() - Decimal::from_ratio(7u64, 13u64)
+        ));
+        assert!(compare_vote_count(
+            Uint128::new(7),
+            VoteCmp::Greater,
+            Uint128::new(13),
+            Decimal::from_ratio(7u64, 13u64)
+        ));
+
+        assert!(!compare_vote_count(
+            Uint128::new(4),
+            VoteCmp::Geq,
+            Uint128::new(9),
+            Decimal::percent(50)
+        ))
+    }
+
+    #[test]
+    fn more_votes_tests() {
+        assert!(compare_vote_count(
             Uint128::new(1),
-            votes_needed(Uint128::new(1), Decimal::percent(1))
-        );
+            VoteCmp::Geq,
+            Uint128::new(3),
+            Decimal::permille(333)
+        ));
 
-        assert_eq!(
+        assert!(!compare_vote_count(
+            Uint128::new(1),
+            VoteCmp::Geq,
+            Uint128::new(3),
+            Decimal::permille(334)
+        ));
+        assert!(compare_vote_count(
+            Uint128::new(2),
+            VoteCmp::Geq,
+            Uint128::new(3),
+            Decimal::permille(334)
+        ));
+
+        assert!(compare_vote_count(
+            Uint128::new(11),
+            VoteCmp::Geq,
+            Uint128::new(30),
+            Decimal::permille(333)
+        ));
+
+        assert!(compare_vote_count(
+            Uint128::new(15),
+            VoteCmp::Geq,
+            Uint128::new(30),
+            Decimal::permille(500)
+        ));
+        assert!(!compare_vote_count(
+            Uint128::new(15),
+            VoteCmp::Greater,
+            Uint128::new(30),
+            Decimal::permille(500)
+        ));
+
+        assert!(compare_vote_count(
             Uint128::new(0),
-            votes_needed(Uint128::new(1), Decimal::percent(0))
-        );
+            VoteCmp::Geq,
+            Uint128::new(0),
+            Decimal::permille(500)
+        ));
+        assert!(!compare_vote_count(
+            Uint128::new(0),
+            VoteCmp::Greater,
+            Uint128::new(0),
+            Decimal::permille(500)
+        ));
 
-        assert_eq!(
-            Uint128::zero(),
-            votes_needed(Uint128::zero(), Decimal::percent(99))
-        );
+        assert!(!compare_vote_count(
+            Uint128::new(0),
+            VoteCmp::Geq,
+            Uint128::new(1),
+            Decimal::permille(1)
+        ));
+        assert!(!compare_vote_count(
+            Uint128::new(0),
+            VoteCmp::Greater,
+            Uint128::new(1),
+            Decimal::permille(1)
+        ));
+
+        assert!(compare_vote_count(
+            Uint128::new(1),
+            VoteCmp::Geq,
+            Uint128::new(1),
+            Decimal::permille(1)
+        ));
+        assert!(compare_vote_count(
+            Uint128::new(1),
+            VoteCmp::Greater,
+            Uint128::new(1),
+            Decimal::permille(1)
+        ));
+
+        assert!(!compare_vote_count(
+            Uint128::new(0),
+            VoteCmp::Geq,
+            Uint128::new(1),
+            Decimal::permille(999)
+        ));
+        assert!(!compare_vote_count(
+            Uint128::new(0),
+            VoteCmp::Greater,
+            Uint128::new(1),
+            Decimal::permille(999)
+        ));
     }
 
     #[test]
     fn tricky_vote_counts() {
         let threshold = Decimal::percent(50);
         for count in 1..50_000 {
-            assert!(votes_meet_threshold(
+            assert!(compare_vote_count(
                 Uint128::new(count),
+                VoteCmp::Geq,
+                Uint128::new(count * 2),
+                threshold
+            ));
+            assert!(!compare_vote_count(
+                Uint128::new(count),
+                VoteCmp::Greater,
                 Uint128::new(count * 2),
                 threshold
             ))
         }
-        /*
-        Zero votes out of zero total power meet any threshold.
-        */
-        assert!(votes_meet_threshold(
-            Uint128::new(0),
-            Uint128::new(0),
-            threshold
-        ));
-        assert!(votes_meet_threshold(
+
+        // Zero votes out of zero total power meet any threshold. When
+        // Geq is used. Always fail otherwise.
+        assert!(compare_vote_count(
             Uint128::zero(),
+            VoteCmp::Geq,
             Uint128::new(1),
             Decimal::percent(0)
         ));
-        assert!(votes_meet_threshold(
+        assert!(compare_vote_count(
             Uint128::zero(),
+            VoteCmp::Geq,
+            Uint128::new(0),
+            Decimal::percent(0)
+        ));
+        assert!(!compare_vote_count(
+            Uint128::zero(),
+            VoteCmp::Greater,
+            Uint128::new(1),
+            Decimal::percent(0)
+        ));
+        assert!(!compare_vote_count(
+            Uint128::zero(),
+            VoteCmp::Greater,
             Uint128::new(0),
             Decimal::percent(0)
         ))


### PR DESCRIPTION
For the majority threshold instead of checking if `votes > threshold /
2`
we can instead check if `votes * 2 > threshold`. This removes a
division and means that we don't have to worry about a round down in
the division reporting a majority before one has actually been
obtained.

This also removes the `votes_needed` function which is no longer used
and adds a number of new tests to make sure this logic is working as
expected.