### PR TITLE
Add code coverage badge to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # DAO DAO Contracts
+[![codecov](https://codecov.io/gh/DA0-DA0/dao-contracts/branch/main/graph/badge.svg?token=SCKOIPYZPV)](https://codecov.io/gh/DA0-DA0/dao-contracts)
 
 | Audited contracts                                                        | Description                                                |
 | :----------------------------------------------------------------------- | :--------------------------------------------------------- |

--- a/packages/cw-core-interface/src/voting.rs
+++ b/packages/cw-core-interface/src/voting.rs
@@ -32,3 +32,31 @@ pub struct InfoResponse {
 pub struct IsActiveResponse {
     pub active: bool,
 }
+
+mod tests {
+    /// Make sure the enum has all of the fields we expect. This will
+    /// fail to compile if not.
+    #[test]
+    fn test_macro_expansion() {
+        use cw_core_macros::{active_query, token_query, voting_query};
+        use schemars::JsonSchema;
+        use serde::{Deserialize, Serialize};
+
+        #[token_query]
+        #[voting_query]
+        #[active_query]
+        #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+        #[serde(rename_all = "snake_case")]
+        enum Query {}
+
+        let query = Query::TokenContract {};
+
+        match query {
+            Query::TokenContract {} => (),
+            Query::VotingPowerAtHeight { .. } => (),
+            Query::TotalPowerAtHeight { .. } => (),
+            Query::IsActive {} => (),
+            Query::Info {} => (),
+        }
+    }
+}


### PR DESCRIPTION
This adds a code coverage badge to the README. It also adds a test to the cw-core-interface package to ensure that its query enum is expanded properly by our macros. The badge looks like this:

![](https://codecov.io/gh/DA0-DA0/dao-contracts/branch/main/graph/badge.svg)