### PR TITLE
Stake CW20 External Rewards: Sub zero reward rate bug

### DIFF
--- a/contracts/stake-cw20-external-rewards/src/contract.rs
+++ b/contracts/stake-cw20-external-rewards/src/contract.rs
@@ -2157,7 +2157,7 @@ mod tests {
 
         let _res = app
             .borrow_mut()
-            .execute_contract(admin, reward_addr.clone(), &fund_msg, &reward_funding)
+            .execute_contract(admin, reward_addr, &fund_msg, &reward_funding)
             .unwrap_err();
     }
 }

--- a/contracts/stake-cw20-external-rewards/src/contract.rs
+++ b/contracts/stake-cw20-external-rewards/src/contract.rs
@@ -2142,7 +2142,7 @@ mod tests {
                 amount: reward_funding.clone(),
             }
         }))
-            .unwrap();
+        .unwrap();
         let reward_addr = setup_reward_contract(
             &mut app,
             staking_addr,

--- a/contracts/stake-cw20-external-rewards/src/error.rs
+++ b/contracts/stake-cw20-external-rewards/src/error.rs
@@ -18,5 +18,5 @@ pub enum ContractError {
     #[error("Invalid Cw20")]
     InvalidCw20 {},
     #[error("Reward rate less then one per block")]
-    RewardRateLessThenOnePerBlock {}
+    RewardRateLessThenOnePerBlock {},
 }

--- a/contracts/stake-cw20-external-rewards/src/error.rs
+++ b/contracts/stake-cw20-external-rewards/src/error.rs
@@ -17,4 +17,6 @@ pub enum ContractError {
     InvalidFunds {},
     #[error("Invalid Cw20")]
     InvalidCw20 {},
+    #[error("Reward rate less then one per block")]
+    RewardRateLessThenOnePerBlock {}
 }


### PR DESCRIPTION
Bug in contract where if reward config results in rewards less then 1 to block the reward rate is rounded down to zero and the tokens are locked. Fixed by throwing an error if the funding configs result in a zero reward rate. 