### PR TITLE
(Audit issue 17) Zero rewards improvements

### DIFF
--- a/contracts/stake-cw20-reward-distributor/src/error.rs
+++ b/contracts/stake-cw20-reward-distributor/src/error.rs
@@ -17,4 +17,7 @@ pub enum ContractError {
 
     #[error("Zero eligible rewards")]
     ZeroRewards {},
+
+    #[error("Rewards have already been distributed for this block")]
+    RewardsDistributedForBlock {},
 }


### PR DESCRIPTION
- Remove distribution_msg from `execute_update_config`. It doesn't seem   necessary to return that information from `execute_update_config`. (at least I don't see any `execute_update_config` test that depend on it)
- Change get_distribution_msg signature to return   Result<CosmosMsg, ContractError>. Option is no longer required since
  in all cases where we would return None, we are now returning an  Error.
- Remove the direct `get_distribution_msg` test. Instead enhance the  existing public contract API test to verify the new
  RewardsDistributedForBlock scenario.

cc @ezekiiel 

ref: #352 