### PR TITLE
Audit issue 18

### DIFF
--- a/contracts/cw4-voting/src/tests.rs
+++ b/contracts/cw4-voting/src/tests.rs
@@ -14,6 +14,7 @@ const DAO_ADDR: &str = "dao";
 const ADDR1: &str = "addr1";
 const ADDR2: &str = "addr2";
 const ADDR3: &str = "addr3";
+const ADDR4: &str = "addr4";
 
 fn cw4_contract() -> Box<dyn Contract<Empty>> {
     let contract = ContractWrapper::new(
@@ -63,6 +64,10 @@ fn setup_test_case(app: &mut App) -> Addr {
         cw4::Member {
             addr: ADDR3.to_string(),
             weight: 1,
+        },
+        cw4::Member {
+            addr: ADDR4.to_string(),
+            weight: 0,
         },
     ];
     instantiate_voting(
@@ -584,4 +589,78 @@ fn test_duplicate_member() {
             None,
         )
         .unwrap_err();
+}
+
+#[test]
+fn test_zero_voting_power() {
+    let mut app = App::default();
+    let voting_addr = setup_test_case(&mut app);
+    app.update_block(next_block);
+
+    let cw4_addr: Addr = app
+        .wrap()
+        .query_wasm_smart(voting_addr.clone(), &QueryMsg::GroupContract {})
+        .unwrap();
+
+    // check that ADDR4 weight is 0
+    let addr4_voting_power: VotingPowerAtHeightResponse = app
+        .wrap()
+        .query_wasm_smart(
+            voting_addr.clone(),
+            &QueryMsg::VotingPowerAtHeight {
+                address: ADDR4.to_string(),
+                height: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(addr4_voting_power.power, Uint128::new(0));
+    assert_eq!(addr4_voting_power.height, app.block_info().height);
+
+    // Update ADDR1's weight to 0
+    let msg = cw4_group::msg::ExecuteMsg::UpdateMembers {
+        remove: vec![],
+        add: vec![cw4::Member {
+            addr: ADDR1.to_string(),
+            weight: 0,
+        }],
+    };
+    app.execute_contract(Addr::unchecked(DAO_ADDR), cw4_addr, &msg, &[])
+        .unwrap();
+
+    // Should still be one as voting power should not update until
+    // the following block.
+    let addr1_voting_power: VotingPowerAtHeightResponse = app
+        .wrap()
+        .query_wasm_smart(
+            voting_addr.clone(),
+            &QueryMsg::VotingPowerAtHeight {
+                address: ADDR1.to_string(),
+                height: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(addr1_voting_power.power, Uint128::new(1u128));
+
+    // update block to see the changes
+    app.update_block(next_block);
+    let addr1_voting_power: VotingPowerAtHeightResponse = app
+        .wrap()
+        .query_wasm_smart(
+            voting_addr.clone(),
+            &QueryMsg::VotingPowerAtHeight {
+                address: ADDR1.to_string(),
+                height: None,
+            },
+        )
+        .unwrap();
+    assert_eq!(addr1_voting_power.power, Uint128::new(0u128));
+    assert_eq!(addr1_voting_power.height, app.block_info().height);
+
+    // Check total power is now 2
+    let total_voting_power: TotalPowerAtHeightResponse = app
+        .wrap()
+        .query_wasm_smart(voting_addr, &QueryMsg::TotalPowerAtHeight { height: None })
+        .unwrap();
+    assert_eq!(total_voting_power.power, Uint128::new(2u128));
+    assert_eq!(total_voting_power.height, app.block_info().height);
 }


### PR DESCRIPTION
I might be pushing my luck here, but it seems  skipping saving when `weight == 0` would work because `query_voting_power_at_height` will return 0 even if the address is missing from storage.