### PR TITLE
Update cw-core admin transfer process.

### DIFF
--- a/contracts/cw-core/examples/schema.rs
+++ b/contracts/cw-core/examples/schema.rs
@@ -5,7 +5,10 @@ use cosmwasm_schema::{export_schema, export_schema_with_title, remove_schemas, s
 use cosmwasm_std::Addr;
 use cw_core::{
     msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg},
-    query::{Cw20BalanceResponse, DumpStateResponse, GetItemResponse, PauseInfoResponse},
+    query::{
+        AdminNominationResponse, Cw20BalanceResponse, DumpStateResponse, GetItemResponse,
+        PauseInfoResponse,
+    },
     state::Config,
 };
 use cw_core_interface::voting::{
@@ -29,6 +32,7 @@ fn main() {
     export_schema(&schema_for!(InfoResponse), &out_dir);
     export_schema(&schema_for!(TotalPowerAtHeightResponse), &out_dir);
     export_schema(&schema_for!(VotingPowerAtHeightResponse), &out_dir);
+    export_schema(&schema_for!(AdminNominationResponse), &out_dir);
 
     // Auto TS code generation expects the query return type as QueryNameResponse
     // Here we map query resonses to the correct name

--- a/contracts/cw-core/schema/admin_nomination_response.json
+++ b/contracts/cw-core/schema/admin_nomination_response.json
@@ -1,26 +1,17 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Cw20BalancesResponse",
-  "description": "Returned by the `Cw20Balances` query.",
+  "title": "AdminNominationResponse",
+  "description": "Returned by the `AdminNomination` query.",
   "type": "object",
-  "required": [
-    "addr",
-    "balance"
-  ],
   "properties": {
-    "addr": {
-      "description": "The address of the token.",
-      "allOf": [
+    "nomination": {
+      "description": "The currently nominated admin or None if no nomination is pending.",
+      "anyOf": [
         {
           "$ref": "#/definitions/Addr"
-        }
-      ]
-    },
-    "balance": {
-      "description": "The contract's balance.",
-      "allOf": [
+        },
         {
-          "$ref": "#/definitions/Uint128"
+          "type": "null"
         }
       ]
     }
@@ -28,10 +19,6 @@
   "definitions": {
     "Addr": {
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-      "type": "string"
-    },
-    "Uint128": {
-      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
       "type": "string"
     }
   }

--- a/contracts/cw-core/schema/dump_state_response.json
+++ b/contracts/cw-core/schema/dump_state_response.json
@@ -4,6 +4,7 @@
   "description": "Relevant state for the governance module. Returned by the `DumpState` query.",
   "type": "object",
   "required": [
+    "admin",
     "config",
     "pause_info",
     "proposal_modules",
@@ -13,12 +14,9 @@
   "properties": {
     "admin": {
       "description": "Optional DAO Admin",
-      "anyOf": [
+      "allOf": [
         {
           "$ref": "#/definitions/Addr"
-        },
-        {
-          "type": "null"
         }
       ]
     },

--- a/contracts/cw-core/schema/execute_msg.json
+++ b/contracts/cw-core/schema/execute_msg.json
@@ -144,7 +144,7 @@
       "additionalProperties": false
     },
     {
-      "description": "Callable by the admin of the contract. If ADMIN is None removes the admin from the contract. If ADMIN is Some a new admin is proposed and that new admin may become the admin by executing the `AcceptAdminNomination` message.\n\nIf there is already a pending admin nomination the `WithdrawAdminNomination` message must be executed before a new admin may be nominated.",
+      "description": "Callable by the admin of the contract. If ADMIN is None the admin is set as the contract itself so that it may be updated later by vote. If ADMIN is Some a new admin is proposed and that new admin may become the admin by executing the `AcceptAdminNomination` message.\n\nIf there is already a pending admin nomination the `WithdrawAdminNomination` message must be executed before a new admin may be nominated.",
       "type": "object",
       "required": [
         "nominate_admin"

--- a/contracts/cw-core/schema/execute_msg.json
+++ b/contracts/cw-core/schema/execute_msg.json
@@ -144,26 +144,48 @@
       "additionalProperties": false
     },
     {
-      "description": "Callable by the Admin, if one is configured, changes the current admin. Setting to None removes the Admin.",
+      "description": "Callable by the admin of the contract. If ADMIN is None removes the admin from the contract. If ADMIN is Some a new admin is proposed and that new admin may become the admin by executing the `AcceptAdminNomination` message.\n\nIf there is already a pending admin nomination the `WithdrawAdminNomination` message must be executed before a new admin may be nominated.",
       "type": "object",
       "required": [
-        "update_admin"
+        "nominate_admin"
       ],
       "properties": {
-        "update_admin": {
+        "nominate_admin": {
           "type": "object",
           "properties": {
             "admin": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Addr"
-                },
-                {
-                  "type": "null"
-                }
+              "type": [
+                "string",
+                "null"
               ]
             }
           }
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Callable by a nominated admin. Admins are nominated via the `NominateAdmin` message. Accepting a nomination will make the nominated address the new admin.\n\nRequiring that the new admin accepts the nomination before becoming the admin protects against a typo causing the admin to change to an invalid address.",
+      "type": "object",
+      "required": [
+        "accept_admin_nomination"
+      ],
+      "properties": {
+        "accept_admin_nomination": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Callable by the current admin. Withdraws the current admin nomination.",
+      "type": "object",
+      "required": [
+        "withdraw_admin_nomination"
+      ],
+      "properties": {
+        "withdraw_admin_nomination": {
+          "type": "object"
         }
       },
       "additionalProperties": false
@@ -305,10 +327,6 @@
     }
   ],
   "definitions": {
-    "Addr": {
-      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-      "type": "string"
-    },
     "Admin": {
       "description": "Information about the admin of a contract.",
       "oneOf": [

--- a/contracts/cw-core/schema/instantiate_msg.json
+++ b/contracts/cw-core/schema/instantiate_msg.json
@@ -12,7 +12,7 @@
   ],
   "properties": {
     "admin": {
-      "description": "Optional Admin with the ability to execute DAO messages directly Useful for building SubDAOs completely controlled by a parent DAO.",
+      "description": "Optional Admin with the ability to execute DAO messages directly. Useful for building SubDAOs controlled by a parent DAO. If no admin is specified the contract is set as its own admin so that the admin may be updated later by governance.",
       "type": [
         "string",
         "null"

--- a/contracts/cw-core/schema/query_msg.json
+++ b/contracts/cw-core/schema/query_msg.json
@@ -16,6 +16,19 @@
       "additionalProperties": false
     },
     {
+      "description": "Get's the currently nominated admin (if any). Returns `AdminNominationResponse`.",
+      "type": "object",
+      "required": [
+        "admin_nomination"
+      ],
+      "properties": {
+        "admin_nomination": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
       "description": "Gets the contract's config. Returns Config.",
       "type": "object",
       "required": [

--- a/contracts/cw-core/schema/query_msg.json
+++ b/contracts/cw-core/schema/query_msg.json
@@ -3,7 +3,7 @@
   "title": "QueryMsg",
   "oneOf": [
     {
-      "description": "Get's the DAO's admin (if configured).",
+      "description": "Get's the DAO's admin. Returns `Addr`.",
       "type": "object",
       "required": [
         "admin"

--- a/contracts/cw-core/src/contract.rs
+++ b/contracts/cw-core/src/contract.rs
@@ -15,9 +15,13 @@ use crate::error::ContractError;
 use crate::msg::{
     ExecuteMsg, InitialItem, InstantiateMsg, MigrateMsg, ModuleInstantiateInfo, QueryMsg,
 };
-use crate::query::{Cw20BalanceResponse, DumpStateResponse, GetItemResponse, PauseInfoResponse};
+use crate::query::{
+    AdminNominationResponse, Cw20BalanceResponse, DumpStateResponse, GetItemResponse,
+    PauseInfoResponse,
+};
 use crate::state::{
-    Config, ADMIN, CONFIG, CW20_LIST, CW721_LIST, ITEMS, PAUSED, PROPOSAL_MODULES, VOTING_MODULE,
+    Config, ADMIN, CONFIG, CW20_LIST, CW721_LIST, ITEMS, NOMINATED_ADMIN, PAUSED, PROPOSAL_MODULES,
+    VOTING_MODULE,
 };
 
 // version info for migration info
@@ -105,7 +109,6 @@ pub fn execute(
         ExecuteMsg::ReceiveNft(_) => execute_receive_cw721(deps, info.sender),
         ExecuteMsg::RemoveItem { key } => execute_remove_item(deps, env, info.sender, key),
         ExecuteMsg::SetItem { key, addr } => execute_set_item(deps, env, info.sender, key, addr),
-        ExecuteMsg::UpdateAdmin { admin } => execute_update_admin(deps, info.sender, admin),
         ExecuteMsg::UpdateConfig { config } => {
             execute_update_config(deps, env, info.sender, config)
         }
@@ -120,6 +123,11 @@ pub fn execute(
         }
         ExecuteMsg::UpdateProposalModules { to_add, to_remove } => {
             execute_update_proposal_modules(deps, env, info.sender, to_add, to_remove)
+        }
+        ExecuteMsg::NominateAdmin { admin } => execute_nominate_admin(deps, info.sender, admin),
+        ExecuteMsg::AcceptAdminNomination {} => execute_accept_admin_nomination(deps, info.sender),
+        ExecuteMsg::WithdrawAdminNomination {} => {
+            execute_withdraw_admin_nomination(deps, info.sender)
         }
     }
 }
@@ -182,37 +190,76 @@ pub fn execute_proposal_hook(
         .add_messages(msgs))
 }
 
-pub fn execute_update_admin(
+pub fn execute_nominate_admin(
     deps: DepsMut,
     sender: Addr,
-    admin: Option<Addr>,
+    nomination: Option<String>,
 ) -> Result<Response, ContractError> {
+    let nomination = nomination.map(|h| deps.api.addr_validate(&h)).transpose()?;
+
     let current_admin = ADMIN.load(deps.storage)?;
-
-    match current_admin {
-        Some(current_admin) => {
-            // Check sender is the DAO Admin
-            if sender != current_admin {
-                return Err(ContractError::Unauthorized {});
-            }
-
-            // Save the new DAO Admin (which may be set to None)
-            ADMIN.save(deps.storage, &admin)?;
-
-            Ok(Response::default()
-                .add_attribute("action", "execute_update_admin")
-                .add_attribute(
-                    "new_admin",
-                    admin
-                        .map(|a| a.into_string())
-                        .unwrap_or_else(|| "None".to_string()),
-                ))
-        }
-        None => {
-            // If no DAO admin is configured, return unauthorized
-            Err(ContractError::Unauthorized {})
-        }
+    if current_admin.as_ref() != Some(&sender) {
+        return Err(ContractError::Unauthorized {});
     }
+
+    let current_nomination = NOMINATED_ADMIN.may_load(deps.storage)?;
+    if current_nomination.is_some() {
+        return Err(ContractError::PendingNomination {});
+    }
+
+    match &nomination {
+        Some(nomination) => NOMINATED_ADMIN.save(deps.storage, nomination)?,
+        None => ADMIN.save(deps.storage, &None)?,
+    }
+
+    Ok(Response::default()
+        .add_attribute("action", "execute_nominate_admin")
+        .add_attribute(
+            "nomination",
+            nomination
+                .map(|n| n.to_string())
+                .unwrap_or_else(|| "None".to_string()),
+        ))
+}
+
+pub fn execute_accept_admin_nomination(
+    deps: DepsMut,
+    sender: Addr,
+) -> Result<Response, ContractError> {
+    let nomination = NOMINATED_ADMIN
+        .may_load(deps.storage)?
+        .ok_or(ContractError::NoAdminNomination {})?;
+    if sender != nomination {
+        return Err(ContractError::Unauthorized {});
+    }
+    NOMINATED_ADMIN.remove(deps.storage);
+    ADMIN.save(deps.storage, &Some(nomination))?;
+
+    Ok(Response::default()
+        .add_attribute("action", "execute_accept_admin_nomination")
+        .add_attribute("new_admin", sender))
+}
+
+pub fn execute_withdraw_admin_nomination(
+    deps: DepsMut,
+    sender: Addr,
+) -> Result<Response, ContractError> {
+    let admin = ADMIN.load(deps.storage)?;
+    if admin.as_ref() != Some(&sender) {
+        return Err(ContractError::Unauthorized {});
+    }
+
+    // Check that there is indeed a nomination to withdraw.
+    let current_nomination = NOMINATED_ADMIN.may_load(deps.storage)?;
+    if current_nomination.is_none() {
+        return Err(ContractError::NoAdminNomination {});
+    }
+
+    NOMINATED_ADMIN.remove(deps.storage);
+
+    Ok(Response::default()
+        .add_attribute("action", "execute_withdraw_admin_nomination")
+        .add_attribute("sender", sender))
 }
 
 pub fn execute_update_config(
@@ -417,6 +464,7 @@ pub fn execute_receive_cw721(deps: DepsMut, sender: Addr) -> Result<Response, Co
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Admin {} => query_admin(deps),
+        QueryMsg::AdminNomination {} => query_admin_nomination(deps),
         QueryMsg::Config {} => query_config(deps),
         QueryMsg::Cw20TokenList { start_at, limit } => query_cw20_list(deps, start_at, limit),
         QueryMsg::Cw20Balances { start_at, limit } => {
@@ -442,6 +490,11 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 pub fn query_admin(deps: Deps) -> StdResult<Binary> {
     let admin = ADMIN.load(deps.storage)?;
     to_binary(&admin)
+}
+
+pub fn query_admin_nomination(deps: Deps) -> StdResult<Binary> {
+    let nomination = NOMINATED_ADMIN.may_load(deps.storage)?;
+    to_binary(&AdminNominationResponse { nomination })
 }
 
 pub fn query_config(deps: Deps) -> StdResult<Binary> {

--- a/contracts/cw-core/src/error.rs
+++ b/contracts/cw-core/src/error.rs
@@ -10,9 +10,6 @@ pub enum ContractError {
     #[error("Unauthorized.")]
     Unauthorized {},
 
-    #[error("DAO does not have an admin configured.")]
-    NoAdmin {},
-
     #[error("The contract is paused.")]
     Paused {},
 

--- a/contracts/cw-core/src/error.rs
+++ b/contracts/cw-core/src/error.rs
@@ -34,9 +34,14 @@ pub enum ContractError {
     #[error("Unsigned integer overflow.")]
     Overflow {},
 
-    #[error("You can only instantiate {0} items during instantiation, but you tried to instantiate {1}.")]
-    TooManyItems(u64, usize),
-
     #[error("Key is missing from storage")]
     KeyMissing {},
+
+    #[error("No pending admin nomination.")]
+    NoAdminNomination {},
+
+    #[error(
+        "The pending admin nomination must be withdrawn before a new nomination can be created."
+    )]
+    PendingNomination {},
 }

--- a/contracts/cw-core/src/msg.rs
+++ b/contracts/cw-core/src/msg.rs
@@ -43,8 +43,10 @@ pub struct InitialItem {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct InstantiateMsg {
-    /// Optional Admin with the ability to execute DAO messages directly
-    /// Useful for building SubDAOs completely controlled by a parent DAO.
+    /// Optional Admin with the ability to execute DAO messages
+    /// directly. Useful for building SubDAOs controlled by a parent
+    /// DAO. If no admin is specified the contract is set as its own
+    /// admin so that the admin may be updated later by governance.
     pub admin: Option<String>,
     /// The name of the core contract.
     pub name: String,
@@ -100,10 +102,11 @@ pub enum ExecuteMsg {
     /// item already exists the existing value is overriden. If the
     /// item does not exist a new item is added.
     SetItem { key: String, addr: String },
-    /// Callable by the admin of the contract. If ADMIN is None
-    /// removes the admin from the contract. If ADMIN is Some a new
-    /// admin is proposed and that new admin may become the admin by
-    /// executing the `AcceptAdminNomination` message.
+    /// Callable by the admin of the contract. If ADMIN is None the
+    /// admin is set as the contract itself so that it may be updated
+    /// later by vote. If ADMIN is Some a new admin is proposed and
+    /// that new admin may become the admin by executing the
+    /// `AcceptAdminNomination` message.
     ///
     /// If there is already a pending admin nomination the
     /// `WithdrawAdminNomination` message must be executed before a
@@ -150,7 +153,7 @@ pub enum ExecuteMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-    /// Get's the DAO's admin (if configured).
+    /// Get's the DAO's admin. Returns `Addr`.
     Admin {},
     /// Get's the currently nominated admin (if any). Returns
     /// `AdminNominationResponse`.

--- a/contracts/cw-core/src/query.rs
+++ b/contracts/cw-core/src/query.rs
@@ -11,7 +11,7 @@ use crate::state::Config;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct DumpStateResponse {
     /// Optional DAO Admin
-    pub admin: Option<Addr>,
+    pub admin: Addr,
     /// The governance contract's config.
     pub config: Config,
     // True if the contract is currently paused.

--- a/contracts/cw-core/src/query.rs
+++ b/contracts/cw-core/src/query.rs
@@ -40,11 +40,19 @@ pub struct GetItemResponse {
     pub item: Option<String>,
 }
 
-/// Returned by Cw20Balances query.
+/// Returned by the `Cw20Balances` query.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct Cw20BalanceResponse {
     /// The address of the token.
     pub addr: Addr,
     /// The contract's balance.
     pub balance: Uint128,
+}
+
+/// Returned by the `AdminNomination` query.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct AdminNominationResponse {
+    /// The currently nominated admin or None if no nomination is
+    /// pending.
+    pub nomination: Option<Addr>,
 }

--- a/contracts/cw-core/src/state.rs
+++ b/contracts/cw-core/src/state.rs
@@ -22,7 +22,19 @@ pub struct Config {
     pub automatically_add_cw721s: bool,
 }
 
+/// The admin of the contract. Typically a DAO. The contract admin may
+/// unilaterally execute messages on this contract.
 pub const ADMIN: Item<Option<Addr>> = Item::new("admin");
+
+/// A new admin that has been nominated by the current admin. The
+/// nominated admin must accept the proposal before becoming the admin
+/// themselves.
+///
+/// NOTE: If no admin is currently nominated this will not have a
+/// value set. To load this value, use
+/// `NOMINATED_ADMIN.may_load(deps.storage)`.
+pub const NOMINATED_ADMIN: Item<Addr> = Item::new("nominated_admin");
+
 pub const CONFIG: Item<Config> = Item::new("config");
 
 pub const PAUSED: Item<Expiration> = Item::new("paused");

--- a/contracts/cw-core/src/state.rs
+++ b/contracts/cw-core/src/state.rs
@@ -24,7 +24,11 @@ pub struct Config {
 
 /// The admin of the contract. Typically a DAO. The contract admin may
 /// unilaterally execute messages on this contract.
-pub const ADMIN: Item<Option<Addr>> = Item::new("admin");
+///
+/// In cases where no admin is wanted the admin should be set to the
+/// contract itself. This will happen by default if no admin is
+/// specified in `NominateAdmin` and instantiate messages.
+pub const ADMIN: Item<Addr> = Item::new("admin");
 
 /// A new admin that has been nominated by the current admin. The
 /// nominated admin must accept the proposal before becoming the admin


### PR DESCRIPTION
The new process is as follows:

1. The current admin nominates a new admin.
2. For the nomination to take effect the nominated admin must execute
   the `AcceptAdminNomination` method on the core contract.
3. At any point the current admin may withdraw their nomination.
4. The current admin may remove the contract's admin entirely without
   any nomination process.

This was suggested by the Oak Security folks and prevents an admin
from accidentally setting the admin of the contract to an invalid
address.