### PR TITLE
Remove `PROPOSAL_MODULES_COUNT` state.

### DIFF
--- a/contracts/cw-core/src/state.rs
+++ b/contracts/cw-core/src/state.rs
@@ -40,12 +40,3 @@ pub const CW20_LIST: Map<Addr, Empty> = Map::new("cw20s");
 /// Set of cw721 tokens that have been registered with this contract's
 /// treasury.
 pub const CW721_LIST: Map<Addr, Empty> = Map::new("cw721s");
-
-/// Stores the number of governance modules present in the governance
-/// contract. This information is avaliable from the governance
-/// modules map but finding it requires a full traversal of the
-/// keys. This means that we can't us that value when adding and
-/// removing modules to check that at least one is present as it could
-/// cause the contract to lock due to gas issues if too many modules
-/// are present.
-pub const PROPOSAL_MODULE_COUNT: Item<u64> = Item::new("governance_module_count");


### PR DESCRIPTION
Storing this led to a state inconsistency when we would update it's
value when the update_proposal_modules method was called. At that
point we would update its value, but the new modules would not
actually be installed as the submessages to add them had not been
executed.

It turns out that we can enforce that there is always a proposal
module in constant time without having that state. This just removes
it in favor of that method.