### PR TITLE
Address audit issue 17: messages with zero rewards are inefficient 

### DIFF
--- a/contracts/stake-cw20-reward-distributor/src/contract.rs
+++ b/contracts/stake-cw20-reward-distributor/src/contract.rs
@@ -143,10 +143,10 @@ pub fn validate_staking(deps: Deps, staking_addr: Addr) -> bool {
 fn get_distribution_msg(deps: Deps, env: &Env) -> Result<Option<CosmosMsg>, ContractError> {
     let config = CONFIG.load(deps.storage)?;
     let last_payment_block = LAST_PAYMENT_BLOCK.load(deps.storage)?;
-    let block_diff = env.block.height - last_payment_block;
-    if block_diff == 0 {
+    if last_payment_block >= env.block.height {
         return Ok(None);
     }
+    let block_diff = env.block.height - last_payment_block;
 
     let pending_rewards: Uint128 = config.reward_rate * Uint128::new(block_diff.into());
 

--- a/contracts/stake-cw20-reward-distributor/src/contract.rs
+++ b/contracts/stake-cw20-reward-distributor/src/contract.rs
@@ -144,6 +144,9 @@ fn get_distribution_msg(deps: Deps, env: &Env) -> Result<Option<CosmosMsg>, Cont
     let config = CONFIG.load(deps.storage)?;
     let last_payment_block = LAST_PAYMENT_BLOCK.load(deps.storage)?;
     let block_diff = env.block.height - last_payment_block;
+    if block_diff <= 0 {
+        return Err(ContractError::ZeroRewards {});
+    }
     let pending_rewards: Uint128 = config.reward_rate * Uint128::new(block_diff.into());
 
     let balance_info: cw20::BalanceResponse = deps.querier.query_wasm_smart(

--- a/contracts/stake-cw20-reward-distributor/src/error.rs
+++ b/contracts/stake-cw20-reward-distributor/src/error.rs
@@ -14,4 +14,7 @@ pub enum ContractError {
 
     #[error("Invalid Staking Contract")]
     InvalidStakingContract {},
+
+    #[error("Zero eligible rewards")]
+    ZeroRewards {},
 }

--- a/contracts/stake-cw20-reward-distributor/src/tests.rs
+++ b/contracts/stake-cw20-reward-distributor/src/tests.rs
@@ -289,50 +289,6 @@ fn test_distribute() {
 }
 
 #[test]
-fn test_distribute_zero_rewards() {
-    let mut app = App::default();
-
-    let cw20_addr = instantiate_cw20(
-        &mut app,
-        vec![cw20::Cw20Coin {
-            address: OWNER.to_string(),
-            amount: Uint128::from(1000u64),
-        }],
-    );
-    let staking_addr = instantiate_staking(&mut app, cw20_addr.clone());
-
-    let msg = InstantiateMsg {
-        owner: OWNER.to_string(),
-        staking_addr: staking_addr.to_string(),
-        reward_rate: Uint128::new(1),
-        reward_token: cw20_addr.to_string(),
-    };
-    let distributor_addr = instantiate_distributor(&mut app, msg);
-
-    let msg = cw20::Cw20ExecuteMsg::Transfer {
-        recipient: distributor_addr.to_string(),
-        amount: Uint128::from(1000u128),
-    };
-
-    app.execute_contract(Addr::unchecked(OWNER), cw20_addr.clone(), &msg, &[])
-        .unwrap();
-
-    let err = app
-        .execute_contract(
-            Addr::unchecked(OWNER),
-            distributor_addr.clone(),
-            &ExecuteMsg::Distribute {},
-            &[],
-        )
-        .unwrap_err();
-
-    assert_eq!(
-        err.downcast::<ContractError>().unwrap(),
-        crate::ContractError::ZeroRewards {}
-    );
-}
-
-#[test]
 fn test_instantiate_invalid_addrs() {
     let mut app = App::default();
     let cw20_addr = instantiate_cw20(

--- a/contracts/stake-cw20-reward-distributor/src/tests.rs
+++ b/contracts/stake-cw20-reward-distributor/src/tests.rs
@@ -289,6 +289,50 @@ fn test_distribute() {
 }
 
 #[test]
+fn test_distribute_zero_rewards() {
+    let mut app = App::default();
+
+    let cw20_addr = instantiate_cw20(
+        &mut app,
+        vec![cw20::Cw20Coin {
+            address: OWNER.to_string(),
+            amount: Uint128::from(1000u64),
+        }],
+    );
+    let staking_addr = instantiate_staking(&mut app, cw20_addr.clone());
+
+    let msg = InstantiateMsg {
+        owner: OWNER.to_string(),
+        staking_addr: staking_addr.to_string(),
+        reward_rate: Uint128::new(1),
+        reward_token: cw20_addr.to_string(),
+    };
+    let distributor_addr = instantiate_distributor(&mut app, msg);
+
+    let msg = cw20::Cw20ExecuteMsg::Transfer {
+        recipient: distributor_addr.to_string(),
+        amount: Uint128::from(1000u128),
+    };
+
+    app.execute_contract(Addr::unchecked(OWNER), cw20_addr.clone(), &msg, &[])
+        .unwrap();
+
+    let err = app
+        .execute_contract(
+            Addr::unchecked(OWNER),
+            distributor_addr.clone(),
+            &ExecuteMsg::Distribute {},
+            &[],
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        err.downcast::<ContractError>().unwrap(),
+        crate::ContractError::ZeroRewards {}
+    );
+}
+
+#[test]
 fn test_instantiate_invalid_addrs() {
     let mut app = App::default();
     let cw20_addr = instantiate_cw20(


### PR DESCRIPTION
Closes #337 -- the issue claims that in contracts/stake-cw20-reward-distributor/src/contract.rs:146, block_diff can be 0 and thus a message will zero rewards will be fired. This actually appears to be handled on line contracts/stake-cw20-reward-distributor/src/contract.rs:162, because if the amount is zero, None will be returned as the msg, but this PR adds a check for block diff <= 0 to circumvent the query on line 153.  


