### PR TITLE
Remove latest field from Proposal

### DIFF
--- a/contracts/cw-named-groups/Cargo.toml
+++ b/contracts/cw-named-groups/Cargo.toml
@@ -15,17 +15,6 @@ exclude = [
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[profile.release]
-opt-level = 3
-debug = false
-rpath = false
-lto = true
-debug-assertions = false
-codegen-units = 1
-panic = 'abort'
-incremental = false
-overflow-checks = true
-
 [features]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]

--- a/contracts/cw-proposal-single/src/msg.rs
+++ b/contracts/cw-proposal-single/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{CosmosMsg, Empty, Uint128};
-use cw_utils::{Duration, Expiration};
+use cw_utils::Duration;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -63,10 +63,6 @@ pub enum ExecuteMsg {
         /// The messages that should be executed in response to this
         /// proposal passing.
         msgs: Vec<CosmosMsg<Empty>>,
-        /// Optionally, a proposal may have a different expiration
-        /// than the one that would be set by the `max_voting_period`
-        /// in the governance module's config.
-        latest: Option<Expiration>,
     },
     /// Votes on a proposal. Voting power is determined by the DAO's
     /// voting power module.

--- a/contracts/cw-proposal-single/src/proposal.rs
+++ b/contracts/cw-proposal-single/src/proposal.rs
@@ -145,14 +145,6 @@ impl Proposal {
                     // expired the number of votes needed to pass a
                     // proposal is compared to the number of votes on
                     // the proposal.
-                    //
-                    // NOTE(zeke): I do not like this
-                    // behavior. Strongly recomend that we either
-                    // remove custom end dates from proposals or
-                    // remove this logic. These together make the cost
-                    // of doing a hostile takeover of the DAO
-                    // `token_price * quorum` as opposed to the
-                    // 'desired' `token_price * threshold`.
                     let options = self.votes.total() - self.votes.abstain;
                     does_vote_count_pass(self.votes.yes, options, threshold)
                 } else {

--- a/contracts/cw-proposal-single/src/tests.rs
+++ b/contracts/cw-proposal-single/src/tests.rs
@@ -173,7 +173,6 @@ fn test_propose() {
             title: "A simple text proposal".to_string(),
             description: "This is a simple text proposal".to_string(),
             msgs: vec![],
-            latest: None,
         },
         &[],
     )
@@ -318,7 +317,6 @@ fn do_test_votes(
             title: "A simple text proposal".to_string(),
             description: "This is a simple text proposal".to_string(),
             msgs: vec![],
-            latest: None,
         },
         &[],
     )
@@ -1091,7 +1089,6 @@ fn test_take_proposal_deposit() {
             title: "A simple text proposal".to_string(),
             description: "This is a simple text proposal".to_string(),
             msgs: vec![],
-            latest: None,
         },
         &[],
     )
@@ -1118,7 +1115,6 @@ fn test_take_proposal_deposit() {
             title: "A simple text proposal".to_string(),
             description: "This is a simple text proposal".to_string(),
             msgs: vec![],
-            latest: None,
         },
         &[],
     )
@@ -1575,7 +1571,6 @@ fn test_query_list_proposals() {
                 title: format!("Text proposal {}.", i),
                 description: "This is a simple text proposal".to_string(),
                 msgs: vec![],
-                latest: None,
             },
             &[],
         )

--- a/contracts/proposal-hooks-counter/src/tests.rs
+++ b/contracts/proposal-hooks-counter/src/tests.rs
@@ -243,7 +243,6 @@ fn test_counters() {
             title: "A simple text proposal".to_string(),
             description: "This is a simple text proposal".to_string(),
             msgs: vec![],
-            latest: None,
         },
         &[],
     )
@@ -342,7 +341,6 @@ fn test_counters() {
             title: "A simple text proposal 2nd".to_string(),
             description: "This is a simple text proposal 2nd".to_string(),
             msgs: vec![],
-            latest: None,
         },
         &[],
     )


### PR DESCRIPTION
The `latest` field previously allowed a proposal to be created that
expires before the default proposal voting period. When a DAO has a
quorum this makes the hostile takeover cost`quorum * threshold * token_price`
as a proposer could create a proposal that instantly
expires and vote on it in one block.