### PR TITLE
Add withdraw method to stake-cw20-reward-distributor

### DIFF
--- a/contracts/stake-cw20-reward-distributor/schema/execute_msg.json
+++ b/contracts/stake-cw20-reward-distributor/schema/execute_msg.json
@@ -45,6 +45,18 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "withdraw"
+      ],
+      "properties": {
+        "withdraw": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/stake-cw20-reward-distributor/src/contract.rs
+++ b/contracts/stake-cw20-reward-distributor/src/contract.rs
@@ -154,7 +154,11 @@ pub fn execute_distribute(deps: DepsMut, env: Env) -> Result<Response, ContractE
     Ok(Response::default().add_message(send_msg))
 }
 
-pub fn execute_withdraw(deps: DepsMut, info: MessageInfo, env: Env) -> Result<Response, ContractError> {
+pub fn execute_withdraw(
+    deps: DepsMut,
+    info: MessageInfo,
+    env: Env,
+) -> Result<Response, ContractError> {
     let config = CONFIG.load(deps.storage)?;
     if config.owner != info.sender {
         return Err(ContractError::Unauthorized {});
@@ -175,7 +179,8 @@ pub fn execute_withdraw(deps: DepsMut, info: MessageInfo, env: Env) -> Result<Re
         contract_addr: config.reward_token.into(),
         msg,
         funds: vec![],
-    }.into();
+    }
+    .into();
 
     Ok(Response::new().add_message(send_msg))
 }

--- a/contracts/stake-cw20-reward-distributor/src/msg.rs
+++ b/contracts/stake-cw20-reward-distributor/src/msg.rs
@@ -21,6 +21,7 @@ pub enum ExecuteMsg {
         reward_token: String,
     },
     Distribute {},
+    Withdraw {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/contracts/stake-cw20-reward-distributor/src/tests.rs
+++ b/contracts/stake-cw20-reward-distributor/src/tests.rs
@@ -405,9 +405,9 @@ fn test_withdraw() {
         &ExecuteMsg::Distribute {},
         &[],
     )
-        .unwrap();
+    .unwrap();
 
-    let staking_balance = get_balance_cw20(&app, cw20_addr.clone(), staking_addr.clone());
+    let staking_balance = get_balance_cw20(&app, cw20_addr.clone(), staking_addr);
     assert_eq!(staking_balance, Uint128::new(10));
 
     let distributor_info = get_info(&app, distributor_addr.clone());
@@ -415,12 +415,13 @@ fn test_withdraw() {
     assert_eq!(distributor_info.last_payment_block, app.block_info().height);
 
     // Unauthorized user cannot withdraw funds
-    let err = app.execute_contract(
-        Addr::unchecked(MANAGER),
-        distributor_addr.clone(),
-        &ExecuteMsg::Withdraw {},
-        &[],
-    )
+    let err = app
+        .execute_contract(
+            Addr::unchecked(MANAGER),
+            distributor_addr.clone(),
+            &ExecuteMsg::Withdraw {},
+            &[],
+        )
         .unwrap_err();
 
     assert_eq!(ContractError::Unauthorized {}, err.downcast().unwrap());
@@ -428,13 +429,12 @@ fn test_withdraw() {
     // Withdraw funds
     app.execute_contract(
         Addr::unchecked(OWNER),
-        distributor_addr.clone(),
+        distributor_addr,
         &ExecuteMsg::Withdraw {},
         &[],
     )
-        .unwrap();
+    .unwrap();
 
-
-    let owner_balance = get_balance_cw20(&app, cw20_addr.clone(), Addr::unchecked(OWNER));
+    let owner_balance = get_balance_cw20(&app, cw20_addr, Addr::unchecked(OWNER));
     assert_eq!(owner_balance, Uint128::new(990));
 }

--- a/contracts/stake-cw20-reward-distributor/src/tests.rs
+++ b/contracts/stake-cw20-reward-distributor/src/tests.rs
@@ -369,3 +369,72 @@ fn test_update_config_invalid_addrs() {
         .unwrap();
     assert_eq!(err, ContractError::InvalidStakingContract {});
 }
+
+#[test]
+fn test_withdraw() {
+    let mut app = App::default();
+
+    let cw20_addr = instantiate_cw20(
+        &mut app,
+        vec![cw20::Cw20Coin {
+            address: OWNER.to_string(),
+            amount: Uint128::from(1000u64),
+        }],
+    );
+    let staking_addr = instantiate_staking(&mut app, cw20_addr.clone());
+
+    let msg = InstantiateMsg {
+        owner: OWNER.to_string(),
+        staking_addr: staking_addr.to_string(),
+        reward_rate: Uint128::new(1),
+        reward_token: cw20_addr.to_string(),
+    };
+    let distributor_addr = instantiate_distributor(&mut app, msg);
+
+    let msg = cw20::Cw20ExecuteMsg::Transfer {
+        recipient: distributor_addr.to_string(),
+        amount: Uint128::from(1000u128),
+    };
+    app.execute_contract(Addr::unchecked(OWNER), cw20_addr.clone(), &msg, &[])
+        .unwrap();
+
+    app.update_block(|mut block| block.height += 10);
+    app.execute_contract(
+        Addr::unchecked(OWNER),
+        distributor_addr.clone(),
+        &ExecuteMsg::Distribute {},
+        &[],
+    )
+        .unwrap();
+
+    let staking_balance = get_balance_cw20(&app, cw20_addr.clone(), staking_addr.clone());
+    assert_eq!(staking_balance, Uint128::new(10));
+
+    let distributor_info = get_info(&app, distributor_addr.clone());
+    assert_eq!(distributor_info.balance, Uint128::new(990));
+    assert_eq!(distributor_info.last_payment_block, app.block_info().height);
+
+    // Unauthorized user cannot withdraw funds
+    let err = app.execute_contract(
+        Addr::unchecked(MANAGER),
+        distributor_addr.clone(),
+        &ExecuteMsg::Withdraw {},
+        &[],
+    )
+        .unwrap_err();
+
+    assert_eq!(ContractError::Unauthorized {}, err.downcast().unwrap());
+
+    // Withdraw funds
+    app.execute_contract(
+        Addr::unchecked(OWNER),
+        distributor_addr.clone(),
+        &ExecuteMsg::Withdraw {},
+        &[],
+    )
+        .unwrap();
+
+
+    let owner_balance = get_balance_cw20(&app, cw20_addr.clone(), Addr::unchecked(OWNER));
+    assert_eq!(owner_balance, Uint128::new(990));
+}


### PR DESCRIPTION
This new execute message allows the owner to reclaim the reward funds. This would be used by a DAO that wants to change something significant about how rewards are being distributed such as lowering by a large amount or change the contract.