### PR TITLE
Absolute count threshold for multi-proposals 

### DIFF
--- a/contracts/cw-proposal-multiple/src/proposal.rs
+++ b/contracts/cw-proposal-multiple/src/proposal.rs
@@ -125,7 +125,7 @@ impl MultipleChoiceProposal {
             VotingStrategy::SingleChoice(threshold) => {
                 match threshold {
                     MultipleProposalThreshold::Absoulute { threshold } => {
-                        if self.votes.total() < Uint128::from(*threshold) {
+                        if self.votes.total() < *threshold {
                             return Ok(false);
                         }
                         

--- a/contracts/cw-proposal-multiple/src/proposal.rs
+++ b/contracts/cw-proposal-multiple/src/proposal.rs
@@ -616,7 +616,7 @@ mod tests {
         // High Precision rounding
         let voting_strategy = VotingStrategy::SingleChoice(
             MultipleProposalThreshold::Percentage { quorum: voting::threshold::PercentageThreshold::Percent(
-                cosmwasm_std::Decimal::percent(10),
+                cosmwasm_std::Decimal::percent(100),
             )}
         );
 
@@ -639,7 +639,7 @@ mod tests {
         // High Precision rounding
         let voting_strategy = VotingStrategy::SingleChoice(
             MultipleProposalThreshold::Percentage { quorum: voting::threshold::PercentageThreshold::Percent(
-                cosmwasm_std::Decimal::percent(10),
+                cosmwasm_std::Decimal::percent(99),
             )}
         );
 

--- a/contracts/cw-proposal-multiple/src/proposal.rs
+++ b/contracts/cw-proposal-multiple/src/proposal.rs
@@ -12,7 +12,7 @@ use voting::{
 use crate::{
     query::ProposalResponse,
     state::{CheckedMultipleChoiceOption, MultipleChoiceOptionType},
-    voting_strategy::{VotingStrategy, MultipleProposalThreshold},
+    voting_strategy::{MultipleProposalThreshold, VotingStrategy},
 };
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema, Debug)]
@@ -122,25 +122,18 @@ impl MultipleChoiceProposal {
         }
 
         match &self.voting_strategy {
-            VotingStrategy::SingleChoice(threshold) => {
-                match threshold {
-                    MultipleProposalThreshold::Absoulute { threshold } => {
-                        if self.votes.total() < *threshold {
-                            return Ok(false);
-                        }
-                        
-                    },
-                    MultipleProposalThreshold::Percentage { quorum } => {
-                         if !does_vote_count_pass(
-                            self.votes.total(),
-                            self.total_power,
-                            *quorum,
-                        ) {
-                            return Ok(false);
-                        }
-                    },
+            VotingStrategy::SingleChoice(threshold) => match threshold {
+                MultipleProposalThreshold::Absoulute { threshold } => {
+                    if self.votes.total() < *threshold {
+                        return Ok(false);
+                    }
                 }
-            }
+                MultipleProposalThreshold::Percentage { quorum } => {
+                    if !does_vote_count_pass(self.votes.total(), self.total_power, *quorum) {
+                        return Ok(false);
+                    }
+                }
+            },
         }
 
         let vote_result = self.calculate_vote_result()?;
@@ -184,26 +177,17 @@ impl MultipleChoiceProposal {
             }
             VoteResult::SingleWinner(winning_choice) => {
                 let vote_passes = match &self.voting_strategy {
-                    VotingStrategy::SingleChoice(threshold) => {
-                        match threshold {
-                            MultipleProposalThreshold::Absoulute { threshold } => {
-                                self.votes.total() > *threshold
-                            },
-                            MultipleProposalThreshold::Percentage { quorum } => {
-                                does_vote_count_pass(
-                                    self.votes.total(),
-                                    self.total_power,
-                                    *quorum,
-                                )
-                            },
+                    VotingStrategy::SingleChoice(threshold) => match threshold {
+                        MultipleProposalThreshold::Absoulute { threshold } => {
+                            self.votes.total() > *threshold
                         }
-                    }
+                        MultipleProposalThreshold::Percentage { quorum } => {
+                            does_vote_count_pass(self.votes.total(), self.total_power, *quorum)
+                        }
+                    },
                 };
 
-                match (
-                    vote_passes,
-                    self.expiration.is_expired(block),
-                ) {
+                match (vote_passes, self.expiration.is_expired(block)) {
                     // Quorum is met and proposal is expired.
                     (true, true) => {
                         // Proposal is rejected if "None" is the winning option.
@@ -355,9 +339,9 @@ mod tests {
     #[test]
     fn test_majority_quorum() {
         let env = mock_env();
-        let voting_strategy = VotingStrategy::SingleChoice (
-            MultipleProposalThreshold::Percentage { quorum: voting::threshold::PercentageThreshold::Majority {} }
-        );
+        let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: voting::threshold::PercentageThreshold::Majority {},
+        });
 
         let votes = MultipleChoiceVotes {
             vote_weights: vec![Uint128::new(1), Uint128::new(0), Uint128::new(0)],
@@ -460,11 +444,11 @@ mod tests {
     #[test]
     fn test_percentage_quorum() {
         let env = mock_env();
-        let voting_strategy = VotingStrategy::SingleChoice(
-            MultipleProposalThreshold::Percentage { quorum: voting::threshold::PercentageThreshold::Percent(
+        let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: voting::threshold::PercentageThreshold::Percent(
                 cosmwasm_std::Decimal::percent(10),
-            )}
-        );
+            ),
+        });
 
         let votes = MultipleChoiceVotes {
             vote_weights: vec![Uint128::new(1), Uint128::new(0), Uint128::new(0)],
@@ -567,9 +551,9 @@ mod tests {
     #[test]
     fn test_absolute_quorum() {
         let env = mock_env();
-        let voting_strategy = VotingStrategy::SingleChoice(
-            MultipleProposalThreshold::Absoulute { threshold: Uint128::new(5) }
-        );
+        let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Absoulute {
+            threshold: Uint128::new(5),
+        });
 
         let votes = MultipleChoiceVotes {
             vote_weights: vec![Uint128::new(10), Uint128::new(0), Uint128::new(0)],
@@ -672,11 +656,11 @@ mod tests {
     #[test]
     fn test_unbeatable_none_option() {
         let env = mock_env();
-        let voting_strategy = VotingStrategy::SingleChoice(
-            MultipleProposalThreshold::Percentage { quorum: voting::threshold::PercentageThreshold::Percent(
+        let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: voting::threshold::PercentageThreshold::Percent(
                 cosmwasm_std::Decimal::percent(10),
-            )}
-        );
+            ),
+        });
         let votes = MultipleChoiceVotes {
             vote_weights: vec![Uint128::new(0), Uint128::new(50), Uint128::new(500)],
         };
@@ -697,11 +681,11 @@ mod tests {
     #[test]
     fn test_quorum_rounding() {
         let env = mock_env();
-        let voting_strategy = VotingStrategy::SingleChoice(
-            MultipleProposalThreshold::Percentage { quorum: voting::threshold::PercentageThreshold::Percent(
+        let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: voting::threshold::PercentageThreshold::Percent(
                 cosmwasm_std::Decimal::percent(10),
-            )}
-        );
+            ),
+        });
         let votes = MultipleChoiceVotes {
             vote_weights: vec![Uint128::new(10), Uint128::new(0), Uint128::new(0)],
         };
@@ -719,11 +703,11 @@ mod tests {
         assert!(!prop.is_rejected(&env.block).unwrap());
 
         // High Precision rounding
-        let voting_strategy = VotingStrategy::SingleChoice(
-            MultipleProposalThreshold::Percentage { quorum: voting::threshold::PercentageThreshold::Percent(
+        let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: voting::threshold::PercentageThreshold::Percent(
                 cosmwasm_std::Decimal::percent(100),
-            )}
-        );
+            ),
+        });
 
         let votes = MultipleChoiceVotes {
             vote_weights: vec![Uint128::new(999999), Uint128::new(0), Uint128::new(0)],
@@ -742,11 +726,11 @@ mod tests {
         assert!(prop.is_rejected(&env.block).unwrap());
 
         // High Precision rounding
-        let voting_strategy = VotingStrategy::SingleChoice(
-            MultipleProposalThreshold::Percentage { quorum: voting::threshold::PercentageThreshold::Percent(
+        let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: voting::threshold::PercentageThreshold::Percent(
                 cosmwasm_std::Decimal::percent(99),
-            )}
-        );
+            ),
+        });
 
         let votes = MultipleChoiceVotes {
             vote_weights: vec![Uint128::new(9888889), Uint128::new(0), Uint128::new(0)],
@@ -768,11 +752,11 @@ mod tests {
     #[test]
     fn test_tricky_pass() {
         let env = mock_env();
-        let voting_strategy = VotingStrategy::SingleChoice(
-            MultipleProposalThreshold::Percentage { quorum: voting::threshold::PercentageThreshold::Percent(
+        let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: voting::threshold::PercentageThreshold::Percent(
                 cosmwasm_std::Decimal::from_ratio(7u32, 13u32),
-            )}
-        );
+            ),
+        });
         let votes = MultipleChoiceVotes {
             vote_weights: vec![Uint128::new(7), Uint128::new(0), Uint128::new(6)],
         };
@@ -806,9 +790,9 @@ mod tests {
     #[test]
     fn test_tricky_pass_majority() {
         let env = mock_env();
-        let voting_strategy = VotingStrategy::SingleChoice (
-            MultipleProposalThreshold::Percentage { quorum: voting::threshold::PercentageThreshold::Majority {} }
-        );
+        let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: voting::threshold::PercentageThreshold::Majority {},
+        });
 
         let votes = MultipleChoiceVotes {
             vote_weights: vec![Uint128::new(7), Uint128::new(0), Uint128::new(0)],
@@ -845,9 +829,9 @@ mod tests {
         // Revoting being allowed means that proposals may not be
         // passed or rejected before they expire.
         let env = mock_env();
-        let voting_strategy = VotingStrategy::SingleChoice (
-            MultipleProposalThreshold::Percentage { quorum: voting::threshold::PercentageThreshold::Majority {} }
-        );
+        let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: voting::threshold::PercentageThreshold::Majority {},
+        });
         let votes = MultipleChoiceVotes {
             vote_weights: vec![Uint128::new(6), Uint128::new(0), Uint128::new(0)],
         };
@@ -880,9 +864,9 @@ mod tests {
         // Revoting being allowed means that proposals may not be
         // passed or rejected before they expire.
         let env = mock_env();
-        let voting_strategy = VotingStrategy::SingleChoice (
-            MultipleProposalThreshold::Percentage { quorum: voting::threshold::PercentageThreshold::Majority {} }
-        );
+        let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: voting::threshold::PercentageThreshold::Majority {},
+        });
         let votes = MultipleChoiceVotes {
             vote_weights: vec![Uint128::new(5), Uint128::new(5), Uint128::new(0)],
         };
@@ -919,11 +903,11 @@ mod tests {
         // Revoting being allowed means that proposals may not be
         // passed or rejected before they expire.
         let env = mock_env();
-        let voting_strategy = VotingStrategy::SingleChoice(
-            MultipleProposalThreshold::Percentage { quorum: voting::threshold::PercentageThreshold::Percent(
+        let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: voting::threshold::PercentageThreshold::Percent(
                 cosmwasm_std::Decimal::percent(80),
-            )}
-        );
+            ),
+        });
 
         let votes = MultipleChoiceVotes {
             vote_weights: vec![Uint128::new(81), Uint128::new(0), Uint128::new(0)],
@@ -957,11 +941,11 @@ mod tests {
         // Revoting being allowed means that proposals may not be
         // passed or rejected before they expire.
         let env = mock_env();
-        let voting_strategy = VotingStrategy::SingleChoice(
-            MultipleProposalThreshold::Percentage { quorum: voting::threshold::PercentageThreshold::Percent(
+        let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: voting::threshold::PercentageThreshold::Percent(
                 cosmwasm_std::Decimal::percent(80),
-            )}
-        );
+            ),
+        });
 
         let votes = MultipleChoiceVotes {
             vote_weights: vec![Uint128::new(90), Uint128::new(0), Uint128::new(0)],

--- a/contracts/cw-proposal-multiple/src/tests.rs
+++ b/contracts/cw-proposal-multiple/src/tests.rs
@@ -568,8 +568,8 @@ where
         );
     }
 
-    // // High Precision
-    // // Proposal should be rejected if < 1% have voted and proposal expires
+    // High Precision
+    // Proposal should be rejected if < 1% have voted and proposal expires
     do_votes(
         vec![TestMultipleChoiceVote {
             voter: "bluenote".to_string(),

--- a/contracts/cw-proposal-multiple/src/tests.rs
+++ b/contracts/cw-proposal-multiple/src/tests.rs
@@ -22,7 +22,7 @@ use crate::{
     proposal::MultipleChoiceProposal,
     query::{ProposalListResponse, ProposalResponse, VoteListResponse, VoteResponse},
     state::{Config, MultipleChoiceOption, MultipleChoiceOptions, VoteInfo, MAX_NUM_CHOICES},
-    voting_strategy::VotingStrategy,
+    voting_strategy::{VotingStrategy, MultipleProposalThreshold},
     ContractError,
 };
 
@@ -339,9 +339,11 @@ where
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Percent(Decimal::percent(100)),
-        },
+        VotingStrategy::SingleChoice(
+            MultipleProposalThreshold::Percentage { 
+                quorum: PercentageThreshold::Percent(Decimal::percent(100)),
+            }
+        ),
         Status::Passed,
         None,
         false,
@@ -355,9 +357,11 @@ where
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Percent(Decimal::percent(100)),
-        },
+        VotingStrategy::SingleChoice(
+            MultipleProposalThreshold::Percentage { 
+                quorum: PercentageThreshold::Percent(Decimal::percent(100)),
+            }
+        ),
         Status::Rejected,
         None,
         false,
@@ -376,9 +380,11 @@ where
             weight: Uint128::new(10),
             should_execute: ShouldExecute::No,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Percent(Decimal::percent(100)),
-        },
+        VotingStrategy::SingleChoice(
+            MultipleProposalThreshold::Percentage { 
+                quorum: PercentageThreshold::Percent(Decimal::percent(100)),
+            }
+        ),
         Status::Open,
         None,
         false,
@@ -396,9 +402,11 @@ where
             weight: Uint128::new(u128::max_value()),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Percent(Decimal::percent(100)),
-        },
+        VotingStrategy::SingleChoice(
+            MultipleProposalThreshold::Percentage { 
+                quorum: PercentageThreshold::Percent(Decimal::percent(100)),
+            }
+        ),
         Status::Passed,
         None,
         false,
@@ -419,9 +427,11 @@ where
                 should_execute: ShouldExecute::Yes,
             },
         ],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Percent(Decimal::percent(100)),
-        },
+        VotingStrategy::SingleChoice(
+            MultipleProposalThreshold::Percentage { 
+                quorum: PercentageThreshold::Percent(Decimal::percent(100)),
+            }
+        ),
         Status::Passed,
         None,
         false,
@@ -447,9 +457,11 @@ where
                 should_execute: ShouldExecute::Yes,
             },
         ],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Percent(Decimal::percent(100)),
-        },
+        VotingStrategy::SingleChoice(
+            MultipleProposalThreshold::Percentage { 
+                quorum: PercentageThreshold::Percent(Decimal::percent(100)),
+            }
+        ),
         Status::Rejected,
         None,
         false,
@@ -467,9 +479,11 @@ where
             weight: Uint128::new(u64::max_value().into()),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Percent(Decimal::percent(100)),
-        },
+        VotingStrategy::SingleChoice(
+            MultipleProposalThreshold::Percentage { 
+                quorum: PercentageThreshold::Percent(Decimal::percent(100)),
+            }
+        ),
         Status::Rejected,
         None,
         false,
@@ -483,9 +497,11 @@ where
                 weight: Uint128::new(u64::max_value().into()),
                 should_execute: ShouldExecute::Yes,
             }],
-            VotingStrategy::SingleChoice {
-                quorum: PercentageThreshold::Percent(Decimal::percent(i)),
-            },
+            VotingStrategy::SingleChoice(
+                MultipleProposalThreshold::Percentage { 
+                    quorum: PercentageThreshold::Percent(Decimal::percent(i)),
+                }
+            ),
             Status::Rejected,
             None,
             false,
@@ -508,9 +524,11 @@ where
             weight: Uint128::new(1),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Percent(Decimal::percent(1)),
-        },
+        VotingStrategy::SingleChoice(
+            MultipleProposalThreshold::Percentage { 
+                quorum: PercentageThreshold::Percent(Decimal::percent(1)),
+            }
+        ),
         Status::Passed,
         Some(Uint128::new(100)),
         true,
@@ -523,9 +541,11 @@ where
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Percent(Decimal::percent(1)),
-        },
+        VotingStrategy::SingleChoice(
+            MultipleProposalThreshold::Percentage { 
+                quorum: PercentageThreshold::Percent(Decimal::percent(1)),
+            }
+        ),
         Status::Passed,
         Some(Uint128::new(1000)),
         true,
@@ -540,9 +560,11 @@ where
             weight: Uint128::new(9999999),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Percent(Decimal::percent(1)),
-        },
+        VotingStrategy::SingleChoice(
+            MultipleProposalThreshold::Percentage { 
+                quorum: PercentageThreshold::Percent(Decimal::percent(1)),
+            }
+        ),
         Status::Rejected,
         Some(Uint128::new(1000000000)),
         true,
@@ -556,9 +578,11 @@ where
             weight: Uint128::new(1),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Percent(Decimal::percent(1)),
-        },
+        VotingStrategy::SingleChoice(
+            MultipleProposalThreshold::Percentage { 
+                quorum: PercentageThreshold::Percent(Decimal::percent(1)),
+            }
+        ),
         Status::Rejected,
         None,
         false,
@@ -584,9 +608,11 @@ where
                 should_execute: ShouldExecute::No,
             },
         ],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Percent(Decimal::percent(100)),
-        },
+        VotingStrategy::SingleChoice(
+            MultipleProposalThreshold::Percentage { 
+                quorum: PercentageThreshold::Percent(Decimal::percent(100)),
+            }
+        ),
         // NOTE: Updating our cw20-base version will cause this to
         // fail. In versions of cw20-base before Feb 15 2022 (the one
         // we use at the time of writing) it was allowed to have an
@@ -620,9 +646,9 @@ where
                 should_execute: ShouldExecute::Yes,
             },
         ],
-        VotingStrategy::SingleChoice {
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Percent(Decimal::percent(50)),
-        },
+        }),
         Status::Passed,
         Some(Uint128::new(40)),
         true,
@@ -644,9 +670,7 @@ where
                 should_execute: ShouldExecute::Yes,
             },
         ],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Majority {},
-        },
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
         Status::Rejected,
         Some(Uint128::new(40)),
         true,
@@ -664,9 +688,9 @@ where
             weight: Uint128::new(60),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Percent(Decimal::percent(60)),
-        },
+        }),
         Status::Passed,
         Some(Uint128::new(100)),
         false,
@@ -680,9 +704,9 @@ where
             weight: Uint128::new(60),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Percent(Decimal::percent(60)),
-        },
+        }),
         Status::Rejected,
         Some(Uint128::new(100)),
         false,
@@ -748,9 +772,7 @@ where
 
         do_votes(
             votes,
-            VotingStrategy::SingleChoice {
-                quorum: PercentageThreshold::Majority {},
-            },
+            VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
             expected_status,
             None,
             true,
@@ -766,7 +788,7 @@ fn test_propose() {
     let max_voting_period = cw_utils::Duration::Height(6);
     let quorum = PercentageThreshold::Majority {};
 
-    let voting_strategy = VotingStrategy::SingleChoice { quorum };
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
 
     let instantiate = InstantiateMsg {
         max_voting_period,
@@ -882,7 +904,7 @@ fn test_propose_wrong_num_choices() {
     let max_voting_period = cw_utils::Duration::Height(6);
     let quorum = PercentageThreshold::Majority {};
 
-    let voting_strategy = VotingStrategy::SingleChoice { quorum };
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
 
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -1078,9 +1100,9 @@ fn test_migrate() {
     let govmod_id = app.store_code(proposal_contract());
 
     let msg = InstantiateMsg {
-        voting_strategy: VotingStrategy::SingleChoice {
+        voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Percent(Decimal::percent(10)),
-        },
+        }),
         max_voting_period: Duration::Time(10),
         min_voting_period: None,
         close_proposal_on_execution_failure: true,
@@ -1137,9 +1159,9 @@ fn test_proposal_count_initialized_to_zero() {
     let mut app = App::default();
     let proposal_id = app.store_code(proposal_contract());
     let msg = InstantiateMsg {
-        voting_strategy: VotingStrategy::SingleChoice {
+        voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Percent(Decimal::percent(10)),
-        },
+        }),
         max_voting_period: Duration::Height(10),
         min_voting_period: None,
         close_proposal_on_execution_failure: true,
@@ -1176,9 +1198,9 @@ fn test_no_early_pass_with_min_duration() {
     let mut app = App::default();
     let govmod_id = app.store_code(proposal_contract());
     let msg = InstantiateMsg {
-        voting_strategy: VotingStrategy::SingleChoice {
+        voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Percent(Decimal::percent(10)),
-        },
+        }),
         max_voting_period: Duration::Height(10),
         min_voting_period: Some(Duration::Height(2)),
         only_members_execute: true,
@@ -1273,9 +1295,9 @@ fn test_propose_with_messages() {
     let mut app = App::default();
     let govmod_id = app.store_code(proposal_contract());
     let msg = InstantiateMsg {
-        voting_strategy: VotingStrategy::SingleChoice {
+        voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Percent(Decimal::percent(10)),
-        },
+        }),
         max_voting_period: Duration::Height(10),
         min_voting_period: None,
         close_proposal_on_execution_failure: true,
@@ -1310,9 +1332,7 @@ fn test_propose_with_messages() {
     let govmod = proposal_modules.into_iter().next().unwrap().address;
 
     let config_msg = ExecuteMsg::UpdateConfig {
-        voting_strategy: VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Majority {},
-        },
+        voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
         min_voting_period: None,
         close_proposal_on_execution_failure: true,
         max_voting_period: cw_utils::Duration::Height(20),
@@ -1396,9 +1416,9 @@ fn test_min_duration_units_missmatch() {
     let mut app = App::default();
     let govmod_id = app.store_code(proposal_contract());
     let msg = InstantiateMsg {
-        voting_strategy: VotingStrategy::SingleChoice {
+        voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Percent(Decimal::percent(10)),
-        },
+        }),
         max_voting_period: Duration::Height(10),
         min_voting_period: Some(Duration::Time(2)),
         only_members_execute: true,
@@ -1429,9 +1449,9 @@ fn test_min_duration_larger_than_proposal_duration() {
     let mut app = App::default();
     let govmod_id = app.store_code(proposal_contract());
     let msg = InstantiateMsg {
-        voting_strategy: VotingStrategy::SingleChoice {
+        voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Percent(Decimal::percent(10)),
-        },
+        }),
         max_voting_period: Duration::Height(10),
         min_voting_period: Some(Duration::Height(11)),
         only_members_execute: true,
@@ -1461,9 +1481,9 @@ fn test_min_duration_same_as_proposal_duration() {
     let mut app = App::default();
     let govmod_id = app.store_code(proposal_contract());
     let msg = InstantiateMsg {
-        voting_strategy: VotingStrategy::SingleChoice {
+        voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Percent(Decimal::percent(10)),
-        },
+        }),
         max_voting_period: Duration::Time(10),
         min_voting_period: Some(Duration::Time(10)),
         only_members_execute: true,
@@ -1573,7 +1593,7 @@ fn test_voting_module_token_proposal_deposit_instantiate() {
     let govmod_id = app.store_code(proposal_contract());
 
     let quorum = PercentageThreshold::Majority {};
-    let voting_strategy = VotingStrategy::SingleChoice { quorum };
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let deposit_info = Some(DepositInfo {
         token: DepositToken::VotingModuleToken {},
@@ -1656,7 +1676,7 @@ fn test_different_token_proposal_deposit() {
         .unwrap();
 
     let quorum = PercentageThreshold::Percent(Decimal::percent(10));
-    let voting_strategy = VotingStrategy::SingleChoice { quorum };
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -1726,7 +1746,7 @@ fn test_bad_token_proposal_deposit() {
     });
 
     let quorum = PercentageThreshold::Percent(Decimal::percent(10));
-    let voting_strategy = VotingStrategy::SingleChoice { quorum };
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -1752,7 +1772,7 @@ fn test_take_proposal_deposit() {
     let govmod_id = app.store_code(proposal_contract());
 
     let quorum = PercentageThreshold::Percent(Decimal::percent(10));
-    let voting_strategy = VotingStrategy::SingleChoice { quorum };
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let deposit_info = Some(DepositInfo {
         token: DepositToken::VotingModuleToken {},
@@ -1879,9 +1899,7 @@ fn test_deposit_return_on_execute() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Majority {},
-        },
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
         Status::Passed,
         None,
         Some(DepositInfo {
@@ -1960,9 +1978,9 @@ fn test_deposit_return_zero() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Majority {},
-        },
+        VotingStrategy::SingleChoice(
+            MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }
+        ),
         Status::Passed,
         None,
         deposit_info,
@@ -2024,9 +2042,7 @@ fn test_query_list_votes() {
                 should_execute: ShouldExecute::Yes,
             },
         ],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Majority {},
-        },
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
         Status::Passed,
         None,
         None,
@@ -2080,9 +2096,9 @@ fn test_invalid_quorum() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Percent(Decimal::from_ratio(1u128, 10u128)),
-        },
+        }),
         Status::Rejected,
         None,
         None,
@@ -2100,9 +2116,7 @@ fn test_cant_vote_executed_or_closed() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Majority {},
-        },
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
         Status::Rejected,
         None,
         None,
@@ -2147,9 +2161,7 @@ fn test_cant_vote_executed_or_closed() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Majority {},
-        },
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
         Status::Passed,
         None,
         None,
@@ -2183,7 +2195,7 @@ fn test_cant_propose_zero_power() {
     let mut app = App::default();
     let govmod_id = app.store_code(proposal_contract());
     let quorum = PercentageThreshold::Percent(Decimal::percent(10));
-    let voting_strategy = VotingStrategy::SingleChoice { quorum };
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -2300,9 +2312,7 @@ fn test_cant_vote_not_registered() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Majority {},
-        },
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
         Status::Open,
         Some(Uint128::new(100)),
         Some(DepositInfo {
@@ -2350,7 +2360,7 @@ fn test_cant_execute_not_member() {
     let max_voting_period = cw_utils::Duration::Height(6);
     let quorum = PercentageThreshold::Majority {};
 
-    let voting_strategy = VotingStrategy::SingleChoice { quorum };
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
 
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -2457,9 +2467,7 @@ fn test_close_open_proposal() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Majority {},
-        },
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
         Status::Open,
         Some(Uint128::new(100)),
         Some(DepositInfo {
@@ -2532,9 +2540,7 @@ fn test_no_refund_failed_proposal() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Majority {},
-        },
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
         Status::Open,
         Some(Uint128::new(100)),
         Some(DepositInfo {
@@ -2596,9 +2602,7 @@ fn test_zero_deposit() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Majority {},
-        },
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
         Status::Passed,
         None,
         Some(DepositInfo {
@@ -2613,7 +2617,7 @@ fn test_zero_deposit() {
 #[test]
 fn test_deposit_return_on_close() {
     let quorum = PercentageThreshold::Percent(Decimal::percent(10));
-    let voting_strategy = VotingStrategy::SingleChoice { quorum };
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
 
     let (mut app, governance_addr) = do_test_votes_cw20_balances(
         vec![TestMultipleChoiceVote {
@@ -2689,7 +2693,7 @@ fn test_execute_expired_proposal() {
     let mut app = App::default();
     let govmod_id = app.store_code(proposal_contract());
     let quorum = PercentageThreshold::Percent(Decimal::percent(10));
-    let voting_strategy = VotingStrategy::SingleChoice { quorum };
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -2823,9 +2827,7 @@ fn test_update_config() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Majority {},
-        },
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
         Status::Passed,
         None,
         Some(DepositInfo {
@@ -2852,9 +2854,9 @@ fn test_update_config() {
 
     assert_eq!(
         govmod_config.voting_strategy,
-        VotingStrategy::SingleChoice {
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Majority {}
-        }
+        })
     );
 
     let dao = govmod_config.dao;
@@ -2865,9 +2867,9 @@ fn test_update_config() {
         Addr::unchecked("wrong"),
         govmod.clone(),
         &ExecuteMsg::UpdateConfig {
-            voting_strategy: VotingStrategy::SingleChoice {
+            voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
                 quorum: PercentageThreshold::Majority {},
-            },
+            }),
             min_voting_period: None,
             close_proposal_on_execution_failure: true,
             max_voting_period: cw_utils::Duration::Height(10),
@@ -2885,9 +2887,9 @@ fn test_update_config() {
         dao.clone(),
         govmod.clone(),
         &ExecuteMsg::UpdateConfig {
-            voting_strategy: VotingStrategy::SingleChoice {
+            voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
                 quorum: PercentageThreshold::Majority {},
-            },
+            }),
             min_voting_period: None,
             close_proposal_on_execution_failure: true,
             max_voting_period: cw_utils::Duration::Height(10),
@@ -2906,9 +2908,7 @@ fn test_update_config() {
         .unwrap();
 
     let expected = Config {
-        voting_strategy: VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Majority {},
-        },
+        voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
         min_voting_period: None,
         close_proposal_on_execution_failure: true,
         max_voting_period: cw_utils::Duration::Height(10),
@@ -2925,9 +2925,9 @@ fn test_update_config() {
         dao,
         govmod,
         &ExecuteMsg::UpdateConfig {
-            voting_strategy: VotingStrategy::SingleChoice {
+            voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
                 quorum: PercentageThreshold::Majority {},
-            },
+            }),
             min_voting_period: None,
             close_proposal_on_execution_failure: true,
             max_voting_period: cw_utils::Duration::Height(10),
@@ -2950,9 +2950,7 @@ fn test_no_return_if_no_refunds() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Majority {},
-        },
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
         Status::Rejected,
         None,
         Some(DepositInfo {
@@ -3006,7 +3004,7 @@ fn test_query_list_proposals() {
     let mut app = App::default();
     let govmod_id = app.store_code(proposal_contract());
     let quorum = PercentageThreshold::Majority {};
-    let voting_strategy = VotingStrategy::SingleChoice { quorum };
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -3175,7 +3173,7 @@ fn test_hooks() {
     let govmod_id = app.store_code(proposal_contract());
 
     let quorum = PercentageThreshold::Majority {};
-    let voting_strategy = VotingStrategy::SingleChoice { quorum };
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -3333,7 +3331,7 @@ fn test_active_threshold_absolute() {
     let govmod_id = app.store_code(proposal_contract());
 
     let quorum = PercentageThreshold::Majority {};
-    let voting_strategy = VotingStrategy::SingleChoice { quorum };
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -3471,7 +3469,7 @@ fn test_active_threshold_percent() {
     let mut app = App::default();
     let govmod_id = app.store_code(proposal_contract());
     let quorum = PercentageThreshold::Majority {};
-    let voting_strategy = VotingStrategy::SingleChoice { quorum };
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -3610,7 +3608,7 @@ fn test_active_threshold_none() {
     let mut app = App::default();
     let govmod_id = app.store_code(proposal_contract());
     let quorum = PercentageThreshold::Majority {};
-    let voting_strategy = VotingStrategy::SingleChoice { quorum };
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -3760,9 +3758,9 @@ fn test_revoting() {
             only_members_execute: false,
             allow_revoting: true,
             deposit_info: None,
-            voting_strategy: VotingStrategy::SingleChoice {
+            voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
                 quorum: PercentageThreshold::Majority {},
-            },
+            }),
             close_proposal_on_execution_failure: false,
         })
         .unwrap(),
@@ -3907,9 +3905,9 @@ fn test_allow_revoting_config_changes() {
             only_members_execute: false,
             allow_revoting: true,
             deposit_info: None,
-            voting_strategy: VotingStrategy::SingleChoice {
+            voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
                 quorum: PercentageThreshold::Majority {},
-            },
+            }),
             close_proposal_on_execution_failure: false,
         })
         .unwrap(),
@@ -3973,9 +3971,9 @@ fn test_allow_revoting_config_changes() {
             allow_revoting: false,
             dao: core_addr.to_string(),
             deposit_info: None,
-            voting_strategy: VotingStrategy::SingleChoice {
+            voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
                 quorum: PercentageThreshold::Majority {},
-            },
+            }),
             close_proposal_on_execution_failure: false,
         },
         &[],
@@ -4069,9 +4067,9 @@ fn test_revoting_same_vote_twice() {
             only_members_execute: false,
             allow_revoting: true,
             deposit_info: None,
-            voting_strategy: VotingStrategy::SingleChoice {
+            voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
                 quorum: PercentageThreshold::Majority {},
-            },
+            }),
             close_proposal_on_execution_failure: false,
         })
         .unwrap(),
@@ -4170,9 +4168,9 @@ fn test_invalid_revote_does_not_invalidate_initial_vote() {
             only_members_execute: false,
             allow_revoting: true,
             deposit_info: None,
-            voting_strategy: VotingStrategy::SingleChoice {
+            voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
                 quorum: PercentageThreshold::Majority {},
-            },
+            }),
             close_proposal_on_execution_failure: false,
         })
         .unwrap(),
@@ -4308,9 +4306,7 @@ fn test_return_deposit_to_dao_on_proposal_failure() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice {
-            quorum: PercentageThreshold::Majority {},
-        },
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
         Status::Open,
         Some(Uint128::new(100)),
         Some(DepositInfo {
@@ -4369,7 +4365,7 @@ fn test_close_failed_proposal() {
     let govmod_id = app.store_code(proposal_contract());
 
     let quorum = PercentageThreshold::Majority {};
-    let voting_strategy = VotingStrategy::SingleChoice { quorum };
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         max_voting_period,
@@ -4533,7 +4529,7 @@ fn test_close_failed_proposal() {
                             msgs: Some(vec![WasmMsg::Execute {
                                 contract_addr: govmod_single.to_string(),
                                 msg: to_binary(&ExecuteMsg::UpdateConfig {
-                                    voting_strategy: VotingStrategy::SingleChoice { quorum },
+                                    voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum }),
                                     max_voting_period: original.max_voting_period,
                                     min_voting_period: original.min_voting_period,
                                     only_members_execute: original.only_members_execute,
@@ -4629,9 +4625,9 @@ fn test_no_double_refund_on_execute_fail_and_close() {
     let mut app = App::default();
     let proposal_module_id = app.store_code(proposal_contract());
 
-    let voting_strategy = VotingStrategy::SingleChoice {
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
         quorum: PercentageThreshold::Majority {},
-    };
+    });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         voting_strategy,
@@ -4859,9 +4855,9 @@ fn test_timestamp_updated() {
     let mut app = App::default();
     let govmod_id = app.store_code(proposal_contract());
 
-    let voting_strategy = VotingStrategy::SingleChoice {
+    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
         quorum: PercentageThreshold::Majority {},
-    };
+    });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         voting_strategy,

--- a/contracts/cw-proposal-multiple/src/tests.rs
+++ b/contracts/cw-proposal-multiple/src/tests.rs
@@ -22,7 +22,7 @@ use crate::{
     proposal::MultipleChoiceProposal,
     query::{ProposalListResponse, ProposalResponse, VoteListResponse, VoteResponse},
     state::{Config, MultipleChoiceOption, MultipleChoiceOptions, VoteInfo, MAX_NUM_CHOICES},
-    voting_strategy::{VotingStrategy, MultipleProposalThreshold},
+    voting_strategy::{MultipleProposalThreshold, VotingStrategy},
     ContractError,
 };
 
@@ -330,12 +330,14 @@ fn do_test_votes_cw20_balances(
 pub fn test_simple_votes<F>(do_test_votes: F)
 where
     F: Fn(Vec<TestMultipleChoiceVote>, VotingStrategy, Status, Option<Uint128>, bool),
-{   
+{
     let strategies = vec![
         VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Percent(Decimal::percent(100)),
         }),
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Absoulute { threshold: Uint128::new(10) }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Absoulute {
+            threshold: Uint128::new(10),
+        }),
     ];
 
     for voting_strategy in strategies {
@@ -367,7 +369,6 @@ where
             false,
         )
     }
-
 }
 
 pub fn test_vote_invalid_option<F>(do_test_votes: F)
@@ -382,11 +383,9 @@ where
             weight: Uint128::new(10),
             should_execute: ShouldExecute::No,
         }],
-        VotingStrategy::SingleChoice(
-            MultipleProposalThreshold::Percentage { 
-                quorum: PercentageThreshold::Percent(Decimal::percent(100)),
-            }
-        ),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Percent(Decimal::percent(100)),
+        }),
         Status::Open,
         None,
         false,
@@ -404,11 +403,9 @@ where
             weight: Uint128::new(u128::max_value()),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice(
-            MultipleProposalThreshold::Percentage { 
-                quorum: PercentageThreshold::Percent(Decimal::percent(100)),
-            }
-        ),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Percent(Decimal::percent(100)),
+        }),
         Status::Passed,
         None,
         false,
@@ -429,11 +426,9 @@ where
                 should_execute: ShouldExecute::Yes,
             },
         ],
-        VotingStrategy::SingleChoice(
-            MultipleProposalThreshold::Percentage { 
-                quorum: PercentageThreshold::Percent(Decimal::percent(100)),
-            }
-        ),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Percent(Decimal::percent(100)),
+        }),
         Status::Passed,
         None,
         false,
@@ -448,7 +443,9 @@ where
         VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Percent(Decimal::percent(100)),
         }),
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Absoulute { threshold: Uint128::new(2) }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Absoulute {
+            threshold: Uint128::new(2),
+        }),
     ];
 
     for voting_strategy in strategies {
@@ -486,11 +483,9 @@ where
             weight: Uint128::new(u64::max_value().into()),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice(
-            MultipleProposalThreshold::Percentage { 
-                quorum: PercentageThreshold::Percent(Decimal::percent(100)),
-            }
-        ),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Percent(Decimal::percent(100)),
+        }),
         Status::Rejected,
         None,
         false,
@@ -504,11 +499,9 @@ where
                 weight: Uint128::new(u64::max_value().into()),
                 should_execute: ShouldExecute::Yes,
             }],
-            VotingStrategy::SingleChoice(
-                MultipleProposalThreshold::Percentage { 
-                    quorum: PercentageThreshold::Percent(Decimal::percent(i)),
-                }
-            ),
+            VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+                quorum: PercentageThreshold::Percent(Decimal::percent(i)),
+            }),
             Status::Rejected,
             None,
             false,
@@ -524,7 +517,9 @@ where
         VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Percent(Decimal::percent(1)),
         }),
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Absoulute { threshold: Uint128::new(1) }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Absoulute {
+            threshold: Uint128::new(1),
+        }),
     ];
 
     for voting_strategy in strategies {
@@ -610,11 +605,9 @@ where
                 should_execute: ShouldExecute::No,
             },
         ],
-        VotingStrategy::SingleChoice(
-            MultipleProposalThreshold::Percentage { 
-                quorum: PercentageThreshold::Percent(Decimal::percent(100)),
-            }
-        ),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Percent(Decimal::percent(100)),
+        }),
         // NOTE: Updating our cw20-base version will cause this to
         // fail. In versions of cw20-base before Feb 15 2022 (the one
         // we use at the time of writing) it was allowed to have an
@@ -637,7 +630,9 @@ where
         VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Percent(Decimal::percent(50)),
         }),
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Absoulute { threshold: Uint128::new(20) }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Absoulute {
+            threshold: Uint128::new(20),
+        }),
     ] {
         do_votes(
             vec![
@@ -666,7 +661,9 @@ where
         VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Majority {},
         }),
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Absoulute { threshold: Uint128::new(21) }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Absoulute {
+            threshold: Uint128::new(21),
+        }),
     ] {
         do_votes(
             vec![
@@ -699,7 +696,9 @@ where
         VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
             quorum: PercentageThreshold::Percent(Decimal::percent(60)),
         }),
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Absoulute { threshold: Uint128::new(60) }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Absoulute {
+            threshold: Uint128::new(60),
+        }),
     ];
 
     for voting_strategy in strategies {
@@ -730,7 +729,6 @@ where
             false,
         );
     }
-
 }
 
 pub fn fuzz_voting<F>(do_votes: F)
@@ -792,7 +790,9 @@ where
 
         do_votes(
             votes,
-            VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
+            VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+                quorum: PercentageThreshold::Majority {},
+            }),
             expected_status,
             None,
             true,
@@ -808,7 +808,8 @@ fn test_propose() {
     let max_voting_period = cw_utils::Duration::Height(6);
     let quorum = PercentageThreshold::Majority {};
 
-    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
+    let voting_strategy =
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
 
     let instantiate = InstantiateMsg {
         max_voting_period,
@@ -924,7 +925,8 @@ fn test_propose_wrong_num_choices() {
     let max_voting_period = cw_utils::Duration::Height(6);
     let quorum = PercentageThreshold::Majority {};
 
-    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
+    let voting_strategy =
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
 
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -1352,7 +1354,9 @@ fn test_propose_with_messages() {
     let govmod = proposal_modules.into_iter().next().unwrap().address;
 
     let config_msg = ExecuteMsg::UpdateConfig {
-        voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
+        voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Majority {},
+        }),
         min_voting_period: None,
         close_proposal_on_execution_failure: true,
         max_voting_period: cw_utils::Duration::Height(20),
@@ -1613,7 +1617,8 @@ fn test_voting_module_token_proposal_deposit_instantiate() {
     let govmod_id = app.store_code(proposal_contract());
 
     let quorum = PercentageThreshold::Majority {};
-    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
+    let voting_strategy =
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let deposit_info = Some(DepositInfo {
         token: DepositToken::VotingModuleToken {},
@@ -1696,7 +1701,8 @@ fn test_different_token_proposal_deposit() {
         .unwrap();
 
     let quorum = PercentageThreshold::Percent(Decimal::percent(10));
-    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
+    let voting_strategy =
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -1766,7 +1772,8 @@ fn test_bad_token_proposal_deposit() {
     });
 
     let quorum = PercentageThreshold::Percent(Decimal::percent(10));
-    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
+    let voting_strategy =
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -1792,7 +1799,8 @@ fn test_take_proposal_deposit() {
     let govmod_id = app.store_code(proposal_contract());
 
     let quorum = PercentageThreshold::Percent(Decimal::percent(10));
-    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
+    let voting_strategy =
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let deposit_info = Some(DepositInfo {
         token: DepositToken::VotingModuleToken {},
@@ -1919,7 +1927,9 @@ fn test_deposit_return_on_execute() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Majority {},
+        }),
         Status::Passed,
         None,
         Some(DepositInfo {
@@ -1998,9 +2008,9 @@ fn test_deposit_return_zero() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice(
-            MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }
-        ),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Majority {},
+        }),
         Status::Passed,
         None,
         deposit_info,
@@ -2062,7 +2072,9 @@ fn test_query_list_votes() {
                 should_execute: ShouldExecute::Yes,
             },
         ],
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Majority {},
+        }),
         Status::Passed,
         None,
         None,
@@ -2136,7 +2148,9 @@ fn test_cant_vote_executed_or_closed() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Majority {},
+        }),
         Status::Rejected,
         None,
         None,
@@ -2181,7 +2195,9 @@ fn test_cant_vote_executed_or_closed() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Majority {},
+        }),
         Status::Passed,
         None,
         None,
@@ -2215,7 +2231,8 @@ fn test_cant_propose_zero_power() {
     let mut app = App::default();
     let govmod_id = app.store_code(proposal_contract());
     let quorum = PercentageThreshold::Percent(Decimal::percent(10));
-    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
+    let voting_strategy =
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -2332,7 +2349,9 @@ fn test_cant_vote_not_registered() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Majority {},
+        }),
         Status::Open,
         Some(Uint128::new(100)),
         Some(DepositInfo {
@@ -2380,7 +2399,8 @@ fn test_cant_execute_not_member() {
     let max_voting_period = cw_utils::Duration::Height(6);
     let quorum = PercentageThreshold::Majority {};
 
-    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
+    let voting_strategy =
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
 
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -2487,7 +2507,9 @@ fn test_close_open_proposal() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Majority {},
+        }),
         Status::Open,
         Some(Uint128::new(100)),
         Some(DepositInfo {
@@ -2560,7 +2582,9 @@ fn test_no_refund_failed_proposal() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Majority {},
+        }),
         Status::Open,
         Some(Uint128::new(100)),
         Some(DepositInfo {
@@ -2622,7 +2646,9 @@ fn test_zero_deposit() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Majority {},
+        }),
         Status::Passed,
         None,
         Some(DepositInfo {
@@ -2637,7 +2663,8 @@ fn test_zero_deposit() {
 #[test]
 fn test_deposit_return_on_close() {
     let quorum = PercentageThreshold::Percent(Decimal::percent(10));
-    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
+    let voting_strategy =
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
 
     let (mut app, governance_addr) = do_test_votes_cw20_balances(
         vec![TestMultipleChoiceVote {
@@ -2713,7 +2740,8 @@ fn test_execute_expired_proposal() {
     let mut app = App::default();
     let govmod_id = app.store_code(proposal_contract());
     let quorum = PercentageThreshold::Percent(Decimal::percent(10));
-    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
+    let voting_strategy =
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -2847,7 +2875,9 @@ fn test_update_config() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Majority {},
+        }),
         Status::Passed,
         None,
         Some(DepositInfo {
@@ -2928,7 +2958,9 @@ fn test_update_config() {
         .unwrap();
 
     let expected = Config {
-        voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
+        voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Majority {},
+        }),
         min_voting_period: None,
         close_proposal_on_execution_failure: true,
         max_voting_period: cw_utils::Duration::Height(10),
@@ -2970,7 +3002,9 @@ fn test_no_return_if_no_refunds() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Majority {},
+        }),
         Status::Rejected,
         None,
         Some(DepositInfo {
@@ -3024,7 +3058,8 @@ fn test_query_list_proposals() {
     let mut app = App::default();
     let govmod_id = app.store_code(proposal_contract());
     let quorum = PercentageThreshold::Majority {};
-    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
+    let voting_strategy =
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -3193,7 +3228,8 @@ fn test_hooks() {
     let govmod_id = app.store_code(proposal_contract());
 
     let quorum = PercentageThreshold::Majority {};
-    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
+    let voting_strategy =
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -3351,7 +3387,8 @@ fn test_active_threshold_absolute() {
     let govmod_id = app.store_code(proposal_contract());
 
     let quorum = PercentageThreshold::Majority {};
-    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
+    let voting_strategy =
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -3489,7 +3526,8 @@ fn test_active_threshold_percent() {
     let mut app = App::default();
     let govmod_id = app.store_code(proposal_contract());
     let quorum = PercentageThreshold::Majority {};
-    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
+    let voting_strategy =
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -3628,7 +3666,8 @@ fn test_active_threshold_none() {
     let mut app = App::default();
     let govmod_id = app.store_code(proposal_contract());
     let quorum = PercentageThreshold::Majority {};
-    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
+    let voting_strategy =
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         min_voting_period: None,
@@ -4326,7 +4365,9 @@ fn test_return_deposit_to_dao_on_proposal_failure() {
             weight: Uint128::new(10),
             should_execute: ShouldExecute::Yes,
         }],
-        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum: PercentageThreshold::Majority {} }),
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage {
+            quorum: PercentageThreshold::Majority {},
+        }),
         Status::Open,
         Some(Uint128::new(100)),
         Some(DepositInfo {
@@ -4385,7 +4426,8 @@ fn test_close_failed_proposal() {
     let govmod_id = app.store_code(proposal_contract());
 
     let quorum = PercentageThreshold::Majority {};
-    let voting_strategy = VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
+    let voting_strategy =
+        VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum });
     let max_voting_period = cw_utils::Duration::Height(6);
     let instantiate = InstantiateMsg {
         max_voting_period,
@@ -4549,7 +4591,9 @@ fn test_close_failed_proposal() {
                             msgs: Some(vec![WasmMsg::Execute {
                                 contract_addr: govmod_single.to_string(),
                                 msg: to_binary(&ExecuteMsg::UpdateConfig {
-                                    voting_strategy: VotingStrategy::SingleChoice(MultipleProposalThreshold::Percentage { quorum }),
+                                    voting_strategy: VotingStrategy::SingleChoice(
+                                        MultipleProposalThreshold::Percentage { quorum },
+                                    ),
                                     max_voting_period: original.max_voting_period,
                                     min_voting_period: original.min_voting_period,
                                     only_members_execute: original.only_members_execute,

--- a/contracts/cw-proposal-multiple/src/tests.rs
+++ b/contracts/cw-proposal-multiple/src/tests.rs
@@ -22,7 +22,7 @@ use crate::{
     proposal::MultipleChoiceProposal,
     query::{ProposalListResponse, ProposalResponse, VoteListResponse, VoteResponse},
     state::{Config, MultipleChoiceOption, MultipleChoiceOptions, VoteInfo, MAX_NUM_CHOICES},
-    voting_strategy::{VotingStrategy, MultipleProposalThreshold, self},
+    voting_strategy::{VotingStrategy, MultipleProposalThreshold},
     ContractError,
 };
 

--- a/contracts/cw-proposal-multiple/src/voting_strategy.rs
+++ b/contracts/cw-proposal-multiple/src/voting_strategy.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::Uint128;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use voting::threshold::{validate_quorum, validate_count, PercentageThreshold, ThresholdError};
+use voting::threshold::{validate_count, validate_quorum, PercentageThreshold, ThresholdError};
 
 /// Determines the way votes are counted.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema, Debug)]
@@ -10,7 +10,6 @@ pub enum MultipleProposalThreshold {
     Percentage { quorum: PercentageThreshold },
     Absoulute { threshold: Uint128 },
 }
-
 
 /// Determines the way votes are counted.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema, Debug)]
@@ -22,12 +21,10 @@ pub enum VotingStrategy {
 impl VotingStrategy {
     pub fn validate(&self) -> Result<(), ThresholdError> {
         match self {
-            VotingStrategy::SingleChoice(thresold) => {
-                match thresold {
-                    MultipleProposalThreshold::Absoulute { threshold } => validate_count(threshold),
-                    MultipleProposalThreshold::Percentage{ quorum } => validate_quorum(quorum),
-                }    
-            }
-        }   
+            VotingStrategy::SingleChoice(thresold) => match thresold {
+                MultipleProposalThreshold::Absoulute { threshold } => validate_count(threshold),
+                MultipleProposalThreshold::Percentage { quorum } => validate_quorum(quorum),
+            },
+        }
     }
 }

--- a/contracts/cw-proposal-multiple/src/voting_strategy.rs
+++ b/contracts/cw-proposal-multiple/src/voting_strategy.rs
@@ -1,24 +1,33 @@
+use cosmwasm_std::Uint128;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use voting::threshold::{validate_quorum, PercentageThreshold, ThresholdError};
+use voting::threshold::{validate_quorum, validate_count, PercentageThreshold, ThresholdError};
+
+/// Determines the way votes are counted.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum MultipleProposalThreshold {
+    Percentage { quorum: PercentageThreshold },
+    Absoulute { threshold: Uint128 },
+}
+
 
 /// Determines the way votes are counted.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
 pub enum VotingStrategy {
-    SingleChoice { quorum: PercentageThreshold },
+    SingleChoice(MultipleProposalThreshold),
 }
 
 impl VotingStrategy {
     pub fn validate(&self) -> Result<(), ThresholdError> {
         match self {
-            VotingStrategy::SingleChoice { quorum } => validate_quorum(quorum),
-        }
-    }
-
-    pub fn get_quorum(&self) -> PercentageThreshold {
-        match self {
-            VotingStrategy::SingleChoice { quorum } => *quorum,
-        }
+            VotingStrategy::SingleChoice(thresold) => {
+                match thresold {
+                    MultipleProposalThreshold::Absoulute { threshold } => validate_count(threshold),
+                    MultipleProposalThreshold::Percentage{ quorum } => validate_quorum(quorum),
+                }    
+            }
+        }   
     }
 }

--- a/packages/voting/src/threshold.rs
+++ b/packages/voting/src/threshold.rs
@@ -85,6 +85,16 @@ fn validate_percentage(percent: &PercentageThreshold) -> Result<(), ThresholdErr
     }
 }
 
+/// Asserts that the threshold is > 0
+pub fn validate_count(threshold: &Uint128) -> Result<(), ThresholdError> {
+    if threshold.is_zero() {
+        Err(ThresholdError::ZeroThreshold {})
+    } else {
+        Ok(())
+    }
+
+}
+
 /// Asserts that a quorum <= 1. Quorums may be zero, to enable plurality-style voting.
 pub fn validate_quorum(quorum: &PercentageThreshold) -> Result<(), ThresholdError> {
     match quorum {
@@ -111,13 +121,7 @@ impl Threshold {
                 validate_percentage(threshold)?;
                 validate_quorum(quorum)
             }
-            Threshold::AbsoluteCount { threshold } => {
-                if threshold.is_zero() {
-                    Err(ThresholdError::ZeroThreshold {})
-                } else {
-                    Ok(())
-                }
-            }
+            Threshold::AbsoluteCount { threshold } => validate_count(threshold),
         }
     }
 }


### PR DESCRIPTION
Related issue https://github.com/DA0-DA0/dao-contracts/issues/368

### Approach

- Pull the `{ quorum: PercentageThreshold }` constraint into a `MultipleProposalThreshold` enum that also allows configuring for a `{ threshold: Uint128 }` constraint
- Update logic in `contract.rs` to accomodate for these changes when verifying the status of a proposal
- Amend many of the tests to accomodate for this new logic 