### PR TITLE
Add "set contract version" to migrate methods 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "cw-admin-factory"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,7 +529,7 @@ dependencies = [
 
 [[package]]
 name = "cw-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "cw-core-interface"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "cw-core-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "proc-macro2",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "cw-named-groups"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "cw-names-registry"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "cw-native-staked-balance-voting"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "cw-paginate"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "cw-proposal-single"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "cw-proposal-sudo"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "cw-token-swap"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-balance-voting"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-staked-balance-voting"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "cw4-voting"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-controllers"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 0.13.4",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-stake"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1644,7 +1644,7 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexable-hooks"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 0.13.4",
@@ -1666,7 +1666,7 @@ dependencies = [
 
 [[package]]
 name = "integration_tests"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "proposal-hooks"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-std",
  "indexable-hooks",
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "proposal-hooks-counter"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "stake-cw20-reward-distributor"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -3222,7 +3222,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vote-hooks"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-std",
  "indexable-hooks",
@@ -3233,7 +3233,7 @@ dependencies = [
 
 [[package]]
 name = "voting"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-std",
  "cw-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 
 [[package]]
 name = "cw-proposal-multiple"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,7 +1666,7 @@ dependencies = [
 
 [[package]]
 name = "integration_tests"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/ci/integration_tests/Cargo.toml
+++ b/ci/integration_tests/Cargo.toml
@@ -15,11 +15,11 @@ cw20 = "0.13"
 cw20-base = "0.13"
 cw-utils = "0.13"
 cosmwasm-std = { version = "1.0.0", features = ["ibc3"] }
-cw-core = { version = "0.1.0", path = "../../contracts/cw-core" }
+cw-core = { version = "*", path = "../../contracts/cw-core" }
 cw20-stake = { version = "*", path = "../../contracts/cw20-stake" }
-cw20-staked-balance-voting = { version = "0.1.0", path = "../../contracts/cw20-staked-balance-voting" }
-cw-proposal-single = { version = "0.1.0", path = "../../contracts/cw-proposal-single" }
-cw-core-interface = { version = "0.1.0", path = "../../packages/cw-core-interface" }
+cw20-staked-balance-voting = { version = "*", path = "../../contracts/cw20-staked-balance-voting" }
+cw-proposal-single = { version = "*", path = "../../contracts/cw-proposal-single" }
+cw-core-interface = { version = "*", path = "../../packages/cw-core-interface" }
 voting = { version = "*", path = "../../packages/voting" }
 
 assert_matches = "1.5"

--- a/ci/integration_tests/Cargo.toml
+++ b/ci/integration_tests/Cargo.toml
@@ -15,7 +15,7 @@ cw20 = "0.13"
 cw20-base = "0.13"
 cw-utils = "0.13"
 cosmwasm-std = { version = "1.0.0", features = ["ibc3"] }
-cw-core = { version = "0.1.0", path = "../../contracts/cw-core" }
+cw-core = { version = "*", path = "../../contracts/cw-core" }
 cw20-stake = { version = "*", path = "../../contracts/cw20-stake" }
 cw20-staked-balance-voting = { version = "0.1.0", path = "../../contracts/cw20-staked-balance-voting" }
 cw-proposal-single = { version = "0.1.0", path = "../../contracts/cw-proposal-single" }

--- a/ci/integration_tests/Cargo.toml
+++ b/ci/integration_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration_tests"
-version = "0.2.0"
+version = "0.1.0"
 edition = "2021"
 
 # This crate depends on rand. These are not features in
@@ -15,11 +15,11 @@ cw20 = "0.13"
 cw20-base = "0.13"
 cw-utils = "0.13"
 cosmwasm-std = { version = "1.0.0", features = ["ibc3"] }
-cw-core = { version = "*", path = "../../contracts/cw-core" }
+cw-core = { version = "0.1.0", path = "../../contracts/cw-core" }
 cw20-stake = { version = "*", path = "../../contracts/cw20-stake" }
-cw20-staked-balance-voting = { version = "0.2.0", path = "../../contracts/cw20-staked-balance-voting" }
-cw-proposal-single = { version = "0.2.0", path = "../../contracts/cw-proposal-single" }
-cw-core-interface = { version = "0.2.0", path = "../../packages/cw-core-interface" }
+cw20-staked-balance-voting = { version = "0.1.0", path = "../../contracts/cw20-staked-balance-voting" }
+cw-proposal-single = { version = "0.1.0", path = "../../contracts/cw-proposal-single" }
+cw-core-interface = { version = "0.1.0", path = "../../packages/cw-core-interface" }
 voting = { version = "*", path = "../../packages/voting" }
 
 assert_matches = "1.5"

--- a/ci/integration_tests/Cargo.toml
+++ b/ci/integration_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration_tests"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # This crate depends on rand. These are not features in
@@ -17,9 +17,9 @@ cw-utils = "0.13"
 cosmwasm-std = { version = "1.0.0", features = ["ibc3"] }
 cw-core = { version = "*", path = "../../contracts/cw-core" }
 cw20-stake = { version = "*", path = "../../contracts/cw20-stake" }
-cw20-staked-balance-voting = { version = "0.1.0", path = "../../contracts/cw20-staked-balance-voting" }
-cw-proposal-single = { version = "0.1.0", path = "../../contracts/cw-proposal-single" }
-cw-core-interface = { version = "0.1.0", path = "../../packages/cw-core-interface" }
+cw20-staked-balance-voting = { version = "0.2.0", path = "../../contracts/cw20-staked-balance-voting" }
+cw-proposal-single = { version = "0.2.0", path = "../../contracts/cw-proposal-single" }
+cw-core-interface = { version = "0.2.0", path = "../../packages/cw-core-interface" }
 voting = { version = "*", path = "../../packages/voting" }
 
 assert_matches = "1.5"

--- a/contracts/cw-admin-factory/Cargo.toml
+++ b/contracts/cw-admin-factory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name ="cw-admin-factory"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["blue-note"]
 edition = "2018"
 

--- a/contracts/cw-admin-factory/src/contract.rs
+++ b/contracts/cw-admin-factory/src/contract.rs
@@ -8,7 +8,7 @@ use cw2::set_contract_version;
 use cw_utils::parse_reply_instantiate_data;
 
 use crate::error::ContractError;
-use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 
 const CONTRACT_NAME: &str = "crates.io:cw-admin-factory";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -88,4 +88,11 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
         }
         _ => Err(ContractError::UnknownReplyID {}),
     }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    // Set contract to version to latest
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::default())
 }

--- a/contracts/cw-admin-factory/src/contract.rs
+++ b/contracts/cw-admin-factory/src/contract.rs
@@ -10,8 +10,8 @@ use cw_utils::parse_reply_instantiate_data;
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 
-const CONTRACT_NAME: &str = "crates.io:cw-admin-factory";
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub(crate) const CONTRACT_NAME: &str = "crates.io:cw-admin-factory";
+pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const INSTANTIATE_CONTRACT_REPLY_ID: u64 = 0;
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/cw-admin-factory/src/msg.rs
+++ b/contracts/cw-admin-factory/src/msg.rs
@@ -20,3 +20,6 @@ pub enum ExecuteMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct MigrateMsg {}

--- a/contracts/cw-admin-factory/src/tests.rs
+++ b/contracts/cw-admin-factory/src/tests.rs
@@ -4,13 +4,14 @@ use cosmwasm_std::{
     testing::{mock_dependencies, mock_env, mock_info},
     to_binary, Addr, Binary, Empty, Reply, SubMsg, SubMsgResponse, SubMsgResult, WasmMsg,
 };
+use cw2::ContractVersion;
 use cw_core::msg::{Admin, ModuleInstantiateInfo};
 use cw_multi_test::{App, Contract, ContractWrapper, Executor};
 
 use crate::{
     contract::instantiate,
-    contract::{reply, INSTANTIATE_CONTRACT_REPLY_ID},
-    msg::{ExecuteMsg, InstantiateMsg},
+    contract::{migrate, reply, CONTRACT_NAME, CONTRACT_VERSION, INSTANTIATE_CONTRACT_REPLY_ID},
+    msg::{ExecuteMsg, InstantiateMsg, MigrateMsg},
 };
 
 fn factory_contract() -> Box<dyn Contract<Empty>> {
@@ -148,4 +149,14 @@ pub fn test_set_admin_mock() {
             admin: "contract2".to_string()
         })
     )
+}
+
+#[test]
+pub fn test_migrate_update_version() {
+    let mut deps = mock_dependencies();
+    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
+    migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+    let version = cw2::get_contract_version(&deps.storage).unwrap();
+    assert_eq!(version.version, CONTRACT_VERSION);
+    assert_eq!(version.contract, CONTRACT_NAME);
 }

--- a/contracts/cw-admin-factory/src/tests.rs
+++ b/contracts/cw-admin-factory/src/tests.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{
     testing::{mock_dependencies, mock_env, mock_info},
     to_binary, Addr, Binary, Empty, Reply, SubMsg, SubMsgResponse, SubMsgResult, WasmMsg,
 };
-use cw2::ContractVersion;
+
 use cw_core::msg::{Admin, ModuleInstantiateInfo};
 use cw_multi_test::{App, Contract, ContractWrapper, Executor};
 

--- a/contracts/cw-core/Cargo.toml
+++ b/contracts/cw-core/Cargo.toml
@@ -39,9 +39,9 @@ cw721 = "0.13"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
-cw-core-interface = { version = "0.1.0", path = "../../packages/cw-core-interface" }
-cw-core-macros = { version = "0.1.0", path = "../../packages/cw-core-macros" }
-cw-paginate = { version = "0.1.0", path = "../../packages/cw-paginate" }
+cw-core-interface = { version = "0.2.0", path = "../../packages/cw-core-interface" }
+cw-core-macros = { version = "0.2.0", path = "../../packages/cw-core-macros" }
+cw-paginate = { version = "0.2.0", path = "../../packages/cw-paginate" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }
@@ -49,5 +49,5 @@ cosmwasm-schema = { version = "1.0.0" }
 cw-multi-test = { git = "https://github.com/CosmWasm/cw-plus", branch = "main",  features = ["stargate"] }
 cw20-base = "0.13"
 cw721-base = "0.13"
-cw-proposal-sudo = { version = "0.1.0", path = "../../debug/cw-proposal-sudo"}
-cw20-balance-voting = { version = "0.1.0", path = "../../debug/cw20-balance-voting"}
+cw-proposal-sudo = { version = "0.2.0", path = "../../debug/cw-proposal-sudo"}
+cw20-balance-voting = { version = "0.2.0", path = "../../debug/cw20-balance-voting"}

--- a/contracts/cw-core/Cargo.toml
+++ b/contracts/cw-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-core"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Zeke Medley <zekemedley@gmail.com>"]
 edition = "2018"
 

--- a/contracts/cw-core/src/contract.rs
+++ b/contracts/cw-core/src/contract.rs
@@ -824,6 +824,7 @@ pub fn query_list_sub_daos(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     match msg {
         MigrateMsg::FromV1 {} => {
             let current_map: Map<Addr, Empty> = Map::new("proposal_modules");
@@ -920,7 +921,7 @@ pub(crate) fn derive_proposal_module_prefix(mut dividend: usize) -> StdResult<St
 
 #[cfg(test)]
 mod test {
-    use crate::contract::derive_proposal_module_prefix;
+    use crate::contract::{derive_proposal_module_prefix, CONTRACT_VERSION};
     use std::collections::HashSet;
 
     #[test]

--- a/contracts/cw-core/src/contract.rs
+++ b/contracts/cw-core/src/contract.rs
@@ -921,7 +921,7 @@ pub(crate) fn derive_proposal_module_prefix(mut dividend: usize) -> StdResult<St
 
 #[cfg(test)]
 mod test {
-    use crate::contract::{derive_proposal_module_prefix, CONTRACT_VERSION};
+    use crate::contract::derive_proposal_module_prefix;
     use std::collections::HashSet;
 
     #[test]

--- a/contracts/cw-core/src/contract.rs
+++ b/contracts/cw-core/src/contract.rs
@@ -26,8 +26,8 @@ use crate::state::{
 };
 
 // version info for migration info
-const CONTRACT_NAME: &str = "crates.io:cw-core";
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub(crate) const CONTRACT_NAME: &str = "crates.io:cw-core";
+pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const PROPOSAL_MODULE_REPLY_ID: u64 = 0;
 const VOTE_MODULE_INSTANTIATE_REPLY_ID: u64 = 1;

--- a/contracts/cw-core/src/tests.rs
+++ b/contracts/cw-core/src/tests.rs
@@ -10,7 +10,7 @@ use cw_storage_plus::Map;
 use cw_utils::{Duration, Expiration};
 
 use crate::{
-    contract::{derive_proposal_module_prefix, migrate},
+    contract::{derive_proposal_module_prefix, migrate, CONTRACT_NAME, CONTRACT_VERSION},
     msg::{
         Admin, ExecuteMsg, InitialItem, InstantiateMsg, MigrateMsg, ModuleInstantiateInfo, QueryMsg,
     },
@@ -2819,4 +2819,14 @@ fn test_add_remove_subdaos() {
     ];
 
     assert_eq!(res, full_result_set);
+}
+
+#[test]
+pub fn test_migrate_update_version() {
+    let mut deps = mock_dependencies();
+    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
+    migrate(deps.as_mut(), mock_env(), MigrateMsg::FromCompatible {}).unwrap();
+    let version = cw2::get_contract_version(&deps.storage).unwrap();
+    assert_eq!(version.version, CONTRACT_VERSION);
+    assert_eq!(version.contract, CONTRACT_NAME);
 }

--- a/contracts/cw-named-groups/Cargo.toml
+++ b/contracts/cw-named-groups/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-named-groups"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["blue-note", "Noah Saso <noahsaso@gmail.com>"]
 edition = "2018"
 

--- a/contracts/cw-names-registry/Cargo.toml
+++ b/contracts/cw-names-registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-names-registry"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Callum Anderson <callumanderson745@gmail.com>"]
 edition = "2018"
 

--- a/contracts/cw-native-staked-balance-voting/Cargo.toml
+++ b/contracts/cw-native-staked-balance-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-native-staked-balance-voting"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Callum Anderson <callumanderson745@gmail.com>"]
 edition = "2018"
 
@@ -33,7 +33,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 cw-core-macros = { version = "*", path = "../../packages/cw-core-macros" }
 cw-core-interface = { version = "*", path = "../../packages/cw-core-interface" }
-cw-paginate = { version = "0.1.0", path = "../../packages/cw-paginate" }
+cw-paginate = { version = "0.2.0", path = "../../packages/cw-paginate" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }

--- a/contracts/cw-native-staked-balance-voting/src/contract.rs
+++ b/contracts/cw-native-staked-balance-voting/src/contract.rs
@@ -1,6 +1,5 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::testing::{mock_dependencies, mock_env};
 use cosmwasm_std::{
     coins, to_binary, BankMsg, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response,
     StdResult, Uint128,
@@ -17,8 +16,8 @@ use crate::msg::{
 };
 use crate::state::{Config, CLAIMS, CONFIG, DAO, MAX_CLAIMS, STAKED_BALANCES, STAKED_TOTAL};
 
-const CONTRACT_NAME: &str = "crates.io:cw-native-staked-balance-voting";
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub(crate) const CONTRACT_NAME: &str = "crates.io:cw-native-staked-balance-voting";
+pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn validate_duration(duration: Option<Duration>) -> Result<(), ContractError> {
     if let Some(unstaking_duration) = duration {
@@ -363,14 +362,4 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
     // Set contract to version to latest
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
-}
-
-#[test]
-pub fn test_migrate_update_version() {
-    let mut deps = mock_dependencies();
-    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
-    migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
-    let version = cw2::get_contract_version(&deps.storage).unwrap();
-    assert_eq!(version.version, CONTRACT_VERSION);
-    assert_eq!(version.contract, CONTRACT_NAME);
 }

--- a/contracts/cw-native-staked-balance-voting/src/contract.rs
+++ b/contracts/cw-native-staked-balance-voting/src/contract.rs
@@ -358,7 +358,8 @@ pub fn query_list_stakers(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // Don't do any state migrations.
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    // Set contract to version to latest
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }

--- a/contracts/cw-native-staked-balance-voting/src/contract.rs
+++ b/contracts/cw-native-staked-balance-voting/src/contract.rs
@@ -1,5 +1,6 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
+use cosmwasm_std::testing::{mock_dependencies, mock_env};
 use cosmwasm_std::{
     coins, to_binary, BankMsg, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response,
     StdResult, Uint128,
@@ -362,4 +363,14 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
     // Set contract to version to latest
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
+}
+
+#[test]
+pub fn test_migrate_update_version() {
+    let mut deps = mock_dependencies();
+    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
+    migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+    let version = cw2::get_contract_version(&deps.storage).unwrap();
+    assert_eq!(version.version, CONTRACT_VERSION);
+    assert_eq!(version.contract, CONTRACT_NAME);
 }

--- a/contracts/cw-native-staked-balance-voting/src/tests.rs
+++ b/contracts/cw-native-staked-balance-voting/src/tests.rs
@@ -1,7 +1,10 @@
+use crate::contract::{migrate, CONTRACT_NAME, CONTRACT_VERSION};
 use crate::msg::{
-    ExecuteMsg, InstantiateMsg, ListStakersResponse, Owner, QueryMsg, StakerBalanceResponse,
+    ExecuteMsg, InstantiateMsg, ListStakersResponse, MigrateMsg, Owner, QueryMsg,
+    StakerBalanceResponse,
 };
 use crate::state::Config;
+use cosmwasm_std::testing::{mock_dependencies, mock_env};
 use cosmwasm_std::{coins, Addr, Coin, Empty, Uint128};
 use cw_controllers::ClaimsResponse;
 use cw_core_interface::voting::{
@@ -969,4 +972,14 @@ fn test_query_list_stakers() {
         .unwrap();
 
     assert_eq!(stakers, ListStakersResponse { stakers: vec![] });
+}
+
+#[test]
+pub fn test_migrate_update_version() {
+    let mut deps = mock_dependencies();
+    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
+    migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+    let version = cw2::get_contract_version(&deps.storage).unwrap();
+    assert_eq!(version.version, CONTRACT_VERSION);
+    assert_eq!(version.contract, CONTRACT_NAME);
 }

--- a/contracts/cw-proposal-multiple/Cargo.toml
+++ b/contracts/cw-proposal-multiple/Cargo.toml
@@ -30,7 +30,7 @@ schemars = "0.8.8"
 serde = { version = "1.0.132", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.30" }
 voting = { path = "../../packages/voting" }
-cw-core = { path = "../cw-core", version = "0.1.0", features = ["library"] }
+cw-core = { path = "../cw-core", version = "*", features = ["library"] }
 cw-core-macros = { version = "0.1.0", path = "../../packages/cw-core-macros" }
 cw-core-interface = { version = "0.1.0", path = "../../packages/cw-core-interface" } 
 proposal-hooks = { version = "0.1.0", path = "../../packages/proposal-hooks" }

--- a/contracts/cw-proposal-multiple/Cargo.toml
+++ b/contracts/cw-proposal-multiple/Cargo.toml
@@ -31,11 +31,11 @@ serde = { version = "1.0.132", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.30" }
 voting = { path = "../../packages/voting" }
 cw-core = { path = "../cw-core", version = "*", features = ["library"] }
-cw-core-macros = { version = "0.1.0", path = "../../packages/cw-core-macros" }
-cw-core-interface = { version = "0.1.0", path = "../../packages/cw-core-interface" } 
-proposal-hooks = { version = "0.1.0", path = "../../packages/proposal-hooks" }
-vote-hooks = { version = "0.1.0", path = "../../packages/vote-hooks" }
-indexable-hooks = { version = "0.1.0", path = "../../packages/indexable-hooks" }
+cw-core-macros = { version = "0.2.0", path = "../../packages/cw-core-macros" }
+cw-core-interface = { version = "0.2.0", path = "../../packages/cw-core-interface" } 
+proposal-hooks = { version = "0.2.0", path = "../../packages/proposal-hooks" }
+vote-hooks = { version = "0.2.0", path = "../../packages/vote-hooks" }
+indexable-hooks = { version = "0.2.0", path = "../../packages/indexable-hooks" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }

--- a/contracts/cw-proposal-multiple/Cargo.toml
+++ b/contracts/cw-proposal-multiple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-proposal-multiple"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["blue-note"]
 edition = "2018"
 

--- a/contracts/cw-proposal-multiple/src/contract.rs
+++ b/contracts/cw-proposal-multiple/src/contract.rs
@@ -775,7 +775,8 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // Don't do any state migrations.
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    // Set contract to version to latest
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }

--- a/contracts/cw-proposal-multiple/src/tests.rs
+++ b/contracts/cw-proposal-multiple/src/tests.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::{
+    testing::{mock_dependencies, mock_env},
     to_binary, Addr, Binary, CosmosMsg, Decimal, Empty, Timestamp, Uint128, WasmMsg,
 };
 use cw20::Cw20Coin;
@@ -16,6 +17,7 @@ use voting::{
 };
 
 use crate::{
+    contract::{migrate, CONTRACT_NAME, CONTRACT_VERSION},
     msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg},
     proposal::MultipleChoiceProposal,
     query::{ProposalListResponse, ProposalResponse, VoteListResponse, VoteResponse},
@@ -5066,4 +5068,14 @@ fn test_timestamp_updated() {
 
     assert_eq!(updated.proposal.last_updated, latest_time);
     assert_eq!(updated.proposal.status, Status::Closed);
+}
+
+#[test]
+pub fn test_migrate_update_version() {
+    let mut deps = mock_dependencies();
+    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
+    migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+    let version = cw2::get_contract_version(&deps.storage).unwrap();
+    assert_eq!(version.version, CONTRACT_VERSION);
+    assert_eq!(version.contract, CONTRACT_NAME);
 }

--- a/contracts/cw-proposal-single/Cargo.toml
+++ b/contracts/cw-proposal-single/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-proposal-single"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Zeke Medley <zekemedley@gmail.com>"]
 edition = "2018"
 

--- a/contracts/cw-proposal-single/src/contract.rs
+++ b/contracts/cw-proposal-single/src/contract.rs
@@ -725,9 +725,12 @@ pub fn query_info(deps: Deps) -> StdResult<Binary> {
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
-    /// This proposal version is from commit
-    /// e531c760a5d057329afd98d62567aaa4dca2c96f (v1.0.0) and code ID
-    /// 427.
+    // Set contract to version to latest
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    // This proposal version is from commit
+    // e531c760a5d057329afd98d62567aaa4dca2c96f (v1.0.0) and code ID
+    // 427.
     #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
     struct V1Proposal {
         pub title: String,

--- a/contracts/cw-proposal-single/src/contract.rs
+++ b/contracts/cw-proposal-single/src/contract.rs
@@ -33,8 +33,8 @@ use crate::{
     state::{Ballot, BALLOTS, CONFIG, PROPOSALS, PROPOSAL_COUNT, PROPOSAL_HOOKS, VOTE_HOOKS},
 };
 
-const CONTRACT_NAME: &str = "crates.io:cw-govmod-single";
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub(crate) const CONTRACT_NAME: &str = "crates.io:cw-govmod-single";
+pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(

--- a/contracts/cw-proposal-single/src/tests.rs
+++ b/contracts/cw-proposal-single/src/tests.rs
@@ -26,7 +26,7 @@ use voting::{
 };
 
 use crate::{
-    contract::migrate,
+    contract::{migrate, CONTRACT_NAME, CONTRACT_VERSION},
     msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg},
     proposal::SingleChoiceProposal,
     query::{ProposalListResponse, ProposalResponse, VoteInfo, VoteResponse},
@@ -4950,4 +4950,14 @@ fn test_no_double_refund_on_execute_fail_and_close() {
         .unwrap();
 
     assert_eq!(balance.balance, Uint128::new(1));
+}
+
+#[test]
+pub fn test_migrate_update_version() {
+    let mut deps = mock_dependencies();
+    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
+    migrate(deps.as_mut(), mock_env(), MigrateMsg::FromCompatible {}).unwrap();
+    let version = cw2::get_contract_version(&deps.storage).unwrap();
+    assert_eq!(version.version, CONTRACT_VERSION);
+    assert_eq!(version.contract, CONTRACT_NAME);
 }

--- a/contracts/cw-token-swap/Cargo.toml
+++ b/contracts/cw-token-swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-token-swap"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Zeke Medley <zekemedley@gmail.com>"]
 edition = "2018"
 

--- a/contracts/cw-token-swap/src/contract.rs
+++ b/contracts/cw-token-swap/src/contract.rs
@@ -9,7 +9,7 @@ use cw_utils::must_pay;
 
 use crate::{
     error::ContractError,
-    msg::{ExecuteMsg, InstantiateMsg, QueryMsg, StatusResponse},
+    msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, StatusResponse},
     state::{CheckedCounterparty, CheckedTokenInfo, COUNTERPARTY_ONE, COUNTERPARTY_TWO},
 };
 
@@ -244,4 +244,11 @@ pub fn query_status(deps: Deps) -> StdResult<Binary> {
         counterparty_one,
         counterparty_two,
     })
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    // Set contract to version to latest
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::default())
 }

--- a/contracts/cw-token-swap/src/contract.rs
+++ b/contracts/cw-token-swap/src/contract.rs
@@ -13,8 +13,8 @@ use crate::{
     state::{CheckedCounterparty, CheckedTokenInfo, COUNTERPARTY_ONE, COUNTERPARTY_TWO},
 };
 
-const CONTRACT_NAME: &str = "crates.io:cw-token-swap";
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub(crate) const CONTRACT_NAME: &str = "crates.io:cw-token-swap";
+pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(

--- a/contracts/cw-token-swap/src/msg.rs
+++ b/contracts/cw-token-swap/src/msg.rs
@@ -58,3 +58,6 @@ pub struct StatusResponse {
     pub counterparty_one: CheckedCounterparty,
     pub counterparty_two: CheckedCounterparty,
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct MigrateMsg {}

--- a/contracts/cw-token-swap/src/tests.rs
+++ b/contracts/cw-token-swap/src/tests.rs
@@ -1,9 +1,15 @@
-use cosmwasm_std::{to_binary, Addr, Coin, Empty, Uint128};
+use cosmwasm_std::{
+    testing::{mock_dependencies, mock_env},
+    to_binary, Addr, Coin, Empty, Uint128,
+};
 use cw20::Cw20Coin;
 use cw_multi_test::{App, BankSudo, Contract, ContractWrapper, Executor, SudoMsg};
 
 use crate::{
-    msg::{Counterparty, ExecuteMsg, InstantiateMsg, QueryMsg, StatusResponse, TokenInfo},
+    contract::{migrate, CONTRACT_NAME, CONTRACT_VERSION},
+    msg::{
+        Counterparty, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, StatusResponse, TokenInfo,
+    },
     state::{CheckedCounterparty, CheckedTokenInfo},
     ContractError,
 };
@@ -1044,4 +1050,14 @@ fn test_fund_invalid_cw20() {
         .unwrap();
 
     assert_eq!(err, ContractError::InvalidFunds {})
+}
+
+#[test]
+pub fn test_migrate_update_version() {
+    let mut deps = mock_dependencies();
+    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
+    migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+    let version = cw2::get_contract_version(&deps.storage).unwrap();
+    assert_eq!(version.version, CONTRACT_VERSION);
+    assert_eq!(version.contract, CONTRACT_NAME);
 }

--- a/contracts/cw20-stake-external-rewards/src/contract.rs
+++ b/contracts/cw20-stake-external-rewards/src/contract.rs
@@ -13,7 +13,6 @@ use crate::ContractError::{
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 
-use cosmwasm_std::testing::{mock_env, mock_dependencies};
 use cosmwasm_std::{
     from_binary, to_binary, Addr, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Empty, Env,
     MessageInfo, Response, StdError, StdResult, Uint128, Uint256, WasmMsg,
@@ -515,9 +514,17 @@ pub fn query_pending_rewards(
 mod tests {
     use std::borrow::BorrowMut;
 
-    use crate::ContractError;
+    use crate::{
+        contract::{migrate, CONTRACT_NAME, CONTRACT_VERSION},
+        msg::MigrateMsg,
+        ContractError,
+    };
 
-    use cosmwasm_std::{coin, to_binary, Addr, Empty, Uint128};
+    use cosmwasm_std::{
+        coin,
+        testing::{mock_dependencies, mock_env},
+        to_binary, Addr, Empty, Uint128,
+    };
     use cw20::{Cw20Coin, Cw20ExecuteMsg, Denom};
     use cw_utils::Duration;
 
@@ -2195,14 +2202,14 @@ mod tests {
             .execute_contract(admin, reward_addr, &fund_msg, &reward_funding)
             .unwrap_err();
     }
-}
 
-#[test]
-pub fn test_migrate_update_version() {
-    let mut deps = mock_dependencies();
-    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
-    migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
-    let version = cw2::get_contract_version(&deps.storage).unwrap();
-    assert_eq!(version.version, CONTRACT_VERSION);
-    assert_eq!(version.contract, CONTRACT_NAME);
+    #[test]
+    pub fn test_migrate_update_version() {
+        let mut deps = mock_dependencies();
+        cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
+        migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+        let version = cw2::get_contract_version(&deps.storage).unwrap();
+        assert_eq!(version.version, CONTRACT_VERSION);
+        assert_eq!(version.contract, CONTRACT_NAME);
+    }
 }

--- a/contracts/cw20-stake-external-rewards/src/contract.rs
+++ b/contracts/cw20-stake-external-rewards/src/contract.rs
@@ -13,6 +13,7 @@ use crate::ContractError::{
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 
+use cosmwasm_std::testing::{mock_env, mock_dependencies};
 use cosmwasm_std::{
     from_binary, to_binary, Addr, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Empty, Env,
     MessageInfo, Response, StdError, StdResult, Uint128, Uint256, WasmMsg,
@@ -2147,7 +2148,7 @@ mod tests {
     }
 
     #[test]
-    fn test_zero_reward_rate_faild() {
+    fn test_zero_reward_rate_failed() {
         // This test is due to a bug when funder provides rewards config that results in less then 1
         // reward per block which rounds down to zer0
         let mut app = mock_app();
@@ -2194,4 +2195,14 @@ mod tests {
             .execute_contract(admin, reward_addr, &fund_msg, &reward_funding)
             .unwrap_err();
     }
+}
+
+#[test]
+pub fn test_migrate_update_version() {
+    let mut deps = mock_dependencies();
+    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
+    migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+    let version = cw2::get_contract_version(&deps.storage).unwrap();
+    assert_eq!(version.version, CONTRACT_VERSION);
+    assert_eq!(version.contract, CONTRACT_NAME);
 }

--- a/contracts/cw20-stake-external-rewards/src/contract.rs
+++ b/contracts/cw20-stake-external-rewards/src/contract.rs
@@ -103,8 +103,9 @@ pub fn instantiate(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // No state migrations performed, just returned a Response
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    // Set contract to version to latest
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }
 

--- a/contracts/cw20-stake-reward-distributor/Cargo.toml
+++ b/contracts/cw20-stake-reward-distributor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stake-cw20-reward-distributor"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 authors = ["Vernon Johnson <vtj2105@columbia.edu>"]
 

--- a/contracts/cw20-stake-reward-distributor/src/contract.rs
+++ b/contracts/cw20-stake-reward-distributor/src/contract.rs
@@ -10,8 +10,8 @@ use crate::state::{Config, CONFIG, LAST_PAYMENT_BLOCK};
 use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 use cw2::set_contract_version;
 
-const CONTRACT_NAME: &str = "crates.io:cw20-stake-reward-distributor";
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub(crate) const CONTRACT_NAME: &str = "crates.io:cw20-stake-reward-distributor";
+pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(

--- a/contracts/cw20-stake-reward-distributor/src/contract.rs
+++ b/contracts/cw20-stake-reward-distributor/src/contract.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::entry_point;
 use cosmwasm_std::{to_binary, Addr, CosmosMsg, StdError, Uint128, WasmMsg};
 
 use crate::error::ContractError;
-use crate::msg::{ExecuteMsg, InfoResponse, InstantiateMsg, QueryMsg};
+use crate::msg::{ExecuteMsg, InfoResponse, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::state::{Config, CONFIG, LAST_PAYMENT_BLOCK};
 use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 use cw2::set_contract_version;
@@ -231,6 +231,13 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Info {} => to_binary(&query_info(deps, env)?),
     }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    // Set contract to version to latest
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::default())
 }
 
 fn query_info(deps: Deps, env: Env) -> StdResult<InfoResponse> {

--- a/contracts/cw20-stake-reward-distributor/src/msg.rs
+++ b/contracts/cw20-stake-reward-distributor/src/msg.rs
@@ -36,3 +36,6 @@ pub struct InfoResponse {
     pub last_payment_block: u64,
     pub balance: Uint128,
 }
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq, Eq)]
+pub struct MigrateMsg {}

--- a/contracts/cw20-stake-reward-distributor/src/tests.rs
+++ b/contracts/cw20-stake-reward-distributor/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::{
-    contract::{migrate, CONTRACT_VERSION, CONTRACT_NAME},
+    contract::{migrate, CONTRACT_NAME, CONTRACT_VERSION},
     msg::{ExecuteMsg, InfoResponse, InstantiateMsg, MigrateMsg, QueryMsg},
     state::Config,
     ContractError,

--- a/contracts/cw20-stake-reward-distributor/src/tests.rs
+++ b/contracts/cw20-stake-reward-distributor/src/tests.rs
@@ -1,9 +1,13 @@
 use crate::{
-    msg::{ExecuteMsg, InfoResponse, InstantiateMsg, QueryMsg},
+    contract::{migrate, CONTRACT_VERSION, CONTRACT_NAME},
+    msg::{ExecuteMsg, InfoResponse, InstantiateMsg, MigrateMsg, QueryMsg},
     state::Config,
     ContractError,
 };
-use cosmwasm_std::{Addr, Empty, Uint128};
+use cosmwasm_std::{
+    testing::{mock_dependencies, mock_env},
+    Addr, Empty, Uint128,
+};
 use cw20::Cw20Coin;
 use cw_multi_test::{App, Contract, ContractWrapper, Executor};
 
@@ -533,4 +537,14 @@ fn test_dao_deploy() {
     let distributor_info = get_info(&app, distributor_addr);
     assert_eq!(distributor_info.balance, Uint128::new(990));
     assert_eq!(distributor_info.last_payment_block, app.block_info().height);
+}
+
+#[test]
+pub fn test_migrate_update_version() {
+    let mut deps = mock_dependencies();
+    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
+    migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+    let version = cw2::get_contract_version(&deps.storage).unwrap();
+    assert_eq!(version.version, CONTRACT_VERSION);
+    assert_eq!(version.contract, CONTRACT_NAME);
 }

--- a/contracts/cw20-stake/Cargo.toml
+++ b/contracts/cw20-stake/Cargo.toml
@@ -27,7 +27,7 @@ cw2 = "0.13"
 schemars = "0.8.8"
 serde = { version = "1.0.132", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.30" }
-cw-paginate = { version = "0.1.0", path = "../../packages/cw-paginate" }
+cw-paginate = { version = "0.2.0", path = "../../packages/cw-paginate" }
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }

--- a/contracts/cw20-stake/src/contract.rs
+++ b/contracts/cw20-stake/src/contract.rs
@@ -32,8 +32,8 @@ pub use cw20_base::enumerable::{query_all_accounts, query_all_allowances};
 use cw_controllers::ClaimsResponse;
 use cw_utils::Duration;
 
-const CONTRACT_NAME: &str = "crates.io:cw20-stake";
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub(crate) const CONTRACT_NAME: &str = "crates.io:cw20-stake";
+pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn validate_duration(duration: Option<Duration>) -> Result<(), ContractError> {
     if let Some(unstaking_duration) = duration {

--- a/contracts/cw20-stake/src/contract.rs
+++ b/contracts/cw20-stake/src/contract.rs
@@ -497,6 +497,9 @@ pub fn query_list_stakers(
 pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
     use serde::{Deserialize, Serialize};
 
+    // Set contract to version to latest
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
     #[derive(Serialize, Deserialize, Clone)]
     struct BetaConfig {
         pub admin: Addr,

--- a/contracts/cw20-stake/src/tests.rs
+++ b/contracts/cw20-stake/src/tests.rs
@@ -1,6 +1,6 @@
 use std::borrow::BorrowMut;
 
-use crate::contract::migrate;
+use crate::contract::{migrate, CONTRACT_NAME, CONTRACT_VERSION};
 use crate::msg::{
     ExecuteMsg, ListStakersResponse, MigrateMsg, QueryMsg, ReceiveMsg,
     StakedBalanceAtHeightResponse, StakedValueResponse, StakerBalanceResponse,
@@ -1201,4 +1201,14 @@ fn test_query_list_stakers() {
     };
 
     assert_eq!(stakers, test_res)
+}
+
+#[test]
+pub fn test_migrate_update_version() {
+    let mut deps = mock_dependencies();
+    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
+    migrate(deps.as_mut(), mock_env(), MigrateMsg::FromCompatible {}).unwrap();
+    let version = cw2::get_contract_version(&deps.storage).unwrap();
+    assert_eq!(version.version, CONTRACT_VERSION);
+    assert_eq!(version.contract, CONTRACT_NAME);
 }

--- a/contracts/cw20-staked-balance-voting/Cargo.toml
+++ b/contracts/cw20-staked-balance-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-staked-balance-voting"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Callum Anderson <callumanderson745@gmail.com>"]
 edition = "2018"
 

--- a/contracts/cw20-staked-balance-voting/src/contract.rs
+++ b/contracts/cw20-staked-balance-voting/src/contract.rs
@@ -20,8 +20,8 @@ use crate::state::{
     STAKING_CONTRACT_UNSTAKING_DURATION, TOKEN,
 };
 
-const CONTRACT_NAME: &str = "crates.io:cw20-staked-balance-voting";
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub(crate) const CONTRACT_NAME: &str = "crates.io:cw20-staked-balance-voting";
+pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const INSTANTIATE_TOKEN_REPLY_ID: u64 = 0;
 const INSTANTIATE_STAKING_REPLY_ID: u64 = 1;

--- a/contracts/cw20-staked-balance-voting/src/contract.rs
+++ b/contracts/cw20-staked-balance-voting/src/contract.rs
@@ -342,8 +342,9 @@ pub fn query_active_threshold(deps: Deps) -> StdResult<Binary> {
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // Don't do any state migrations.
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    // Set contract to version to latest
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }
 

--- a/contracts/cw20-staked-balance-voting/src/tests.rs
+++ b/contracts/cw20-staked-balance-voting/src/tests.rs
@@ -1,12 +1,18 @@
-use cosmwasm_std::{to_binary, Addr, CosmosMsg, Decimal, Empty, Uint128, WasmMsg};
+use cosmwasm_std::{
+    testing::{mock_dependencies, mock_env},
+    to_binary, Addr, CosmosMsg, Decimal, Empty, Uint128, WasmMsg,
+};
 use cw2::ContractVersion;
 use cw20::{BalanceResponse, Cw20Coin, MinterResponse, TokenInfoResponse};
 use cw_core_interface::voting::{InfoResponse, IsActiveResponse, VotingPowerAtHeightResponse};
 use cw_multi_test::{next_block, App, Contract, ContractWrapper, Executor};
 
-use crate::msg::{
-    ActiveThreshold, ActiveThresholdResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
-    StakingInfo,
+use crate::{
+    contract::{migrate, CONTRACT_NAME, CONTRACT_VERSION},
+    msg::{
+        ActiveThreshold, ActiveThresholdResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
+        StakingInfo,
+    },
 };
 
 const DAO_ADDR: &str = "dao";
@@ -1349,4 +1355,14 @@ fn test_migrate() {
         .unwrap();
 
     assert_eq!(info, new_info);
+}
+
+#[test]
+pub fn test_migrate_update_version() {
+    let mut deps = mock_dependencies();
+    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
+    migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+    let version = cw2::get_contract_version(&deps.storage).unwrap();
+    assert_eq!(version.version, CONTRACT_VERSION);
+    assert_eq!(version.contract, CONTRACT_NAME);
 }

--- a/contracts/cw4-voting/Cargo.toml
+++ b/contracts/cw4-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw4-voting"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Callum Anderson <callumanderson745@gmail.com>"]
 edition = "2018"
 
@@ -37,8 +37,8 @@ cw-utils = "0.13"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
-cw-core-macros = { version = "0.1.0", path = "../../packages/cw-core-macros" }
-cw-core-interface = { version = "0.1.0", path = "../../packages/cw-core-interface" }
+cw-core-macros = { version = "0.2.0", path = "../../packages/cw-core-macros" }
+cw-core-interface = { version = "0.2.0", path = "../../packages/cw-core-interface" }
 cw4 = "0.13"
 cw4-group = "0.13"
 

--- a/contracts/cw4-voting/src/contract.rs
+++ b/contracts/cw4-voting/src/contract.rs
@@ -186,8 +186,9 @@ pub fn query_info(deps: Deps) -> StdResult<Binary> {
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    // Don't do any state migrations.
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    // Set contract to version to latest
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
 }
 

--- a/contracts/cw4-voting/src/contract.rs
+++ b/contracts/cw4-voting/src/contract.rs
@@ -11,8 +11,8 @@ use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::state::{DAO_ADDRESS, GROUP_CONTRACT, TOTAL_WEIGHT, USER_WEIGHTS};
 
-const CONTRACT_NAME: &str = "crates.io:cw4-voting";
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub(crate) const CONTRACT_NAME: &str = "crates.io:cw4-voting";
+pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 const INSTANTIATE_GROUP_REPLY_ID: u64 = 0;
 

--- a/contracts/cw4-voting/src/tests.rs
+++ b/contracts/cw4-voting/src/tests.rs
@@ -1,4 +1,7 @@
-use cosmwasm_std::{to_binary, Addr, CosmosMsg, Empty, Uint128, WasmMsg, testing::{mock_dependencies, mock_env}};
+use cosmwasm_std::{
+    testing::{mock_dependencies, mock_env},
+    to_binary, Addr, CosmosMsg, Empty, Uint128, WasmMsg,
+};
 use cw2::ContractVersion;
 use cw_core_interface::voting::{
     InfoResponse, TotalPowerAtHeightResponse, VotingPowerAtHeightResponse,
@@ -6,8 +9,9 @@ use cw_core_interface::voting::{
 use cw_multi_test::{next_block, App, Contract, ContractWrapper, Executor};
 
 use crate::{
+    contract::{migrate, CONTRACT_NAME, CONTRACT_VERSION},
     msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg},
-    ContractError, contract::{migrate, CONTRACT_VERSION, CONTRACT_NAME},
+    ContractError,
 };
 
 const DAO_ADDR: &str = "dao";

--- a/contracts/cw4-voting/src/tests.rs
+++ b/contracts/cw4-voting/src/tests.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{to_binary, Addr, CosmosMsg, Empty, Uint128, WasmMsg};
+use cosmwasm_std::{to_binary, Addr, CosmosMsg, Empty, Uint128, WasmMsg, testing::{mock_dependencies, mock_env}};
 use cw2::ContractVersion;
 use cw_core_interface::voting::{
     InfoResponse, TotalPowerAtHeightResponse, VotingPowerAtHeightResponse,
@@ -7,7 +7,7 @@ use cw_multi_test::{next_block, App, Contract, ContractWrapper, Executor};
 
 use crate::{
     msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg},
-    ContractError,
+    ContractError, contract::{migrate, CONTRACT_VERSION, CONTRACT_NAME},
 };
 
 const DAO_ADDR: &str = "dao";
@@ -663,4 +663,14 @@ fn test_zero_voting_power() {
         .unwrap();
     assert_eq!(total_voting_power.power, Uint128::new(2u128));
     assert_eq!(total_voting_power.height, app.block_info().height);
+}
+
+#[test]
+pub fn test_migrate_update_version() {
+    let mut deps = mock_dependencies();
+    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
+    migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+    let version = cw2::get_contract_version(&deps.storage).unwrap();
+    assert_eq!(version.version, CONTRACT_VERSION);
+    assert_eq!(version.contract, CONTRACT_NAME);
 }

--- a/contracts/cw721-stake/Cargo.toml
+++ b/contracts/cw721-stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721-stake"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["CypherApe cypherape@protonmail.com"]
 edition = "2018"
 license = "Apache-2.0"
@@ -19,10 +19,10 @@ library = []
 cosmwasm-std = { version = "1.0.0" }
 cw-storage-plus = { version = "0.13" }
 cw-controllers = "0.13"
-cw-core-macros = { version = "0.1.0", path = "../../packages/cw-core-macros" }
-cw-core-interface =  { version = "0.1.0", path = "../../packages/cw-core-interface" }
-cw721-controllers = { version = "0.1.0", path = "../../packages/cw721-controllers" }
-cw-paginate = { version = "0.1.0", path = "../../packages/cw-paginate" }
+cw-core-macros = { version = "0.2.0", path = "../../packages/cw-core-macros" }
+cw-core-interface =  { version = "0.2.0", path = "../../packages/cw-core-interface" }
+cw721-controllers = { version = "0.2.0", path = "../../packages/cw721-controllers" }
+cw-paginate = { version = "0.2.0", path = "../../packages/cw-paginate" }
 cw721 = { version = "0.13" }
 cw-utils = { version = "0.13" }
 cw2 = "0.13"

--- a/contracts/cw721-stake/src/contract.rs
+++ b/contracts/cw721-stake/src/contract.rs
@@ -1,4 +1,5 @@
 use crate::hooks::{stake_hook_msgs, unstake_hook_msgs};
+use crate::msg::MigrateMsg;
 #[cfg(not(feature = "library"))]
 use crate::msg::{
     ExecuteMsg, GetHooksResponse, InstantiateMsg, Owner, QueryMsg, StakedBalanceAtHeightResponse,
@@ -524,4 +525,11 @@ pub fn query_staked_nfts(
     }
 
     to_binary(&res)
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    // Set contract to version to latest
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::default())
 }

--- a/contracts/cw721-stake/src/contract.rs
+++ b/contracts/cw721-stake/src/contract.rs
@@ -9,7 +9,6 @@ use crate::state::{
     Config, CONFIG, HOOKS, MAX_CLAIMS, NFT_CLAIMS, STAKED_NFTS_PER_OWNER, TOTAL_STAKED_NFTS,
 };
 use crate::ContractError;
-use cosmwasm_std::testing::{mock_dependencies, mock_env};
 use cosmwasm_std::{
     entry_point, to_binary, Addr, Binary, CosmosMsg, Deps, DepsMut, Empty, Env, MessageInfo,
     Response, StdError, StdResult, Uint128, WasmMsg,
@@ -533,14 +532,4 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
     // Set contract to version to latest
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
-}
-
-#[test]
-pub fn test_migrate_update_version() {
-    let mut deps = mock_dependencies();
-    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
-    migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
-    let version = cw2::get_contract_version(&deps.storage).unwrap();
-    assert_eq!(version.version, CONTRACT_VERSION);
-    assert_eq!(version.contract, CONTRACT_NAME);
 }

--- a/contracts/cw721-stake/src/contract.rs
+++ b/contracts/cw721-stake/src/contract.rs
@@ -9,6 +9,7 @@ use crate::state::{
     Config, CONFIG, HOOKS, MAX_CLAIMS, NFT_CLAIMS, STAKED_NFTS_PER_OWNER, TOTAL_STAKED_NFTS,
 };
 use crate::ContractError;
+use cosmwasm_std::testing::{mock_dependencies, mock_env};
 use cosmwasm_std::{
     entry_point, to_binary, Addr, Binary, CosmosMsg, Deps, DepsMut, Empty, Env, MessageInfo,
     Response, StdError, StdResult, Uint128, WasmMsg,
@@ -532,4 +533,14 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, C
     // Set contract to version to latest
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default())
+}
+
+#[test]
+pub fn test_migrate_update_version() {
+    let mut deps = mock_dependencies();
+    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
+    migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+    let version = cw2::get_contract_version(&deps.storage).unwrap();
+    assert_eq!(version.version, CONTRACT_VERSION);
+    assert_eq!(version.contract, CONTRACT_NAME);
 }

--- a/contracts/cw721-stake/src/msg.rs
+++ b/contracts/cw721-stake/src/msg.rs
@@ -103,3 +103,6 @@ pub struct TotalStakedAtHeightResponse {
 pub struct GetHooksResponse {
     pub hooks: Vec<String>,
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+pub struct MigrateMsg {}

--- a/contracts/cw721-stake/src/tests.rs
+++ b/contracts/cw721-stake/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::contract::{CONTRACT_NAME, CONTRACT_VERSION, migrate};
+use crate::contract::{migrate, CONTRACT_NAME, CONTRACT_VERSION};
 use crate::msg::{
     ExecuteMsg, MigrateMsg, Owner, QueryMsg, StakedBalanceAtHeightResponse,
     TotalStakedAtHeightResponse,

--- a/contracts/cw721-stake/src/tests.rs
+++ b/contracts/cw721-stake/src/tests.rs
@@ -1,6 +1,7 @@
-use crate::contract::{CONTRACT_NAME, CONTRACT_VERSION};
+use crate::contract::{CONTRACT_NAME, CONTRACT_VERSION, migrate};
 use crate::msg::{
-    ExecuteMsg, Owner, QueryMsg, StakedBalanceAtHeightResponse, TotalStakedAtHeightResponse,
+    ExecuteMsg, MigrateMsg, Owner, QueryMsg, StakedBalanceAtHeightResponse,
+    TotalStakedAtHeightResponse,
 };
 use crate::state::{Config, MAX_CLAIMS};
 use crate::ContractError;
@@ -1189,4 +1190,14 @@ fn test_unstake_that_which_you_do_not_own() {
 
     let total_staked = query_total_staked(&app, &staking_addr);
     assert_eq!(total_staked, Uint128::zero());
+}
+
+#[test]
+pub fn test_migrate_update_version() {
+    let mut deps = mock_dependencies();
+    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
+    migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+    let version = cw2::get_contract_version(&deps.storage).unwrap();
+    assert_eq!(version.version, CONTRACT_VERSION);
+    assert_eq!(version.contract, CONTRACT_NAME);
 }

--- a/debug/cw-proposal-sudo/Cargo.toml
+++ b/debug/cw-proposal-sudo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-proposal-sudo"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Zeke Medley <zekemedley@gmail.com>"]
 edition = "2018"
 

--- a/debug/cw20-balance-voting/Cargo.toml
+++ b/debug/cw20-balance-voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw20-balance-voting"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Zeke Medley <zekemedley@gmail.com>"]
 edition = "2018"
 
@@ -38,8 +38,8 @@ cw-utils = "0.13"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
-cw-core-macros = { version = "0.1.0", path = "../../packages/cw-core-macros" }
-cw-core-interface = { version = "0.1.0", path = "../../packages/cw-core-interface" }
+cw-core-macros = { version = "0.2.0", path = "../../packages/cw-core-macros" }
+cw-core-interface = { version = "0.2.0", path = "../../packages/cw-core-interface" }
 cw20-base = {  version = "0.13", features = ["library"] }
 
 [dev-dependencies]

--- a/debug/proposal-hooks-counter/Cargo.toml
+++ b/debug/proposal-hooks-counter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proposal-hooks-counter"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Callum Anderson <callumanderson745@gmail.com>"]
 edition = "2018"
 
@@ -36,16 +36,16 @@ cw2 = "0.13"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
-proposal-hooks = { version = "0.1.0", path = "../../packages/proposal-hooks" }
-vote-hooks = { version = "0.1.0", path = "../../packages/vote-hooks" }
+proposal-hooks = { version = "0.2.0", path = "../../packages/proposal-hooks" }
+vote-hooks = { version = "0.2.0", path = "../../packages/vote-hooks" }
 
 [dev-dependencies]
-indexable-hooks = { version = "0.1.0", path = "../../packages/indexable-hooks" }
+indexable-hooks = { version = "0.2.0", path = "../../packages/indexable-hooks" }
 cw20 = "0.13"
-cw20-balance-voting = { path = "../cw20-balance-voting", version = "0.1.0" }
+cw20-balance-voting = { path = "../cw20-balance-voting", version = "0.2.0" }
 cw20-base = "0.13"
 cw-utils = "0.13"
-voting = { version = "0.1.0", path = "../../packages/voting" }
+voting = { version = "0.2.0", path = "../../packages/voting" }
 cw-core = { path = "../../contracts/cw-core", version = "*", features = ["library"] }
 cw-proposal-single = { path = "../../contracts/cw-proposal-single" }
 cosmwasm-schema = { version = "1.0.0" }

--- a/debug/proposal-hooks-counter/Cargo.toml
+++ b/debug/proposal-hooks-counter/Cargo.toml
@@ -46,7 +46,7 @@ cw20-balance-voting = { path = "../cw20-balance-voting", version = "0.1.0" }
 cw20-base = "0.13"
 cw-utils = "0.13"
 voting = { version = "0.1.0", path = "../../packages/voting" }
-cw-core = { path = "../../contracts/cw-core", version = "0.1.0", features = ["library"] }
+cw-core = { path = "../../contracts/cw-core", version = "*", features = ["library"] }
 cw-proposal-single = { path = "../../contracts/cw-proposal-single" }
 cosmwasm-schema = { version = "1.0.0" }
 cw-multi-test = "0.13"

--- a/legacy/cw3-dao/Cargo.lock
+++ b/legacy/cw3-dao/Cargo.lock
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "cw_dao"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/legacy/cw4-registry/Cargo.lock
+++ b/legacy/cw4-registry/Cargo.lock
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "project-name"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
   "cosmwasm-schema",
   "cosmwasm-std",

--- a/packages/cw-core-interface/Cargo.toml
+++ b/packages/cw-core-interface/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "cw-core-interface"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 cosmwasm-std = { version = "1.0.0" }
-cw-core-macros = { version = "0.1.0", path = "../../packages/cw-core-macros" } 
+cw-core-macros = { version = "0.2.0", path = "../../packages/cw-core-macros" } 
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 schemars = "0.8"
 cw2 = "0.13"

--- a/packages/cw-core-macros/Cargo.toml
+++ b/packages/cw-core-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-core-macros"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]

--- a/packages/cw-paginate/Cargo.toml
+++ b/packages/cw-paginate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-paginate"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/packages/cw721-controllers/Cargo.toml
+++ b/packages/cw721-controllers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw721-controllers"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["CypherApe cypherape@protonmail.com"]
 edition = "2018"
 description = "Common cw721 controllers we can reuse in many contracts"

--- a/packages/indexable-hooks/Cargo.toml
+++ b/packages/indexable-hooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexable-hooks"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/packages/proposal-hooks/Cargo.toml
+++ b/packages/proposal-hooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proposal-hooks"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,5 +9,5 @@ edition = "2021"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 cosmwasm-std = "1.0.0"
-indexable-hooks = { version = "0.1.0", path = "../indexable-hooks" }
-voting = { version = "0.1.0", path = "../voting" }
+indexable-hooks = { version = "0.2.0", path = "../indexable-hooks" }
+voting = { version = "0.2.0", path = "../voting" }

--- a/packages/testing/Cargo.toml
+++ b/packages/testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testing"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # This crate depends on multi-test and rand. These are not features in

--- a/packages/vote-hooks/Cargo.toml
+++ b/packages/vote-hooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vote-hooks"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,5 +9,5 @@ edition = "2021"
 schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 cosmwasm-std = "1.0.0"
-indexable-hooks = { version = "0.1.0", path = "../indexable-hooks" }
-voting = { version = "0.1.0", path = "../voting" }
+indexable-hooks = { version = "0.2.0", path = "../indexable-hooks" }
+voting = { version = "0.2.0", path = "../voting" }

--- a/packages/voting/Cargo.toml
+++ b/packages/voting/Cargo.toml
@@ -12,6 +12,6 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 cw20 = "0.12"
 cw-core-interface = { version = "0.1.0", path = "../cw-core-interface" } 
-cw-core = { path = "../../contracts/cw-core", version = "0.1.0"}
+cw-core = { path = "../../contracts/cw-core", version = "*"}
 cw-utils = "0.13"
 cw-storage-plus = "0.12"

--- a/packages/voting/Cargo.toml
+++ b/packages/voting/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voting"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,7 +11,7 @@ schemars = "0.8"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 cw20 = "0.12"
-cw-core-interface = { version = "0.1.0", path = "../cw-core-interface" } 
+cw-core-interface = { version = "0.2.0", path = "../cw-core-interface" } 
 cw-core = { path = "../../contracts/cw-core", version = "*"}
 cw-utils = "0.13"
 cw-storage-plus = "0.12"

--- a/types/yarn.lock
+++ b/types/yarn.lock
@@ -7,7 +7,7 @@
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
   integrity sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==
   dependencies:
-    "@jridgewell/gen-mapping" "^0.2.0"
+    "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@apidevtools/json-schema-ref-parser@9.0.9":
@@ -1194,7 +1194,7 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@jridgewell/gen-mapping@^0.2.0":
+"@jridgewell/gen-mapping@^0.1.0":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
   integrity sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==
@@ -1510,9 +1510,9 @@ arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-ast-stringify@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/ast-stringify/-/ast-stringify-0.2.0.tgz#5c6439fbfb4513dcc26c7d34464ccd084ed91cb7"
+ast-stringify@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ast-stringify/-/ast-stringify-0.1.0.tgz#5c6439fbfb4513dcc26c7d34464ccd084ed91cb7"
   integrity sha512-J1PgFYV3RG6r37+M6ySZJH406hR82okwGvFM9hLXpOvdx4WC4GEW8/qiw6pi1hKTrqcRvoHP8a7mp87egYr6iA==
   dependencies:
     "@babel/runtime" "^7.11.2"
@@ -2101,8 +2101,8 @@ follow-redirects@^1.14.0:
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
 fs-extra@^10.0.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.2.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
   dependencies:
     graceful-fs "^4.2.0"
@@ -2609,9 +2609,9 @@ long@^5.2.0:
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.0.tgz#2696dadf4b4da2ce3f6f6b89186085d94d52fd61"
   integrity sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==
 
-lru-queue@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.2.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
+lru-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
   integrity sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==
   dependencies:
     es5-ext "~0.10.2"
@@ -2631,7 +2631,7 @@ memoizee@^0.4.15:
     es6-weak-map "^2.0.3"
     event-emitter "^0.3.5"
     is-promise "^2.2.2"
-    lru-queue "^0.2.0"
+    lru-queue "^0.1.0"
     next-tick "^1.1.0"
     timers-ext "^0.1.7"
 
@@ -3478,7 +3478,7 @@ wasm-ast-types@^0.4.3:
   dependencies:
     "@babel/runtime" "^7.18.3"
     "@babel/types" "7.18.4"
-    ast-stringify "0.2.0"
+    ast-stringify "0.1.0"
     case "1.6.3"
 
 which@^2.0.1:

--- a/types/yarn.lock
+++ b/types/yarn.lock
@@ -7,7 +7,7 @@
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
   integrity sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==
   dependencies:
-    "@jridgewell/gen-mapping" "^0.1.0"
+    "@jridgewell/gen-mapping" "^0.2.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
 "@apidevtools/json-schema-ref-parser@9.0.9":
@@ -1194,7 +1194,7 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@jridgewell/gen-mapping@^0.1.0":
+"@jridgewell/gen-mapping@^0.2.0":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
   integrity sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==
@@ -1510,9 +1510,9 @@ arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-ast-stringify@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/ast-stringify/-/ast-stringify-0.1.0.tgz#5c6439fbfb4513dcc26c7d34464ccd084ed91cb7"
+ast-stringify@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ast-stringify/-/ast-stringify-0.2.0.tgz#5c6439fbfb4513dcc26c7d34464ccd084ed91cb7"
   integrity sha512-J1PgFYV3RG6r37+M6ySZJH406hR82okwGvFM9hLXpOvdx4WC4GEW8/qiw6pi1hKTrqcRvoHP8a7mp87egYr6iA==
   dependencies:
     "@babel/runtime" "^7.11.2"
@@ -2101,8 +2101,8 @@ follow-redirects@^1.14.0:
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
 fs-extra@^10.0.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.2.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
   dependencies:
     graceful-fs "^4.2.0"
@@ -2609,9 +2609,9 @@ long@^5.2.0:
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.0.tgz#2696dadf4b4da2ce3f6f6b89186085d94d52fd61"
   integrity sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==
 
-lru-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
+lru-queue@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.2.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
   integrity sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==
   dependencies:
     es5-ext "~0.10.2"
@@ -2631,7 +2631,7 @@ memoizee@^0.4.15:
     es6-weak-map "^2.0.3"
     event-emitter "^0.3.5"
     is-promise "^2.2.2"
-    lru-queue "^0.1.0"
+    lru-queue "^0.2.0"
     next-tick "^1.1.0"
     timers-ext "^0.1.7"
 
@@ -3478,7 +3478,7 @@ wasm-ast-types@^0.4.3:
   dependencies:
     "@babel/runtime" "^7.18.3"
     "@babel/types" "7.18.4"
-    ast-stringify "0.1.0"
+    ast-stringify "0.2.0"
     case "1.6.3"
 
 which@^2.0.1:


### PR DESCRIPTION
I know how we do the versioning will change with [this PR](https://github.com/DA0-DA0/dao-contracts/pull/461), but let's also make sure we update the contract version in the migrate methods. This will enable us to start testing v2 contracts from frontend as well (checks the contract version)