### PR TITLE
rust-optimizer -> workspace-optimizer

### DIFF
--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -41,7 +41,7 @@ docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
   --platform linux/amd64 \
-  cosmwasm/rust-optimizer:0.12.5
+  cosmwasm/workspace-optimizer:0.12.6
 
 # Download cw20_base.wasm
 curl -LO https://github.com/CosmWasm/cw-plus/releases/download/v0.11.1/cw20_base.wasm


### PR DESCRIPTION
`rust-optimizer` -> `workspace-optimizer`, uses version `0.12.6`, avoids:


```
... Error during static Wasm validation: Wasm contract doesn't have required export: "instantiate". Exports required by VM: ["allocate", "deallocate", "instantiate"].: create wasm contract failed: invalid request
```