### PR TITLE
Remove old naming and update schema for cw-core.

### DIFF
--- a/contracts/cw-core/schema/dump_state_response.json
+++ b/contracts/cw-core/schema/dump_state_response.json
@@ -5,8 +5,8 @@
   "type": "object",
   "required": [
     "config",
-    "governance_modules",
     "pause_info",
+    "proposal_modules",
     "version",
     "voting_module"
   ],
@@ -19,15 +19,15 @@
         }
       ]
     },
-    "governance_modules": {
+    "pause_info": {
+      "$ref": "#/definitions/PauseInfoResponse"
+    },
+    "proposal_modules": {
       "description": "The governance modules associated with the governance contract.",
       "type": "array",
       "items": {
         "$ref": "#/definitions/Addr"
       }
-    },
-    "pause_info": {
-      "$ref": "#/definitions/PauseInfoResponse"
     },
     "version": {
       "description": "The governance contract's version.",

--- a/contracts/cw-core/schema/execute_msg.json
+++ b/contracts/cw-core/schema/execute_msg.json
@@ -3,7 +3,7 @@
   "title": "ExecuteMsg",
   "oneOf": [
     {
-      "description": "Callable by governance modules. The DAO will execute the messages in the hook in order.",
+      "description": "Callable by proposal modules. The DAO will execute the messages in the hook in order.",
       "type": "object",
       "required": [
         "execute_proposal_hook"
@@ -27,7 +27,7 @@
       "additionalProperties": false
     },
     {
-      "description": "Callable by the governance contract. Replaces the current governance contract config with the provided config.",
+      "description": "Callable by the core contract. Replaces the current governance contract config with the provided config.",
       "type": "object",
       "required": [
         "update_config"
@@ -48,7 +48,7 @@
       "additionalProperties": false
     },
     {
-      "description": "Callable by the governance contract. Replaces the current voting module with a new one instantiated by the governance contract.",
+      "description": "Callable by the core contract. Replaces the current voting module with a new one instantiated by the governance contract.",
       "type": "object",
       "required": [
         "update_voting_module"
@@ -72,10 +72,10 @@
       "description": "Updates the governance contract's governance modules. Module instantiate info in `to_add` is used to create new modules and install them.",
       "type": "object",
       "required": [
-        "update_governance_modules"
+        "update_proposal_modules"
       ],
       "properties": {
-        "update_governance_modules": {
+        "update_proposal_modules": {
           "type": "object",
           "required": [
             "to_add",
@@ -280,13 +280,13 @@
           "additionalProperties": false
         },
         {
-          "description": "The governance contract itself. The contract will fill this in while instantiation takes place.",
+          "description": "The core contract itself. The contract will fill this in while instantiation takes place.",
           "type": "object",
           "required": [
-            "governance_contract"
+            "core_contract"
           ],
           "properties": {
-            "governance_contract": {
+            "core_contract": {
               "type": "object"
             }
           },
@@ -609,7 +609,7 @@
       "type": "object"
     },
     "ModuleInstantiateInfo": {
-      "description": "Information needed to instantiate a governance or voting module.",
+      "description": "Information needed to instantiate a proposal or voting module.",
       "type": "object",
       "required": [
         "admin",

--- a/contracts/cw-core/schema/instantiate_msg.json
+++ b/contracts/cw-core/schema/instantiate_msg.json
@@ -6,8 +6,8 @@
     "automatically_add_cw20s",
     "automatically_add_cw721s",
     "description",
-    "governance_modules_instantiate_info",
     "name",
+    "proposal_modules_instantiate_info",
     "voting_module_instantiate_info"
   ],
   "properties": {
@@ -20,18 +20,11 @@
       "type": "boolean"
     },
     "description": {
-      "description": "A description of the governance contract.",
+      "description": "A description of the core contract.",
       "type": "string"
     },
-    "governance_modules_instantiate_info": {
-      "description": "Instantiate information for the governance contract's governance modules.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/ModuleInstantiateInfo"
-      }
-    },
     "image_url": {
-      "description": "An image URL to describe the governance module contract.",
+      "description": "An image URL to describe the core module contract.",
       "type": [
         "string",
         "null"
@@ -48,11 +41,18 @@
       }
     },
     "name": {
-      "description": "The name of the governance contract.",
+      "description": "The name of the core contract.",
       "type": "string"
     },
+    "proposal_modules_instantiate_info": {
+      "description": "Instantiate information for the core contract's proposal modules.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ModuleInstantiateInfo"
+      }
+    },
     "voting_module_instantiate_info": {
-      "description": "Instantiate information for the governance contract's voting power module.",
+      "description": "Instantiate information for the core contract's voting power module.",
       "allOf": [
         {
           "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -86,13 +86,13 @@
           "additionalProperties": false
         },
         {
-          "description": "The governance contract itself. The contract will fill this in while instantiation takes place.",
+          "description": "The core contract itself. The contract will fill this in while instantiation takes place.",
           "type": "object",
           "required": [
-            "governance_contract"
+            "core_contract"
           ],
           "properties": {
-            "governance_contract": {
+            "core_contract": {
               "type": "object"
             }
           },
@@ -185,7 +185,7 @@
       ]
     },
     "ModuleInstantiateInfo": {
-      "description": "Information needed to instantiate a governance or voting module.",
+      "description": "Information needed to instantiate a proposal or voting module.",
       "type": "object",
       "required": [
         "admin",

--- a/contracts/cw-core/schema/query_msg.json
+++ b/contracts/cw-core/schema/query_msg.json
@@ -42,13 +42,13 @@
       "additionalProperties": false
     },
     {
-      "description": "Gets the governance modules assocaited with the contract. Returns Vec<Addr>.",
+      "description": "Gets the proposal modules assocaited with the contract. Returns Vec<Addr>.",
       "type": "object",
       "required": [
-        "governance_modules"
+        "proposal_modules"
       ],
       "properties": {
-        "governance_modules": {
+        "proposal_modules": {
           "type": "object",
           "properties": {
             "limit": {
@@ -71,7 +71,7 @@
       "additionalProperties": false
     },
     {
-      "description": "Dumps all of the governance contract's state in a single query. Useful for frontends as performance for queries is more limited by network times than compute times. Returns `DumpStateResponse`.",
+      "description": "Dumps all of the core contract's state in a single query. Useful for frontends as performance for queries is more limited by network times than compute times. Returns `DumpStateResponse`.",
       "type": "object",
       "required": [
         "dump_state"

--- a/contracts/cw-core/src/query.rs
+++ b/contracts/cw-core/src/query.rs
@@ -18,7 +18,7 @@ pub struct DumpStateResponse {
     pub version: ContractVersion,
     /// The governance modules associated with the governance
     /// contract.
-    pub governance_modules: Vec<Addr>,
+    pub proposal_modules: Vec<Addr>,
     /// The voting module associated with the governance contract.
     pub voting_module: Addr,
 }

--- a/contracts/cw-core/src/state.rs
+++ b/contracts/cw-core/src/state.rs
@@ -28,7 +28,7 @@ pub const PAUSED: Item<Expiration> = Item::new("paused");
 
 /// The voting module associated with this contract.
 pub const VOTING_MODULE: Item<Addr> = Item::new("voting_module");
-pub const PROPOSAL_MODULES: Map<Addr, Empty> = Map::new("governance_modules");
+pub const PROPOSAL_MODULES: Map<Addr, Empty> = Map::new("proposal_modules");
 
 pub const ITEMS: Map<String, Addr> = Map::new("items");
 pub const PENDING_ITEM_INSTANTIATION_NAMES: Map<u64, String> =

--- a/contracts/cw-proposal-single/src/staking_tests.rs
+++ b/contracts/cw-proposal-single/src/staking_tests.rs
@@ -132,7 +132,7 @@ fn instantiate_with_staked_balances_voting() {
         .query_wasm_smart(core_addr, &cw_core::msg::QueryMsg::DumpState {})
         .unwrap();
 
-    assert_eq!(state.governance_modules.len(), 1);
+    assert_eq!(state.proposal_modules.len(), 1);
     assert_eq!(
         state.config,
         cw_core::state::Config {

--- a/contracts/cw-proposal-single/src/tests.rs
+++ b/contracts/cw-proposal-single/src/tests.rs
@@ -885,7 +885,7 @@ fn test_voting_module_token_proposal_deposit_instantiate() {
         .wrap()
         .query_wasm_smart(governance_addr, &cw_core::msg::QueryMsg::DumpState {})
         .unwrap();
-    let governance_modules = gov_state.governance_modules;
+    let governance_modules = gov_state.proposal_modules;
     let voting_module = gov_state.voting_module;
 
     assert_eq!(governance_modules.len(), 1);
@@ -1047,7 +1047,7 @@ fn test_take_proposal_deposit() {
         .wrap()
         .query_wasm_smart(governance_addr, &cw_core::msg::QueryMsg::DumpState {})
         .unwrap();
-    let governance_modules = gov_state.governance_modules;
+    let governance_modules = gov_state.proposal_modules;
 
     assert_eq!(governance_modules.len(), 1);
     let govmod_single = governance_modules.into_iter().next().unwrap();
@@ -1144,7 +1144,7 @@ fn test_deposit_return_on_execute() {
         .wrap()
         .query_wasm_smart(governance_addr, &cw_core::msg::QueryMsg::DumpState {})
         .unwrap();
-    let governance_modules = gov_state.governance_modules;
+    let governance_modules = gov_state.proposal_modules;
 
     assert_eq!(governance_modules.len(), 1);
     let govmod_single = governance_modules.into_iter().next().unwrap();
@@ -1217,7 +1217,7 @@ fn test_close_open_proposal() {
         .wrap()
         .query_wasm_smart(governance_addr, &cw_core::msg::QueryMsg::DumpState {})
         .unwrap();
-    let governance_modules = gov_state.governance_modules;
+    let governance_modules = gov_state.proposal_modules;
 
     assert_eq!(governance_modules.len(), 1);
     let govmod_single = governance_modules.into_iter().next().unwrap();
@@ -1312,7 +1312,7 @@ fn test_deposit_return_on_close() {
         .wrap()
         .query_wasm_smart(governance_addr, &cw_core::msg::QueryMsg::DumpState {})
         .unwrap();
-    let governance_modules = gov_state.governance_modules;
+    let governance_modules = gov_state.proposal_modules;
 
     assert_eq!(governance_modules.len(), 1);
     let govmod_single = governance_modules.into_iter().next().unwrap();
@@ -1392,7 +1392,7 @@ fn test_execute_expired_proposal() {
         .wrap()
         .query_wasm_smart(core_addr, &cw_core::msg::QueryMsg::DumpState {})
         .unwrap();
-    let proposal_modules = gov_state.governance_modules;
+    let proposal_modules = gov_state.proposal_modules;
 
     assert_eq!(proposal_modules.len(), 1);
     let proposal_single = proposal_modules.into_iter().next().unwrap();
@@ -1503,7 +1503,7 @@ fn test_update_config() {
         .wrap()
         .query_wasm_smart(governance_addr, &cw_core::msg::QueryMsg::DumpState {})
         .unwrap();
-    let governance_modules = gov_state.governance_modules;
+    let governance_modules = gov_state.proposal_modules;
 
     assert_eq!(governance_modules.len(), 1);
     let govmod_single = governance_modules.into_iter().next().unwrap();
@@ -1616,7 +1616,7 @@ fn test_no_return_if_no_refunds() {
         .wrap()
         .query_wasm_smart(governance_addr, &cw_core::msg::QueryMsg::DumpState {})
         .unwrap();
-    let governance_modules = gov_state.governance_modules;
+    let governance_modules = gov_state.proposal_modules;
 
     assert_eq!(governance_modules.len(), 1);
     let govmod_single = governance_modules.into_iter().next().unwrap();


### PR DESCRIPTION
This removes usage of the old naming "governance modules" from the cw-core contract in favor of the current "proposal modules" naming.