### PR TITLE
Simple adversarial tests for cw721 staking.

### DIFF
--- a/contracts/voting/cwd-voting-cw721-staked/src/error.rs
+++ b/contracts/voting/cwd-voting-cw721-staked/src/error.rs
@@ -9,7 +9,7 @@ pub enum ContractError {
     #[error("Nothing to claim")]
     NothingToClaim {},
 
-    #[error("Invalid token")]
+    #[error("Invalid token. Got ({received}), expected ({expected})")]
     InvalidToken { received: Addr, expected: Addr },
 
     #[error("Unauthorized")]

--- a/contracts/voting/cwd-voting-cw721-staked/src/testing/adversarial.rs
+++ b/contracts/voting/cwd-voting-cw721-staked/src/testing/adversarial.rs
@@ -1,0 +1,143 @@
+use cosmwasm_std::Uint128;
+use cw_multi_test::next_block;
+
+use crate::testing::{
+    execute::{stake_nft, unstake_nfts},
+    instantiate::instantiate_cw721_base,
+    queries::query_voting_power,
+};
+
+use super::{
+    execute::mint_and_stake_nft, is_error, queries::query_total_and_voting_power, setup_test,
+    CommonTest, CREATOR_ADDR,
+};
+
+/// Staking tokens has a one block delay before staked tokens are
+/// reflected in voting power. Unstaking tokens has a one block delay
+/// before the unstaking is reflected in voting power, yet you have
+/// access to the NFT. If I immediately stake an unstaked NFT, my
+/// voting power should not change.
+#[test]
+fn test_circular_stake() -> anyhow::Result<()> {
+    let CommonTest {
+        mut app,
+        module,
+        nft,
+    } = setup_test(None, None);
+
+    mint_and_stake_nft(&mut app, &nft, &module, CREATOR_ADDR, "1")?;
+    mint_and_stake_nft(&mut app, &nft, &module, CREATOR_ADDR, "2")?;
+
+    app.update_block(next_block);
+
+    let (total, voting) = query_total_and_voting_power(&app, &module, CREATOR_ADDR, None)?;
+    assert_eq!(total, Uint128::new(2));
+    assert_eq!(voting, Uint128::new(2));
+
+    unstake_nfts(&mut app, &module, CREATOR_ADDR, &["1", "2"])?;
+
+    // Unchanged, one block delay.
+    let (total, voting) = query_total_and_voting_power(&app, &module, CREATOR_ADDR, None)?;
+    assert_eq!(total, Uint128::new(2));
+    assert_eq!(voting, Uint128::new(2));
+
+    stake_nft(&mut app, &nft, &module, CREATOR_ADDR, "1")?;
+    stake_nft(&mut app, &nft, &module, CREATOR_ADDR, "2")?;
+
+    // Unchanged.
+    let (total, voting) = query_total_and_voting_power(&app, &module, CREATOR_ADDR, None)?;
+    assert_eq!(total, Uint128::new(2));
+    assert_eq!(voting, Uint128::new(2));
+
+    app.update_block(next_block);
+
+    // Still unchanged.
+    let (total, voting) = query_total_and_voting_power(&app, &module, CREATOR_ADDR, None)?;
+    assert_eq!(total, Uint128::new(2));
+    assert_eq!(voting, Uint128::new(2));
+
+    Ok(())
+}
+
+/// I can immediately unstake after staking even though voting powers
+/// aren't updated until one block later. Voting power does not change
+/// if I do this.
+#[test]
+fn test_immediate_unstake() -> anyhow::Result<()> {
+    let CommonTest {
+        mut app,
+        module,
+        nft,
+    } = setup_test(None, None);
+
+    mint_and_stake_nft(&mut app, &nft, &module, CREATOR_ADDR, "1")?;
+    mint_and_stake_nft(&mut app, &nft, &module, CREATOR_ADDR, "2")?;
+
+    unstake_nfts(&mut app, &module, CREATOR_ADDR, &["1", "2"])?;
+
+    app.update_block(next_block);
+
+    let (total, voting) = query_total_and_voting_power(&app, &module, CREATOR_ADDR, None)?;
+    assert_eq!(total, Uint128::zero());
+    assert_eq!(voting, Uint128::zero());
+
+    Ok(())
+}
+
+/// I can not stake NFTs from a collection other than the one this has
+/// been configured for.
+#[test]
+fn test_stake_wrong_nft() -> anyhow::Result<()> {
+    let CommonTest {
+        mut app, module, ..
+    } = setup_test(None, None);
+    let other_nft = instantiate_cw721_base(&mut app, CREATOR_ADDR, CREATOR_ADDR);
+
+    let res = mint_and_stake_nft(&mut app, &other_nft, &module, CREATOR_ADDR, "1");
+    is_error!(res => "Invalid token.");
+
+    app.update_block(next_block);
+    let voting = query_voting_power(&app, &module, CREATOR_ADDR, None)?;
+    assert_eq!(voting.power, Uint128::new(0));
+
+    Ok(())
+}
+
+/// I can determine what my voting power _will_ be after staking by
+/// asking for my voting power one block in the future.
+#[test]
+fn test_query_the_future() -> anyhow::Result<()> {
+    let CommonTest {
+        mut app,
+        module,
+        nft,
+    } = setup_test(None, None);
+
+    mint_and_stake_nft(&mut app, &nft, &module, CREATOR_ADDR, "1")?;
+
+    // Future voting power will be one under current conditions.
+    let voting = query_voting_power(
+        &app,
+        &module,
+        CREATOR_ADDR,
+        Some(app.block_info().height + 100),
+    )?;
+    assert_eq!(voting.power, Uint128::new(1));
+
+    // Current voting power is zero.
+    let voting = query_voting_power(&app, &module, CREATOR_ADDR, None)?;
+    assert_eq!(voting.power, Uint128::new(0));
+
+    unstake_nfts(&mut app, &module, CREATOR_ADDR, &["1"])?;
+
+    // Future voting power is now zero.
+    let voting = query_voting_power(
+        &app,
+        &module,
+        CREATOR_ADDR,
+        Some(app.block_info().height + 100),
+    )?;
+    assert_eq!(voting.power, Uint128::zero());
+
+    Ok(())
+}

--- a/contracts/voting/cwd-voting-cw721-staked/src/testing/instantiate.rs
+++ b/contracts/voting/cwd-voting-cw721-staked/src/testing/instantiate.rs
@@ -1,0 +1,21 @@
+use cosmwasm_std::Addr;
+use cw_multi_test::{App, Executor};
+use cwd_testing::contracts::cw721_base_contract;
+
+pub fn instantiate_cw721_base(app: &mut App, sender: &str, minter: &str) -> Addr {
+    let cw721_id = app.store_code(cw721_base_contract());
+
+    app.instantiate_contract(
+        cw721_id,
+        Addr::unchecked(sender),
+        &cw721_base::InstantiateMsg {
+            name: "bad kids".to_string(),
+            symbol: "bad kids".to_string(),
+            minter: minter.to_string(),
+        },
+        &[],
+        "cw721_base".to_string(),
+        None,
+    )
+    .unwrap()
+}

--- a/contracts/voting/cwd-voting-cw721-staked/src/testing/mod.rs
+++ b/contracts/voting/cwd-voting-cw721-staked/src/testing/mod.rs
@@ -1,5 +1,58 @@
+mod adversarial;
 mod execute;
+mod instantiate;
 mod queries;
 mod tests;
 
+use cosmwasm_std::Addr;
+use cw_multi_test::{App, Executor};
+use cw_utils::Duration;
+
+use cwd_interface::Admin;
+use cwd_testing::contracts::voting_cw721_staked_contract;
+
+use crate::msg::InstantiateMsg;
+
+use self::instantiate::instantiate_cw721_base;
+
+/// Address used as the owner, instantiator, and minter.
 pub(crate) const CREATOR_ADDR: &str = "creator";
+
+pub(crate) struct CommonTest {
+    app: App,
+    module: Addr,
+    nft: Addr,
+}
+
+pub(crate) fn setup_test(owner: Option<Admin>, unstaking_duration: Option<Duration>) -> CommonTest {
+    let mut app = App::default();
+    let module_id = app.store_code(voting_cw721_staked_contract());
+
+    let nft = instantiate_cw721_base(&mut app, CREATOR_ADDR, CREATOR_ADDR);
+    let module = app
+        .instantiate_contract(
+            module_id,
+            Addr::unchecked(CREATOR_ADDR),
+            &InstantiateMsg {
+                owner,
+                nft_address: nft.to_string(),
+                unstaking_duration,
+            },
+            &[],
+            "cw721_voting",
+            None,
+        )
+        .unwrap();
+    CommonTest { app, module, nft }
+}
+
+// Advantage to using a macro for this is that the error trace links
+// to the exact line that the error occured, instead of inside of a
+// function where the assertion would otherwise happen.
+macro_rules! is_error {
+    ($x:expr => $e:tt) => {
+        assert!(format!("{:#}", $x.unwrap_err()).contains($e))
+    };
+}
+
+pub(crate) use is_error;


### PR DESCRIPTION
This adds some adversarial tests to the cw721 stake voting module which focus on making sure it correctly updates voting power in the face of strange query and staking events.