### PR TITLE
Rename governance modules -> proposal modules in cw-core messages.

### DIFF
--- a/contracts/cw-core/src/error.rs
+++ b/contracts/cw-core/src/error.rs
@@ -14,7 +14,7 @@ pub enum ContractError {
     NoVotingModule {},
 
     #[error("Execution would result in no governance modules being present.")]
-    NoGovernanceModule {},
+    NoProposalModule {},
 
     #[error("An unknown reply ID was received.")]
     UnknownReplyID {},

--- a/contracts/cw-core/src/helpers.rs
+++ b/contracts/cw-core/src/helpers.rs
@@ -7,7 +7,7 @@ impl ModuleInstantiateInfo {
         WasmMsg::Instantiate {
             admin: match self.admin {
                 Admin::Address { addr } => Some(addr),
-                Admin::GovernanceContract {} => Some(contract_address.to_string()),
+                Admin::CoreContract {} => Some(contract_address.to_string()),
                 Admin::None {} => None,
             },
             code_id: self.code_id,

--- a/contracts/cw-core/src/msg.rs
+++ b/contracts/cw-core/src/msg.rs
@@ -12,14 +12,14 @@ use crate::state::Config;
 pub enum Admin {
     /// A specific address.
     Address { addr: String },
-    /// The governance contract itself. The contract will fill this in
+    /// The core contract itself. The contract will fill this in
     /// while instantiation takes place.
-    GovernanceContract {},
+    CoreContract {},
     /// No admin.
     None {},
 }
 
-/// Information needed to instantiate a governance or voting module.
+/// Information needed to instantiate a proposal or voting module.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ModuleInstantiateInfo {
     /// Code ID of the contract to be instantiated.
@@ -50,11 +50,11 @@ pub struct InitialItem {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
-    /// The name of the governance contract.
+    /// The name of the core contract.
     pub name: String,
-    /// A description of the governance contract.
+    /// A description of the core contract.
     pub description: String,
-    /// An image URL to describe the governance module contract.
+    /// An image URL to describe the core module contract.
     pub image_url: Option<String>,
 
     /// If true the contract will automatically add received cw20
@@ -64,12 +64,12 @@ pub struct InstantiateMsg {
     /// tokens to its treasury.
     pub automatically_add_cw721s: bool,
 
-    /// Instantiate information for the governance contract's voting
+    /// Instantiate information for the core contract's voting
     /// power module.
     pub voting_module_instantiate_info: ModuleInstantiateInfo,
-    /// Instantiate information for the governance contract's
-    /// governance modules.
-    pub governance_modules_instantiate_info: Vec<ModuleInstantiateInfo>,
+    /// Instantiate information for the core contract's
+    /// proposal modules.
+    pub proposal_modules_instantiate_info: Vec<ModuleInstantiateInfo>,
 
     /// Initial information for arbitrary contract addresses to be
     /// added to the items map. The key is the name of the item in the
@@ -81,28 +81,28 @@ pub struct InstantiateMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    /// Callable by governance modules. The DAO will execute the
+    /// Callable by proposal modules. The DAO will execute the
     /// messages in the hook in order.
     ExecuteProposalHook { msgs: Vec<CosmosMsg<Empty>> },
-    /// Callable by the governance contract. Replaces the current
+    /// Callable by the core contract. Replaces the current
     /// governance contract config with the provided config.
     UpdateConfig { config: Config },
-    /// Callable by the governance contract. Replaces the current
+    /// Callable by the core contract. Replaces the current
     /// voting module with a new one instantiated by the governance
     /// contract.
     UpdateVotingModule { module: ModuleInstantiateInfo },
-    /// Updates the governance contract's governance modules. Module
+    /// Updates the core contract's proposal modules. Module
     /// instantiate info in `to_add` is used to create new modules and
     /// install them.
     UpdateGovernanceModules {
         to_add: Vec<ModuleInstantiateInfo>,
         to_remove: Vec<String>,
     },
-    /// Adds an item to the governance contract's item map. If the
+    /// Adds an item to the core contract's item map. If the
     /// item already exists the existing value is overriden. If the
     /// item does not exist a new item is added.
     SetItem { key: String, addr: String },
-    /// Removes an item from the governance contract's item map.
+    /// Removes an item from the core contract's item map.
     RemoveItem { key: String },
     /// Executed when the contract receives a cw20 token. Depending on
     /// the contract's configuration the contract will automatically
@@ -132,13 +132,13 @@ pub enum QueryMsg {
     Config {},
     /// Gets the contract's voting module. Returns Addr.
     VotingModule {},
-    /// Gets the governance modules assocaited with the
+    /// Gets the proposal modules assocaited with the
     /// contract. Returns Vec<Addr>.
-    GovernanceModules {
+    ProposalModules {
         start_at: Option<String>,
         limit: Option<u64>,
     },
-    /// Dumps all of the governance contract's state in a single
+    /// Dumps all of the core contract's state in a single
     /// query. Useful for frontends as performance for queries is more
     /// limited by network times than compute times. Returns
     /// `DumpStateResponse`.

--- a/contracts/cw-core/src/state.rs
+++ b/contracts/cw-core/src/state.rs
@@ -23,7 +23,7 @@ pub struct Config {
 
 pub const CONFIG: Item<Config> = Item::new("config");
 pub const VOTING_MODULE: Item<Addr> = Item::new("voting_module");
-pub const GOVERNANCE_MODULES: Map<Addr, Empty> = Map::new("governance_modules");
+pub const PROPOSAL_MODULES: Map<Addr, Empty> = Map::new("governance_modules");
 pub const ITEMS: Map<String, Addr> = Map::new("items");
 pub const PENDING_ITEM_INSTANTIATION_NAMES: Map<u64, String> =
     Map::new("pending_item_instantiations");
@@ -42,4 +42,4 @@ pub const CW721_LIST: Map<Addr, Empty> = Map::new("cw721s");
 /// removing modules to check that at least one is present as it could
 /// cause the contract to lock due to gas issues if too many modules
 /// are present.
-pub const GOVERNANCE_MODULE_COUNT: Item<u64> = Item::new("governance_module_count");
+pub const PROPOSAL_MODULE_COUNT: Item<u64> = Item::new("governance_module_count");

--- a/contracts/cw-core/src/tests.rs
+++ b/contracts/cw-core/src/tests.rs
@@ -96,14 +96,14 @@ fn test_instantiate_with_n_gov_modules(n: usize) {
         voting_module_instantiate_info: ModuleInstantiateInfo {
             code_id: cw20_id,
             msg: to_binary(&cw20_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: "voting module".to_string(),
         },
-        governance_modules_instantiate_info: (0..n)
+        proposal_modules_instantiate_info: (0..n)
             .map(|n| ModuleInstantiateInfo {
                 code_id: cw20_id,
                 msg: to_binary(&cw20_instantiate).unwrap(),
-                admin: Admin::GovernanceContract {},
+                admin: Admin::CoreContract {},
                 label: format!("governance module {}", n),
             })
             .collect(),
@@ -172,20 +172,20 @@ fn test_instantiate_with_submessage_failure() {
         .map(|n| ModuleInstantiateInfo {
             code_id: cw20_id,
             msg: to_binary(&cw20_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: format!("governance module {}", n),
         })
         .collect::<Vec<_>>();
     governance_modules.push(ModuleInstantiateInfo {
         code_id: cw20_id,
         msg: to_binary("bad").unwrap(),
-        admin: Admin::GovernanceContract {},
+        admin: Admin::CoreContract {},
         label: "I have a bad instantiate message".to_string(),
     });
     governance_modules.push(ModuleInstantiateInfo {
         code_id: cw20_id,
         msg: to_binary(&cw20_instantiate).unwrap(),
-        admin: Admin::GovernanceContract {},
+        admin: Admin::CoreContract {},
         label: "Everybody knowing
 that goodness is good
 makes wickedness."
@@ -201,10 +201,10 @@ makes wickedness."
         voting_module_instantiate_info: ModuleInstantiateInfo {
             code_id: cw20_id,
             msg: to_binary(&cw20_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: "voting module".to_string(),
         },
-        governance_modules_instantiate_info: governance_modules,
+        proposal_modules_instantiate_info: governance_modules,
         initial_items: None,
     };
     instantiate_gov(&mut app, gov_id, instantiate);
@@ -229,13 +229,13 @@ fn test_update_config() {
         voting_module_instantiate_info: ModuleInstantiateInfo {
             code_id: govmod_id,
             msg: to_binary(&govmod_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: "voting module".to_string(),
         },
-        governance_modules_instantiate_info: vec![ModuleInstantiateInfo {
+        proposal_modules_instantiate_info: vec![ModuleInstantiateInfo {
             code_id: govmod_id,
             msg: to_binary(&govmod_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: "voting module".to_string(),
         }],
         initial_items: None,
@@ -256,7 +256,7 @@ fn test_update_config() {
         .wrap()
         .query_wasm_smart(
             gov_addr.clone(),
-            &QueryMsg::GovernanceModules {
+            &QueryMsg::ProposalModules {
                 start_at: None,
                 limit: None,
             },
@@ -317,13 +317,13 @@ fn test_swap_governance(swaps: Vec<(u64, u64)>) {
         voting_module_instantiate_info: ModuleInstantiateInfo {
             code_id: govmod_id,
             msg: to_binary(&govmod_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: "voting module".to_string(),
         },
-        governance_modules_instantiate_info: vec![ModuleInstantiateInfo {
+        proposal_modules_instantiate_info: vec![ModuleInstantiateInfo {
             code_id: govmod_id,
             msg: to_binary(&govmod_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: "governance module".to_string(),
         }],
         initial_items: None,
@@ -344,7 +344,7 @@ fn test_swap_governance(swaps: Vec<(u64, u64)>) {
         .wrap()
         .query_wasm_smart(
             gov_addr.clone(),
-            &QueryMsg::GovernanceModules {
+            &QueryMsg::ProposalModules {
                 start_at: None,
                 limit: None,
             },
@@ -358,7 +358,7 @@ fn test_swap_governance(swaps: Vec<(u64, u64)>) {
             .wrap()
             .query_wasm_smart(
                 gov_addr.clone(),
-                &QueryMsg::GovernanceModules {
+                &QueryMsg::ProposalModules {
                     start_at: None,
                     limit: None,
                 },
@@ -369,7 +369,7 @@ fn test_swap_governance(swaps: Vec<(u64, u64)>) {
             .map(|n| ModuleInstantiateInfo {
                 code_id: govmod_id,
                 msg: to_binary(&govmod_instantiate).unwrap(),
-                admin: Admin::GovernanceContract {},
+                admin: Admin::CoreContract {},
                 label: format!("governance module {}", n),
             })
             .collect();
@@ -400,7 +400,7 @@ fn test_swap_governance(swaps: Vec<(u64, u64)>) {
             .wrap()
             .query_wasm_smart(
                 gov_addr.clone(),
-                &QueryMsg::GovernanceModules {
+                &QueryMsg::ProposalModules {
                     start_at: None,
                     limit: None,
                 },
@@ -447,13 +447,13 @@ fn test_swap_voting_module() {
         voting_module_instantiate_info: ModuleInstantiateInfo {
             code_id: govmod_id,
             msg: to_binary(&govmod_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: "voting module".to_string(),
         },
-        governance_modules_instantiate_info: vec![ModuleInstantiateInfo {
+        proposal_modules_instantiate_info: vec![ModuleInstantiateInfo {
             code_id: govmod_id,
             msg: to_binary(&govmod_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: "governance module".to_string(),
         }],
         initial_items: None,
@@ -479,7 +479,7 @@ fn test_swap_voting_module() {
         .wrap()
         .query_wasm_smart(
             gov_addr.clone(),
-            &QueryMsg::GovernanceModules {
+            &QueryMsg::ProposalModules {
                 start_at: None,
                 limit: None,
             },
@@ -499,7 +499,7 @@ fn test_swap_voting_module() {
                     module: ModuleInstantiateInfo {
                         code_id: govmod_id,
                         msg: to_binary(&govmod_instantiate).unwrap(),
-                        admin: Admin::GovernanceContract {},
+                        admin: Admin::CoreContract {},
                         label: "voting module".to_string(),
                     },
                 })
@@ -546,13 +546,13 @@ fn test_permissions() {
         voting_module_instantiate_info: ModuleInstantiateInfo {
             code_id: govmod_id,
             msg: to_binary(&govmod_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: "voting module".to_string(),
         },
-        governance_modules_instantiate_info: vec![ModuleInstantiateInfo {
+        proposal_modules_instantiate_info: vec![ModuleInstantiateInfo {
             code_id: govmod_id,
             msg: to_binary(&govmod_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: "governance module".to_string(),
         }],
         initial_items: None,
@@ -578,7 +578,7 @@ fn test_permissions() {
             module: ModuleInstantiateInfo {
                 code_id: govmod_id,
                 msg: to_binary(&govmod_instantiate).unwrap(),
-                admin: Admin::GovernanceContract {},
+                admin: Admin::CoreContract {},
                 label: "voting module".to_string(),
             },
         },
@@ -642,13 +642,13 @@ fn do_standard_instantiate(auto_add: bool) -> (Addr, App) {
         voting_module_instantiate_info: ModuleInstantiateInfo {
             code_id: voting_id,
             msg: to_binary(&voting_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: "voting module".to_string(),
         },
-        governance_modules_instantiate_info: vec![ModuleInstantiateInfo {
+        proposal_modules_instantiate_info: vec![ModuleInstantiateInfo {
             code_id: govmod_id,
             msg: to_binary(&govmod_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: "governance module".to_string(),
         }],
         initial_items: None,
@@ -792,13 +792,13 @@ fn test_list_items() {
         voting_module_instantiate_info: ModuleInstantiateInfo {
             code_id: voting_id,
             msg: to_binary(&voting_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: "voting module".to_string(),
         },
-        governance_modules_instantiate_info: vec![ModuleInstantiateInfo {
+        proposal_modules_instantiate_info: vec![ModuleInstantiateInfo {
             code_id: govmod_id,
             msg: to_binary(&govmod_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: "governance module".to_string(),
         }],
         initial_items: None,
@@ -877,13 +877,13 @@ fn test_instantiate_with_items() {
         voting_module_instantiate_info: ModuleInstantiateInfo {
             code_id: voting_id,
             msg: to_binary(&voting_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: "voting module".to_string(),
         },
-        governance_modules_instantiate_info: vec![ModuleInstantiateInfo {
+        proposal_modules_instantiate_info: vec![ModuleInstantiateInfo {
             code_id: govmod_id,
             msg: to_binary(&govmod_instantiate).unwrap(),
-            admin: Admin::GovernanceContract {},
+            admin: Admin::CoreContract {},
             label: "governance module".to_string(),
         }],
         initial_items: Some(vec![
@@ -893,7 +893,7 @@ fn test_instantiate_with_items() {
                     info: ModuleInstantiateInfo {
                         code_id: voting_id,
                         msg: to_binary(&voting_instantiate).unwrap(),
-                        admin: Admin::GovernanceContract {},
+                        admin: Admin::CoreContract {},
                         label: "item0: a voting module".to_string(),
                     },
                 },
@@ -904,7 +904,7 @@ fn test_instantiate_with_items() {
                     info: ModuleInstantiateInfo {
                         code_id: voting_id,
                         msg: to_binary(&voting_instantiate).unwrap(),
-                        admin: Admin::GovernanceContract {},
+                        admin: Admin::CoreContract {},
                         label: "item1: another voting module".to_string(),
                     },
                 },

--- a/contracts/cw-proposal-single/src/tests.rs
+++ b/contracts/cw-proposal-single/src/tests.rs
@@ -124,13 +124,13 @@ fn instantiate_with_default_governance(
                 },
             })
             .unwrap(),
-            admin: cw_core::msg::Admin::GovernanceContract {},
+            admin: cw_core::msg::Admin::CoreContract {},
             label: "DAO DAO voting module".to_string(),
         },
-        governance_modules_instantiate_info: vec![cw_core::msg::ModuleInstantiateInfo {
+        proposal_modules_instantiate_info: vec![cw_core::msg::ModuleInstantiateInfo {
             code_id,
             msg: to_binary(&msg).unwrap(),
-            admin: cw_core::msg::Admin::GovernanceContract {},
+            admin: cw_core::msg::Admin::CoreContract {},
             label: "DAO DAO governance module".to_string(),
         }],
         initial_items: None,
@@ -182,13 +182,13 @@ fn instantiate_with_staking_default_governance(
                 active_threshold,
             })
             .unwrap(),
-            admin: cw_core::msg::Admin::GovernanceContract {},
+            admin: cw_core::msg::Admin::CoreContract {},
             label: "DAO DAO voting module".to_string(),
         },
-        governance_modules_instantiate_info: vec![cw_core::msg::ModuleInstantiateInfo {
+        proposal_modules_instantiate_info: vec![cw_core::msg::ModuleInstantiateInfo {
             code_id,
             msg: to_binary(&msg).unwrap(),
-            admin: cw_core::msg::Admin::GovernanceContract {},
+            admin: cw_core::msg::Admin::CoreContract {},
             label: "DAO DAO governance module".to_string(),
         }],
         initial_items: None,
@@ -219,7 +219,7 @@ fn test_propose() {
         .wrap()
         .query_wasm_smart(
             governance_addr.clone(),
-            &cw_core::msg::QueryMsg::GovernanceModules {
+            &cw_core::msg::QueryMsg::ProposalModules {
                 start_at: None,
                 limit: None,
             },
@@ -356,7 +356,7 @@ fn do_test_votes(
         .wrap()
         .query_wasm_smart(
             governance_addr.clone(),
-            &cw_core::msg::QueryMsg::GovernanceModules {
+            &cw_core::msg::QueryMsg::ProposalModules {
                 start_at: None,
                 limit: None,
             },
@@ -1631,7 +1631,7 @@ fn test_query_list_proposals() {
         .wrap()
         .query_wasm_smart(
             gov_addr,
-            &cw_core::msg::QueryMsg::GovernanceModules {
+            &cw_core::msg::QueryMsg::ProposalModules {
                 start_at: None,
                 limit: None,
             },
@@ -1771,7 +1771,7 @@ fn test_hooks() {
         .wrap()
         .query_wasm_smart(
             governance_addr,
-            &cw_core::msg::QueryMsg::GovernanceModules {
+            &cw_core::msg::QueryMsg::ProposalModules {
                 start_at: None,
                 limit: None,
             },
@@ -1950,7 +1950,7 @@ fn test_active_threshold_absolute() {
         .wrap()
         .query_wasm_smart(
             governance_addr,
-            &cw_core::msg::QueryMsg::GovernanceModules {
+            &cw_core::msg::QueryMsg::ProposalModules {
                 start_at: None,
                 limit: None,
             },
@@ -2075,7 +2075,7 @@ fn test_active_threshold_percent() {
         .wrap()
         .query_wasm_smart(
             governance_addr,
-            &cw_core::msg::QueryMsg::GovernanceModules {
+            &cw_core::msg::QueryMsg::ProposalModules {
                 start_at: None,
                 limit: None,
             },
@@ -2192,7 +2192,7 @@ fn test_active_threshold_none() {
         .wrap()
         .query_wasm_smart(
             governance_addr,
-            &cw_core::msg::QueryMsg::GovernanceModules {
+            &cw_core::msg::QueryMsg::ProposalModules {
                 start_at: None,
                 limit: None,
             },
@@ -2269,7 +2269,7 @@ fn test_active_threshold_none() {
         .wrap()
         .query_wasm_smart(
             governance_addr,
-            &cw_core::msg::QueryMsg::GovernanceModules {
+            &cw_core::msg::QueryMsg::ProposalModules {
                 start_at: None,
                 limit: None,
             },

--- a/contracts/proposal-hooks-counter/src/tests.rs
+++ b/contracts/proposal-hooks-counter/src/tests.rs
@@ -110,13 +110,13 @@ fn instantiate_with_default_governance(
                 },
             })
             .unwrap(),
-            admin: cw_core::msg::Admin::GovernanceContract {},
+            admin: cw_core::msg::Admin::CoreContract {},
             label: "DAO DAO voting module".to_string(),
         },
-        governance_modules_instantiate_info: vec![cw_core::msg::ModuleInstantiateInfo {
+        proposal_modules_instantiate_info: vec![cw_core::msg::ModuleInstantiateInfo {
             code_id,
             msg: to_binary(&msg).unwrap(),
-            admin: cw_core::msg::Admin::GovernanceContract {},
+            admin: cw_core::msg::Admin::CoreContract {},
             label: "DAO DAO governance module".to_string(),
         }],
         initial_items: None,
@@ -148,7 +148,7 @@ fn test_counters() {
         .wrap()
         .query_wasm_smart(
             governance_addr,
-            &cw_core::msg::QueryMsg::GovernanceModules {
+            &cw_core::msg::QueryMsg::ProposalModules {
                 start_at: None,
                 limit: None,
             },


### PR DESCRIPTION
Noticed that we had missed some renaming when I was instantiating the latest contracts.