### PR TITLE
Add migrate method to cw20-stake to allow migration from beta.

### DIFF
--- a/contracts/cw20-stake/src/msg.rs
+++ b/contracts/cw20-stake/src/msg.rs
@@ -68,6 +68,13 @@ pub enum QueryMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+pub enum MigrateMsg {
+    FromBeta { manager: Option<String> },
+    FromCompatible {},
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub struct StakedBalanceAtHeightResponse {
     pub balance: Uint128,
     pub height: u64,


### PR DESCRIPTION
This adds a migrate method to `cw20-stake` which allows migration from a beta staking contract to a non-beta staking contract. I have tested this migration using a testnet DAO which can be found here: https://testnet.daodao.zone/dao/juno1m4wsr4wj0hz9uz4kavh0yt8v3ghsf347etqzt66rkqprfn5myajqhw3vpd