### PR TITLE
Allow setting owner as instantiator in native token staking.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "base64ct"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea908e7347a8c64e378c17e30ef880ad73e3b4498346b055c2c00ea342f3179"
+checksum = "3bdca834647821e0b13d9539a8634eb62d3501b6b6c2cec1722786ee6671b851"
 
 [[package]]
 name = "block-buffer"
@@ -49,9 +49,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
 
 [[package]]
 name = "cfg-if"
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
  "byteorder",
  "digest",
@@ -182,10 +182,10 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-core",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-multi-test 0.13.4",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw20-base",
  "schemars",
  "serde",
@@ -199,8 +199,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f0bc6019b4d3d81e11f5c384bcce7173e2210bd654d75c6c9668e12cca05dfa"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
  "schemars",
  "serde",
  "thiserror",
@@ -215,12 +215,12 @@ dependencies = [
  "cosmwasm-storage",
  "cw-core-interface",
  "cw-core-macros",
- "cw-multi-test 0.13.4 (git+https://github.com/CosmWasm/cw-plus?branch=main)",
+ "cw-multi-test 0.14.0",
  "cw-paginate",
  "cw-proposal-sudo",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw20 0.13.4",
  "cw20-balance-voting",
  "cw20-base",
@@ -238,7 +238,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-core-macros",
- "cw2",
+ "cw2 0.13.4",
  "schemars",
  "serde",
 ]
@@ -264,8 +264,8 @@ dependencies = [
  "anyhow",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
  "derivative",
  "itertools",
  "prost",
@@ -276,14 +276,14 @@ dependencies = [
 
 [[package]]
 name = "cw-multi-test"
-version = "0.13.4"
-source = "git+https://github.com/CosmWasm/cw-plus?branch=main#14f4e922fac9e2097a8efa99e5b71d04747e340a"
+version = "0.14.0"
+source = "git+https://github.com/CosmWasm/cw-plus?branch=main#d67face967d2a7f0f59ed4c29b5bbf8f00ce1523"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus 0.13.4 (git+https://github.com/CosmWasm/cw-plus?branch=main)",
- "cw-utils 0.13.4 (git+https://github.com/CosmWasm/cw-plus?branch=main)",
+ "cw-storage-plus 0.14.0",
+ "cw-utils 0.14.0",
  "derivative",
  "itertools",
  "prost",
@@ -299,9 +299,9 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-multi-test 0.13.4",
+ "cw-storage-plus 0.13.4",
+ "cw2 0.13.4",
  "schemars",
  "serde",
  "thiserror",
@@ -315,9 +315,9 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-multi-test 0.13.4",
+ "cw-storage-plus 0.13.4",
+ "cw2 0.13.4",
  "cw20 0.13.4",
  "cw20-base",
  "schemars",
@@ -336,10 +336,10 @@ dependencies = [
  "cw-controllers",
  "cw-core-interface",
  "cw-core-macros",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-multi-test 0.13.4",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "schemars",
  "serde",
  "thiserror",
@@ -351,8 +351,8 @@ version = "0.1.0"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-multi-test 0.13.4",
+ "cw-storage-plus 0.13.4",
  "serde",
 ]
 
@@ -365,10 +365,10 @@ dependencies = [
  "cw-core",
  "cw-core-interface",
  "cw-core-macros",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-multi-test 0.13.4",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw20 0.13.4",
  "cw20-balance-voting",
  "cw20-base",
@@ -398,10 +398,11 @@ dependencies = [
  "cw-core",
  "cw-core-interface",
  "cw-core-macros",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-multi-test 0.13.4",
+ "cw-native-staked-balance-voting",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw20 0.13.4",
  "cw20-balance-voting",
  "cw20-base",
@@ -432,9 +433,9 @@ dependencies = [
  "cosmwasm-storage",
  "cw-core-interface",
  "cw-core-macros",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-multi-test 0.13.4",
+ "cw-storage-plus 0.13.4",
+ "cw2 0.13.4",
  "schemars",
  "serde",
  "thiserror",
@@ -464,8 +465,8 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.13.4"
-source = "git+https://github.com/CosmWasm/cw-plus?branch=main#14f4e922fac9e2097a8efa99e5b71d04747e340a"
+version = "0.14.0"
+source = "git+https://github.com/CosmWasm/cw-plus?branch=main#d67face967d2a7f0f59ed4c29b5bbf8f00ce1523"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -479,10 +480,10 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-multi-test 0.13.4",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw20 0.13.4",
  "cw20-base",
  "schemars",
@@ -516,11 +517,13 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.13.4"
-source = "git+https://github.com/CosmWasm/cw-plus?branch=main#14f4e922fac9e2097a8efa99e5b71d04747e340a"
+version = "0.14.0"
+source = "git+https://github.com/CosmWasm/cw-plus?branch=main#d67face967d2a7f0f59ed4c29b5bbf8f00ce1523"
 dependencies = [
  "cosmwasm-std",
+ "cw2 0.14.0",
  "schemars",
+ "semver",
  "serde",
  "thiserror",
 ]
@@ -532,7 +535,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cf4639517490dd36b333bbd6c4fbd92e325fd0acf4683b41753bc5eb63bfc1"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 0.13.4",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw2"
+version = "0.14.0"
+source = "git+https://github.com/CosmWasm/cw-plus?branch=main#d67face967d2a7f0f59ed4c29b5bbf8f00ce1523"
+dependencies = [
+ "cosmwasm-std",
+ "cw-storage-plus 0.14.0",
  "schemars",
  "serde",
 ]
@@ -556,7 +570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cb782b8f110819a4eb5dbbcfed25ffba49ec16bbe32b4ad8da50a5ce68fec05"
 dependencies = [
  "cosmwasm-std",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-utils 0.13.4",
  "schemars",
  "serde",
 ]
@@ -570,10 +584,10 @@ dependencies = [
  "cosmwasm-storage",
  "cw-core-interface",
  "cw-core-macros",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-multi-test 0.13.4",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw20 0.13.4",
  "cw20-base",
  "schemars",
@@ -588,9 +602,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0306e606581f4fb45e82bcbb7f0333179ed53dd949c6523f01a99b4bfc1475a0"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw20 0.13.4",
  "schemars",
  "serde",
@@ -606,10 +620,10 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-controllers",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-multi-test 0.13.4",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw20 0.13.4",
  "cw20-base",
  "schemars",
@@ -626,10 +640,10 @@ dependencies = [
  "cosmwasm-storage",
  "cw-core-interface",
  "cw-core-macros",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-multi-test 0.13.4",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw20 0.13.4",
  "cw20-base",
  "cw20-stake",
@@ -645,7 +659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe19462a7f644ba60c19d3443cb90d00c50d9b6b3b0a3a7fca93df8261af979b"
 dependencies = [
  "cosmwasm-std",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-utils 0.13.4",
  "schemars",
  "serde",
 ]
@@ -657,7 +671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0acc3549d5ce11c6901b3a676f2e2628684722197054d97cd0101ea174ed5cbd"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 0.13.4",
  "schemars",
  "serde",
 ]
@@ -670,9 +684,9 @@ checksum = "a6c95c89153e7831c8306c8eba40a3daa76f9c7b8f5179dd0b8628aca168ec7a"
 dependencies = [
  "cosmwasm-std",
  "cw-controllers",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw4",
  "schemars",
  "serde",
@@ -688,10 +702,10 @@ dependencies = [
  "cosmwasm-storage",
  "cw-core-interface",
  "cw-core-macros",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-multi-test 0.13.4",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw4",
  "cw4-group",
  "schemars",
@@ -701,26 +715,26 @@ dependencies = [
 
 [[package]]
 name = "cw721"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b9fd71276795554c35899bb3a378561ed0c288d231113e9915f6ee1f42b7b5"
+checksum = "035818368a74c07dd9ed5c5a93340199ba251530162010b9f34c3809e3b97df1"
 dependencies = [
  "cosmwasm-std",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-utils 0.13.4",
  "schemars",
  "serde",
 ]
 
 [[package]]
 name = "cw721-base"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61200af4e027af2d7485dbdc37c2a9c4093b6b2f2b811732329ef456076f97e"
+checksum = "423d4efe8b649d228d1533e141c238415f49aa8a9ee4e40fce192d7a93ffd057"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw721",
  "schemars",
  "serde",
@@ -732,8 +746,8 @@ name = "cw721-controllers"
 version = "0.1.0"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
  "schemars",
  "serde",
  "thiserror",
@@ -749,11 +763,11 @@ dependencies = [
  "cw-controllers",
  "cw-core-interface",
  "cw-core-macros",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-multi-test 0.13.4",
  "cw-paginate",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw721",
  "cw721-base",
  "cw721-controllers",
@@ -794,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "140206b78fb2bc3edbcfc9b5ccbd0b30699cfe8d348b8b31b330e47df5291a5a"
+checksum = "9d07a982d1fb29db01e5a59b1918e03da4df7297eaeee7686ac45542fd4e59c8"
 
 [[package]]
 name = "ecdsa"
@@ -827,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "elliptic-curve"
@@ -910,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hex"
@@ -935,7 +949,7 @@ name = "indexable-hooks"
 version = "0.1.0"
 dependencies = [
  "cosmwasm-std",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-storage-plus 0.13.4",
  "schemars",
  "serde",
  "thiserror",
@@ -1011,9 +1025,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "c278e965f1d8cf32d6e0e96de3d3e79712178ae67986d9cf9151f51e95aac89b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1036,11 +1050,11 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-core",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-multi-test 0.13.4",
  "cw-proposal-single",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw20 0.13.4",
  "cw20-balance-voting",
  "cw20-base",
@@ -1179,10 +1193,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.137"
+name = "semver"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
+
+[[package]]
+name = "serde"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
 dependencies = [
  "serde_derive",
 ]
@@ -1198,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1220,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa",
  "ryu",
@@ -1271,10 +1291,10 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-controllers",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-multi-test 0.13.4",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw20 0.13.4",
  "cw20-base",
  "cw20-stake",
@@ -1290,10 +1310,10 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-multi-test 0.13.4",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw20 0.13.4",
  "cw20-base",
  "cw20-stake",
@@ -1333,9 +1353,9 @@ dependencies = [
  "cosmwasm-std",
  "cw-core",
  "cw-core-interface",
- "cw-multi-test 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2",
+ "cw-multi-test 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
  "cw20 0.13.4",
  "cw20-balance-voting",
  "cw20-base",
@@ -1389,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "version_check"
@@ -1417,7 +1437,7 @@ dependencies = [
  "cw-core",
  "cw-core-interface",
  "cw-storage-plus 0.12.1",
- "cw-utils 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-utils 0.13.4",
  "cw20 0.12.1",
  "schemars",
  "serde",
@@ -1438,6 +1458,6 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "zeroize"
-version = "1.5.5"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"

--- a/contracts/cw-native-staked-balance-voting/examples/schema.rs
+++ b/contracts/cw-native-staked-balance-voting/examples/schema.rs
@@ -7,7 +7,9 @@ use cw_controllers::ClaimsResponse;
 use cw_core_interface::voting::{
     InfoResponse, IsActiveResponse, TotalPowerAtHeightResponse, VotingPowerAtHeightResponse,
 };
-use cw_native_staked_balance_voting::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use cw_native_staked_balance_voting::msg::{
+    ExecuteMsg, InstantiateMsg, MigrateMsg, Owner, QueryMsg,
+};
 use cw_native_staked_balance_voting::state::Config;
 
 fn main() {
@@ -20,6 +22,7 @@ fn main() {
     export_schema(&schema_for!(ExecuteMsg), &out_dir);
     export_schema(&schema_for!(QueryMsg), &out_dir);
     export_schema(&schema_for!(MigrateMsg), &out_dir);
+    export_schema(&schema_for!(Owner), &out_dir);
 
     export_schema(&schema_for!(InfoResponse), &out_dir);
     export_schema(&schema_for!(TotalPowerAtHeightResponse), &out_dir);

--- a/contracts/cw-native-staked-balance-voting/schema/instantiate_msg.json
+++ b/contracts/cw-native-staked-balance-voting/schema/instantiate_msg.json
@@ -16,9 +16,13 @@
       ]
     },
     "owner": {
-      "type": [
-        "string",
-        "null"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Owner"
+        },
+        {
+          "type": "null"
+        }
       ]
     },
     "unstaking_duration": {
@@ -61,6 +65,36 @@
               "type": "integer",
               "format": "uint64",
               "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Owner": {
+      "oneOf": [
+        {
+          "description": "Set the owner to a specific address.",
+          "type": "object",
+          "required": [
+            "addr"
+          ],
+          "properties": {
+            "addr": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "Set the owner to the address that instantiates this contract. This is useful for DAOs that instantiate this contract as part of their creation process and would like to set themselces as the admin.",
+          "type": "object",
+          "required": [
+            "instantiator"
+          ],
+          "properties": {
+            "instantiator": {
+              "type": "object"
             }
           },
           "additionalProperties": false

--- a/contracts/cw-native-staked-balance-voting/schema/owner.json
+++ b/contracts/cw-native-staked-balance-voting/schema/owner.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Owner",
+  "oneOf": [
+    {
+      "description": "Set the owner to a specific address.",
+      "type": "object",
+      "required": [
+        "addr"
+      ],
+      "properties": {
+        "addr": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    {
+      "description": "Set the owner to the address that instantiates this contract. This is useful for DAOs that instantiate this contract as part of their creation process and would like to set themselces as the admin.",
+      "type": "object",
+      "required": [
+        "instantiator"
+      ],
+      "properties": {
+        "instantiator": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
+    }
+  ]
+}

--- a/contracts/cw-native-staked-balance-voting/src/contract.rs
+++ b/contracts/cw-native-staked-balance-voting/src/contract.rs
@@ -10,7 +10,7 @@ use cw_core_interface::voting::{TotalPowerAtHeightResponse, VotingPowerAtHeightR
 use cw_utils::{must_pay, Duration};
 
 use crate::error::ContractError;
-use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, Owner, QueryMsg};
 use crate::state::{Config, CLAIMS, CONFIG, DAO, MAX_CLAIMS, STAKED_BALANCES, STAKED_TOTAL};
 
 const CONTRACT_NAME: &str = "crates.io:cw-native-staked-balance-voting";
@@ -45,7 +45,11 @@ pub fn instantiate(
 
     let owner = msg
         .owner
-        .map(|owner| deps.api.addr_validate(&owner))
+        .as_ref()
+        .map(|owner| match owner {
+            Owner::Addr(address) => deps.api.addr_validate(address),
+            Owner::Instantiator {} => Ok(info.sender.clone()),
+        })
         .transpose()?;
     let manager = msg
         .manager

--- a/contracts/cw-native-staked-balance-voting/src/msg.rs
+++ b/contracts/cw-native-staked-balance-voting/src/msg.rs
@@ -4,10 +4,22 @@ use cw_utils::Duration;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum Owner {
+    /// Set the owner to a specific address.
+    Addr(String),
+    /// Set the owner to the address that instantiates this
+    /// contract. This is useful for DAOs that instantiate this
+    /// contract as part of their creation process and would like to
+    /// set themselces as the admin.
+    Instantiator {},
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
 pub struct InstantiateMsg {
     // Owner can update all configs including changing the owner. This will generally be a DAO.
-    pub owner: Option<String>,
+    pub owner: Option<Owner>,
     // Manager can update all configs except changing the owner. This will generally be an operations multisig for a DAO.
     pub manager: Option<String>,
     // Token denom e.g. ujuno, or some ibc denom
@@ -16,7 +28,7 @@ pub struct InstantiateMsg {
     pub unstaking_duration: Option<Duration>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     Stake {},
@@ -32,7 +44,7 @@ pub enum ExecuteMsg {
 }
 
 #[voting_query]
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     Dao {},

--- a/contracts/cw-native-staked-balance-voting/src/tests.rs
+++ b/contracts/cw-native-staked-balance-voting/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use crate::msg::{ExecuteMsg, InstantiateMsg, Owner, QueryMsg};
 use crate::state::Config;
 use cosmwasm_std::{coins, Addr, Coin, Empty, Uint128};
 use cw_controllers::ClaimsResponse;
@@ -199,7 +199,7 @@ fn test_instantiate() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -220,6 +220,27 @@ fn test_instantiate() {
 }
 
 #[test]
+fn test_instantiate_dao_owner() {
+    let mut app = mock_app();
+    let staking_id = app.store_code(staking_contract());
+    // Populated fields
+    let addr = instantiate_staking(
+        &mut app,
+        staking_id,
+        InstantiateMsg {
+            owner: Some(Owner::Instantiator {}),
+            manager: Some(ADDR1.to_string()),
+            denom: DENOM.to_string(),
+            unstaking_duration: Some(Duration::Height(5)),
+        },
+    );
+
+    let config = get_config(&mut app, addr);
+
+    assert_eq!(config.owner, Some(Addr::unchecked(DAO_ADDR)))
+}
+
+#[test]
 #[should_panic(expected = "Invalid unstaking duration, unstaking duration cannot be 0")]
 fn test_instantiate_invalid_unstaking_duration() {
     let mut app = mock_app();
@@ -229,7 +250,7 @@ fn test_instantiate_invalid_unstaking_duration() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(0)),
@@ -258,7 +279,7 @@ fn test_stake_invalid_denom() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -277,7 +298,7 @@ fn test_stake_valid_denom() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -298,7 +319,7 @@ fn test_unstake_none_staked() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -317,7 +338,7 @@ fn test_unstake_invalid_balance() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -340,7 +361,7 @@ fn test_unstake() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -375,7 +396,7 @@ fn test_unstake_no_unstaking_duration() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: None,
@@ -412,7 +433,7 @@ fn test_claim_no_claims() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -431,7 +452,7 @@ fn test_claim_claim_not_reached() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -458,7 +479,7 @@ fn test_claim() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -509,7 +530,7 @@ fn test_update_config_invalid_sender() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -537,7 +558,7 @@ fn test_update_config_non_owner_changes_owner() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -556,7 +577,7 @@ fn test_update_config_as_owner() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -594,7 +615,7 @@ fn test_update_config_as_manager() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -633,7 +654,7 @@ fn test_update_config_invalid_duration() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -660,7 +681,7 @@ fn test_query_dao() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -680,7 +701,7 @@ fn test_query_info() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -703,7 +724,7 @@ fn test_query_claims() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -739,7 +760,7 @@ fn test_query_get_config() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),
@@ -766,7 +787,7 @@ fn test_voting_power_queries() {
         &mut app,
         staking_id,
         InstantiateMsg {
-            owner: Some(DAO_ADDR.to_string()),
+            owner: Some(Owner::Addr(DAO_ADDR.to_string())),
             manager: Some(ADDR1.to_string()),
             denom: DENOM.to_string(),
             unstaking_duration: Some(Duration::Height(5)),

--- a/contracts/cw-proposal-multiple/src/tests.rs
+++ b/contracts/cw-proposal-multiple/src/tests.rs
@@ -1038,10 +1038,18 @@ fn test_pass_exact_quorum() {
 }
 
 #[test]
-fn fuzz_votes() {
-    fuzz_voting(do_votes_cw20_balances);
-    fuzz_voting(do_votes_cw4_weights);
-    fuzz_voting(do_votes_staked_balances);
+fn fuzz_votes_cw20_balances() {
+    fuzz_voting(do_votes_cw20_balances)
+}
+
+#[test]
+fn fuzz_votes_cw4_weights() {
+    fuzz_voting(do_votes_cw4_weights)
+}
+
+#[test]
+fn fuzz_votes_staked_balances() {
+    fuzz_voting(do_votes_staked_balances)
 }
 
 #[test]

--- a/contracts/cw-proposal-single/Cargo.toml
+++ b/contracts/cw-proposal-single/Cargo.toml
@@ -53,6 +53,7 @@ cw-multi-test = "0.13"
 cw4-voting = { path = "../cw4-voting", version = "*" }
 cw20-balance-voting = { path = "../../debug/cw20-balance-voting", version = "*" }
 cw20-staked-balance-voting = { path = "../cw20-staked-balance-voting", version = "*" }
+cw-native-staked-balance-voting = { path = "../cw-native-staked-balance-voting", version = "*" }
 cw721-stake = { path = "../cw721-stake", version = "*" }
 cw721-base = "0.13"
 testing = { version = "*", path = "../../packages/testing" }

--- a/contracts/cw-proposal-single/src/tests.rs
+++ b/contracts/cw-proposal-single/src/tests.rs
@@ -1,9 +1,9 @@
 use std::u128;
 
-use cosmwasm_std::{to_binary, Addr, CosmosMsg, Decimal, Empty, Timestamp, Uint128, WasmMsg};
+use cosmwasm_std::{to_binary, Addr, Coin, CosmosMsg, Decimal, Empty, Timestamp, Uint128, WasmMsg};
 use cw20::Cw20Coin;
 use cw20_staked_balance_voting::msg::ActiveThreshold;
-use cw_multi_test::{next_block, App, Contract, ContractWrapper, Executor};
+use cw_multi_test::{next_block, App, BankSudo, Contract, ContractWrapper, Executor, SudoMsg};
 
 use cw_core::msg::ModuleInstantiateInfo;
 use cw_utils::Duration;
@@ -74,6 +74,15 @@ fn cw20_staked_balances_voting() -> Box<dyn Contract<Empty>> {
         cw20_staked_balance_voting::contract::query,
     )
     .with_reply(cw20_staked_balance_voting::contract::reply);
+    Box::new(contract)
+}
+
+fn native_staked_balances_voting() -> Box<dyn Contract<Empty>> {
+    let contract = ContractWrapper::new(
+        cw_native_staked_balance_voting::contract::execute,
+        cw_native_staked_balance_voting::contract::instantiate,
+        cw_native_staked_balance_voting::contract::query,
+    );
     Box::new(contract)
 }
 
@@ -265,6 +274,109 @@ fn instantiate_with_staked_cw721_governance(
 
     // Update the block so that staked balances appear.
     app.update_block(|block| block.height += 1);
+
+    core_addr
+}
+
+fn instantiate_with_native_staked_balances_governance(
+    app: &mut App,
+    proposal_module_code_id: u64,
+    proposal_module_instantiate: InstantiateMsg,
+    initial_balances: Option<Vec<Cw20Coin>>,
+) -> Addr {
+    let initial_balances = initial_balances.unwrap_or_else(|| {
+        vec![Cw20Coin {
+            address: CREATOR_ADDR.to_string(),
+            amount: Uint128::new(100_000_000),
+        }]
+    });
+
+    // Collapse balances so that we can test double votes.
+    let initial_balances: Vec<Cw20Coin> = {
+        let mut already_seen = vec![];
+        initial_balances
+            .into_iter()
+            .filter(|Cw20Coin { address, amount: _ }| {
+                if already_seen.contains(address) {
+                    false
+                } else {
+                    already_seen.push(address.clone());
+                    true
+                }
+            })
+            .collect()
+    };
+
+    let native_stake_id = app.store_code(native_staked_balances_voting());
+    let core_contract_id = app.store_code(cw_gov_contract());
+
+    let instantiate_core = cw_core::msg::InstantiateMsg {
+        admin: None,
+        name: "DAO DAO".to_string(),
+        description: "A DAO that builds DAOs".to_string(),
+        image_url: None,
+        automatically_add_cw20s: true,
+        automatically_add_cw721s: false,
+        voting_module_instantiate_info: ModuleInstantiateInfo {
+            code_id: native_stake_id,
+            msg: to_binary(&cw_native_staked_balance_voting::msg::InstantiateMsg {
+                owner: Some(cw_native_staked_balance_voting::msg::Owner::Instantiator {}),
+                manager: None,
+                denom: "ujuno".to_string(),
+                unstaking_duration: None,
+            })
+            .unwrap(),
+            admin: cw_core::msg::Admin::None {},
+            label: "DAO DAO voting module".to_string(),
+        },
+        proposal_modules_instantiate_info: vec![ModuleInstantiateInfo {
+            code_id: proposal_module_code_id,
+            label: "DAO DAO governance module.".to_string(),
+            admin: cw_core::msg::Admin::CoreContract {},
+            msg: to_binary(&proposal_module_instantiate).unwrap(),
+        }],
+        initial_items: None,
+    };
+
+    let core_addr = app
+        .instantiate_contract(
+            core_contract_id,
+            Addr::unchecked(CREATOR_ADDR),
+            &instantiate_core,
+            &[],
+            "DAO DAO",
+            None,
+        )
+        .unwrap();
+
+    let gov_state: cw_core::query::DumpStateResponse = app
+        .wrap()
+        .query_wasm_smart(core_addr.clone(), &cw_core::msg::QueryMsg::DumpState {})
+        .unwrap();
+    let native_staking_addr = gov_state.voting_module;
+
+    for Cw20Coin { address, amount } in initial_balances {
+        app.sudo(SudoMsg::Bank(BankSudo::Mint {
+            to_address: address.clone(),
+            amount: vec![Coin {
+                denom: "ujuno".to_string(),
+                amount,
+            }],
+        }))
+        .unwrap();
+        app.execute_contract(
+            Addr::unchecked(&address),
+            native_staking_addr.clone(),
+            &cw_native_staked_balance_voting::msg::ExecuteMsg::Stake {},
+            &[Coin {
+                amount,
+                denom: "ujuno".to_string(),
+            }],
+        )
+        .unwrap();
+    }
+
+    app.update_block(next_block);
 
     core_addr
 }
@@ -660,6 +772,22 @@ fn do_votes_nft_balances(
     );
 }
 
+fn do_votes_native_staked_balances(
+    votes: Vec<TestSingleChoiceVote>,
+    threshold: Threshold,
+    expected_status: Status,
+    total_supply: Option<Uint128>,
+) {
+    do_test_votes(
+        votes,
+        threshold,
+        expected_status,
+        total_supply,
+        None,
+        instantiate_with_native_staked_balances_governance,
+    );
+}
+
 fn do_votes_cw4_weights(
     votes: Vec<TestSingleChoiceVote>,
     threshold: Threshold,
@@ -1034,19 +1162,22 @@ fn test_vote_simple() {
     testing::test_simple_votes(do_votes_cw20_balances);
     testing::test_simple_votes(do_votes_cw4_weights);
     testing::test_simple_votes(do_votes_staked_balances);
-    testing::test_simple_votes(do_votes_nft_balances)
+    testing::test_simple_votes(do_votes_nft_balances);
+    testing::test_simple_votes(do_votes_native_staked_balances)
 }
 
 #[test]
 fn test_simple_vote_no_overflow() {
     testing::test_simple_vote_no_overflow(do_votes_cw20_balances);
     testing::test_simple_vote_no_overflow(do_votes_staked_balances);
+    testing::test_simple_vote_no_overflow(do_votes_native_staked_balances);
 }
 
 #[test]
 fn test_vote_no_overflow() {
     testing::test_vote_no_overflow(do_votes_cw20_balances);
     testing::test_vote_no_overflow(do_votes_staked_balances);
+    testing::test_vote_no_overflow(do_votes_native_staked_balances);
 }
 
 #[test]
@@ -1054,6 +1185,7 @@ fn test_simple_early_rejection() {
     testing::test_simple_early_rejection(do_votes_cw20_balances);
     testing::test_simple_early_rejection(do_votes_cw4_weights);
     testing::test_simple_early_rejection(do_votes_staked_balances);
+    testing::test_simple_early_rejection(do_votes_native_staked_balances);
 }
 
 #[test]
@@ -1061,6 +1193,7 @@ fn test_vote_abstain_only() {
     testing::test_vote_abstain_only(do_votes_cw20_balances);
     testing::test_vote_abstain_only(do_votes_cw4_weights);
     testing::test_vote_abstain_only(do_votes_staked_balances);
+    testing::test_vote_abstain_only(do_votes_native_staked_balances);
 }
 
 #[test]
@@ -1068,6 +1201,7 @@ fn test_tricky_rounding() {
     testing::test_tricky_rounding(do_votes_cw20_balances);
     testing::test_tricky_rounding(do_votes_cw4_weights);
     testing::test_tricky_rounding(do_votes_staked_balances);
+    testing::test_tricky_rounding(do_votes_native_staked_balances);
 }
 
 #[test]
@@ -1076,6 +1210,7 @@ fn test_no_double_votes() {
     testing::test_no_double_votes(do_votes_cw4_weights);
     testing::test_no_double_votes(do_votes_staked_balances);
     testing::test_no_double_votes(do_votes_nft_balances);
+    testing::test_no_double_votes(do_votes_native_staked_balances);
 }
 
 #[test]
@@ -1083,6 +1218,7 @@ fn test_votes_favor_yes() {
     testing::test_votes_favor_yes(do_votes_cw20_balances);
     testing::test_votes_favor_yes(do_votes_staked_balances);
     testing::test_votes_favor_yes(do_votes_nft_balances);
+    testing::test_votes_favor_yes(do_votes_native_staked_balances);
 }
 
 #[test]
@@ -1091,6 +1227,7 @@ fn test_votes_low_threshold() {
     testing::test_votes_low_threshold(do_votes_cw4_weights);
     testing::test_votes_low_threshold(do_votes_staked_balances);
     testing::test_votes_low_threshold(do_votes_nft_balances);
+    testing::test_votes_low_threshold(do_votes_native_staked_balances);
 }
 
 #[test]
@@ -1099,6 +1236,7 @@ fn test_majority_vs_half() {
     testing::test_majority_vs_half(do_votes_cw4_weights);
     testing::test_majority_vs_half(do_votes_staked_balances);
     testing::test_majority_vs_half(do_votes_nft_balances);
+    testing::test_majority_vs_half(do_votes_native_staked_balances);
 }
 
 #[test]
@@ -1107,6 +1245,7 @@ fn test_pass_threshold_not_quorum() {
     testing::test_pass_threshold_not_quorum(do_votes_cw4_weights);
     testing::test_pass_threshold_not_quorum(do_votes_staked_balances);
     testing::test_pass_threshold_not_quorum(do_votes_nft_balances);
+    testing::test_pass_threshold_not_quorum(do_votes_native_staked_balances);
 }
 
 #[test]
@@ -1115,15 +1254,30 @@ fn test_pass_threshold_exactly_quorum() {
     testing::test_pass_exactly_quorum(do_votes_cw4_weights);
     testing::test_pass_exactly_quorum(do_votes_staked_balances);
     testing::test_pass_exactly_quorum(do_votes_nft_balances);
+    testing::test_pass_exactly_quorum(do_votes_native_staked_balances);
 }
 
 /// Generate some random voting selections and make sure they behave
-/// as expected.
+/// as expected. We split this test up as these take a while and cargo
+/// can parallize tests.
 #[test]
-fn fuzz_voting() {
-    testing::fuzz_voting(do_votes_cw20_balances);
-    testing::fuzz_voting(do_votes_cw4_weights);
-    testing::fuzz_voting(do_votes_staked_balances);
+fn fuzz_voting_cw20_balances() {
+    testing::fuzz_voting(do_votes_cw20_balances)
+}
+
+#[test]
+fn fuzz_voting_cw4_weights() {
+    testing::fuzz_voting(do_votes_cw4_weights)
+}
+
+#[test]
+fn fuzz_voting_staked_balances() {
+    testing::fuzz_voting(do_votes_staked_balances)
+}
+
+#[test]
+fn fuzz_voting_native_staked_balances() {
+    testing::fuzz_voting(do_votes_native_staked_balances)
 }
 
 /// Instantiate the contract and use the voting module's token

--- a/types/contracts/cw-native-staked-balance-voting/CwNativeStakedBalanceVotingContract.ts
+++ b/types/contracts/cw-native-staked-balance-voting/CwNativeStakedBalanceVotingContract.ts
@@ -71,10 +71,17 @@ export interface ContractVersion {
   version: string;
   [k: string]: unknown;
 }
+export type Owner = {
+  addr: string;
+} | {
+  instantiator: {
+    [k: string]: unknown;
+  };
+};
 export interface InstantiateMsg {
   denom: string;
   manager?: string | null;
-  owner?: string | null;
+  owner?: Owner | null;
   unstaking_duration?: Duration | null;
   [k: string]: unknown;
 }


### PR DESCRIPTION
Resolves #419

Also runs `cargo update` to get our dependencies up to date and adds the native token staking voting module to the test suite for `cw-proposal-single` so we've got complete integration tests for that.