### PR TITLE
fix empty attribute bug in external staking contract

### DIFF
--- a/contracts/stake-cw20-external-rewards/src/contract.rs
+++ b/contracts/stake-cw20-external-rewards/src/contract.rs
@@ -72,14 +72,14 @@ pub fn instantiate(
             config
                 .owner
                 .map(|a| a.into_string())
-                .unwrap_or_else(|| "".to_string()),
+                .unwrap_or_else(|| "None".to_string()),
         )
         .add_attribute(
             "manager",
             config
                 .manager
                 .map(|a| a.into_string())
-                .unwrap_or_else(|| "".to_string()),
+                .unwrap_or_else(|| "None".to_string()),
         )
         .add_attribute("staking_contract", config.staking_contract)
         .add_attribute(


### PR DESCRIPTION
this contract was failing to instantiate if optional values were not given as it would try to make a response msg attribute with and empty string which is invalid. 