### PR TITLE
Add periodic cargo audit GitHub action.

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,12 @@
+name: Cargo audit
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a GitHub action that will run `cargo audit` nightly and report any vulnerabilities found by creating a new GitHub issue. Monitoring our dependencies is important because a severe enough issue may mean that we need to release new module versions and have DAOs upgrade.