### PR TITLE
Allow the core contract to pause itself.

### DIFF
--- a/contracts/cw-core/examples/schema.rs
+++ b/contracts/cw-core/examples/schema.rs
@@ -5,7 +5,7 @@ use cosmwasm_schema::{export_schema, export_schema_with_title, remove_schemas, s
 use cosmwasm_std::Addr;
 use cw_core::{
     msg::{ExecuteMsg, InstantiateMsg, QueryMsg},
-    query::{Cw20BalanceResponse, DumpStateResponse, GetItemResponse},
+    query::{Cw20BalanceResponse, DumpStateResponse, GetItemResponse, PauseInfoResponse},
     state::Config,
 };
 use cw_core_interface::voting::{
@@ -23,6 +23,7 @@ fn main() {
     export_schema(&schema_for!(QueryMsg), &out_dir);
 
     export_schema(&schema_for!(DumpStateResponse), &out_dir);
+    export_schema(&schema_for!(PauseInfoResponse), &out_dir);
     export_schema(&schema_for!(GetItemResponse), &out_dir);
     export_schema(&schema_for!(InfoResponse), &out_dir);
     export_schema(&schema_for!(TotalPowerAtHeightResponse), &out_dir);

--- a/contracts/cw-core/schema/dump_state_response.json
+++ b/contracts/cw-core/schema/dump_state_response.json
@@ -6,6 +6,7 @@
   "required": [
     "config",
     "governance_modules",
+    "pause_info",
     "version",
     "voting_module"
   ],
@@ -24,6 +25,9 @@
       "items": {
         "$ref": "#/definitions/Addr"
       }
+    },
+    "pause_info": {
+      "$ref": "#/definitions/PauseInfoResponse"
     },
     "version": {
       "description": "The governance contract's version.",
@@ -97,6 +101,101 @@
           "type": "string"
         }
       }
+    },
+    "Expiration": {
+      "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+      "oneOf": [
+        {
+          "description": "AtHeight will expire when `env.block.height` >= height",
+          "type": "object",
+          "required": [
+            "at_height"
+          ],
+          "properties": {
+            "at_height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "AtTime will expire when `env.block.time` >= time",
+          "type": "object",
+          "required": [
+            "at_time"
+          ],
+          "properties": {
+            "at_time": {
+              "$ref": "#/definitions/Timestamp"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Never will never expire. Used to express the empty variant",
+          "type": "object",
+          "required": [
+            "never"
+          ],
+          "properties": {
+            "never": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "PauseInfoResponse": {
+      "description": "Information about if the contract is currently paused.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "Paused"
+          ],
+          "properties": {
+            "Paused": {
+              "type": "object",
+              "required": [
+                "expiration"
+              ],
+              "properties": {
+                "expiration": {
+                  "$ref": "#/definitions/Expiration"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "Unpaused"
+          ],
+          "properties": {
+            "Unpaused": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
     }
   }
 }

--- a/contracts/cw-core/schema/execute_msg.json
+++ b/contracts/cw-core/schema/execute_msg.json
@@ -100,6 +100,26 @@
       "additionalProperties": false
     },
     {
+      "type": "object",
+      "required": [
+        "pause"
+      ],
+      "properties": {
+        "pause": {
+          "type": "object",
+          "required": [
+            "duration"
+          ],
+          "properties": {
+            "duration": {
+              "$ref": "#/definitions/Duration"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Adds an item to the governance contract's item map. If the item already exists the existing value is overriden. If the item does not exist a new item is added.",
       "type": "object",
       "required": [
@@ -544,6 +564,40 @@
                   "type": "string"
                 }
               }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Duration": {
+      "description": "Duration is a delta of time. You can add it to a BlockInfo or Expiration to move that further in the future. Note that an height-based Duration and a time-based Expiration cannot be combined",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "height"
+          ],
+          "properties": {
+            "height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Time in seconds",
+          "type": "object",
+          "required": [
+            "time"
+          ],
+          "properties": {
+            "time": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
             }
           },
           "additionalProperties": false

--- a/contracts/cw-core/schema/pause_info_response.json
+++ b/contracts/cw-core/schema/pause_info_response.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PauseInfoResponse",
+  "description": "Information about if the contract is currently paused.",
+  "oneOf": [
+    {
+      "type": "object",
+      "required": [
+        "Paused"
+      ],
+      "properties": {
+        "Paused": {
+          "type": "object",
+          "required": [
+            "expiration"
+          ],
+          "properties": {
+            "expiration": {
+              "$ref": "#/definitions/Expiration"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "Unpaused"
+      ],
+      "properties": {
+        "Unpaused": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    }
+  ],
+  "definitions": {
+    "Expiration": {
+      "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+      "oneOf": [
+        {
+          "description": "AtHeight will expire when `env.block.height` >= height",
+          "type": "object",
+          "required": [
+            "at_height"
+          ],
+          "properties": {
+            "at_height": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "AtTime will expire when `env.block.time` >= time",
+          "type": "object",
+          "required": [
+            "at_time"
+          ],
+          "properties": {
+            "at_time": {
+              "$ref": "#/definitions/Timestamp"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Never will never expire. Used to express the empty variant",
+          "type": "object",
+          "required": [
+            "never"
+          ],
+          "properties": {
+            "never": {
+              "type": "object"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/cw-core/schema/query_msg.json
+++ b/contracts/cw-core/schema/query_msg.json
@@ -16,6 +16,19 @@
       "additionalProperties": false
     },
     {
+      "description": "Returns information about if the contract is currently paused.",
+      "type": "object",
+      "required": [
+        "pause_info"
+      ],
+      "properties": {
+        "pause_info": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Gets the contract's voting module. Returns Addr.",
       "type": "object",
       "required": [

--- a/contracts/cw-core/src/error.rs
+++ b/contracts/cw-core/src/error.rs
@@ -10,6 +10,9 @@ pub enum ContractError {
     #[error("Unauthorized.")]
     Unauthorized {},
 
+    #[error("The contract is paused.")]
+    Paused {},
+
     #[error("No voting module provided.")]
     NoVotingModule {},
 

--- a/contracts/cw-core/src/msg.rs
+++ b/contracts/cw-core/src/msg.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::{Binary, CosmosMsg, Empty};
+use cw_utils::Duration;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -83,27 +84,41 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     /// Callable by proposal modules. The DAO will execute the
     /// messages in the hook in order.
-    ExecuteProposalHook { msgs: Vec<CosmosMsg<Empty>> },
+    ExecuteProposalHook {
+        msgs: Vec<CosmosMsg<Empty>>,
+    },
     /// Callable by the core contract. Replaces the current
-    /// core contract config with the provided config.
-    UpdateConfig { config: Config },
+    /// governance contract config with the provided config.
+    UpdateConfig {
+        config: Config,
+    },
     /// Callable by the core contract. Replaces the current
-    /// voting module with a new one instantiated by the core
+    /// voting module with a new one instantiated by the governance
     /// contract.
-    UpdateVotingModule { module: ModuleInstantiateInfo },
-    /// Updates the core contract's proposal modules. Module
+    UpdateVotingModule {
+        module: ModuleInstantiateInfo,
+    },
+    /// Updates the governance contract's governance modules. Module
     /// instantiate info in `to_add` is used to create new modules and
     /// install them.
     UpdateProposalModules {
         to_add: Vec<ModuleInstantiateInfo>,
         to_remove: Vec<String>,
     },
-    /// Adds an item to the core contract's item map. If the
+    Pause {
+        duration: Duration,
+    },
+    /// Adds an item to the governance contract's item map. If the
     /// item already exists the existing value is overriden. If the
     /// item does not exist a new item is added.
-    SetItem { key: String, addr: String },
-    /// Removes an item from the core contract's item map.
-    RemoveItem { key: String },
+    SetItem {
+        key: String,
+        addr: String,
+    },
+    /// Removes an item from the governance contract's item map.
+    RemoveItem {
+        key: String,
+    },
     /// Executed when the contract receives a cw20 token. Depending on
     /// the contract's configuration the contract will automatically
     /// add the token to its treasury.
@@ -130,6 +145,8 @@ pub enum ExecuteMsg {
 pub enum QueryMsg {
     /// Gets the contract's config. Returns Config.
     Config {},
+    /// Returns information about if the contract is currently paused.
+    PauseInfo {},
     /// Gets the contract's voting module. Returns Addr.
     VotingModule {},
     /// Gets the proposal modules assocaited with the

--- a/contracts/cw-core/src/query.rs
+++ b/contracts/cw-core/src/query.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::{Addr, Uint128};
 use cw2::ContractVersion;
+use cw_utils::Expiration;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -11,6 +12,8 @@ use crate::state::Config;
 pub struct DumpStateResponse {
     /// The governance contract's config.
     pub config: Config,
+    // True if the contract is currently paused.
+    pub pause_info: PauseInfoResponse,
     /// The governance contract's version.
     pub version: ContractVersion,
     /// The governance modules associated with the governance
@@ -18,6 +21,13 @@ pub struct DumpStateResponse {
     pub governance_modules: Vec<Addr>,
     /// The voting module associated with the governance contract.
     pub voting_module: Addr,
+}
+
+/// Information about if the contract is currently paused.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub enum PauseInfoResponse {
+    Paused { expiration: Expiration },
+    Unpaused {},
 }
 
 /// Returned by the `GetItem` query.

--- a/contracts/cw-core/src/state.rs
+++ b/contracts/cw-core/src/state.rs
@@ -1,3 +1,4 @@
+use cw_utils::Expiration;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -22,8 +23,13 @@ pub struct Config {
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");
+
+pub const PAUSED: Item<Expiration> = Item::new("paused");
+
+/// The voting module associated with this contract.
 pub const VOTING_MODULE: Item<Addr> = Item::new("voting_module");
 pub const PROPOSAL_MODULES: Map<Addr, Empty> = Map::new("governance_modules");
+
 pub const ITEMS: Map<String, Addr> = Map::new("items");
 pub const PENDING_ITEM_INSTANTIATION_NAMES: Map<u64, String> =
     Map::new("pending_item_instantiations");


### PR DESCRIPTION
Stops literally all execute messages from happening for the duration of the pause.