### PR TITLE
Return proposal deposits to the DAO on proposal failure.

### DIFF
--- a/packages/voting/src/deposit.rs
+++ b/packages/voting/src/deposit.rs
@@ -107,7 +107,7 @@ pub fn get_deposit_msg(
 
 pub fn get_return_deposit_msg(
     deposit_info: &CheckedDepositInfo,
-    proposer: &Addr,
+    receiver: &Addr,
 ) -> StdResult<Vec<CosmosMsg>> {
     if deposit_info.deposit.is_zero() {
         return Ok(vec![]);
@@ -116,7 +116,7 @@ pub fn get_return_deposit_msg(
         contract_addr: deposit_info.token.to_string(),
         funds: vec![],
         msg: to_binary(&cw20::Cw20ExecuteMsg::Transfer {
-            recipient: proposer.to_string(),
+            recipient: receiver.to_string(),
             amount: deposit_info.deposit,
         })?,
     };


### PR DESCRIPTION
If a proposal fails and we are not refunding failed proposals we
should return that proposal to the DAO instead of holding it in the
proposal module.