### PR TITLE
node dev dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ together.
 - [Yarn](https://yarnpkg.com/)
 - [Docker](https://docs.docker.com/engine/install/)
 - [jq](https://stedolan.github.io/jq/download/)
+- [node](https://nodejs.org/en/download/) (>= v15)
 
 Our development workflow is just like a regular Rust project:
 


### PR DESCRIPTION
Running `just gen-typescript` would fail to generate schemas because of `String.replaceAll()` being unsupported for Node.js versions below v15.
https://github.com/DA0-DA0/dao-contracts/blob/1a2accbb425ba928845fa0a0f4231cb1fe9824a6/typescript/src/codegen.ts#L109
