### PR TITLE
Rename QueryMsg::Vote -> QueryMsg::GetVote since it causes the typescript generation to break

### DIFF
--- a/contracts/cw-proposal-single/examples/schema.rs
+++ b/contracts/cw-proposal-single/examples/schema.rs
@@ -56,4 +56,5 @@ fn main() {
         "ProposalHooksResponse",
     );
     export_schema_with_title(&schema_for!(HooksResponse), &out_dir, "VoteHooksResponse");
+    export_schema_with_title(&schema_for!(VoteResponse), &out_dir, "GetVoteResponse");
 }

--- a/contracts/cw-proposal-single/schema/get_vote_response.json
+++ b/contracts/cw-proposal-single/schema/get_vote_response.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "GetVoteResponse",
+  "description": "Information about a vote.",
+  "type": "object",
+  "properties": {
+    "vote": {
+      "description": "None if no such vote, Some otherwise.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/VoteInfo"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Vote": {
+      "type": "string",
+      "enum": [
+        "yes",
+        "no",
+        "abstain"
+      ]
+    },
+    "VoteInfo": {
+      "description": "Information about a vote that was cast.",
+      "type": "object",
+      "required": [
+        "power",
+        "vote",
+        "voter"
+      ],
+      "properties": {
+        "power": {
+          "description": "The voting power behind the vote.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint128"
+            }
+          ]
+        },
+        "vote": {
+          "description": "Position on the vote.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Vote"
+            }
+          ]
+        },
+        "voter": {
+          "description": "The address that voted.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/contracts/cw-proposal-single/schema/query_msg.json
+++ b/contracts/cw-proposal-single/schema/query_msg.json
@@ -113,10 +113,10 @@
     {
       "type": "object",
       "required": [
-        "vote"
+        "get_vote"
       ],
       "properties": {
-        "vote": {
+        "get_vote": {
           "type": "object",
           "required": [
             "proposal_id",

--- a/contracts/cw-proposal-single/src/contract.rs
+++ b/contracts/cw-proposal-single/src/contract.rs
@@ -585,7 +585,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             query_list_proposals(deps, env, start_after, limit)
         }
         QueryMsg::ProposalCount {} => query_proposal_count(deps),
-        QueryMsg::Vote { proposal_id, voter } => query_vote(deps, proposal_id, voter),
+        QueryMsg::GetVote { proposal_id, voter } => query_vote(deps, proposal_id, voter),
         QueryMsg::ListVotes {
             proposal_id,
             start_after,

--- a/contracts/cw-proposal-single/src/msg.rs
+++ b/contracts/cw-proposal-single/src/msg.rs
@@ -161,7 +161,7 @@ pub enum QueryMsg {
         limit: Option<u64>,
     },
     ProposalCount {},
-    Vote {
+    GetVote {
         proposal_id: u64,
         voter: String,
     },

--- a/contracts/cw-proposal-single/src/tests.rs
+++ b/contracts/cw-proposal-single/src/tests.rs
@@ -633,7 +633,7 @@ where
                     .wrap()
                     .query_wasm_smart(
                         govmod_single.clone(),
-                        &QueryMsg::Vote {
+                        &QueryMsg::GetVote {
                             proposal_id: 1,
                             voter: voter.clone(),
                         },


### PR DESCRIPTION
closes: https://github.com/DA0-DA0/dao-contracts/issues/369


I also confirmed that [the generated typescript files](https://github.com/DA0-DA0/dao-contracts/pull/347) are now `yarn build`ing after these changes.