### PR TITLE
Limit the size of proposals.

### DIFF
--- a/contracts/cw-proposal-single/src/contract.rs
+++ b/contracts/cw-proposal-single/src/contract.rs
@@ -32,6 +32,7 @@ const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Default limit for proposal pagination.
 const DEFAULT_LIMIT: u64 = 30;
+const MAX_PROPOSAL_SIZE: u64 = 30_000;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
@@ -168,6 +169,29 @@ pub fn execute_propose(
         proposal
     };
     let id = advance_proposal_id(deps.storage)?;
+
+    // Limit the size of proposals.
+    //
+    // The Juno mainnet has a larger limit for data that can be
+    // uploaded as part of an execute message than it does for data
+    // that can be queried as part of a query. This means that without
+    // this check it is possible to create a proposal that can not be
+    // queried.
+    //
+    // The size selected was determined by uploading versions of this
+    // contract to the Juno mainnet until queries worked within a
+    // reasonable margin of error.
+    //
+    // `to_vec` is the method used by cosmwasm to convert a struct
+    // into it's byte representation in storage.
+    let proposal_size = cosmwasm_std::to_vec(&proposal)?.len() as u64;
+    if proposal_size > MAX_PROPOSAL_SIZE {
+        return Err(ContractError::ProposalTooLarge {
+            size: proposal_size,
+            max: MAX_PROPOSAL_SIZE,
+        });
+    }
+
     PROPOSALS.save(deps.storage, id, &proposal)?;
 
     let deposit_msg = get_deposit_msg(&config.deposit_info, &env.contract.address, &sender)?;

--- a/contracts/cw-proposal-single/src/error.rs
+++ b/contracts/cw-proposal-single/src/error.rs
@@ -27,6 +27,9 @@ pub enum ContractError {
     #[error("No such proposal ({id})")]
     NoSuchProposal { id: u64 },
 
+    #[error("Proposal is ({size}) bytes, must be <= ({max}) bytes")]
+    ProposalTooLarge { size: u64, max: u64 },
+
     #[error("Proposal is not open ({id})")]
     NotOpen { id: u64 },
 


### PR DESCRIPTION
The Juno mainnet allows storage writes in execute messages that are
larger than the amount of data queryable in a query message. This
means that a sufficiently large proposal (around 40,000 bytes) will
be unqueriable after being created.

To prevent this, this commit limits the size, in bytes, that a proposal
may be. A sensible limit for this size was found by repeatedly storing
a contract on the mainnet and creating the largest possible proposal.