### PR TITLE
Initialize PROPOSAL_COUNT to zero.

### DIFF
--- a/contracts/cw-proposal-single/src/contract.rs
+++ b/contracts/cw-proposal-single/src/contract.rs
@@ -60,6 +60,9 @@ pub fn instantiate(
         allow_revoting: msg.allow_revoting,
     };
 
+    // Initialize proposal count to zero so that queries return zero
+    // instead of None.
+    PROPOSAL_COUNT.save(deps.storage, &0)?;
     CONFIG.save(deps.storage, &config)?;
 
     Ok(Response::default()

--- a/contracts/cw-proposal-single/src/proposal.rs
+++ b/contracts/cw-proposal-single/src/proposal.rs
@@ -33,7 +33,7 @@ pub struct Proposal {
 }
 
 pub fn advance_proposal_id(store: &mut dyn Storage) -> StdResult<u64> {
-    let id: u64 = PROPOSAL_COUNT.may_load(store)?.unwrap_or_default() + 1;
+    let id: u64 = PROPOSAL_COUNT.load(store)? + 1;
     PROPOSAL_COUNT.save(store, &id)?;
     Ok(id)
 }


### PR DESCRIPTION
Before if no proposals had been created `PROPOSAL_COUNT` would have no
value. This would cause trouble in queries as they would attempt to
load the value and locate nothing causing an error in frontends.