### PR TITLE
Staking external rewards scale factor bug

### DIFF
--- a/contracts/stake-cw20-external-rewards/src/contract.rs
+++ b/contracts/stake-cw20-external-rewards/src/contract.rs
@@ -2088,12 +2088,7 @@ mod tests {
 
         let _res = app
             .borrow_mut()
-            .execute_contract(
-                admin,
-                reward_addr.clone(),
-                &fund_msg,
-                &reward_funding,
-            )
+            .execute_contract(admin, reward_addr.clone(), &fund_msg, &reward_funding)
             .unwrap();
 
         let res: InfoResponse = app


### PR DESCRIPTION
This bug was breaking the contract when rewards were low. Fixed the bug and added a test for this edge case.

# Bug

We use a scale factor when dividing the rewards accured during a time period and the total staked to ensure the numerator is always larger then the denominator. We then unscale this value when we calculate the rewards earned by a user. The issue here was we were unscaling too early and were running into issues where the value was lower then the scale factor resutling in zero pending rewards.

## Remove uint512
This PR also removes the unecessary use of uint512. When calculating the rewards the total rewards accrued during a certain time period we do not need to worry about this value overflowing a u128. Given the total amount of tokens is bound by a u128 and rewards accrued cannot excced the total amount of tokens in existence therefore rewards accrued cannot exceed a u128.