### PR TITLE
Add migration for `close_proposal_on_execution_failure` field.

### DIFF
--- a/contracts/cw-core/src/contract.rs
+++ b/contracts/cw-core/src/contract.rs
@@ -584,7 +584,7 @@ pub fn query_proposal_modules(
 }
 
 /// Note: this is not gas efficient as we need to potentially visit all modules in order to
-/// filter out the modules with active status.  
+/// filter out the modules with active status.
 pub fn query_active_proposal_modules(
     deps: Deps,
     start_after: Option<String>,

--- a/contracts/cw-proposal-single/schema/migrate_msg.json
+++ b/contracts/cw-proposal-single/schema/migrate_msg.json
@@ -9,7 +9,16 @@
       ],
       "properties": {
         "from_v1": {
-          "type": "object"
+          "type": "object",
+          "required": [
+            "close_proposal_on_execution_failure"
+          ],
+          "properties": {
+            "close_proposal_on_execution_failure": {
+              "description": "This field was not present in DAO DAO v1. To migrate, a value must be specified.\n\nIf set to true proposals will be closed if their execution fails. Otherwise, proposals will remain open after execution failure. For example, with this enabled a proposal to send 5 tokens out of a DAO's treasury with 4 tokens would be closed when it is executed. With this disabled, that same proposal would remain open until the DAO's treasury was large enough for it to be executed.",
+              "type": "boolean"
+            }
+          }
         }
       },
       "additionalProperties": false

--- a/contracts/cw-proposal-single/src/msg.rs
+++ b/contracts/cw-proposal-single/src/msg.rs
@@ -209,6 +209,18 @@ pub enum QueryMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MigrateMsg {
-    FromV1 {},
+    FromV1 {
+        /// This field was not present in DAO DAO v1. To migrate, a
+        /// value must be specified.
+        ///
+        /// If set to true proposals will be closed if their execution
+        /// fails. Otherwise, proposals will remain open after execution
+        /// failure. For example, with this enabled a proposal to send 5
+        /// tokens out of a DAO's treasury with 4 tokens would be closed when
+        /// it is executed. With this disabled, that same proposal would
+        /// remain open until the DAO's treasury was large enough for it to be
+        /// executed.
+        close_proposal_on_execution_failure: bool,
+    },
     FromCompatible {},
 }

--- a/contracts/cw-proposal-single/src/state.rs
+++ b/contracts/cw-proposal-single/src/state.rs
@@ -57,8 +57,9 @@ pub struct Config {
     pub close_proposal_on_execution_failure: bool,
 }
 
-/// The current top level config for the module.
-pub const CONFIG: Item<Config> = Item::new("config");
+/// The current top level config for the module.  The "config" key was
+/// previously used to store configs for v1 DAOs.
+pub const CONFIG: Item<Config> = Item::new("config_v2");
 /// The number of proposals that have been created.
 pub const PROPOSAL_COUNT: Item<u64> = Item::new("proposal_count");
 pub const PROPOSALS: Map<u64, SingleChoiceProposal> = Map::new("proposals_v2");

--- a/types/contracts/cw-proposal-single/CwProposalSingleContract.ts
+++ b/types/contracts/cw-proposal-single/CwProposalSingleContract.ts
@@ -356,6 +356,7 @@ export interface ListVotesResponse {
 }
 export type MigrateMsg = {
   from_v1: {
+    close_proposal_on_execution_failure: boolean;
     [k: string]: unknown;
   };
 } | {


### PR DESCRIPTION
Resolves #452

This removes the non-mocked migration test. The test was effectively a
no-op as (so far as I am aware) we don't have a good way worked out to
mock v1 state. The new change errors if the `"config"` key isn't
present wheras the old one would just do nothing if the `"proposals"`
key was not present so the test had to go.

I tried mocking v1 state using the `AppBuilder` from multi-test and
instantiating it with a custom deps. From memory since I deleted the
code (so not real code):

```rust
let mut deps = mock_dependencies();
let v1_item: Item<V1Config> = Item::new("config");
let v1_config = V1Config { /* ... */ };
v1_item.save(&mut deps.storage, &v1_config).unwrap();
let mut app =
AppBuilder::default().with_storage(deps.storage).build(|_, _, _| ());
```

This doesn't work which makes some amount of sense as you'd expect
storage to be set on a per-contract level anyhow. There may be
something here we could explore.