### PR TITLE
Don't allow zero reward durations.

### DIFF
--- a/contracts/cw20-stake-external-rewards/src/error.rs
+++ b/contracts/cw20-stake-external-rewards/src/error.rs
@@ -19,4 +19,6 @@ pub enum ContractError {
     InvalidCw20 {},
     #[error("Reward rate less then one per block")]
     RewardRateLessThenOnePerBlock {},
+    #[error("Reward duration can not be zero")]
+    ZeroRewardDuration {},
 }


### PR DESCRIPTION
Resolves #327.

Previously a rewards duration of zero was allowed. This is suboptimal because should the admin set a zero rewards duration there are a few places where we'd run into divide by zero errors. This adds the needed checks to be sure a zero reward duration is not set.