### PR TITLE
Allow revoting on proposals.

### DIFF
--- a/contracts/cw-proposal-single/schema/config_response.json
+++ b/contracts/cw-proposal-single/schema/config_response.json
@@ -208,6 +208,27 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
+          "type": "object",
+          "required": [
+            "absolute_count"
+          ],
+          "properties": {
+            "absolute_count": {
+              "type": "object",
+              "required": [
+                "threshold"
+              ],
+              "properties": {
+                "threshold": {
+                  "$ref": "#/definitions/Uint128"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/contracts/cw-proposal-single/schema/config_response.json
+++ b/contracts/cw-proposal-single/schema/config_response.json
@@ -4,12 +4,17 @@
   "description": "The governance module's configuration.",
   "type": "object",
   "required": [
+    "allow_revoting",
     "dao",
     "max_voting_period",
     "only_members_execute",
     "threshold"
   ],
   "properties": {
+    "allow_revoting": {
+      "description": "Allows changing votes before the proposal expires. If this is enabled proposals will not be able to complete early as final vote information is not known until the time of proposal expiration.",
+      "type": "boolean"
+    },
     "dao": {
       "description": "The address of the DAO that this governance module is associated with.",
       "allOf": [

--- a/contracts/cw-proposal-single/schema/execute_msg.json
+++ b/contracts/cw-proposal-single/schema/execute_msg.json
@@ -725,6 +725,27 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
+          "type": "object",
+          "required": [
+            "absolute_count"
+          ],
+          "properties": {
+            "absolute_count": {
+              "type": "object",
+              "required": [
+                "threshold"
+              ],
+              "properties": {
+                "threshold": {
+                  "$ref": "#/definitions/Uint128"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/contracts/cw-proposal-single/schema/execute_msg.json
+++ b/contracts/cw-proposal-single/schema/execute_msg.json
@@ -21,17 +21,6 @@
               "description": "A description of the proposal.",
               "type": "string"
             },
-            "latest": {
-              "description": "Optionally, a proposal may have a different expiration than the one that would be set by the `max_voting_period` in the governance module's config.",
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Expiration"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
             "msgs": {
               "description": "The messages that should be executed in response to this proposal passing.",
               "type": "array",
@@ -139,12 +128,17 @@
         "update_config": {
           "type": "object",
           "required": [
+            "allow_revoting",
             "dao",
             "max_voting_period",
             "only_members_execute",
             "threshold"
           ],
           "properties": {
+            "allow_revoting": {
+              "description": "Allows changing votes before the proposal expires. If this is enabled proposals will not be able to complete early as final vote information is not known until the time of proposal expiration.",
+              "type": "boolean"
+            },
             "dao": {
               "description": "The address if tge DAO that this governance module is associated with.",
               "type": "string"
@@ -568,52 +562,6 @@
       "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
       "type": "object"
     },
-    "Expiration": {
-      "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
-      "oneOf": [
-        {
-          "description": "AtHeight will expire when `env.block.height` >= height",
-          "type": "object",
-          "required": [
-            "at_height"
-          ],
-          "properties": {
-            "at_height": {
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "AtTime will expire when `env.block.time` >= time",
-          "type": "object",
-          "required": [
-            "at_time"
-          ],
-          "properties": {
-            "at_time": {
-              "$ref": "#/definitions/Timestamp"
-            }
-          },
-          "additionalProperties": false
-        },
-        {
-          "description": "Never will never expire. Used to express the empty variant",
-          "type": "object",
-          "required": [
-            "never"
-          ],
-          "properties": {
-            "never": {
-              "type": "object"
-            }
-          },
-          "additionalProperties": false
-        }
-      ]
-    },
     "PercentageThreshold": {
       "description": "A percentage of voting power that must vote yes for a proposal to pass. An example of why this is needed:\n\nIf a user specifies a 60% passing threshold, and there are 10 voters they likely expect that proposal to pass when there are 6 yes votes. This implies that the condition for passing should be `yes_votes >= total_votes * threshold`.\n\nWith this in mind, how should a user specify that they would like proposals to pass if the majority of voters choose yes? Selecting a 50% passing threshold with those rules doesn't properly cover that case as 5 voters voting yes out of 10 would pass the proposal. Selecting 50.0001% or or some variation of that also does not work as a very small yes vote which technically makes the majority yes may not reach that threshold.\n\nTo handle these cases we provide both a majority and percent option for all percentages. If majority is selected passing will be determined by `yes > total_votes * 0.5`. If percent is selected passing is determined by `yes >= total_votes * percent`.\n\nIn both of these cases a proposal with only abstain votes must fail. This requires a special case passing logic.",
       "oneOf": [
@@ -780,20 +728,8 @@
         }
       ]
     },
-    "Timestamp": {
-      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Uint64"
-        }
-      ]
-    },
     "Uint128": {
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
-      "type": "string"
-    },
-    "Uint64": {
-      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
       "type": "string"
     },
     "Vote": {

--- a/contracts/cw-proposal-single/schema/instantiate_msg.json
+++ b/contracts/cw-proposal-single/schema/instantiate_msg.json
@@ -233,6 +233,27 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
+          "type": "object",
+          "required": [
+            "absolute_count"
+          ],
+          "properties": {
+            "absolute_count": {
+              "type": "object",
+              "required": [
+                "threshold"
+              ],
+              "properties": {
+                "threshold": {
+                  "$ref": "#/definitions/Uint128"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/contracts/cw-proposal-single/schema/instantiate_msg.json
+++ b/contracts/cw-proposal-single/schema/instantiate_msg.json
@@ -3,11 +3,16 @@
   "title": "InstantiateMsg",
   "type": "object",
   "required": [
+    "allow_revoting",
     "max_voting_period",
     "only_members_execute",
     "threshold"
   ],
   "properties": {
+    "allow_revoting": {
+      "description": "Allows changing votes before the proposal expires. If this is enabled proposals will not be able to complete early as final vote information is not known until the time of proposal expiration.",
+      "type": "boolean"
+    },
     "deposit_info": {
       "description": "Information about the deposit required to create a proposal. None if there is no deposit requirement, Some otherwise.",
       "anyOf": [

--- a/contracts/cw-proposal-single/schema/list_proposals_response.json
+++ b/contracts/cw-proposal-single/schema/list_proposals_response.json
@@ -327,6 +327,7 @@
     "Proposal": {
       "type": "object",
       "required": [
+        "allow_revoting",
         "description",
         "expiration",
         "msgs",
@@ -339,6 +340,9 @@
         "votes"
       ],
       "properties": {
+        "allow_revoting": {
+          "type": "boolean"
+        },
         "deposit_info": {
           "description": "Information about the deposit that was sent as part of this proposal. None if no deposit.",
           "anyOf": [

--- a/contracts/cw-proposal-single/schema/list_proposals_response.json
+++ b/contracts/cw-proposal-single/schema/list_proposals_response.json
@@ -551,6 +551,27 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
+          "type": "object",
+          "required": [
+            "absolute_count"
+          ],
+          "properties": {
+            "absolute_count": {
+              "type": "object",
+              "required": [
+                "threshold"
+              ],
+              "properties": {
+                "threshold": {
+                  "$ref": "#/definitions/Uint128"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/contracts/cw-proposal-single/schema/proposal_response.json
+++ b/contracts/cw-proposal-single/schema/proposal_response.json
@@ -330,6 +330,7 @@
     "Proposal": {
       "type": "object",
       "required": [
+        "allow_revoting",
         "description",
         "expiration",
         "msgs",
@@ -342,6 +343,9 @@
         "votes"
       ],
       "properties": {
+        "allow_revoting": {
+          "type": "boolean"
+        },
         "deposit_info": {
           "description": "Information about the deposit that was sent as part of this proposal. None if no deposit.",
           "anyOf": [

--- a/contracts/cw-proposal-single/schema/proposal_response.json
+++ b/contracts/cw-proposal-single/schema/proposal_response.json
@@ -536,6 +536,27 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
+          "type": "object",
+          "required": [
+            "absolute_count"
+          ],
+          "properties": {
+            "absolute_count": {
+              "type": "object",
+              "required": [
+                "threshold"
+              ],
+              "properties": {
+                "threshold": {
+                  "$ref": "#/definitions/Uint128"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/contracts/cw-proposal-single/schema/reverse_proposals_response.json
+++ b/contracts/cw-proposal-single/schema/reverse_proposals_response.json
@@ -327,6 +327,7 @@
     "Proposal": {
       "type": "object",
       "required": [
+        "allow_revoting",
         "description",
         "expiration",
         "msgs",
@@ -339,6 +340,9 @@
         "votes"
       ],
       "properties": {
+        "allow_revoting": {
+          "type": "boolean"
+        },
         "deposit_info": {
           "description": "Information about the deposit that was sent as part of this proposal. None if no deposit.",
           "anyOf": [

--- a/contracts/cw-proposal-single/schema/reverse_proposals_response.json
+++ b/contracts/cw-proposal-single/schema/reverse_proposals_response.json
@@ -551,6 +551,27 @@
             }
           },
           "additionalProperties": false
+        },
+        {
+          "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
+          "type": "object",
+          "required": [
+            "absolute_count"
+          ],
+          "properties": {
+            "absolute_count": {
+              "type": "object",
+              "required": [
+                "threshold"
+              ],
+              "properties": {
+                "threshold": {
+                  "$ref": "#/definitions/Uint128"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/contracts/cw-proposal-single/src/error.rs
+++ b/contracts/cw-proposal-single/src/error.rs
@@ -36,8 +36,11 @@ pub enum ContractError {
     #[error("Not registered to vote (no voting power) at time of proposal creation.")]
     NotRegistered {},
 
-    #[error("Already voted")]
+    #[error("Already voted. This proposal does not support revoting.")]
     AlreadyVoted {},
+
+    #[error("Already cast that vote. Change your vote to revote.")]
+    AlreadyCast {},
 
     #[error("Proposal is not in 'passed' state.")]
     NotPassed {},

--- a/contracts/cw-proposal-single/src/error.rs
+++ b/contracts/cw-proposal-single/src/error.rs
@@ -39,7 +39,7 @@ pub enum ContractError {
     #[error("Already voted. This proposal does not support revoting.")]
     AlreadyVoted {},
 
-    #[error("Already cast that vote. Change your vote to revote.")]
+    #[error("Already cast a vote with that option. Change your vote to revote.")]
     AlreadyCast {},
 
     #[error("Proposal is not in 'passed' state.")]

--- a/contracts/cw-proposal-single/src/msg.rs
+++ b/contracts/cw-proposal-single/src/msg.rs
@@ -17,6 +17,11 @@ pub struct InstantiateMsg {
     /// proposals. Otherwise, any address may execute a passed
     /// proposal.
     pub only_members_execute: bool,
+    /// Allows changing votes before the proposal expires. If this is
+    /// enabled proposals will not be able to complete early as final
+    /// vote information is not known until the time of proposal
+    /// expiration.
+    pub allow_revoting: bool,
     /// Information about the deposit required to create a
     /// proposal. None if there is no deposit requirement, Some
     /// otherwise.
@@ -98,6 +103,11 @@ pub enum ExecuteMsg {
         /// proposals. Otherwise, any address may execute a passed
         /// proposal. Applies to all outstanding and future proposals.
         only_members_execute: bool,
+        /// Allows changing votes before the proposal expires. If this is
+        /// enabled proposals will not be able to complete early as final
+        /// vote information is not known until the time of proposal
+        /// expiration.
+        allow_revoting: bool,
         /// The address if tge DAO that this governance module is
         /// associated with.
         dao: String,

--- a/contracts/cw-proposal-single/src/proposal.rs
+++ b/contracts/cw-proposal-single/src/proposal.rs
@@ -25,6 +25,7 @@ pub struct Proposal {
 
     pub status: Status,
     pub votes: Votes,
+    pub allow_revoting: bool,
 
     /// Information about the deposit that was sent as part of this
     /// proposal. None if no deposit.
@@ -110,8 +111,14 @@ impl Proposal {
 
     /// Returns true iff this proposal is sure to pass (even before
     /// expiration if no future sequence of possible votes can cause
-    /// it to fail)
+    /// it to fail).
     pub fn is_passed(&self, block: &BlockInfo) -> bool {
+        // If re-voting is allowed nothing is known until the proposal
+        // has expired.
+        if self.allow_revoting && !self.expiration.is_expired(block) {
+            return false;
+        }
+
         match self.threshold {
             Threshold::AbsolutePercentage { percentage } => {
                 let options = self.total_power - self.votes.abstain;
@@ -140,6 +147,12 @@ impl Proposal {
     /// As above for the passed check, used to check if a proposal is
     /// already rejected.
     pub fn is_rejected(&self, block: &BlockInfo) -> bool {
+        // If re-voting is allowed and the proposal is not expired no
+        // information is known.
+        if self.allow_revoting && !self.expiration.is_expired(block) {
+            return false;
+        }
+
         match self.threshold {
             Threshold::AbsolutePercentage {
                 percentage: percentage_needed,
@@ -249,6 +262,7 @@ mod test {
         votes: Votes,
         total_power: Uint128,
         is_expired: bool,
+        allow_revoting: bool,
     ) -> (Proposal, BlockInfo) {
         let block = mock_env().block;
         let expiration = match is_expired {
@@ -261,6 +275,7 @@ mod test {
             proposer: Addr::unchecked("test"),
             start_height: 100,
             expiration,
+            allow_revoting,
             msgs: vec![],
             status: Status::Open,
             threshold,
@@ -276,8 +291,9 @@ mod test {
         votes: Votes,
         total_power: Uint128,
         is_expired: bool,
+        allow_revoting: bool,
     ) -> bool {
-        let (prop, block) = setup_prop(threshold, votes, total_power, is_expired);
+        let (prop, block) = setup_prop(threshold, votes, total_power, is_expired, allow_revoting);
         prop.is_passed(&block)
     }
 
@@ -286,8 +302,9 @@ mod test {
         votes: Votes,
         total_power: Uint128,
         is_expired: bool,
+        allow_revoting: bool,
     ) -> bool {
-        let (prop, block) = setup_prop(threshold, votes, total_power, is_expired);
+        let (prop, block) = setup_prop(threshold, votes, total_power, is_expired, allow_revoting);
         prop.is_rejected(&block)
     }
 
@@ -308,18 +325,91 @@ mod test {
             threshold.clone(),
             votes.clone(),
             Uint128::new(15),
-            false
+            false,
+            false,
         ));
         // Proposal being expired should not effect those results.
         assert!(check_is_passed(
             threshold.clone(),
             votes.clone(),
             Uint128::new(15),
-            true
+            true,
+            false
         ));
 
         // More votes == higher threshold => not passed.
-        assert!(!check_is_passed(threshold, votes, Uint128::new(17), false));
+        assert!(!check_is_passed(
+            threshold,
+            votes,
+            Uint128::new(17),
+            false,
+            false
+        ));
+    }
+
+    #[test]
+    fn test_revoting_majority_no_pass() {
+        // Revoting being allowed means that proposals may not be
+        // passed or rejected before they expire.
+        let threshold = Threshold::AbsolutePercentage {
+            percentage: PercentageThreshold::Majority {},
+        };
+        let votes = Votes {
+            yes: Uint128::new(7),
+            no: Uint128::new(4),
+            abstain: Uint128::new(2),
+        };
+
+        // 15 total votes. 7 yes and 2 abstain. Majority threshold. This
+        // should pass but revoting is enabled.
+        assert!(!check_is_passed(
+            threshold.clone(),
+            votes.clone(),
+            Uint128::new(15),
+            false,
+            true,
+        ));
+        // Proposal being expired should cause the proposal to be
+        // passed as votes may no longer be cast.
+        assert!(check_is_passed(
+            threshold,
+            votes,
+            Uint128::new(15),
+            true,
+            true
+        ));
+    }
+
+    #[test]
+    fn test_revoting_majority_rejection() {
+        // Revoting being allowed means that proposals may not be
+        // passed or rejected before they expire.
+        let threshold = Threshold::AbsolutePercentage {
+            percentage: PercentageThreshold::Majority {},
+        };
+        let votes = Votes {
+            yes: Uint128::new(4),
+            no: Uint128::new(7),
+            abstain: Uint128::new(2),
+        };
+
+        // Not expired, revoting allowed => no rejection.
+        assert!(!check_is_rejected(
+            threshold.clone(),
+            votes.clone(),
+            Uint128::new(15),
+            false,
+            true
+        ));
+
+        // Expired, revoting allowed => rejection.
+        assert!(check_is_rejected(
+            threshold,
+            votes,
+            Uint128::new(15),
+            true,
+            true
+        ));
     }
 
     #[test]
@@ -332,7 +422,13 @@ mod test {
             no: Uint128::new(6),
             abstain: Uint128::zero(),
         };
-        assert!(check_is_passed(threshold, votes, Uint128::new(13), false))
+        assert!(check_is_passed(
+            threshold,
+            votes,
+            Uint128::new(13),
+            false,
+            false
+        ))
     }
 
     #[test]
@@ -349,12 +445,14 @@ mod test {
             threshold.clone(),
             votes.clone(),
             Uint128::new(13),
+            false,
             false
         ));
         assert!(!check_is_rejected(
             threshold,
             votes,
             Uint128::new(13),
+            false,
             false
         ));
     }
@@ -373,9 +471,16 @@ mod test {
             threshold.clone(),
             votes.clone(),
             Uint128::new(13),
+            false,
             false
         ));
-        assert!(!check_is_passed(threshold, votes, Uint128::new(14), false))
+        assert!(!check_is_passed(
+            threshold,
+            votes,
+            Uint128::new(14),
+            false,
+            false
+        ))
     }
 
     #[test]
@@ -398,13 +503,15 @@ mod test {
             percent.clone(),
             votes.clone(),
             Uint128::new(15),
-            false
+            false,
+            false,
         ));
         assert!(check_is_rejected(
             percent.clone(),
             votes.clone(),
             Uint128::new(15),
-            true
+            true,
+            false
         ));
 
         // 17 total voting power
@@ -413,13 +520,15 @@ mod test {
             percent.clone(),
             votes.clone(),
             Uint128::new(17),
+            false,
             false
         ));
         assert!(!check_is_rejected(
             percent.clone(),
             votes.clone(),
             Uint128::new(17),
-            true
+            true,
+            false
         ));
 
         // Rejected if total was lower
@@ -427,9 +536,16 @@ mod test {
             percent.clone(),
             votes.clone(),
             Uint128::new(14),
+            false,
             false
         ));
-        assert!(check_is_rejected(percent, votes, Uint128::new(14), true));
+        assert!(check_is_rejected(
+            percent,
+            votes,
+            Uint128::new(14),
+            true,
+            false
+        ));
     }
 
     #[test]
@@ -463,14 +579,16 @@ mod test {
             quorum.clone(),
             passing.clone(),
             Uint128::new(30),
-            true
+            true,
+            false,
         ));
         // under quorum it is not passing (40% of 33 = 13.2 > 13)
         assert!(!check_is_passed(
             quorum.clone(),
             passing.clone(),
             Uint128::new(33),
-            true
+            true,
+            false
         ));
         // over quorum, threshold passes if we ignore abstain
         // 17 total votes w/ abstain => 40% quorum of 40 total
@@ -479,14 +597,16 @@ mod test {
             quorum.clone(),
             passes_ignoring_abstain.clone(),
             Uint128::new(40),
-            true
+            true,
+            false,
         ));
         // over quorum, but under threshold fails also
         assert!(!check_is_passed(
             quorum.clone(),
             failing,
             Uint128::new(20),
-            true
+            true,
+            false
         ));
 
         // now, check with open voting period
@@ -495,12 +615,14 @@ mod test {
             quorum.clone(),
             passing.clone(),
             Uint128::new(30),
+            false,
             false
         ));
         assert!(!check_is_passed(
             quorum.clone(),
             passes_ignoring_abstain.clone(),
             Uint128::new(40),
+            false,
             false
         ));
         // if we have threshold * total_weight as yes votes this must pass
@@ -508,6 +630,7 @@ mod test {
             quorum.clone(),
             passing.clone(),
             Uint128::new(14),
+            false,
             false
         ));
         // all votes have been cast, some abstain
@@ -515,10 +638,17 @@ mod test {
             quorum.clone(),
             passes_ignoring_abstain,
             Uint128::new(17),
+            false,
             false
         ));
         // 3 votes uncast, if they all vote no, we have 7 yes, 7 no+veto, 2 abstain (out of 16)
-        assert!(check_is_passed(quorum, passing, Uint128::new(16), false));
+        assert!(check_is_passed(
+            quorum,
+            passing,
+            Uint128::new(16),
+            false,
+            false
+        ));
     }
 
     #[test]
@@ -552,7 +682,8 @@ mod test {
             quorum.clone(),
             rejecting.clone(),
             Uint128::new(30),
-            true
+            true,
+            false
         ));
         // Total power of 33. 13 total votes. 8 no votes, 3 yes, 2
         // abstain. 39.3% turnout. Expired. As it is expired we see if
@@ -562,7 +693,8 @@ mod test {
             quorum.clone(),
             rejecting.clone(),
             Uint128::new(33),
-            true
+            true,
+            false
         ));
 
         // over quorum, threshold passes if we ignore abstain
@@ -572,7 +704,8 @@ mod test {
             quorum.clone(),
             rejected_ignoring_abstain.clone(),
             Uint128::new(40),
-            true
+            true,
+            false
         ));
 
         // Over quorum, but under threshold fails if the proposal is
@@ -583,12 +716,14 @@ mod test {
             quorum.clone(),
             failing.clone(),
             Uint128::new(20),
-            true
+            true,
+            false
         ));
         assert!(!check_is_rejected(
             quorum.clone(),
             failing,
             Uint128::new(20),
+            false,
             false
         ));
 
@@ -598,12 +733,14 @@ mod test {
             quorum.clone(),
             rejecting.clone(),
             Uint128::new(30),
+            false,
             false
         ));
         assert!(!check_is_rejected(
             quorum.clone(),
             rejected_ignoring_abstain.clone(),
             Uint128::new(40),
+            false,
             false
         ));
         // if we have threshold * total_weight as no votes this must reject
@@ -611,6 +748,7 @@ mod test {
             quorum.clone(),
             rejecting.clone(),
             Uint128::new(14),
+            false,
             false
         ));
         // all votes have been cast, some abstain
@@ -618,6 +756,7 @@ mod test {
             quorum.clone(),
             rejected_ignoring_abstain,
             Uint128::new(17),
+            false,
             false
         ));
         // 3 votes uncast, if they all vote yes, we have 7 no, 7 yes+veto, 2 abstain (out of 16)
@@ -625,6 +764,7 @@ mod test {
             quorum,
             rejecting,
             Uint128::new(16),
+            false,
             false
         ));
     }
@@ -650,13 +790,15 @@ mod test {
             quorum.clone(),
             missing_voters.clone(),
             Uint128::new(15),
+            false,
             false
         ));
         assert!(!check_is_passed(
             quorum.clone(),
             missing_voters,
             Uint128::new(15),
-            true
+            true,
+            false
         ));
 
         // 1 less yes, 3 vetos and this passes only when expired.
@@ -669,13 +811,15 @@ mod test {
             quorum.clone(),
             wait_til_expired.clone(),
             Uint128::new(15),
+            false,
             false
         ));
         assert!(check_is_passed(
             quorum.clone(),
             wait_til_expired,
             Uint128::new(15),
-            true
+            true,
+            false
         ));
 
         // 9 yes and 3 nos passes early
@@ -688,13 +832,15 @@ mod test {
             quorum.clone(),
             passes_early.clone(),
             Uint128::new(15),
+            false,
             false
         ));
         assert!(check_is_passed(
             quorum,
             passes_early,
             Uint128::new(15),
-            true
+            true,
+            false
         ));
     }
 }

--- a/contracts/cw-proposal-single/src/proposal.rs
+++ b/contracts/cw-proposal-single/src/proposal.rs
@@ -419,8 +419,10 @@ mod test {
         ));
     }
 
+    /// Simple checks for absolute count passing and failing
+    /// conditions.
     #[test]
-    fn test_absolute_threshold() {
+    fn test_absolute_count_threshold() {
         let threshold = Threshold::AbsoluteCount {
             threshold: Uint128::new(10),
         };
@@ -474,8 +476,10 @@ mod test {
         ));
     }
 
+    /// Tests that revoting works as expected with an absolute count
+    /// style threshold.
     #[test]
-    fn test_absolute_threshold_revoting() {
+    fn test_absolute_count_threshold_revoting() {
         let threshold = Threshold::AbsoluteCount {
             threshold: Uint128::new(10),
         };

--- a/contracts/cw-proposal-single/src/staking_tests.rs
+++ b/contracts/cw-proposal-single/src/staking_tests.rs
@@ -109,6 +109,7 @@ fn instantiate_with_staked_balances_voting() {
                 },
                 max_voting_period: Duration::Height(10u64),
                 only_members_execute: true,
+                allow_revoting: false,
                 deposit_info: None,
             })
             .unwrap(),

--- a/contracts/cw-proposal-single/src/state.rs
+++ b/contracts/cw-proposal-single/src/state.rs
@@ -38,6 +38,11 @@ pub struct Config {
     /// proposals. Otherwise, any address may execute a passed
     /// proposal.
     pub only_members_execute: bool,
+    /// Allows changing votes before the proposal expires. If this is
+    /// enabled proposals will not be able to complete early as final
+    /// vote information is not known until the time of proposal
+    /// expiration.
+    pub allow_revoting: bool,
     /// The address of the DAO that this governance module is
     /// associated with.
     pub dao: Addr,

--- a/contracts/cw-proposal-single/src/tests.rs
+++ b/contracts/cw-proposal-single/src/tests.rs
@@ -2364,6 +2364,7 @@ fn test_active_threshold_none() {
         .unwrap();
 }
 
+/// Simple test for revoting.
 #[test]
 fn test_revoting() {
     let mut app = App::default();
@@ -2397,7 +2398,7 @@ fn test_revoting() {
         .wrap()
         .query_wasm_smart(core_addr, &cw_core::msg::QueryMsg::DumpState {})
         .unwrap();
-    let proposal_module = core_state.governance_modules.into_iter().next().unwrap();
+    let proposal_module = core_state.proposal_modules.into_iter().next().unwrap();
 
     // The supreme galatic floob rules over many DAOs with benevolance
     // and grace. The people of floob have become complacent in the
@@ -2486,6 +2487,9 @@ fn test_revoting() {
     assert_eq!(proposal.proposal.status, Status::Rejected);
 }
 
+/// Tests that revoting is stored at a per-proposal level. Proposals
+/// created while revoting is enabled should not have it disabled if a
+/// config change turns if off.
 #[test]
 fn test_allow_revoting_config_changes() {
     let mut app = App::default();
@@ -2519,7 +2523,7 @@ fn test_allow_revoting_config_changes() {
         .wrap()
         .query_wasm_smart(core_addr.clone(), &cw_core::msg::QueryMsg::DumpState {})
         .unwrap();
-    let proposal_module = core_state.governance_modules.into_iter().next().unwrap();
+    let proposal_module = core_state.proposal_modules.into_iter().next().unwrap();
 
     // Create a proposal. This proposal should allow revoting.
     app.execute_contract(
@@ -2625,6 +2629,8 @@ fn test_allow_revoting_config_changes() {
     assert!(matches!(err, ContractError::AlreadyVoted {}))
 }
 
+/// Tests that we error if a revote casts the same vote as the
+/// previous vote.
 #[test]
 fn test_revoting_same_vote_twice() {
     let mut app = App::default();
@@ -2658,7 +2664,7 @@ fn test_revoting_same_vote_twice() {
         .wrap()
         .query_wasm_smart(core_addr, &cw_core::msg::QueryMsg::DumpState {})
         .unwrap();
-    let proposal_module = core_state.governance_modules.into_iter().next().unwrap();
+    let proposal_module = core_state.proposal_modules.into_iter().next().unwrap();
 
     app.execute_contract(
         Addr::unchecked("ekez"),
@@ -2726,6 +2732,7 @@ fn test_revoting_same_vote_twice() {
     }
 }
 
+/// Tests a simple three of five multisig configuration.
 #[test]
 fn test_three_of_five_multisig() {
     let mut app = App::default();
@@ -2770,7 +2777,7 @@ fn test_three_of_five_multisig() {
         .wrap()
         .query_wasm_smart(core_addr, &cw_core::msg::QueryMsg::DumpState {})
         .unwrap();
-    let proposal_module = core_state.governance_modules.into_iter().next().unwrap();
+    let proposal_module = core_state.proposal_modules.into_iter().next().unwrap();
 
     app.execute_contract(
         Addr::unchecked("one"),
@@ -2850,6 +2857,7 @@ fn test_three_of_five_multisig() {
     assert_eq!(proposal.proposal.status, Status::Executed);
 }
 
+/// Tests proposal rejection with three of five multisig style voting.
 #[test]
 fn test_three_of_five_multisig_reject() {
     let mut app = App::default();
@@ -2894,7 +2902,7 @@ fn test_three_of_five_multisig_reject() {
         .wrap()
         .query_wasm_smart(core_addr, &cw_core::msg::QueryMsg::DumpState {})
         .unwrap();
-    let proposal_module = core_state.governance_modules.into_iter().next().unwrap();
+    let proposal_module = core_state.proposal_modules.into_iter().next().unwrap();
 
     app.execute_contract(
         Addr::unchecked("one"),
@@ -2978,6 +2986,8 @@ fn test_three_of_five_multisig_reject() {
     assert_eq!(proposal.proposal.status, Status::Closed);
 }
 
+/// Tests that we fail to instantiate when using multisig style voting
+/// power and `VotingModuleToken {}`.
 #[test]
 #[should_panic]
 fn test_voting_module_token_with_multisig_style_voting() {
@@ -3016,6 +3026,7 @@ fn test_voting_module_token_with_multisig_style_voting() {
     );
 }
 
+/// Tests revoting with multisig style absolute count thresholds.
 #[test]
 fn test_three_of_five_multisig_revoting() {
     let mut app = App::default();
@@ -3060,7 +3071,7 @@ fn test_three_of_five_multisig_revoting() {
         .wrap()
         .query_wasm_smart(core_addr, &cw_core::msg::QueryMsg::DumpState {})
         .unwrap();
-    let proposal_module = core_state.governance_modules.into_iter().next().unwrap();
+    let proposal_module = core_state.proposal_modules.into_iter().next().unwrap();
 
     app.execute_contract(
         Addr::unchecked("one"),
@@ -3165,8 +3176,10 @@ fn test_three_of_five_multisig_revoting() {
     assert_eq!(proposal.proposal.status, Status::Executed);
 }
 
+/// Tests that absolute count style thresholds work with token style
+/// voting.
 #[test]
-fn test_absolute_threshold_non_multisig() {
+fn test_absolute_count_threshold_non_multisig() {
     do_votes_staked_balances(
         vec![
             TestVote {
@@ -3196,8 +3209,10 @@ fn test_absolute_threshold_non_multisig() {
     );
 }
 
+/// Tests that we do not overflow when faced with really high token /
+/// vote supply.
 #[test]
-fn test_large_absolute_threshold() {
+fn test_large_absolute_count_threshold() {
     do_votes_staked_balances(
         vec![
             // Instant rejection after this.

--- a/debug/proposal-hooks-counter/src/tests.rs
+++ b/debug/proposal-hooks-counter/src/tests.rs
@@ -136,6 +136,7 @@ fn test_counters() {
         threshold,
         max_voting_period,
         only_members_execute: false,
+        allow_revoting: false,
         deposit_info: None,
     };
 

--- a/packages/voting/src/threshold.rs
+++ b/packages/voting/src/threshold.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::Decimal;
+use cosmwasm_std::{Decimal, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -64,6 +64,10 @@ pub enum Threshold {
         threshold: PercentageThreshold,
         quorum: PercentageThreshold,
     },
+
+    /// An absolute number of votes needed for something to cross the
+    /// threshold. Useful for multisig style voting.
+    AbsoluteCount { threshold: Uint128 },
 }
 
 /// Asserts that the 0.0 < percent <= 1.0
@@ -105,6 +109,13 @@ impl Threshold {
             Threshold::ThresholdQuorum { threshold, quorum } => {
                 validate_percentage(threshold)?;
                 validate_quorum(quorum)
+            }
+            Threshold::AbsoluteCount { threshold } => {
+                if threshold.is_zero() {
+                    Err(ThresholdError::ZeroThreshold {})
+                } else {
+                    Ok(())
+                }
             }
         }
     }

--- a/packages/voting/src/voting.rs
+++ b/packages/voting/src/voting.rs
@@ -113,6 +113,17 @@ impl Votes {
         }
     }
 
+    /// Removes a vote from the votes. The vote being removed must
+    /// have been previously added or this method will cause an
+    /// overflow.
+    pub fn remove_vote(&mut self, vote: Vote, power: Uint128) {
+        match vote {
+            Vote::Yes => self.yes -= power,
+            Vote::No => self.no -= power,
+            Vote::Abstain => self.abstain -= power,
+        }
+    }
+
     /// Computes the total number of votes cast.
     ///
     /// NOTE: The total number of votes avaliable from a voting module


### PR DESCRIPTION
This PR adds a config option to the `cw_proposal_single` contract to allow revoting on proposals. If this config option is toggled:

- Proposals will not be passed or rejected until they have expired.
- Voters may cast new votes before the proposal expires.