### PR TITLE
Move initial DAO balance into `TokenInfo::New`.

### DIFF
--- a/contracts/cw20-staked-balance-voting/src/contract.rs
+++ b/contracts/cw20-staked-balance-voting/src/contract.rs
@@ -92,6 +92,7 @@ pub fn instantiate(
             symbol,
             decimals,
             mut initial_balances,
+            initial_dao_balance,
             marketing,
             staking_code_id,
             unstaking_duration,
@@ -105,7 +106,7 @@ pub fn instantiate(
             }
 
             // Add DAO initial balance to initial_balances vector if defined.
-            if let Some(initial_dao_balance) = msg.initial_dao_balance {
+            if let Some(initial_dao_balance) = initial_dao_balance {
                 if initial_dao_balance > Uint128::zero() {
                     initial_balances.push(Cw20Coin {
                         address: info.sender.to_string(),

--- a/contracts/cw20-staked-balance-voting/src/msg.rs
+++ b/contracts/cw20-staked-balance-voting/src/msg.rs
@@ -20,6 +20,7 @@ pub enum StakingInfo {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[allow(clippy::large_enum_variant)]
 pub enum TokenInfo {
     Existing {
         address: String,
@@ -36,13 +37,13 @@ pub enum TokenInfo {
         marketing: Option<InstantiateMarketingInfo>,
         staking_code_id: u64,
         unstaking_duration: Option<Duration>,
+        initial_dao_balance: Option<Uint128>,
     },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
     pub token_info: TokenInfo,
-    pub initial_dao_balance: Option<Uint128>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/cw20-staked-balance-voting/src/tests.rs
+++ b/contracts/cw20-staked-balance-voting/src/tests.rs
@@ -83,8 +83,8 @@ fn test_instantiate_zero_supply() {
                 marketing: None,
                 unstaking_duration: None,
                 staking_code_id: staking_contract_id,
+                initial_dao_balance: Some(Uint128::zero()),
             },
-            initial_dao_balance: Some(Uint128::zero()),
         },
     );
 }
@@ -110,8 +110,8 @@ fn test_instantiate_no_balances() {
                 marketing: None,
                 unstaking_duration: None,
                 staking_code_id: staking_contract_id,
+                initial_dao_balance: Some(Uint128::zero()),
             },
-            initial_dao_balance: Some(Uint128::zero()),
         },
     );
 }
@@ -140,8 +140,8 @@ fn test_contract_info() {
                 marketing: None,
                 unstaking_duration: None,
                 staking_code_id: staking_contract_id,
+                initial_dao_balance: Some(Uint128::zero()),
             },
-            initial_dao_balance: Some(Uint128::zero()),
         },
     );
 
@@ -190,8 +190,8 @@ fn test_new_cw20() {
                 marketing: None,
                 unstaking_duration: None,
                 staking_code_id: staking_contract_id,
+                initial_dao_balance: Some(Uint128::from(10u64)),
             },
-            initial_dao_balance: Some(Uint128::from(10u64)),
         },
     );
 
@@ -365,7 +365,6 @@ fn test_existing_cw20_new_staking() {
                     unstaking_duration: None,
                 },
             },
-            initial_dao_balance: None,
         },
     );
 
@@ -516,7 +515,6 @@ fn test_existing_cw20_existing_staking() {
                     unstaking_duration: None,
                 },
             },
-            initial_dao_balance: None,
         },
     );
 
@@ -554,7 +552,6 @@ fn test_existing_cw20_existing_staking() {
                     staking_contract_address: staking_addr.to_string(),
                 },
             },
-            initial_dao_balance: None,
         },
     );
 
@@ -669,7 +666,6 @@ fn test_existing_cw20_existing_staking() {
                     staking_contract_address: staking_addr.to_string(),
                 },
             },
-            initial_dao_balance: None,
         },
         &[],
         "voting module",
@@ -717,7 +713,6 @@ fn test_different_heights() {
                     unstaking_duration: None,
                 },
             },
-            initial_dao_balance: None,
         },
     );
 


### PR DESCRIPTION
This was previously in the top level instantiate message but had not
effect if the contract was instantiated with an existing staking
contract.