### PR TITLE
Fix Gas Diff

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -83,7 +83,7 @@ jobs:
           name: dao-dao-gas-report-refs-heads-main
 
       - name: Post gas diff to PR
-        if: ${{ github.ref != 'refs/heads/main' && steps.download_gas.outputs.error_message == '' }}
+        if: ${{ github.ref != 'refs/heads/main' && steps.download_gas.found_artifact == true }}
         uses: de-husk/cosm-orc-gas-diff-action@v0.6.2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -83,7 +83,7 @@ jobs:
           name: dao-dao-gas-report-refs-heads-main
 
       - name: Post gas diff to PR
-        if: ${{ github.ref != 'refs/heads/main' && steps.download_gas.outputs.found_artifact == true }}
+        if: ${{ github.ref != 'refs/heads/main' && steps.download_gas.outputs.found_artifact == 'true' }}
         uses: de-husk/cosm-orc-gas-diff-action@v0.6.2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -83,7 +83,7 @@ jobs:
           name: dao-dao-gas-report-refs-heads-main
 
       - name: Post gas diff to PR
-        if: ${{ github.ref != 'refs/heads/main' && steps.download_gas.outputs.error_message == ''}}
+        if: ${{ github.ref != 'refs/heads/main' && steps.download_gas.found_artifact }}
         uses: de-husk/cosm-orc-gas-diff-action@v0.6.2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -83,7 +83,7 @@ jobs:
           name: dao-dao-gas-report-refs-heads-main
 
       - name: Post gas diff to PR
-        if: ${{ github.ref != 'refs/heads/main' && steps.download_gas.found_artifact == true }}
+        if: ${{ github.ref != 'refs/heads/main' && steps.download_gas.found_artifact == 'true' }}
         uses: de-husk/cosm-orc-gas-diff-action@v0.6.2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -83,7 +83,7 @@ jobs:
           name: dao-dao-gas-report-refs-heads-main
 
       - name: Post gas diff to PR
-        if: ${{ github.ref != 'refs/heads/main' && steps.download_gas.found_artifact }}
+        if: ${{ github.ref != 'refs/heads/main' && steps.download_gas.outputs.error_message == '' }}
         uses: de-husk/cosm-orc-gas-diff-action@v0.6.2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -83,7 +83,7 @@ jobs:
           name: dao-dao-gas-report-refs-heads-main
 
       - name: Post gas diff to PR
-        if: ${{ github.ref != 'refs/heads/main' && steps.download_gas.found_artifact == 'true' }}
+        if: ${{ github.ref != 'refs/heads/main' && steps.download_gas.outputs.found_artifact == true }}
         uses: de-husk/cosm-orc-gas-diff-action@v0.6.2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -79,7 +79,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           branch: main
-          workflow: integration-tests.yml
+          workflow: integration_tests.yml
           name: dao-dao-gas-report-refs-heads-main
 
       - name: Post gas diff to PR


### PR DESCRIPTION
I noticed the main gas file download broke after the name change PR merged: https://github.com/DA0-DA0/dao-contracts/actions/runs/3230162112/jobs/5288290668#step:13:24

But also, this PR will also pull in @0xekez 's fix from the cw-nfts PR (where it wasnt actually gracefully failing if the main's gas file wasn't found).