### PR TITLE
Add comment explaining overflow checks being important.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,6 @@ lto = true
 debug-assertions = false
 panic = 'abort'
 incremental = false
+# Please do not disable these. Doing so will cause overflow checks in
+# all workspace members to stop working. Overflows should be errors. 
 overflow-checks = true
- 


### PR DESCRIPTION
Resolves #335 

Adding overflow checks to each profile leads to a ton of warnings during compilation. Seems more likely to confuse folks than to help us. My vote is that we just add this comment and keep our eyes open for accidental removal of overflow checks.

<img width="1062" alt="image" src="https://user-images.githubusercontent.com/30676292/172475659-c9975896-0404-4fb3-b3b8-e4dd6d709067.png">
