### PR TITLE
Small changes for `query_dump()`, so it passes clippy and extra

### DIFF
--- a/contracts/cw-named-groups/src/contract.rs
+++ b/contracts/cw-named-groups/src/contract.rs
@@ -199,20 +199,13 @@ fn query_dump(deps: Deps) -> StdResult<DumpResponse> {
         .group_names
         .keys(deps.storage, None, None, Order::Ascending)
     {
-        if let Err(e) = group {
-            return Err(e);
-        }
-
-        let name = group.unwrap();
+        let name = group?;
         let addrs = GROUPS
             .groups_to_addresses
             .prefix(&name)
             .keys(deps.storage, None, None, Order::Ascending)
             .into_iter()
-            .map(|addr| match addr {
-                Ok(_) => Ok(addr.unwrap().to_string()),
-                Err(_) => Err(addr.unwrap_err()),
-            })
+            .map(|addr| addr.map(Into::into))
             .collect::<StdResult<Vec<String>>>()?;
 
         dump.push(Group {


### PR DESCRIPTION
Clippy was unhappy with:
```rust
        if let Err(e) = group {
            return Err(e);
        }
```

And since we touching this method
extra: `map(|addr|..` looks cleaner this way or we want `String::from`/ `addr.into_string()` here?