### PR TITLE
Remove errors and make update config force a distributions stake-cw20-reward-distributor

### DIFF
--- a/contracts/stake-cw20-reward-distributor/src/contract.rs
+++ b/contracts/stake-cw20-reward-distributor/src/contract.rs
@@ -34,9 +34,9 @@ pub fn instantiate(
     }
 
     let config = Config {
-        owner,
-        staking_addr,
-        reward_token,
+        owner: owner.clone(),
+        staking_addr: staking_addr.clone(),
+        reward_token: reward_token.clone(),
         reward_rate: msg.reward_rate,
     };
     CONFIG.save(deps.storage, &config)?;
@@ -46,9 +46,9 @@ pub fn instantiate(
 
     Ok(Response::new()
         .add_attribute("action", "instantiate")
-        .add_attribute("owner", owner.into())
-        .add_attribute("staking_addr", staking_addr.into())
-        .add_attribute("reward_token", reward_token.into())
+        .add_attribute("owner", owner.into_string())
+        .add_attribute("staking_addr", staking_addr.into_string())
+        .add_attribute("reward_token", reward_token.into_string())
         .add_attribute("reward_rate", msg.reward_rate)
     )
 }
@@ -97,18 +97,18 @@ pub fn execute_update_config(
     }
 
     let config = Config {
-        owner,
-        staking_addr,
-        reward_token,
+        owner: owner.clone(),
+        staking_addr: staking_addr.clone(),
+        reward_token: reward_token.clone(),
         reward_rate,
     };
     CONFIG.save(deps.storage, &config)?;
 
     Ok(Response::new()
         .add_attribute("action", "update_config")
-        .add_attribute("owner", owner.into())
-        .add_attribute("staking_addr", staking_addr.into())
-        .add_attribute("reward_token", reward_token.into())
+        .add_attribute("owner", owner.into_string())
+        .add_attribute("staking_addr", staking_addr.into_string())
+        .add_attribute("reward_token", reward_token.into_string())
         .add_attribute("reward_rate", reward_rate)
     )
 }
@@ -190,7 +190,7 @@ pub fn execute_withdraw(
     )?;
 
     let msg = to_binary(&cw20::Cw20ExecuteMsg::Transfer {
-        recipient: config.owner.into(),
+        recipient: config.owner.clone().into(),
         amount: balance_info.balance,
     })?;
     let send_msg: CosmosMsg = WasmMsg::Execute {
@@ -204,6 +204,7 @@ pub fn execute_withdraw(
         .add_message(send_msg)
         .add_attribute("action", "withdraw")
         .add_attribute("amount", balance_info.balance)
+        .add_attribute("recipient", config.owner.into_string())
     )
 }
 

--- a/contracts/stake-cw20-reward-distributor/src/contract.rs
+++ b/contracts/stake-cw20-reward-distributor/src/contract.rs
@@ -44,7 +44,13 @@ pub fn instantiate(
     // Initialize last payment block
     LAST_PAYMENT_BLOCK.save(deps.storage, &env.block.height)?;
 
-    Ok(Response::new().add_attribute("action", "instantiate"))
+    Ok(Response::new()
+        .add_attribute("action", "instantiate")
+        .add_attribute("owner", owner.into())
+        .add_attribute("staking_addr", staking_addr.into())
+        .add_attribute("reward_token", reward_token.into())
+        .add_attribute("reward_rate", msg.reward_rate)
+    )
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
@@ -97,7 +103,14 @@ pub fn execute_update_config(
         reward_rate,
     };
     CONFIG.save(deps.storage, &config)?;
-    Ok(Response::default())
+
+    Ok(Response::new()
+        .add_attribute("action", "update_config")
+        .add_attribute("owner", owner.into())
+        .add_attribute("staking_addr", staking_addr.into())
+        .add_attribute("reward_token", reward_token.into())
+        .add_attribute("reward_rate", reward_rate)
+    )
 }
 
 pub fn validate_cw20(deps: Deps, cw20_addr: Addr) -> bool {
@@ -151,7 +164,12 @@ pub fn execute_distribute(deps: DepsMut, env: Env) -> Result<Response, ContractE
         funds: vec![],
     }
     .into();
-    Ok(Response::default().add_message(send_msg))
+
+    Ok(Response::new()
+        .add_message(send_msg)
+        .add_attribute("action", "distribute")
+        .add_attribute("amount", amount)
+    )
 }
 
 pub fn execute_withdraw(
@@ -182,7 +200,11 @@ pub fn execute_withdraw(
     }
     .into();
 
-    Ok(Response::new().add_message(send_msg))
+    Ok(Response::new()
+        .add_message(send_msg)
+        .add_attribute("action", "withdraw")
+        .add_attribute("amount", balance_info.balance)
+    )
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/stake-cw20-reward-distributor/src/error.rs
+++ b/contracts/stake-cw20-reward-distributor/src/error.rs
@@ -9,12 +9,6 @@ pub enum ContractError {
     #[error("Unauthorized")]
     Unauthorized {},
 
-    #[error("No Pending Payments")]
-    NoPendingPayments {},
-
-    #[error("Out of Funds")]
-    OutOfFunds {},
-
     #[error("Invalid Cw20")]
     InvalidCw20 {},
 

--- a/contracts/stake-cw20-reward-distributor/src/tests.rs
+++ b/contracts/stake-cw20-reward-distributor/src/tests.rs
@@ -450,3 +450,35 @@ fn test_withdraw() {
     let owner_balance = get_balance_cw20(&app, cw20_addr, Addr::unchecked(OWNER));
     assert_eq!(owner_balance, Uint128::new(990));
 }
+
+#[test]
+fn test_dao_deploy() {
+    // DAOs will deploy this contract with following steps
+    // Contract is instantiated by any address with 0 reward rate
+    // Dao updates reward rate and funds in same transaction
+    let mut app = App::default();
+
+    let cw20_addr = instantiate_cw20(
+        &mut app,
+        vec![cw20::Cw20Coin {
+            address: OWNER.to_string(),
+            amount: Uint128::from(1000u64),
+        }],
+    );
+    let staking_addr = instantiate_staking(&mut app, cw20_addr.clone());
+
+    let msg = InstantiateMsg {
+        owner: OWNER.to_string(),
+        staking_addr: staking_addr.to_string(),
+        reward_rate: Uint128::new(1),
+        reward_token: cw20_addr.to_string(),
+    };
+    let distributor_addr = instantiate_distributor(&mut app, msg);
+
+    let msg = cw20::Cw20ExecuteMsg::Transfer {
+        recipient: distributor_addr.to_string(),
+        amount: Uint128::from(1000u128),
+    };
+    app.execute_contract(Addr::unchecked(OWNER), cw20_addr.clone(), &msg, &[])
+        .unwrap();
+}

--- a/contracts/stake-cw20-reward-distributor/src/tests.rs
+++ b/contracts/stake-cw20-reward-distributor/src/tests.rs
@@ -271,12 +271,13 @@ fn test_distribute() {
 
     // Pays out nothing
     app.update_block(|mut block| block.height += 1100);
-    let err = app.execute_contract(
-        Addr::unchecked(OWNER),
-        distributor_addr.clone(),
-        &ExecuteMsg::Distribute {},
-        &[],
-    )
+    let _err = app
+        .execute_contract(
+            Addr::unchecked(OWNER),
+            distributor_addr.clone(),
+            &ExecuteMsg::Distribute {},
+            &[],
+        )
         .unwrap();
 
     let staking_balance = get_balance_cw20(&app, cw20_addr, staking_addr);
@@ -285,8 +286,6 @@ fn test_distribute() {
     let distributor_info = get_info(&app, distributor_addr);
     assert_eq!(distributor_info.balance, Uint128::new(0));
     assert_eq!(distributor_info.last_payment_block, app.block_info().height);
-
-
 }
 
 #[test]
@@ -500,7 +499,6 @@ fn test_dao_deploy() {
     app.execute_contract(Addr::unchecked(OWNER), cw20_addr.clone(), &msg, &[])
         .unwrap();
 
-
     app.update_block(|mut block| block.height += 10);
     app.execute_contract(
         Addr::unchecked(OWNER),
@@ -508,12 +506,12 @@ fn test_dao_deploy() {
         &ExecuteMsg::Distribute {},
         &[],
     )
-        .unwrap();
+    .unwrap();
 
-    let staking_balance = get_balance_cw20(&app, cw20_addr.clone(), staking_addr.clone());
+    let staking_balance = get_balance_cw20(&app, cw20_addr, staking_addr);
     assert_eq!(staking_balance, Uint128::new(10));
 
-    let distributor_info = get_info(&app, distributor_addr.clone());
+    let distributor_info = get_info(&app, distributor_addr);
     assert_eq!(distributor_info.balance, Uint128::new(990));
     assert_eq!(distributor_info.last_payment_block, app.block_info().height);
 }

--- a/contracts/stake-cw20-reward-distributor/src/tests.rs
+++ b/contracts/stake-cw20-reward-distributor/src/tests.rs
@@ -265,9 +265,21 @@ fn test_distribute() {
     let staking_balance = get_balance_cw20(&app, cw20_addr, staking_addr);
     assert_eq!(staking_balance, Uint128::new(1000));
 
-    let distributor_info = get_info(&app, distributor_addr);
+    let distributor_info = get_info(&app, distributor_addr.clone());
     assert_eq!(distributor_info.balance, Uint128::new(0));
     assert_eq!(distributor_info.last_payment_block, app.block_info().height);
+
+    // Returns out of funds error
+    app.update_block(|mut block| block.height += 1001);
+    let err = app.execute_contract(
+        Addr::unchecked(OWNER),
+        distributor_addr,
+        &ExecuteMsg::Distribute {},
+        &[],
+    )
+        .unwrap_err();
+
+    assert_eq!(ContractError::OutOfFunds {}, err.downcast().unwrap())
 }
 
 #[test]


### PR DESCRIPTION
This PR includes a bunch of random fixs for the rewards distribution contract. 

## Remove Errors

This PR remove `out_of_funds` and `no_pending_payments`. Instead of pushing an error the contract will just not distribute any funds, but still update the `last_payment_block` variable to the current block. This imo is a better behavior for when the contract is out of funds. With these errors, when the contract is refunded it will have to pay out for all the previous blocks. 

## Distribution when updating config

This PR makes it so a distribution happens before config is updated. I feels updating the config should not affect blocks in the past. In current implementation if I update the config and a distribution hasn't occured for a while, when I update the config these undistributed past blocks will be paid at the new updated rate.

## Improve Response Attributes

This PR also improves the attributes added to each response. 

## Test for dao deployment strategy

Added a new test that runs through the sequence of how a DAO will deploy this contract.