### PR TITLE
Fix lints on stake-cw20.

### DIFF
--- a/contracts/cw20-stake-external-rewards/src/contract.rs
+++ b/contracts/cw20-stake-external-rewards/src/contract.rs
@@ -1865,7 +1865,7 @@ mod tests {
                 owner.clone(),
                 reward_addr.clone(),
                 &fund_msg,
-                &*invalid_funding,
+                &invalid_funding,
             )
             .unwrap_err()
             .downcast()
@@ -1890,7 +1890,7 @@ mod tests {
                 owner.clone(),
                 reward_addr.clone(),
                 &fund_msg,
-                &*extra_funding,
+                &extra_funding,
             )
             .unwrap_err()
             .downcast()
@@ -1987,7 +1987,7 @@ mod tests {
 
         let err: ContractError = app
             .borrow_mut()
-            .execute_contract(admin, reward_addr, &fund_msg, &*invalid_funding)
+            .execute_contract(admin, reward_addr, &fund_msg, &invalid_funding)
             .unwrap_err()
             .downcast()
             .unwrap();

--- a/contracts/cw20-stake/src/contract.rs
+++ b/contracts/cw20-stake/src/contract.rs
@@ -55,7 +55,7 @@ pub fn instantiate(
     let config = Config {
         owner,
         manager,
-        token_address: deps.api.addr_validate(&*msg.token_address)?,
+        token_address: deps.api.addr_validate(&msg.token_address)?,
         unstaking_duration: msg.unstaking_duration,
     };
     CONFIG.save(deps.storage, &config)?;
@@ -93,10 +93,10 @@ pub fn execute_update_config(
     duration: Option<Duration>,
 ) -> Result<Response, ContractError> {
     let new_owner = new_owner
-        .map(|new_owner| deps.api.addr_validate(&*new_owner))
+        .map(|new_owner| deps.api.addr_validate(&new_owner))
         .transpose()?;
     let new_manager = new_manager
-        .map(|new_manager| deps.api.addr_validate(&*new_manager))
+        .map(|new_manager| deps.api.addr_validate(&new_manager))
         .transpose()?;
     let mut config: Config = CONFIG.load(deps.storage)?;
     if Some(info.sender.clone()) != config.owner && Some(info.sender.clone()) != config.manager {


### PR DESCRIPTION
This fixes some lint errors in the stake-cw20 contract. These errors broke CI on main. It appears that happened because clippy added a new lint (we use nightly clippy) as the commit that added the offending lines is three months old.