### PR TITLE
Refactor macro code for better hygiene.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,22 +48,32 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-io"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e21f3a490c72b3b0cf44962180e60045de2925d8dff97918f7ee43c8f637c7"
+checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
 dependencies = [
+ "async-lock",
  "autocfg",
  "concurrent-queue",
  "futures-lite",
  "libc",
  "log",
- "once_cell",
  "parking",
  "polling",
  "slab",
  "socket2",
  "waker-fn",
  "winapi",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
+dependencies = [
+ "event-listener",
+ "futures-lite",
 ]
 
 [[package]]
@@ -294,9 +304,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
 
 [[package]]
 name = "cfg-if"
@@ -1602,6 +1612,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,9 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -1944,9 +1960,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2368,9 +2384,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opaque-debug"
@@ -2861,9 +2877,9 @@ dependencies = [
 
 [[package]]
 name = "scoped-tls"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "sct"

--- a/contracts/cwd-core/src/msg.rs
+++ b/contracts/cwd-core/src/msg.rs
@@ -2,9 +2,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Addr;
 use cosmwasm_std::{CosmosMsg, Empty};
 use cw_utils::Duration;
-use cwd_interface::voting::InfoResponse;
-use cwd_interface::voting::TotalPowerAtHeightResponse;
-use cwd_interface::voting::VotingPowerAtHeightResponse;
+
 use cwd_interface::ModuleInstantiateInfo;
 
 use cwd_macros::{info_query, voting_query};

--- a/contracts/proposal/cwd-proposal-multiple/src/msg.rs
+++ b/contracts/proposal/cwd-proposal-multiple/src/msg.rs
@@ -4,10 +4,10 @@ use crate::{
     state::Config,
 };
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Addr;
+
 use cw_utils::Duration;
 use cwd_hooks::HooksResponse;
-use cwd_interface::voting::InfoResponse;
+
 use cwd_macros::{info_query, proposal_module_query};
 use cwd_voting::{
     multiple_choice::{MultipleChoiceOptions, MultipleChoiceVote, VotingStrategy},

--- a/contracts/proposal/cwd-proposal-single/src/msg.rs
+++ b/contracts/proposal/cwd-proposal-single/src/msg.rs
@@ -1,8 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, CosmosMsg, Empty};
+use cosmwasm_std::{CosmosMsg, Empty};
 use cw_utils::Duration;
 use cwd_hooks::HooksResponse;
-use cwd_interface::voting::InfoResponse;
 
 use cwd_macros::{info_query, proposal_module_query};
 use cwd_voting::{

--- a/contracts/voting/cwd-voting-cw20-staked/src/msg.rs
+++ b/contracts/voting/cwd-voting-cw20-staked/src/msg.rs
@@ -4,9 +4,7 @@ use cosmwasm_std::{Decimal, Uint128};
 use cw20::Cw20Coin;
 use cw20_base::msg::InstantiateMarketingInfo;
 use cw_utils::Duration;
-use cwd_interface::voting::InfoResponse;
-use cwd_interface::voting::TotalPowerAtHeightResponse;
-use cwd_interface::voting::VotingPowerAtHeightResponse;
+
 use cwd_macros::{active_query, info_query, token_query, voting_query};
 
 #[cw_serde]

--- a/contracts/voting/cwd-voting-cw4/src/msg.rs
+++ b/contracts/voting/cwd-voting-cw4/src/msg.rs
@@ -1,8 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Addr;
-use cwd_interface::voting::InfoResponse;
-use cwd_interface::voting::TotalPowerAtHeightResponse;
-use cwd_interface::voting::VotingPowerAtHeightResponse;
+
 use cwd_macros::{info_query, voting_query};
 
 #[cw_serde]

--- a/contracts/voting/cwd-voting-cw721-staked/src/msg.rs
+++ b/contracts/voting/cwd-voting-cw721-staked/src/msg.rs
@@ -2,9 +2,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Uint128};
 use cw721::Cw721ReceiveMsg;
 use cw_utils::Duration;
-use cwd_interface::voting::InfoResponse;
-use cwd_interface::voting::TotalPowerAtHeightResponse;
-use cwd_interface::voting::VotingPowerAtHeightResponse;
+
 use cwd_interface::Admin;
 use cwd_macros::{info_query, voting_query};
 

--- a/contracts/voting/cwd-voting-native-staked/src/msg.rs
+++ b/contracts/voting/cwd-voting-native-staked/src/msg.rs
@@ -2,9 +2,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Uint128};
 use cw_controllers::ClaimsResponse;
 use cw_utils::Duration;
-use cwd_interface::voting::InfoResponse;
-use cwd_interface::voting::TotalPowerAtHeightResponse;
-use cwd_interface::voting::VotingPowerAtHeightResponse;
+
 use cwd_interface::Admin;
 use cwd_macros::{info_query, voting_query};
 

--- a/contracts/voting/cwd-voting-staking-denom-staked/src/msg.rs
+++ b/contracts/voting/cwd-voting-staking-denom-staked/src/msg.rs
@@ -1,8 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Addr;
-use cwd_interface::voting::InfoResponse;
-use cwd_interface::voting::TotalPowerAtHeightResponse;
-use cwd_interface::voting::VotingPowerAtHeightResponse;
+
 use cwd_macros::{info_query, voting_query};
 
 #[cw_serde]

--- a/packages/cwd-interface/src/voting.rs
+++ b/packages/cwd-interface/src/voting.rs
@@ -1,5 +1,4 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Addr;
 use cosmwasm_std::Uint128;
 use cw2::ContractVersion;
 use cwd_macros::{active_query, info_query, proposal_module_query, token_query, voting_query};
@@ -41,11 +40,8 @@ mod tests {
     /// fail to compile if not.
     #[test]
     fn test_macro_expansion() {
-        use crate::voting::InfoResponse;
-        use crate::voting::TotalPowerAtHeightResponse;
-        use crate::voting::VotingPowerAtHeightResponse;
         use cosmwasm_schema::{cw_serde, QueryResponses};
-        use cosmwasm_std::Addr;
+
         use cwd_macros::{active_query, info_query, token_query, voting_query};
         let query = Query::TokenContract {};
 

--- a/packages/cwd-macros/tests/govmod.rs
+++ b/packages/cwd-macros/tests/govmod.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Addr;
+
 use cwd_macros::proposal_module_query;
 
 #[proposal_module_query]

--- a/packages/cwd-macros/tests/voting.rs
+++ b/packages/cwd-macros/tests/voting.rs
@@ -1,7 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cwd_interface::voting::InfoResponse;
-use cwd_interface::voting::TotalPowerAtHeightResponse;
-use cwd_interface::voting::VotingPowerAtHeightResponse;
+
 use cwd_macros::{info_query, voting_query};
 
 /// enum for testing. Important that this derives things / has other

--- a/test-contracts/cwd-proposal-sudo/src/msg.rs
+++ b/test-contracts/cwd-proposal-sudo/src/msg.rs
@@ -1,6 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, CosmosMsg};
-use cwd_interface::voting::InfoResponse;
 
 use cwd_macros::{info_query, proposal_module_query};
 

--- a/test-contracts/cwd-voting-cw20-balance/src/msg.rs
+++ b/test-contracts/cwd-voting-cw20-balance/src/msg.rs
@@ -1,10 +1,8 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Addr;
+
 use cw20::Cw20Coin;
 use cw20_base::msg::InstantiateMarketingInfo;
-use cwd_interface::voting::InfoResponse;
-use cwd_interface::voting::TotalPowerAtHeightResponse;
-use cwd_interface::voting::VotingPowerAtHeightResponse;
+
 use cwd_macros::{info_query, token_query, voting_query};
 
 #[cw_serde]


### PR DESCRIPTION
deduplicates the macro code a fair bit and makes it more hygenic by using absolute paths for imports.