### PR TITLE
Audit issue 4

### DIFF
--- a/contracts/stake-cw20-reward-distributor/schema/execute_msg.json
+++ b/contracts/stake-cw20-reward-distributor/schema/execute_msg.json
@@ -53,7 +53,15 @@
       ],
       "properties": {
         "withdraw": {
-          "type": "object"
+          "type": "object",
+          "required": [
+            "amount"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Uint128"
+            }
+          }
         }
       },
       "additionalProperties": false

--- a/contracts/stake-cw20-reward-distributor/src/contract.rs
+++ b/contracts/stake-cw20-reward-distributor/src/contract.rs
@@ -205,7 +205,7 @@ pub fn execute_withdraw(
 
     let msg = to_binary(&cw20::Cw20ExecuteMsg::Transfer {
         recipient: config.owner.clone().into(),
-        amount: amount,
+        amount,
     })?;
     let send_msg: CosmosMsg = WasmMsg::Execute {
         contract_addr: config.reward_token.into(),

--- a/contracts/stake-cw20-reward-distributor/src/contract.rs
+++ b/contracts/stake-cw20-reward-distributor/src/contract.rs
@@ -205,7 +205,7 @@ pub fn execute_withdraw(
 
     let msg = to_binary(&cw20::Cw20ExecuteMsg::Transfer {
         recipient: config.owner.clone().into(),
-        amount: amount.clone(),
+        amount: amount,
     })?;
     let send_msg: CosmosMsg = WasmMsg::Execute {
         contract_addr: config.reward_token.into(),

--- a/contracts/stake-cw20-reward-distributor/src/error.rs
+++ b/contracts/stake-cw20-reward-distributor/src/error.rs
@@ -14,4 +14,7 @@ pub enum ContractError {
 
     #[error("Invalid Staking Contract")]
     InvalidStakingContract {},
+
+    #[error("Invalid Amount For Withdraw")]
+    InvalidAmountForWithdraw {},
 }

--- a/contracts/stake-cw20-reward-distributor/src/msg.rs
+++ b/contracts/stake-cw20-reward-distributor/src/msg.rs
@@ -21,7 +21,9 @@ pub enum ExecuteMsg {
         reward_token: String,
     },
     Distribute {},
-    Withdraw {},
+    Withdraw {
+        amount: Uint128,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]

--- a/contracts/stake-cw20-reward-distributor/src/tests.rs
+++ b/contracts/stake-cw20-reward-distributor/src/tests.rs
@@ -495,7 +495,6 @@ fn test_withdraw() {
     assert_eq!(owner_balance, Uint128::new(400));
     let distributor_info = get_info(&app, distributor_addr.clone());
     assert_eq!(distributor_info.balance, Uint128::new(590));
-    
 
     // Withdraw all rest funds
     app.execute_contract(
@@ -529,7 +528,6 @@ fn test_withdraw() {
         ContractError::InvalidAmountForWithdraw {},
         err.downcast().unwrap()
     );
-    
 }
 
 #[test]

--- a/contracts/stake-cw20-reward-distributor/src/tests.rs
+++ b/contracts/stake-cw20-reward-distributor/src/tests.rs
@@ -516,7 +516,7 @@ fn test_withdraw() {
     let err = app
         .execute_contract(
             Addr::unchecked(OWNER),
-            distributor_addr.clone(),
+            distributor_addr,
             &ExecuteMsg::Withdraw {
                 amount: Uint128::from(1u64),
             },

--- a/contracts/stake-cw20-reward-distributor/src/tests.rs
+++ b/contracts/stake-cw20-reward-distributor/src/tests.rs
@@ -437,18 +437,56 @@ fn test_withdraw() {
         .execute_contract(
             Addr::unchecked(MANAGER),
             distributor_addr.clone(),
-            &ExecuteMsg::Withdraw {},
+            &ExecuteMsg::Withdraw {
+                amount: Uint128::from(990u64),
+            },
             &[],
         )
         .unwrap_err();
 
     assert_eq!(ContractError::Unauthorized {}, err.downcast().unwrap());
 
+    // Withdraw amount must be greater than zero
+    let err = app
+        .execute_contract(
+            Addr::unchecked(OWNER),
+            distributor_addr.clone(),
+            &ExecuteMsg::Withdraw {
+                amount: Uint128::from(0u64),
+            },
+            &[],
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        ContractError::InvalidAmountForWithdraw {},
+        err.downcast().unwrap()
+    );
+
+    // Withdraw amount must be less than or equal to distributor contract balance
+    let err = app
+        .execute_contract(
+            Addr::unchecked(OWNER),
+            distributor_addr.clone(),
+            &ExecuteMsg::Withdraw {
+                amount: Uint128::from(991u64),
+            },
+            &[],
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        ContractError::InvalidAmountForWithdraw {},
+        err.downcast().unwrap()
+    );
+
     // Withdraw funds
     app.execute_contract(
         Addr::unchecked(OWNER),
         distributor_addr,
-        &ExecuteMsg::Withdraw {},
+        &ExecuteMsg::Withdraw {
+            amount: Uint128::from(990u64),
+        },
         &[],
     )
     .unwrap();


### PR DESCRIPTION
@Callum-A @ezekiiel 
As in the audit written, admin can only withdraw the entire balance, not a partial withdrawal. I solved it by adding an `amount` field in `ExecuteMsg::Withdraw` that allows withdrawal of an amount token (0 < amount <= contract balance). Anh I also add test for invalid amount. Thank you guys for review.
Close #326 