### PR TITLE
Add min_voting_period to cw-proposal-single.

### DIFF
--- a/contracts/cw-proposal-single/schema/config_response.json
+++ b/contracts/cw-proposal-single/schema/config_response.json
@@ -42,6 +42,17 @@
         }
       ]
     },
+    "min_voting_period": {
+      "description": "The minimum amount of time a proposal must be open before passing. A proposal may fail before this amount of time has elapsed, but it will not pass. This can be useful for preventing governance attacks wherein an attacker aquires a large number of tokens and forces a proposal through.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Duration"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "only_members_execute": {
       "description": "If set to true only members may execute passed proposals. Otherwise, any address may execute a passed proposal.",
       "type": "boolean"

--- a/contracts/cw-proposal-single/schema/execute_msg.json
+++ b/contracts/cw-proposal-single/schema/execute_msg.json
@@ -162,6 +162,17 @@
                 }
               ]
             },
+            "min_voting_period": {
+              "description": "The minimum amount of time a proposal must be open before passing. A proposal may fail before this amount of time has elapsed, but it will not pass. This can be useful for preventing governance attacks wherein an attacker aquires a large number of tokens and forces a proposal through.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Duration"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
             "only_members_execute": {
               "description": "If set to true only members may execute passed proposals. Otherwise, any address may execute a passed proposal. Applies to all outstanding and future proposals.",
               "type": "boolean"

--- a/contracts/cw-proposal-single/schema/instantiate_msg.json
+++ b/contracts/cw-proposal-single/schema/instantiate_msg.json
@@ -32,6 +32,17 @@
         }
       ]
     },
+    "min_voting_period": {
+      "description": "The minimum amount of time a proposal must be open before passing. A proposal may fail before this amount of time has elapsed, but it will not pass. This can be useful for preventing governance attacks wherein an attacker aquires a large number of tokens and forces a proposal through.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Duration"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "only_members_execute": {
       "description": "If set to true only members may execute passed proposals. Otherwise, any address may execute a passed proposal.",
       "type": "boolean"

--- a/contracts/cw-proposal-single/schema/list_proposals_response.json
+++ b/contracts/cw-proposal-single/schema/list_proposals_response.json
@@ -591,18 +591,41 @@
           "type": "string"
         },
         "expiration": {
-          "$ref": "#/definitions/Expiration"
+          "description": "The the time at which this proposal will expire and close for additional votes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            }
+          ]
+        },
+        "min_voting_period": {
+          "description": "The minimum amount of time this proposal must remain open for voting. The proposal may not pass unless this is expired or None.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "msgs": {
+          "description": "The messages that will be executed should this proposal pass.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/CosmosMsg_for_Empty"
           }
         },
         "proposer": {
-          "$ref": "#/definitions/Addr"
+          "description": "The address that created this proposal.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            }
+          ]
         },
         "start_height": {
+          "description": "The block height at which this proposal was created. Voting power queries should query for voting power at this block height.",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
@@ -611,13 +634,23 @@
           "$ref": "#/definitions/Status"
         },
         "threshold": {
-          "$ref": "#/definitions/Threshold"
+          "description": "The threshold at which this proposal will pass.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Threshold"
+            }
+          ]
         },
         "title": {
           "type": "string"
         },
         "total_power": {
-          "$ref": "#/definitions/Uint128"
+          "description": "The total amount of voting power at the time of this proposal's creation.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint128"
+            }
+          ]
         },
         "votes": {
           "$ref": "#/definitions/Votes"

--- a/contracts/cw-proposal-single/schema/proposal_response.json
+++ b/contracts/cw-proposal-single/schema/proposal_response.json
@@ -594,18 +594,41 @@
           "type": "string"
         },
         "expiration": {
-          "$ref": "#/definitions/Expiration"
+          "description": "The the time at which this proposal will expire and close for additional votes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            }
+          ]
+        },
+        "min_voting_period": {
+          "description": "The minimum amount of time this proposal must remain open for voting. The proposal may not pass unless this is expired or None.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "msgs": {
+          "description": "The messages that will be executed should this proposal pass.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/CosmosMsg_for_Empty"
           }
         },
         "proposer": {
-          "$ref": "#/definitions/Addr"
+          "description": "The address that created this proposal.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            }
+          ]
         },
         "start_height": {
+          "description": "The block height at which this proposal was created. Voting power queries should query for voting power at this block height.",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
@@ -614,13 +637,23 @@
           "$ref": "#/definitions/Status"
         },
         "threshold": {
-          "$ref": "#/definitions/Threshold"
+          "description": "The threshold at which this proposal will pass.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Threshold"
+            }
+          ]
         },
         "title": {
           "type": "string"
         },
         "total_power": {
-          "$ref": "#/definitions/Uint128"
+          "description": "The total amount of voting power at the time of this proposal's creation.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint128"
+            }
+          ]
         },
         "votes": {
           "$ref": "#/definitions/Votes"

--- a/contracts/cw-proposal-single/schema/reverse_proposals_response.json
+++ b/contracts/cw-proposal-single/schema/reverse_proposals_response.json
@@ -591,18 +591,41 @@
           "type": "string"
         },
         "expiration": {
-          "$ref": "#/definitions/Expiration"
+          "description": "The the time at which this proposal will expire and close for additional votes.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            }
+          ]
+        },
+        "min_voting_period": {
+          "description": "The minimum amount of time this proposal must remain open for voting. The proposal may not pass unless this is expired or None.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "msgs": {
+          "description": "The messages that will be executed should this proposal pass.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/CosmosMsg_for_Empty"
           }
         },
         "proposer": {
-          "$ref": "#/definitions/Addr"
+          "description": "The address that created this proposal.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            }
+          ]
         },
         "start_height": {
+          "description": "The block height at which this proposal was created. Voting power queries should query for voting power at this block height.",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
@@ -611,13 +634,23 @@
           "$ref": "#/definitions/Status"
         },
         "threshold": {
-          "$ref": "#/definitions/Threshold"
+          "description": "The threshold at which this proposal will pass.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Threshold"
+            }
+          ]
         },
         "title": {
           "type": "string"
         },
         "total_power": {
-          "$ref": "#/definitions/Uint128"
+          "description": "The total amount of voting power at the time of this proposal's creation.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint128"
+            }
+          ]
         },
         "votes": {
           "$ref": "#/definitions/Votes"

--- a/contracts/cw-proposal-single/src/error.rs
+++ b/contracts/cw-proposal-single/src/error.rs
@@ -56,4 +56,10 @@ pub enum ContractError {
 
     #[error("The DAO is currently inactive, you cannot create proposals")]
     InactiveDao {},
+
+    #[error("min_voting_period and max_voting_period must have the same units (height or time)")]
+    DurationUnitsConflict {},
+
+    #[error("Min voting period must be less than or equal to max voting period")]
+    InvalidMinVotingPeriod {},
 }

--- a/contracts/cw-proposal-single/src/msg.rs
+++ b/contracts/cw-proposal-single/src/msg.rs
@@ -13,6 +13,12 @@ pub struct InstantiateMsg {
     /// The default maximum amount of time a proposal may be voted on
     /// before expiring.
     pub max_voting_period: Duration,
+    /// The minimum amount of time a proposal must be open before
+    /// passing. A proposal may fail before this amount of time has
+    /// elapsed, but it will not pass. This can be useful for
+    /// preventing governance attacks wherein an attacker aquires a
+    /// large number of tokens and forces a proposal through.
+    pub min_voting_period: Option<Duration>,
     /// If set to true only members may execute passed
     /// proposals. Otherwise, any address may execute a passed
     /// proposal.
@@ -99,6 +105,12 @@ pub enum ExecuteMsg {
         /// on before expiring. This will only apply to proposals
         /// created after the config update.
         max_voting_period: Duration,
+        /// The minimum amount of time a proposal must be open before
+        /// passing. A proposal may fail before this amount of time has
+        /// elapsed, but it will not pass. This can be useful for
+        /// preventing governance attacks wherein an attacker aquires a
+        /// large number of tokens and forces a proposal through.
+        min_voting_period: Option<Duration>,
         /// If set to true only members may execute passed
         /// proposals. Otherwise, any address may execute a passed
         /// proposal. Applies to all outstanding and future proposals.

--- a/contracts/cw-proposal-single/src/proposal.rs
+++ b/contracts/cw-proposal-single/src/proposal.rs
@@ -134,12 +134,10 @@ impl Proposal {
         // time to remove liquidity / scheme on a recovery plan if a
         // single actor accumulates enough tokens to unilaterally pass
         // proposals.
-        if !self
-            .min_voting_period
-            .map(|min| min.is_expired(block))
-            .unwrap_or(true)
-        {
-            return false;
+        if let Some(min) = self.min_voting_period {
+            if !min.is_expired(block) {
+                return false;
+            }
         }
 
         match self.threshold {

--- a/contracts/cw-proposal-single/src/staking_tests.rs
+++ b/contracts/cw-proposal-single/src/staking_tests.rs
@@ -109,6 +109,7 @@ fn instantiate_with_staked_balances_voting() {
                     quorum: voting::PercentageThreshold::Percent(Decimal::percent(30)),
                 },
                 max_voting_period: Duration::Height(10u64),
+                min_voting_period: None,
                 only_members_execute: true,
                 allow_revoting: false,
                 deposit_info: None,

--- a/contracts/cw-proposal-single/src/state.rs
+++ b/contracts/cw-proposal-single/src/state.rs
@@ -34,6 +34,12 @@ pub struct Config {
     /// The default maximum amount of time a proposal may be voted on
     /// before expiring.
     pub max_voting_period: Duration,
+    /// The minimum amount of time a proposal must be open before
+    /// passing. A proposal may fail before this amount of time has
+    /// elapsed, but it will not pass. This can be useful for
+    /// preventing governance attacks wherein an attacker aquires a
+    /// large number of tokens and forces a proposal through.
+    pub min_voting_period: Option<Duration>,
     /// If set to true only members may execute passed
     /// proposals. Otherwise, any address may execute a passed
     /// proposal.

--- a/contracts/cw-proposal-single/src/tests.rs
+++ b/contracts/cw-proposal-single/src/tests.rs
@@ -550,6 +550,7 @@ where
     let instantiate = InstantiateMsg {
         threshold,
         max_voting_period,
+        min_voting_period: None,
         only_members_execute: false,
         allow_revoting: false,
         deposit_info,
@@ -705,6 +706,7 @@ fn test_propose() {
     let instantiate = InstantiateMsg {
         threshold: threshold.clone(),
         max_voting_period,
+        min_voting_period: None,
         only_members_execute: false,
         allow_revoting: false,
         deposit_info: None,
@@ -734,6 +736,7 @@ fn test_propose() {
     let expected = Config {
         threshold: threshold.clone(),
         max_voting_period,
+        min_voting_period: None,
         only_members_execute: false,
         allow_revoting: false,
         dao: governance_addr,
@@ -765,6 +768,7 @@ fn test_propose() {
         proposer: Addr::unchecked(CREATOR_ADDR),
         start_height: current_block.height,
         expiration: max_voting_period.after(&current_block),
+        min_voting_period: None,
         threshold,
         allow_revoting: false,
         total_power: Uint128::new(100_000_000),
@@ -790,6 +794,7 @@ fn test_propose_supports_stargate_message() {
     let instantiate = InstantiateMsg {
         threshold: threshold.clone(),
         max_voting_period,
+        min_voting_period: None,
         only_members_execute: false,
         allow_revoting: false,
         deposit_info: None,
@@ -838,6 +843,7 @@ fn test_propose_supports_stargate_message() {
         proposer: Addr::unchecked(CREATOR_ADDR),
         start_height: current_block.height,
         expiration: max_voting_period.after(&current_block),
+        min_voting_period: None,
         threshold,
         allow_revoting: false,
         total_power: Uint128::new(100_000_000),
@@ -958,6 +964,7 @@ fn test_voting_module_token_proposal_deposit_instantiate() {
     let instantiate = InstantiateMsg {
         threshold,
         max_voting_period,
+        min_voting_period: None,
         only_members_execute: false,
         allow_revoting: false,
         deposit_info: Some(DepositInfo {
@@ -1034,6 +1041,7 @@ fn test_different_token_proposal_deposit() {
     let instantiate = InstantiateMsg {
         threshold,
         max_voting_period,
+        min_voting_period: None,
         only_members_execute: false,
         allow_revoting: false,
         deposit_info: Some(DepositInfo {
@@ -1090,6 +1098,7 @@ fn test_bad_token_proposal_deposit() {
     let instantiate = InstantiateMsg {
         threshold,
         max_voting_period,
+        min_voting_period: None,
         only_members_execute: false,
         allow_revoting: false,
         deposit_info: Some(DepositInfo {
@@ -1116,6 +1125,7 @@ fn test_take_proposal_deposit() {
     let instantiate = InstantiateMsg {
         threshold,
         max_voting_period,
+        min_voting_period: None,
         only_members_execute: false,
         allow_revoting: false,
         deposit_info: Some(DepositInfo {
@@ -1465,6 +1475,7 @@ fn test_execute_expired_proposal() {
                 quorum: PercentageThreshold::Percent(Decimal::percent(10)),
             },
             max_voting_period: Duration::Height(10),
+            min_voting_period: None,
             only_members_execute: true,
             allow_revoting: false,
             deposit_info: None,
@@ -1625,6 +1636,7 @@ fn test_update_config() {
                 percentage: PercentageThreshold::Majority {},
             },
             max_voting_period: cw_utils::Duration::Height(10),
+            min_voting_period: None,
             only_members_execute: false,
             allow_revoting: false,
             dao: CREATOR_ADDR.to_string(),
@@ -1643,6 +1655,7 @@ fn test_update_config() {
                 percentage: PercentageThreshold::Majority {},
             },
             max_voting_period: cw_utils::Duration::Height(10),
+            min_voting_period: None,
             only_members_execute: false,
             allow_revoting: false,
             dao: CREATOR_ADDR.to_string(),
@@ -1662,6 +1675,7 @@ fn test_update_config() {
             percentage: PercentageThreshold::Majority {},
         },
         max_voting_period: cw_utils::Duration::Height(10),
+        min_voting_period: None,
         only_members_execute: false,
         allow_revoting: false,
         dao: Addr::unchecked(CREATOR_ADDR),
@@ -1679,6 +1693,7 @@ fn test_update_config() {
                 percentage: PercentageThreshold::Majority {},
             },
             max_voting_period: cw_utils::Duration::Height(10),
+            min_voting_period: None,
             only_members_execute: false,
             allow_revoting: false,
             dao: CREATOR_ADDR.to_string(),
@@ -1761,6 +1776,7 @@ fn test_query_list_proposals() {
                 quorum: PercentageThreshold::Percent(Decimal::percent(0)),
             },
             max_voting_period: cw_utils::Duration::Height(100),
+            min_voting_period: None,
             only_members_execute: true,
             allow_revoting: false,
             deposit_info: None,
@@ -1832,6 +1848,7 @@ fn test_query_list_proposals() {
             proposer: Addr::unchecked(CREATOR_ADDR),
             start_height: app.block_info().height,
             expiration: cw_utils::Expiration::AtHeight(app.block_info().height + 100),
+            min_voting_period: None,
             threshold: Threshold::ThresholdQuorum {
                 threshold: PercentageThreshold::Majority {},
                 quorum: PercentageThreshold::Percent(Decimal::percent(0)),
@@ -1876,6 +1893,7 @@ fn test_query_list_proposals() {
             proposer: Addr::unchecked(CREATOR_ADDR),
             start_height: app.block_info().height,
             expiration: cw_utils::Expiration::AtHeight(app.block_info().height + 100),
+            min_voting_period: None,
             threshold: Threshold::ThresholdQuorum {
                 threshold: PercentageThreshold::Majority {},
                 quorum: PercentageThreshold::Percent(Decimal::percent(0)),
@@ -1907,6 +1925,7 @@ fn test_hooks() {
     let instantiate = InstantiateMsg {
         threshold,
         max_voting_period,
+        min_voting_period: None,
         only_members_execute: false,
         allow_revoting: false,
         deposit_info: None,
@@ -2080,6 +2099,7 @@ fn test_active_threshold_absolute() {
     let instantiate = InstantiateMsg {
         threshold,
         max_voting_period,
+        min_voting_period: None,
         only_members_execute: false,
         allow_revoting: false,
         deposit_info: None,
@@ -2205,6 +2225,7 @@ fn test_active_threshold_percent() {
     let instantiate = InstantiateMsg {
         threshold,
         max_voting_period,
+        min_voting_period: None,
         only_members_execute: false,
         allow_revoting: false,
         deposit_info: None,
@@ -2331,6 +2352,7 @@ fn test_active_threshold_none() {
     let instantiate = InstantiateMsg {
         threshold,
         max_voting_period,
+        min_voting_period: None,
         only_members_execute: false,
         allow_revoting: false,
         deposit_info: None,
@@ -2409,6 +2431,7 @@ fn test_active_threshold_none() {
     let instantiate = InstantiateMsg {
         threshold,
         max_voting_period,
+        min_voting_period: None,
         only_members_execute: false,
         allow_revoting: false,
         deposit_info: None,
@@ -2459,6 +2482,7 @@ fn test_revoting() {
                 quorum: PercentageThreshold::Percent(Decimal::percent(10)),
             },
             max_voting_period: Duration::Height(10),
+            min_voting_period: None,
             only_members_execute: true,
             allow_revoting: true,
             deposit_info: None,
@@ -2584,6 +2608,7 @@ fn test_allow_revoting_config_changes() {
                 quorum: PercentageThreshold::Percent(Decimal::percent(10)),
             },
             max_voting_period: Duration::Height(10),
+            min_voting_period: None,
             only_members_execute: true,
             allow_revoting: true,
             deposit_info: None,
@@ -2629,6 +2654,7 @@ fn test_allow_revoting_config_changes() {
                 quorum: PercentageThreshold::Percent(Decimal::percent(10)),
             },
             max_voting_period: Duration::Height(10),
+            min_voting_period: None,
             only_members_execute: true,
             allow_revoting: false,
             deposit_info: None,
@@ -2725,6 +2751,7 @@ fn test_revoting_same_vote_twice() {
                 quorum: PercentageThreshold::Percent(Decimal::percent(10)),
             },
             max_voting_period: Duration::Height(10),
+            min_voting_period: None,
             only_members_execute: true,
             allow_revoting: true,
             deposit_info: None,
@@ -2826,6 +2853,7 @@ fn test_three_of_five_multisig() {
                 threshold: Uint128::new(3),
             },
             max_voting_period: Duration::Height(10),
+            min_voting_period: None,
             only_members_execute: true,
             allow_revoting: false,
             deposit_info: None,
@@ -2951,6 +2979,7 @@ fn test_three_of_five_multisig_reject() {
                 threshold: Uint128::new(3),
             },
             max_voting_period: Duration::Height(10),
+            min_voting_period: None,
             only_members_execute: true,
             allow_revoting: false,
             deposit_info: None,
@@ -3082,6 +3111,7 @@ fn test_voting_module_token_with_multisig_style_voting() {
                 threshold: Uint128::new(3),
             },
             max_voting_period: Duration::Height(10),
+            min_voting_period: None,
             only_members_execute: true,
             allow_revoting: false,
             deposit_info: Some(DepositInfo {
@@ -3120,6 +3150,7 @@ fn test_three_of_five_multisig_revoting() {
                 threshold: Uint128::new(3),
             },
             max_voting_period: Duration::Height(10),
+            min_voting_period: None,
             only_members_execute: true,
             allow_revoting: true,
             deposit_info: None,
@@ -3352,6 +3383,7 @@ fn test_migrate() {
     let instantiate = InstantiateMsg {
         threshold,
         max_voting_period,
+        min_voting_period: None,
         only_members_execute: false,
         allow_revoting: false,
         deposit_info: None,
@@ -3409,6 +3441,7 @@ fn test_proposal_count_initialized_to_zero() {
                 quorum: PercentageThreshold::Percent(Decimal::percent(10)),
             },
             max_voting_period: Duration::Height(10),
+            min_voting_period: None,
             only_members_execute: true,
             allow_revoting: false,
             deposit_info: None,
@@ -3439,4 +3472,252 @@ fn test_proposal_count_initialized_to_zero() {
         .query_wasm_smart(proposal_single, &QueryMsg::ProposalCount {})
         .unwrap();
     assert_eq!(proposal_count, 0);
+}
+
+#[test]
+fn test_no_early_pass_with_min_duration() {
+    let mut app = App::default();
+    let govmod_id = app.store_code(single_proposal_contract());
+    let core_addr = instantiate_with_staked_balances_governance(
+        &mut app,
+        govmod_id,
+        InstantiateMsg {
+            threshold: Threshold::ThresholdQuorum {
+                threshold: PercentageThreshold::Majority {},
+                quorum: PercentageThreshold::Percent(Decimal::percent(10)),
+            },
+            max_voting_period: Duration::Height(10),
+            min_voting_period: Some(Duration::Height(2)),
+            only_members_execute: true,
+            allow_revoting: false,
+            deposit_info: None,
+        },
+        Some(vec![
+            Cw20Coin {
+                address: "ekez".to_string(),
+                amount: Uint128::new(10),
+            },
+            Cw20Coin {
+                address: "wale".to_string(),
+                amount: Uint128::new(90),
+            },
+        ]),
+    );
+
+    let gov_state: cw_core::query::DumpStateResponse = app
+        .wrap()
+        .query_wasm_smart(core_addr, &cw_core::msg::QueryMsg::DumpState {})
+        .unwrap();
+    let proposal_modules = gov_state.proposal_modules;
+
+    assert_eq!(proposal_modules.len(), 1);
+    let proposal_single = proposal_modules.into_iter().next().unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("wale"),
+        proposal_single.clone(),
+        &ExecuteMsg::Propose {
+            title: "A simple text proposal".to_string(),
+            description: "This is a simple text proposal".to_string(),
+            msgs: vec![],
+        },
+        &[],
+    )
+    .unwrap();
+
+    // Wale votes yes which under normal curcumstances would cause the
+    // proposal to pass. Because there is a min duration it does not.
+    app.execute_contract(
+        Addr::unchecked("wale"),
+        proposal_single.clone(),
+        &ExecuteMsg::Vote {
+            proposal_id: 1,
+            vote: Vote::Yes,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let proposal: ProposalResponse = app
+        .wrap()
+        .query_wasm_smart(
+            proposal_single.clone(),
+            &QueryMsg::Proposal { proposal_id: 1 },
+        )
+        .unwrap();
+
+    assert_eq!(proposal.proposal.status, Status::Open);
+
+    // Let the min voting period pass.
+    app.update_block(|b| b.height += 2);
+
+    let proposal: ProposalResponse = app
+        .wrap()
+        .query_wasm_smart(proposal_single, &QueryMsg::Proposal { proposal_id: 1 })
+        .unwrap();
+
+    assert_eq!(proposal.proposal.status, Status::Passed);
+}
+
+#[test]
+#[should_panic(
+    expected = "min_voting_period and max_voting_period must have the same units (height or time)"
+)]
+fn test_min_duration_units_missmatch() {
+    let mut app = App::default();
+    let govmod_id = app.store_code(single_proposal_contract());
+    instantiate_with_staked_balances_governance(
+        &mut app,
+        govmod_id,
+        InstantiateMsg {
+            threshold: Threshold::ThresholdQuorum {
+                threshold: PercentageThreshold::Majority {},
+                quorum: PercentageThreshold::Percent(Decimal::percent(10)),
+            },
+            max_voting_period: Duration::Height(10),
+            min_voting_period: Some(Duration::Time(2)),
+            only_members_execute: true,
+            allow_revoting: false,
+            deposit_info: None,
+        },
+        Some(vec![
+            Cw20Coin {
+                address: "ekez".to_string(),
+                amount: Uint128::new(10),
+            },
+            Cw20Coin {
+                address: "wale".to_string(),
+                amount: Uint128::new(90),
+            },
+        ]),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Min voting period must be less than or equal to max voting period")]
+fn test_min_duration_larger_than_proposal_duration() {
+    let mut app = App::default();
+    let govmod_id = app.store_code(single_proposal_contract());
+    instantiate_with_staked_balances_governance(
+        &mut app,
+        govmod_id,
+        InstantiateMsg {
+            threshold: Threshold::ThresholdQuorum {
+                threshold: PercentageThreshold::Majority {},
+                quorum: PercentageThreshold::Percent(Decimal::percent(10)),
+            },
+            max_voting_period: Duration::Height(10),
+            min_voting_period: Some(Duration::Height(11)),
+            only_members_execute: true,
+            allow_revoting: false,
+            deposit_info: None,
+        },
+        Some(vec![
+            Cw20Coin {
+                address: "ekez".to_string(),
+                amount: Uint128::new(10),
+            },
+            Cw20Coin {
+                address: "wale".to_string(),
+                amount: Uint128::new(90),
+            },
+        ]),
+    );
+}
+
+#[test]
+fn test_min_duration_same_as_proposal_duration() {
+    let mut app = App::default();
+    let govmod_id = app.store_code(single_proposal_contract());
+    let core_addr = instantiate_with_staked_balances_governance(
+        &mut app,
+        govmod_id,
+        InstantiateMsg {
+            threshold: Threshold::ThresholdQuorum {
+                threshold: PercentageThreshold::Majority {},
+                quorum: PercentageThreshold::Percent(Decimal::percent(10)),
+            },
+            max_voting_period: Duration::Time(10),
+            min_voting_period: Some(Duration::Time(10)),
+            only_members_execute: true,
+            allow_revoting: false,
+            deposit_info: None,
+        },
+        Some(vec![
+            Cw20Coin {
+                address: "ekez".to_string(),
+                amount: Uint128::new(10),
+            },
+            Cw20Coin {
+                address: "wale".to_string(),
+                amount: Uint128::new(90),
+            },
+        ]),
+    );
+
+    let gov_state: cw_core::query::DumpStateResponse = app
+        .wrap()
+        .query_wasm_smart(core_addr, &cw_core::msg::QueryMsg::DumpState {})
+        .unwrap();
+    let proposal_modules = gov_state.proposal_modules;
+
+    assert_eq!(proposal_modules.len(), 1);
+    let proposal_single = proposal_modules.into_iter().next().unwrap();
+
+    app.execute_contract(
+        Addr::unchecked("wale"),
+        proposal_single.clone(),
+        &ExecuteMsg::Propose {
+            title: "A simple text proposal".to_string(),
+            description: "This is a simple text proposal".to_string(),
+            msgs: vec![],
+        },
+        &[],
+    )
+    .unwrap();
+
+    // Wale votes yes which under normal curcumstances would cause the
+    // proposal to pass. Because there is a min duration it does not.
+    app.execute_contract(
+        Addr::unchecked("wale"),
+        proposal_single.clone(),
+        &ExecuteMsg::Vote {
+            proposal_id: 1,
+            vote: Vote::Yes,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let proposal: ProposalResponse = app
+        .wrap()
+        .query_wasm_smart(
+            proposal_single.clone(),
+            &QueryMsg::Proposal { proposal_id: 1 },
+        )
+        .unwrap();
+
+    assert_eq!(proposal.proposal.status, Status::Open);
+
+    // ekez can vote no.
+    app.execute_contract(
+        Addr::unchecked("ekez"),
+        proposal_single.clone(),
+        &ExecuteMsg::Vote {
+            proposal_id: 1,
+            vote: Vote::No,
+        },
+        &[],
+    )
+    .unwrap();
+
+    // Let the min voting period pass.
+    app.update_block(|b| b.time = b.time.plus_seconds(10));
+
+    let proposal: ProposalResponse = app
+        .wrap()
+        .query_wasm_smart(proposal_single, &QueryMsg::Proposal { proposal_id: 1 })
+        .unwrap();
+
+    assert_eq!(proposal.proposal.status, Status::Passed);
 }

--- a/contracts/cw-proposal-single/src/utils.rs
+++ b/contracts/cw-proposal-single/src/utils.rs
@@ -1,6 +1,9 @@
 use cosmwasm_std::{Addr, Deps, StdResult, Uint128};
 
 use cw_core_interface::voting;
+use cw_utils::Duration;
+
+use crate::ContractError;
 
 pub fn get_voting_power(
     deps: Deps,
@@ -23,4 +26,28 @@ pub fn get_total_power(deps: Deps, dao: Addr, height: Option<u64>) -> StdResult<
         .querier
         .query_wasm_smart(dao, &voting::Query::TotalPowerAtHeight { height })?;
     Ok(response.power)
+}
+
+/// Validates that the min voting period is less than the max voting
+/// period. Passes arguments through the function.
+pub fn validate_voting_period(
+    min: Option<Duration>,
+    max: Duration,
+) -> Result<(Option<Duration>, Duration), ContractError> {
+    let min = min
+        .map(|min| {
+            let valid = match (min, max) {
+                (Duration::Time(min), Duration::Time(max)) => min <= max,
+                (Duration::Height(min), Duration::Height(max)) => min <= max,
+                _ => return Err(ContractError::DurationUnitsConflict {}),
+            };
+            if valid {
+                Ok(min)
+            } else {
+                Err(ContractError::InvalidMinVotingPeriod {})
+            }
+        })
+        .transpose()?;
+
+    Ok((min, max))
 }

--- a/contracts/cw20-staked-balance-voting/schema/migrate_msg.json
+++ b/contracts/cw20-staked-balance-voting/schema/migrate_msg.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MigrateMsg",
+  "type": "object"
+}

--- a/contracts/cw4-voting/schema/migrate_msg.json
+++ b/contracts/cw4-voting/schema/migrate_msg.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MigrateMsg",
+  "type": "object"
+}

--- a/debug/proposal-hooks-counter/src/tests.rs
+++ b/debug/proposal-hooks-counter/src/tests.rs
@@ -136,6 +136,7 @@ fn test_counters() {
     let instantiate = cw_proposal_single::msg::InstantiateMsg {
         threshold,
         max_voting_period,
+        min_voting_period: None,
         only_members_execute: false,
         allow_revoting: false,
         deposit_info: None,


### PR DESCRIPTION
This adds a minimum voting period. Having a minimum voting period
allows DAO members some time to respond in the event of a DAO hostile
takeover.

For example, say a DAO exists with some tokens in a LP pool. An
attacker may purchase a large number of those tokens and stake them to
take over the DAO and give the DAO's treasury to themselves. If a
minimum voting period is configured DAO members will have some time to
see this occuring and remove liquidity from the pool to reduce the
amount of damage the attacker might do.

See this issue for some context: https://github.com/DA0-DA0/dao-contracts/issues/356#issuecomment-1154476150

IMO if folks are against this change I'd be happy to just close this PR and
move on. I do think that, on balance, this is probably worth the added
complexity.