### PR TITLE
Prevent multiple executions of proposals and closing of passed proposals.

### DIFF
--- a/contracts/cw-proposal-single/src/error.rs
+++ b/contracts/cw-proposal-single/src/error.rs
@@ -42,8 +42,11 @@ pub enum ContractError {
     #[error("Proposal is not passed.")]
     NotPassed {},
 
-    #[error("Proposal is not expired.")]
-    NotExpired {},
+    #[error("Proposal has already been executed.")]
+    AlreadyExecuted {},
+
+    #[error("Proposal is closed.")]
+    Closed {},
 
     #[error("Only rejected or expired proposals may be closed.")]
     WrongCloseStatus {},

--- a/contracts/cw-proposal-single/src/tests.rs
+++ b/contracts/cw-proposal-single/src/tests.rs
@@ -1442,6 +1442,16 @@ fn test_execute_expired_proposal() {
         .unwrap();
     assert_eq!(proposal.proposal.status, Status::Passed);
 
+    // Try to close the proposal. This should fail as the proposal is
+    // passed.
+    app.execute_contract(
+        Addr::unchecked("ekez"),
+        proposal_single.clone(),
+        &ExecuteMsg::Close { proposal_id: 1 },
+        &[],
+    )
+    .unwrap_err();
+
     // Check that we can execute the proposal despite the fact that it
     // is technically expired.
     app.execute_contract(
@@ -1451,6 +1461,16 @@ fn test_execute_expired_proposal() {
         &[],
     )
     .unwrap();
+
+    // Can't execute more than once.
+    app.execute_contract(
+        Addr::unchecked("ekez"),
+        proposal_single.clone(),
+        &ExecuteMsg::Execute { proposal_id: 1 },
+        &[],
+    )
+    .unwrap_err();
+
     let proposal: ProposalResponse = app
         .wrap()
         .query_wasm_smart(proposal_single, &QueryMsg::Proposal { proposal_id: 1 })


### PR DESCRIPTION
This upstreams two important security fixes for our single choice proposals module. These changes have already been applied for all the DAOs currently using these contracts.