### PR TITLE
Simplify external rewards for easier usability

### DIFF
--- a/contracts/stake-cw20-external-rewards/src/contract.rs
+++ b/contracts/stake-cw20-external-rewards/src/contract.rs
@@ -6,7 +6,7 @@ use crate::state::{
     REWARD_PER_TOKEN, USER_REWARD_PER_TOKEN,
 };
 use crate::ContractError;
-use crate::ContractError::{InvalidCw20, InvalidFunds, NoRewardsClaimable, Unauthorized};
+use crate::ContractError::{InvalidCw20, InvalidFunds, NoRewardsClaimable, RewardPeriodNotFinished, Unauthorized};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 
@@ -167,26 +167,16 @@ pub fn execute_fund(
 
     update_rewards(&mut deps, &env, &sender)?;
     let reward_config = REWARD_CONFIG.load(deps.storage)?;
-    let new_reward_config = if reward_config.period_finish <= env.block.height {
-        RewardConfig {
+    if reward_config.period_finish > env.block.height {
+        return Err(RewardPeriodNotFinished {})
+    }
+    let new_reward_config = RewardConfig {
             period_finish: env.block.height + reward_config.reward_duration,
             reward_rate: amount
                 .checked_div(Uint128::from(reward_config.reward_duration))
                 .map_err(StdError::divide_by_zero)?,
             reward_duration: reward_config.reward_duration,
-        }
-    } else {
-        RewardConfig {
-            period_finish: reward_config.period_finish, // period finish needs to be incremented by the rewards duration
-            reward_rate: reward_config.reward_rate
-                + (amount
-                    .checked_div(Uint128::from(
-                        reward_config.period_finish - env.block.height,
-                    ))
-                    .map_err(StdError::divide_by_zero)?),
-            reward_duration: reward_config.reward_duration,
-        }
-    };
+        };
 
     if new_reward_config.reward_rate == Uint128::zero() {
         return Err(ContractError::RewardRateLessThenOnePerBlock {});
@@ -901,8 +891,8 @@ mod tests {
             Uint128::new(74997500)
         );
 
-        // Add more rewards, then add even more on top
-        let reward_funding = vec![coin(100000000, denom.clone())];
+        // Add more rewards
+        let reward_funding = vec![coin(200000000, denom.clone())];
         app.sudo(SudoMsg::Bank({
             BankSudo::Mint {
                 to_address: admin.to_string(),
@@ -919,20 +909,6 @@ mod tests {
                 &fund_msg,
                 &reward_funding,
             )
-            .unwrap();
-
-        let reward_funding = vec![coin(100000000, denom.clone())];
-        app.sudo(SudoMsg::Bank({
-            BankSudo::Mint {
-                to_address: admin.to_string(),
-                amount: reward_funding.clone(),
-            }
-        }))
-        .unwrap();
-
-        let _res = app
-            .borrow_mut()
-            .execute_contract(admin, reward_addr.clone(), &fund_msg, &reward_funding)
             .unwrap();
 
         app.borrow_mut().update_block(|b| b.height = 400000);
@@ -1157,21 +1133,13 @@ mod tests {
             Uint128::new(74997500)
         );
 
-        // Add more rewards, then add even more on top
+        // Add more rewards
         fund_rewards_cw20(
             &mut app,
             &admin,
             reward_token.clone(),
             &reward_addr,
-            100000000,
-        );
-
-        fund_rewards_cw20(
-            &mut app,
-            &admin,
-            reward_token.clone(),
-            &reward_addr,
-            100000000,
+            200000000,
         );
 
         app.borrow_mut().update_block(|b| b.height = 400000);
@@ -1293,35 +1261,6 @@ mod tests {
         assert_eq!(res.reward.period_finish, 101000);
         assert_eq!(res.reward.reward_duration, 100000);
 
-        // Increase rewards for current period
-        let reward_funding = vec![coin(100000000, denom.clone())];
-        app.sudo(SudoMsg::Bank({
-            BankSudo::Mint {
-                to_address: admin.to_string(),
-                amount: reward_funding.clone(),
-            }
-        }))
-        .unwrap();
-        let _res = app
-            .borrow_mut()
-            .execute_contract(
-                admin.clone(),
-                reward_addr.clone(),
-                &fund_msg,
-                &reward_funding,
-            )
-            .unwrap();
-
-        let res: InfoResponse = app
-            .borrow_mut()
-            .wrap()
-            .query_wasm_smart(&reward_addr, &QueryMsg::Info {})
-            .unwrap();
-
-        assert_eq!(res.reward.reward_rate, Uint128::new(3000));
-        assert_eq!(res.reward.period_finish, 101000);
-        assert_eq!(res.reward.reward_duration, 100000);
-
         // Create new period after old period
         app.borrow_mut().update_block(|b| b.height = 101000);
 
@@ -1353,7 +1292,7 @@ mod tests {
         assert_eq!(res.reward.period_finish, 201000);
         assert_eq!(res.reward.reward_duration, 100000);
 
-        // Add funds in middle of period
+        // Add funds in middle of period returns an error
         app.borrow_mut().update_block(|b| b.height = 151000);
 
         let reward_funding = vec![coin(200000000, denom)];
@@ -1364,10 +1303,11 @@ mod tests {
             }
         }))
         .unwrap();
-        let _res = app
+        let err = app
             .borrow_mut()
             .execute_contract(admin, reward_addr.clone(), &fund_msg, &reward_funding)
-            .unwrap();
+            .unwrap_err();
+        assert_eq!(ContractError::RewardPeriodNotFinished {},err.downcast().unwrap());
 
         let res: InfoResponse = app
             .borrow_mut()
@@ -1375,7 +1315,7 @@ mod tests {
             .query_wasm_smart(&reward_addr, &QueryMsg::Info {})
             .unwrap();
 
-        assert_eq!(res.reward.reward_rate, Uint128::new(5000));
+        assert_eq!(res.reward.reward_rate, Uint128::new(1000));
         assert_eq!(res.reward.period_finish, 201000);
         assert_eq!(res.reward.reward_duration, 100000);
     }

--- a/contracts/stake-cw20-external-rewards/src/contract.rs
+++ b/contracts/stake-cw20-external-rewards/src/contract.rs
@@ -6,7 +6,9 @@ use crate::state::{
     REWARD_PER_TOKEN, USER_REWARD_PER_TOKEN,
 };
 use crate::ContractError;
-use crate::ContractError::{InvalidCw20, InvalidFunds, NoRewardsClaimable, RewardPeriodNotFinished, Unauthorized};
+use crate::ContractError::{
+    InvalidCw20, InvalidFunds, NoRewardsClaimable, RewardPeriodNotFinished, Unauthorized,
+};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 
@@ -168,15 +170,15 @@ pub fn execute_fund(
     update_rewards(&mut deps, &env, &sender)?;
     let reward_config = REWARD_CONFIG.load(deps.storage)?;
     if reward_config.period_finish > env.block.height {
-        return Err(RewardPeriodNotFinished {})
+        return Err(RewardPeriodNotFinished {});
     }
     let new_reward_config = RewardConfig {
-            period_finish: env.block.height + reward_config.reward_duration,
-            reward_rate: amount
-                .checked_div(Uint128::from(reward_config.reward_duration))
-                .map_err(StdError::divide_by_zero)?,
-            reward_duration: reward_config.reward_duration,
-        };
+        period_finish: env.block.height + reward_config.reward_duration,
+        reward_rate: amount
+            .checked_div(Uint128::from(reward_config.reward_duration))
+            .map_err(StdError::divide_by_zero)?,
+        reward_duration: reward_config.reward_duration,
+    };
 
     if new_reward_config.reward_rate == Uint128::zero() {
         return Err(ContractError::RewardRateLessThenOnePerBlock {});
@@ -904,7 +906,7 @@ mod tests {
         let _res = app
             .borrow_mut()
             .execute_contract(
-                admin.clone(),
+                admin,
                 reward_addr.clone(),
                 &fund_msg,
                 &reward_funding,
@@ -1307,7 +1309,10 @@ mod tests {
             .borrow_mut()
             .execute_contract(admin, reward_addr.clone(), &fund_msg, &reward_funding)
             .unwrap_err();
-        assert_eq!(ContractError::RewardPeriodNotFinished {},err.downcast().unwrap());
+        assert_eq!(
+            ContractError::RewardPeriodNotFinished {},
+            err.downcast().unwrap()
+        );
 
         let res: InfoResponse = app
             .borrow_mut()

--- a/contracts/stake-cw20-external-rewards/src/contract.rs
+++ b/contracts/stake-cw20-external-rewards/src/contract.rs
@@ -905,12 +905,7 @@ mod tests {
 
         let _res = app
             .borrow_mut()
-            .execute_contract(
-                admin,
-                reward_addr.clone(),
-                &fund_msg,
-                &reward_funding,
-            )
+            .execute_contract(admin, reward_addr.clone(), &fund_msg, &reward_funding)
             .unwrap();
 
         app.borrow_mut().update_block(|b| b.height = 400000);


### PR DESCRIPTION
This PR remove the ability to update the external rewards during the current period. This somewhat unexpectedly will make the contract easier to manage in production. The biggest use case of this contract so far is to give out a certain amount of rewards over a certain time period. Once the time period is over, the reward distributor either wants to continue with the same amount of rewards or modify it. With the ability to add more rewards during the current period, it becomes difficult to continue the rewards at the current rate as if you send your fund message too early, you will accidentally top up the current period. This change makes it so a fund message sent too early will fail. 

With this change a multisig that wants to continue the rewards for another period can set up their fund message early and it will error if accidentally executed before the rewards period is finished. They can then set up a cron job to execute the message exactly when the current period is finished. 