### PR TITLE
multiple choice cleanups for frontend

### DIFF
--- a/contracts/pre-propose/cwd-pre-propose-multiple/schema/cwd-pre-propose-multiple.json
+++ b/contracts/pre-propose/cwd-pre-propose-multiple/schema/cwd-pre-propose-multiple.json
@@ -841,17 +841,15 @@
         "description": "Unchecked multiple choice option",
         "type": "object",
         "required": [
-          "description"
+          "description",
+          "msgs"
         ],
         "properties": {
           "description": {
             "type": "string"
           },
           "msgs": {
-            "type": [
-              "array",
-              "null"
-            ],
+            "type": "array",
             "items": {
               "$ref": "#/definitions/CosmosMsg_for_Empty"
             }

--- a/contracts/pre-propose/cwd-pre-propose-multiple/schema/cwd-pre-propose-multiple.json
+++ b/contracts/pre-propose/cwd-pre-propose-multiple/schema/cwd-pre-propose-multiple.json
@@ -842,7 +842,8 @@
         "type": "object",
         "required": [
           "description",
-          "msgs"
+          "msgs",
+          "title"
         ],
         "properties": {
           "description": {
@@ -853,6 +854,9 @@
             "items": {
               "$ref": "#/definitions/CosmosMsg_for_Empty"
             }
+          },
+          "title": {
+            "type": "string"
           }
         },
         "additionalProperties": false

--- a/contracts/pre-propose/cwd-pre-propose-multiple/src/tests.rs
+++ b/contracts/pre-propose/cwd-pre-propose-multiple/src/tests.rs
@@ -192,11 +192,11 @@ fn make_proposal(
                         options: vec![
                             MultipleChoiceOption {
                                 description: "multiple choice option 1".to_string(),
-                                msgs: None,
+                                msgs: vec![],
                             },
                             MultipleChoiceOption {
                                 description: "multiple choice option 2".to_string(),
-                                msgs: None,
+                                msgs: vec![],
                             },
                         ],
                     },
@@ -229,21 +229,21 @@ fn make_proposal(
         vec![
             CheckedMultipleChoiceOption {
                 description: "multiple choice option 1".to_string(),
-                msgs: None,
+                msgs: vec![],
                 option_type: MultipleChoiceOptionType::Standard,
                 vote_count: Uint128::zero(),
                 index: 0,
             },
             CheckedMultipleChoiceOption {
                 description: "multiple choice option 2".to_string(),
-                msgs: None,
+                msgs: vec![],
                 option_type: MultipleChoiceOptionType::Standard,
                 vote_count: Uint128::zero(),
                 index: 1,
             },
             CheckedMultipleChoiceOption {
                 description: "None of the above".to_string(),
-                msgs: None,
+                msgs: vec![],
                 option_type: MultipleChoiceOptionType::None,
                 vote_count: Uint128::zero(),
                 index: 2,
@@ -874,7 +874,7 @@ fn test_permissions() {
                     choices: MultipleChoiceOptions {
                         options: vec![MultipleChoiceOption {
                             description: "multiple choice option 1".to_string(),
-                            msgs: None,
+                            msgs: vec![],
                         }],
                     },
                 },
@@ -979,7 +979,7 @@ fn test_no_deposit_required_members_submission() {
                     choices: MultipleChoiceOptions {
                         options: vec![MultipleChoiceOption {
                             description: "multiple choice option 1".to_string(),
-                            msgs: None,
+                            msgs: vec![],
                         }],
                     },
                 },

--- a/contracts/pre-propose/cwd-pre-propose-multiple/src/tests.rs
+++ b/contracts/pre-propose/cwd-pre-propose-multiple/src/tests.rs
@@ -193,10 +193,12 @@ fn make_proposal(
                             MultipleChoiceOption {
                                 description: "multiple choice option 1".to_string(),
                                 msgs: vec![],
+                                title: "title".to_string(),
                             },
                             MultipleChoiceOption {
                                 description: "multiple choice option 2".to_string(),
                                 msgs: vec![],
+                                title: "title".to_string(),
                             },
                         ],
                     },
@@ -233,6 +235,7 @@ fn make_proposal(
                 option_type: MultipleChoiceOptionType::Standard,
                 vote_count: Uint128::zero(),
                 index: 0,
+                title: "title".to_string(),
             },
             CheckedMultipleChoiceOption {
                 description: "multiple choice option 2".to_string(),
@@ -240,6 +243,7 @@ fn make_proposal(
                 option_type: MultipleChoiceOptionType::Standard,
                 vote_count: Uint128::zero(),
                 index: 1,
+                title: "title".to_string(),
             },
             CheckedMultipleChoiceOption {
                 description: "None of the above".to_string(),
@@ -247,6 +251,7 @@ fn make_proposal(
                 option_type: MultipleChoiceOptionType::None,
                 vote_count: Uint128::zero(),
                 index: 2,
+                title: "None of the above".to_string(),
             },
         ]
     );
@@ -875,6 +880,7 @@ fn test_permissions() {
                         options: vec![MultipleChoiceOption {
                             description: "multiple choice option 1".to_string(),
                             msgs: vec![],
+                            title: "title".to_string(),
                         }],
                     },
                 },
@@ -980,6 +986,7 @@ fn test_no_deposit_required_members_submission() {
                         options: vec![MultipleChoiceOption {
                             description: "multiple choice option 1".to_string(),
                             msgs: vec![],
+                            title: "title".to_string(),
                         }],
                     },
                 },

--- a/contracts/proposal/cwd-proposal-multiple/schema/cwd-proposal-multiple.json
+++ b/contracts/proposal/cwd-proposal-multiple/schema/cwd-proposal-multiple.json
@@ -3457,103 +3457,21 @@
     },
     "proposal": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "MultipleChoiceProposal",
+      "title": "ProposalResponse",
+      "description": "Information about a proposal returned by proposal queries.",
       "type": "object",
       "required": [
-        "allow_revoting",
-        "choices",
-        "description",
-        "expiration",
-        "proposer",
-        "start_height",
-        "status",
-        "title",
-        "total_power",
-        "votes",
-        "voting_strategy"
+        "id",
+        "proposal"
       ],
       "properties": {
-        "allow_revoting": {
-          "description": "Whether DAO members are allowed to change their votes. When disabled, proposals can be executed as soon as they pass. When enabled, proposals can only be executed after the voting perid has ended and the proposal passed.",
-          "type": "boolean"
-        },
-        "choices": {
-          "description": "The options to be chosen from in the vote.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/CheckedMultipleChoiceOption"
-          }
-        },
-        "description": {
-          "type": "string"
-        },
-        "expiration": {
-          "description": "The the time at which this proposal will expire and close for additional votes.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Expiration"
-            }
-          ]
-        },
-        "min_voting_period": {
-          "description": "The minimum amount of time this proposal must remain open for voting. The proposal may not pass unless this is expired or None.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Expiration"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "proposer": {
-          "description": "The address that created this proposal.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Addr"
-            }
-          ]
-        },
-        "start_height": {
-          "description": "The block height at which this proposal was created. Voting power queries should query for voting power at this block height.",
+        "id": {
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
         },
-        "status": {
-          "description": "Prosal status (Open, rejected, executed, execution failed, closed, passed)",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Status"
-            }
-          ]
-        },
-        "title": {
-          "type": "string"
-        },
-        "total_power": {
-          "description": "The total power when the proposal started (used to calculate percentages)",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Uint128"
-            }
-          ]
-        },
-        "votes": {
-          "description": "The vote tally.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/MultipleChoiceVotes"
-            }
-          ]
-        },
-        "voting_strategy": {
-          "description": "Voting settings (threshold, quorum, etc.)",
-          "allOf": [
-            {
-              "$ref": "#/definitions/VotingStrategy"
-            }
-          ]
+        "proposal": {
+          "$ref": "#/definitions/MultipleChoiceProposal"
         }
       },
       "additionalProperties": false,
@@ -4092,6 +4010,107 @@
               ]
             }
           ]
+        },
+        "MultipleChoiceProposal": {
+          "type": "object",
+          "required": [
+            "allow_revoting",
+            "choices",
+            "description",
+            "expiration",
+            "proposer",
+            "start_height",
+            "status",
+            "title",
+            "total_power",
+            "votes",
+            "voting_strategy"
+          ],
+          "properties": {
+            "allow_revoting": {
+              "description": "Whether DAO members are allowed to change their votes. When disabled, proposals can be executed as soon as they pass. When enabled, proposals can only be executed after the voting perid has ended and the proposal passed.",
+              "type": "boolean"
+            },
+            "choices": {
+              "description": "The options to be chosen from in the vote.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CheckedMultipleChoiceOption"
+              }
+            },
+            "description": {
+              "type": "string"
+            },
+            "expiration": {
+              "description": "The the time at which this proposal will expire and close for additional votes.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                }
+              ]
+            },
+            "min_voting_period": {
+              "description": "The minimum amount of time this proposal must remain open for voting. The proposal may not pass unless this is expired or None.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "proposer": {
+              "description": "The address that created this proposal.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                }
+              ]
+            },
+            "start_height": {
+              "description": "The block height at which this proposal was created. Voting power queries should query for voting power at this block height.",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "status": {
+              "description": "Prosal status (Open, rejected, executed, execution failed, closed, passed)",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Status"
+                }
+              ]
+            },
+            "title": {
+              "type": "string"
+            },
+            "total_power": {
+              "description": "The total power when the proposal started (used to calculate percentages)",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "votes": {
+              "description": "The vote tally.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/MultipleChoiceVotes"
+                }
+              ]
+            },
+            "voting_strategy": {
+              "description": "Voting settings (threshold, quorum, etc.)",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/VotingStrategy"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
         },
         "MultipleChoiceVotes": {
           "type": "object",

--- a/contracts/proposal/cwd-proposal-multiple/schema/cwd-proposal-multiple.json
+++ b/contracts/proposal/cwd-proposal-multiple/schema/cwd-proposal-multiple.json
@@ -1688,7 +1688,7 @@
         "additionalProperties": false
       },
       {
-        "description": "Returns the number of proposals that have been created in this module./// Returns a voters position on a propsal.",
+        "description": "Returns the number of proposals that have been created in this module.",
         "type": "object",
         "required": [
           "proposal_count"

--- a/contracts/proposal/cwd-proposal-multiple/schema/cwd-proposal-multiple.json
+++ b/contracts/proposal/cwd-proposal-multiple/schema/cwd-proposal-multiple.json
@@ -1146,17 +1146,15 @@
         "description": "Unchecked multiple choice option",
         "type": "object",
         "required": [
-          "description"
+          "description",
+          "msgs"
         ],
         "properties": {
           "description": {
             "type": "string"
           },
           "msgs": {
-            "type": [
-              "array",
-              "null"
-            ],
+            "type": "array",
             "items": {
               "$ref": "#/definitions/CosmosMsg_for_Empty"
             }
@@ -2388,6 +2386,7 @@
           "required": [
             "description",
             "index",
+            "msgs",
             "option_type",
             "vote_count"
           ],
@@ -2401,10 +2400,7 @@
               "minimum": 0.0
             },
             "msgs": {
-              "type": [
-                "array",
-                "null"
-              ],
+              "type": "array",
               "items": {
                 "$ref": "#/definitions/CosmosMsg_for_Empty"
               }
@@ -3547,6 +3543,7 @@
           "required": [
             "description",
             "index",
+            "msgs",
             "option_type",
             "vote_count"
           ],
@@ -3560,10 +3557,7 @@
               "minimum": 0.0
             },
             "msgs": {
-              "type": [
-                "array",
-                "null"
-              ],
+              "type": "array",
               "items": {
                 "$ref": "#/definitions/CosmosMsg_for_Empty"
               }
@@ -4677,6 +4671,7 @@
           "required": [
             "description",
             "index",
+            "msgs",
             "option_type",
             "vote_count"
           ],
@@ -4690,10 +4685,7 @@
               "minimum": 0.0
             },
             "msgs": {
-              "type": [
-                "array",
-                "null"
-              ],
+              "type": "array",
               "items": {
                 "$ref": "#/definitions/CosmosMsg_for_Empty"
               }

--- a/contracts/proposal/cwd-proposal-multiple/schema/cwd-proposal-multiple.json
+++ b/contracts/proposal/cwd-proposal-multiple/schema/cwd-proposal-multiple.json
@@ -1147,7 +1147,8 @@
         "type": "object",
         "required": [
           "description",
-          "msgs"
+          "msgs",
+          "title"
         ],
         "properties": {
           "description": {
@@ -1158,6 +1159,9 @@
             "items": {
               "$ref": "#/definitions/CosmosMsg_for_Empty"
             }
+          },
+          "title": {
+            "type": "string"
           }
         },
         "additionalProperties": false
@@ -2388,6 +2392,7 @@
             "index",
             "msgs",
             "option_type",
+            "title",
             "vote_count"
           ],
           "properties": {
@@ -2407,6 +2412,9 @@
             },
             "option_type": {
               "$ref": "#/definitions/MultipleChoiceOptionType"
+            },
+            "title": {
+              "type": "string"
             },
             "vote_count": {
               "$ref": "#/definitions/Uint128"
@@ -3545,6 +3553,7 @@
             "index",
             "msgs",
             "option_type",
+            "title",
             "vote_count"
           ],
           "properties": {
@@ -3564,6 +3573,9 @@
             },
             "option_type": {
               "$ref": "#/definitions/MultipleChoiceOptionType"
+            },
+            "title": {
+              "type": "string"
             },
             "vote_count": {
               "$ref": "#/definitions/Uint128"
@@ -4673,6 +4685,7 @@
             "index",
             "msgs",
             "option_type",
+            "title",
             "vote_count"
           ],
           "properties": {
@@ -4692,6 +4705,9 @@
             },
             "option_type": {
               "$ref": "#/definitions/MultipleChoiceOptionType"
+            },
+            "title": {
+              "type": "string"
             },
             "vote_count": {
               "$ref": "#/definitions/Uint128"

--- a/contracts/proposal/cwd-proposal-multiple/src/msg.rs
+++ b/contracts/proposal/cwd-proposal-multiple/src/msg.rs
@@ -141,7 +141,7 @@ pub enum QueryMsg {
     #[returns(crate::state::Config)]
     Config {},
     /// Gets information about a proposal.
-    #[returns(crate::proposal::MultipleChoiceProposal)]
+    #[returns(crate::query::ProposalResponse)]
     Proposal { proposal_id: u64 },
     /// Lists all the proposals that have been cast in this
     /// module.

--- a/contracts/proposal/cwd-proposal-multiple/src/msg.rs
+++ b/contracts/proposal/cwd-proposal-multiple/src/msg.rs
@@ -158,7 +158,7 @@ pub enum QueryMsg {
         limit: Option<u64>,
     },
     /// Returns the number of proposals that have been created in this
-    /// module./// Returns a voters position on a propsal.
+    /// module.
     #[returns(u64)]
     ProposalCount {},
     /// Returns a voters position on a proposal.

--- a/contracts/proposal/cwd-proposal-multiple/src/proposal.rs
+++ b/contracts/proposal/cwd-proposal-multiple/src/proposal.rs
@@ -285,11 +285,11 @@ mod tests {
         let options = vec![
             MultipleChoiceOption {
                 description: "multiple choice option 1".to_string(),
-                msgs: None,
+                msgs: vec![],
             },
             MultipleChoiceOption {
                 description: "multiple choice option 2".to_string(),
-                msgs: None,
+                msgs: vec![],
             },
         ];
 

--- a/contracts/proposal/cwd-proposal-multiple/src/proposal.rs
+++ b/contracts/proposal/cwd-proposal-multiple/src/proposal.rs
@@ -286,10 +286,12 @@ mod tests {
             MultipleChoiceOption {
                 description: "multiple choice option 1".to_string(),
                 msgs: vec![],
+                title: "title".to_string(),
             },
             MultipleChoiceOption {
                 description: "multiple choice option 2".to_string(),
                 msgs: vec![],
+                title: "title".to_string(),
             },
         ];
 

--- a/contracts/proposal/cwd-proposal-multiple/src/testing/do_votes.rs
+++ b/contracts/proposal/cwd-proposal-multiple/src/testing/do_votes.rs
@@ -193,10 +193,12 @@ where
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
 

--- a/contracts/proposal/cwd-proposal-multiple/src/testing/do_votes.rs
+++ b/contracts/proposal/cwd-proposal-multiple/src/testing/do_votes.rs
@@ -192,11 +192,11 @@ where
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
 

--- a/contracts/proposal/cwd-proposal-multiple/src/testing/tests.rs
+++ b/contracts/proposal/cwd-proposal-multiple/src/testing/tests.rs
@@ -140,11 +140,11 @@ fn test_propose() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
 
@@ -234,7 +234,7 @@ fn test_propose_wrong_num_choices() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         };
         std::convert::TryInto::try_into(MAX_NUM_CHOICES + 1).unwrap()
     ];
@@ -334,11 +334,11 @@ fn test_no_early_pass_with_min_duration() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
 
@@ -443,11 +443,11 @@ fn test_propose_with_messages() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: Some(vec![CosmosMsg::Wasm(wasm_msg)]),
+            msgs: vec![CosmosMsg::Wasm(wasm_msg)],
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
 
@@ -604,11 +604,11 @@ fn test_min_duration_same_as_proposal_duration() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
 
@@ -877,11 +877,11 @@ fn test_take_proposal_deposit() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
 
@@ -991,11 +991,11 @@ fn test_native_proposal_deposit() {
             options: vec![
                 MultipleChoiceOption {
                     description: "multiple choice option 1".to_string(),
-                    msgs: None,
+                    msgs: vec![],
                 },
                 MultipleChoiceOption {
                     description: "multiple choice option 2".to_string(),
-                    msgs: None,
+                    msgs: vec![],
                 },
             ],
         };
@@ -1401,11 +1401,11 @@ fn test_cant_propose_zero_power() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
 
@@ -1549,11 +1549,11 @@ fn test_cant_execute_not_member() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
 
@@ -1630,11 +1630,11 @@ fn test_open_proposal_submission() {
             options: vec![
                 MultipleChoiceOption {
                     description: "multiple choice option 1".to_string(),
-                    msgs: None,
+                    msgs: vec![],
                 },
                 MultipleChoiceOption {
                     description: "multiple choice option 2".to_string(),
-                    msgs: None,
+                    msgs: vec![],
                 },
             ],
         },
@@ -1658,21 +1658,21 @@ fn test_open_proposal_submission() {
         choices: vec![
             CheckedMultipleChoiceOption {
                 description: "multiple choice option 1".to_string(),
-                msgs: None,
+                msgs: vec![],
                 option_type: MultipleChoiceOptionType::Standard,
                 vote_count: Uint128::zero(),
                 index: 0,
             },
             CheckedMultipleChoiceOption {
                 description: "multiple choice option 2".to_string(),
-                msgs: None,
+                msgs: vec![],
                 option_type: MultipleChoiceOptionType::Standard,
                 vote_count: Uint128::zero(),
                 index: 1,
             },
             CheckedMultipleChoiceOption {
                 description: "None of the above".to_string(),
-                msgs: None,
+                msgs: vec![],
                 option_type: MultipleChoiceOptionType::None,
                 vote_count: Uint128::zero(),
                 index: 2,
@@ -1935,11 +1935,11 @@ fn test_execute_expired_proposal() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
 
@@ -2221,11 +2221,11 @@ fn test_query_list_proposals() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
 
@@ -2487,11 +2487,11 @@ fn test_active_threshold_absolute() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
 
@@ -2613,11 +2613,11 @@ fn test_active_threshold_percent() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
 
@@ -2742,11 +2742,11 @@ fn test_active_threshold_none() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
 
@@ -2828,11 +2828,11 @@ fn test_revoting() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
     let mc_options = MultipleChoiceOptions { options };
@@ -2955,11 +2955,11 @@ fn test_allow_revoting_config_changes() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
     let mc_options = MultipleChoiceOptions { options };
@@ -3100,11 +3100,11 @@ fn test_revoting_same_vote_twice() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
     let mc_options = MultipleChoiceOptions { options };
@@ -3190,11 +3190,11 @@ fn test_invalid_revote_does_not_invalidate_initial_vote() {
     let options = vec![
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
     let mc_options = MultipleChoiceOptions { options };
@@ -3404,16 +3404,16 @@ fn test_close_failed_proposal() {
     let options = vec![
         MultipleChoiceOption {
             description: "Burn or burn".to_string(),
-            msgs: Some(vec![WasmMsg::Execute {
+            msgs: vec![WasmMsg::Execute {
                 contract_addr: token_contract.to_string(),
                 msg: binary_msg,
                 funds: vec![],
             }
-            .into()]),
+            .into()],
         },
         MultipleChoiceOption {
             description: "Don't burn".to_string(),
-            msgs: None,
+            msgs: vec![],
         },
     ];
 
@@ -3476,7 +3476,7 @@ fn test_close_failed_proposal() {
                     options: vec![
                         MultipleChoiceOption {
                             description: "Disable closing failed proposals".to_string(),
-                            msgs: Some(vec![WasmMsg::Execute {
+                            msgs: vec![WasmMsg::Execute {
                                 contract_addr: govmod.to_string(),
                                 msg: to_binary(&ExecuteMsg::UpdateConfig {
                                     voting_strategy: VotingStrategy::SingleChoice { quorum },
@@ -3490,11 +3490,11 @@ fn test_close_failed_proposal() {
                                 .unwrap(),
                                 funds: vec![],
                             }
-                            .into()]),
+                            .into()],
                         },
                         MultipleChoiceOption {
                             description: "Don't disable".to_string(),
-                            msgs: None,
+                            msgs: vec![],
                         },
                     ],
                 },
@@ -3683,16 +3683,16 @@ fn test_no_double_refund_on_execute_fail_and_close() {
         options: vec![
             MultipleChoiceOption {
                 description: "Burning more tokens, than dao treasury have".to_string(),
-                msgs: Some(vec![WasmMsg::Execute {
+                msgs: vec![WasmMsg::Execute {
                     contract_addr: token_contract.to_string(),
                     msg: binary_msg,
                     funds: vec![],
                 }
-                .into()]),
+                .into()],
             },
             MultipleChoiceOption {
                 description: "hi there".to_string(),
-                msgs: None,
+                msgs: vec![],
             },
         ],
     };

--- a/contracts/proposal/cwd-proposal-multiple/src/testing/tests.rs
+++ b/contracts/proposal/cwd-proposal-multiple/src/testing/tests.rs
@@ -141,10 +141,12 @@ fn test_propose() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
 
@@ -235,6 +237,7 @@ fn test_propose_wrong_num_choices() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         };
         std::convert::TryInto::try_into(MAX_NUM_CHOICES + 1).unwrap()
     ];
@@ -335,10 +338,12 @@ fn test_no_early_pass_with_min_duration() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
 
@@ -444,10 +449,12 @@ fn test_propose_with_messages() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![CosmosMsg::Wasm(wasm_msg)],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
 
@@ -605,10 +612,12 @@ fn test_min_duration_same_as_proposal_duration() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
 
@@ -878,10 +887,12 @@ fn test_take_proposal_deposit() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
 
@@ -992,10 +1003,12 @@ fn test_native_proposal_deposit() {
                 MultipleChoiceOption {
                     description: "multiple choice option 1".to_string(),
                     msgs: vec![],
+                    title: "title".to_string(),
                 },
                 MultipleChoiceOption {
                     description: "multiple choice option 2".to_string(),
                     msgs: vec![],
+                    title: "title".to_string(),
                 },
             ],
         };
@@ -1402,10 +1415,12 @@ fn test_cant_propose_zero_power() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
 
@@ -1550,10 +1565,12 @@ fn test_cant_execute_not_member() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
 
@@ -1631,10 +1648,12 @@ fn test_open_proposal_submission() {
                 MultipleChoiceOption {
                     description: "multiple choice option 1".to_string(),
                     msgs: vec![],
+                    title: "title".to_string(),
                 },
                 MultipleChoiceOption {
                     description: "multiple choice option 2".to_string(),
                     msgs: vec![],
+                    title: "title".to_string(),
                 },
             ],
         },
@@ -1662,6 +1681,7 @@ fn test_open_proposal_submission() {
                 option_type: MultipleChoiceOptionType::Standard,
                 vote_count: Uint128::zero(),
                 index: 0,
+                title: "title".to_string(),
             },
             CheckedMultipleChoiceOption {
                 description: "multiple choice option 2".to_string(),
@@ -1669,6 +1689,7 @@ fn test_open_proposal_submission() {
                 option_type: MultipleChoiceOptionType::Standard,
                 vote_count: Uint128::zero(),
                 index: 1,
+                title: "title".to_string(),
             },
             CheckedMultipleChoiceOption {
                 description: "None of the above".to_string(),
@@ -1676,6 +1697,7 @@ fn test_open_proposal_submission() {
                 option_type: MultipleChoiceOptionType::None,
                 vote_count: Uint128::zero(),
                 index: 2,
+                title: "None of the above".to_string(),
             },
         ],
         votes: MultipleChoiceVotes {
@@ -1936,10 +1958,12 @@ fn test_execute_expired_proposal() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
 
@@ -2222,10 +2246,12 @@ fn test_query_list_proposals() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
 
@@ -2488,10 +2514,12 @@ fn test_active_threshold_absolute() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
 
@@ -2614,10 +2642,12 @@ fn test_active_threshold_percent() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
 
@@ -2743,10 +2773,12 @@ fn test_active_threshold_none() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
 
@@ -2829,10 +2861,12 @@ fn test_revoting() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
     let mc_options = MultipleChoiceOptions { options };
@@ -2956,10 +2990,12 @@ fn test_allow_revoting_config_changes() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
     let mc_options = MultipleChoiceOptions { options };
@@ -3101,10 +3137,12 @@ fn test_revoting_same_vote_twice() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
     let mc_options = MultipleChoiceOptions { options };
@@ -3191,10 +3229,12 @@ fn test_invalid_revote_does_not_invalidate_initial_vote() {
         MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "multiple choice option 2".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
     let mc_options = MultipleChoiceOptions { options };
@@ -3410,10 +3450,12 @@ fn test_close_failed_proposal() {
                 funds: vec![],
             }
             .into()],
+            title: "title".to_string(),
         },
         MultipleChoiceOption {
             description: "Don't burn".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         },
     ];
 
@@ -3491,10 +3533,12 @@ fn test_close_failed_proposal() {
                                 funds: vec![],
                             }
                             .into()],
+                            title: "title".to_string(),
                         },
                         MultipleChoiceOption {
                             description: "Don't disable".to_string(),
                             msgs: vec![],
+                            title: "title".to_string(),
                         },
                     ],
                 },
@@ -3689,10 +3733,12 @@ fn test_no_double_refund_on_execute_fail_and_close() {
                     funds: vec![],
                 }
                 .into()],
+                title: "title".to_string(),
             },
             MultipleChoiceOption {
                 description: "hi there".to_string(),
                 msgs: vec![],
+                title: "title".to_string(),
             },
         ],
     };

--- a/contracts/proposal/cwd-proposal-single/schema/cwd-proposal-single.json
+++ b/contracts/proposal/cwd-proposal-single/schema/cwd-proposal-single.json
@@ -3608,92 +3608,22 @@
     },
     "proposal": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "SingleChoiceProposal",
+      "title": "ProposalResponse",
+      "description": "Information about a proposal returned by proposal queries.",
       "type": "object",
       "required": [
-        "allow_revoting",
-        "description",
-        "expiration",
-        "msgs",
-        "proposer",
-        "start_height",
-        "status",
-        "threshold",
-        "title",
-        "total_power",
-        "votes"
+        "id",
+        "proposal"
       ],
       "properties": {
-        "allow_revoting": {
-          "type": "boolean"
-        },
-        "description": {
-          "type": "string"
-        },
-        "expiration": {
-          "description": "The the time at which this proposal will expire and close for additional votes.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Expiration"
-            }
-          ]
-        },
-        "min_voting_period": {
-          "description": "The minimum amount of time this proposal must remain open for voting. The proposal may not pass unless this is expired or None.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Expiration"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "msgs": {
-          "description": "The messages that will be executed should this proposal pass.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/CosmosMsg_for_Empty"
-          }
-        },
-        "proposer": {
-          "description": "The address that created this proposal.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Addr"
-            }
-          ]
-        },
-        "start_height": {
-          "description": "The block height at which this proposal was created. Voting power queries should query for voting power at this block height.",
+        "id": {
+          "description": "The ID of the proposal being returned.",
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
         },
-        "status": {
-          "$ref": "#/definitions/Status"
-        },
-        "threshold": {
-          "description": "The threshold at which this proposal will pass.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Threshold"
-            }
-          ]
-        },
-        "title": {
-          "type": "string"
-        },
-        "total_power": {
-          "description": "The total amount of voting power at the time of this proposal's creation.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Uint128"
-            }
-          ]
-        },
-        "votes": {
-          "$ref": "#/definitions/Votes"
+        "proposal": {
+          "$ref": "#/definitions/SingleChoiceProposal"
         }
       },
       "additionalProperties": false,
@@ -4210,6 +4140,96 @@
               "additionalProperties": false
             }
           ]
+        },
+        "SingleChoiceProposal": {
+          "type": "object",
+          "required": [
+            "allow_revoting",
+            "description",
+            "expiration",
+            "msgs",
+            "proposer",
+            "start_height",
+            "status",
+            "threshold",
+            "title",
+            "total_power",
+            "votes"
+          ],
+          "properties": {
+            "allow_revoting": {
+              "type": "boolean"
+            },
+            "description": {
+              "type": "string"
+            },
+            "expiration": {
+              "description": "The the time at which this proposal will expire and close for additional votes.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                }
+              ]
+            },
+            "min_voting_period": {
+              "description": "The minimum amount of time this proposal must remain open for voting. The proposal may not pass unless this is expired or None.",
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Expiration"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "msgs": {
+              "description": "The messages that will be executed should this proposal pass.",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/CosmosMsg_for_Empty"
+              }
+            },
+            "proposer": {
+              "description": "The address that created this proposal.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Addr"
+                }
+              ]
+            },
+            "start_height": {
+              "description": "The block height at which this proposal was created. Voting power queries should query for voting power at this block height.",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "status": {
+              "$ref": "#/definitions/Status"
+            },
+            "threshold": {
+              "description": "The threshold at which this proposal will pass.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Threshold"
+                }
+              ]
+            },
+            "title": {
+              "type": "string"
+            },
+            "total_power": {
+              "description": "The total amount of voting power at the time of this proposal's creation.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "votes": {
+              "$ref": "#/definitions/Votes"
+            }
+          },
+          "additionalProperties": false
         },
         "StakingMsg": {
           "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",

--- a/contracts/proposal/cwd-proposal-single/src/msg.rs
+++ b/contracts/proposal/cwd-proposal-single/src/msg.rs
@@ -142,7 +142,7 @@ pub enum QueryMsg {
     #[returns(crate::state::Config)]
     Config {},
     /// Gets information about a proposal.
-    #[returns(crate::proposal::SingleChoiceProposal)]
+    #[returns(crate::query::ProposalResponse)]
     Proposal { proposal_id: u64 },
     /// Lists all the proposals that have been cast in this
     /// module.

--- a/packages/cwd-voting/src/multiple_choice.rs
+++ b/packages/cwd-voting/src/multiple_choice.rs
@@ -3,8 +3,9 @@ use cosmwasm_std::{CosmosMsg, Empty, StdError, StdResult, Uint128};
 
 use crate::threshold::{validate_quorum, PercentageThreshold, ThresholdError};
 
-/// Maximum number of choices for multiple choice votes
-pub const MAX_NUM_CHOICES: u32 = 10;
+/// Maximum number of choices for multiple choice votes. Chosen
+/// in order to impose a bound on state / queries.
+pub const MAX_NUM_CHOICES: u32 = 20;
 const NONE_OPTION_DESCRIPTION: &str = "None of the above";
 
 /// Determines how many choices may be selected.
@@ -98,6 +99,7 @@ pub struct MultipleChoiceOptions {
 /// Unchecked multiple choice option
 #[cw_serde]
 pub struct MultipleChoiceOption {
+    pub title: String,
     pub description: String,
     pub msgs: Vec<CosmosMsg<Empty>>,
 }
@@ -116,6 +118,7 @@ pub struct CheckedMultipleChoiceOption {
     // Workaround due to not being able to use HashMaps in Cosmwasm.
     pub index: u32,
     pub option_type: MultipleChoiceOptionType,
+    pub title: String,
     pub description: String,
     pub msgs: Vec<CosmosMsg<Empty>>,
     pub vote_count: Uint128,
@@ -143,8 +146,9 @@ impl MultipleChoiceOptions {
                     description: choice.description,
                     msgs: choice.msgs,
                     vote_count: Uint128::zero(),
+                    title: choice.title,
                 };
-                checked_options.push(checked_option);
+                checked_options.push(checked_option)
             });
 
         // Add a "None of the above" option, required for every multiple choice proposal.
@@ -154,6 +158,7 @@ impl MultipleChoiceOptions {
             description: NONE_OPTION_DESCRIPTION.to_string(),
             msgs: vec![],
             vote_count: Uint128::zero(),
+            title: NONE_OPTION_DESCRIPTION.to_string(),
         };
 
         checked_options.push(none_option);
@@ -207,10 +212,12 @@ mod test {
             super::MultipleChoiceOption {
                 description: "multiple choice option 1".to_string(),
                 msgs: vec![],
+                title: "title".to_string(),
             },
             super::MultipleChoiceOption {
                 description: "multiple choice option 2".to_string(),
                 msgs: vec![],
+                title: "title".to_string(),
             },
         ];
 
@@ -250,6 +257,7 @@ mod test {
         let options = vec![super::MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
             msgs: vec![],
+            title: "title".to_string(),
         }];
 
         let mc_options = super::MultipleChoiceOptions { options };

--- a/packages/cwd-voting/src/multiple_choice.rs
+++ b/packages/cwd-voting/src/multiple_choice.rs
@@ -99,7 +99,7 @@ pub struct MultipleChoiceOptions {
 #[cw_serde]
 pub struct MultipleChoiceOption {
     pub description: String,
-    pub msgs: Option<Vec<CosmosMsg<Empty>>>,
+    pub msgs: Vec<CosmosMsg<Empty>>,
 }
 
 /// Multiple choice options that have been verified for correctness, and have all fields
@@ -117,7 +117,7 @@ pub struct CheckedMultipleChoiceOption {
     pub index: u32,
     pub option_type: MultipleChoiceOptionType,
     pub description: String,
-    pub msgs: Option<Vec<CosmosMsg<Empty>>>,
+    pub msgs: Vec<CosmosMsg<Empty>>,
     pub vote_count: Uint128,
 }
 
@@ -152,7 +152,7 @@ impl MultipleChoiceOptions {
             index: (checked_options.capacity() - 1) as u32,
             option_type: MultipleChoiceOptionType::None,
             description: NONE_OPTION_DESCRIPTION.to_string(),
-            msgs: None,
+            msgs: vec![],
             vote_count: Uint128::zero(),
         };
 
@@ -167,6 +167,8 @@ impl MultipleChoiceOptions {
 
 #[cfg(test)]
 mod test {
+    use std::vec;
+
     use super::*;
 
     #[test]
@@ -204,11 +206,11 @@ mod test {
         let options = vec![
             super::MultipleChoiceOption {
                 description: "multiple choice option 1".to_string(),
-                msgs: None,
+                msgs: vec![],
             },
             super::MultipleChoiceOption {
                 description: "multiple choice option 2".to_string(),
-                msgs: None,
+                msgs: vec![],
             },
         ];
 
@@ -247,7 +249,7 @@ mod test {
     fn test_into_checked_wrong_num_choices() {
         let options = vec![super::MultipleChoiceOption {
             description: "multiple choice option 1".to_string(),
-            msgs: None,
+            msgs: vec![],
         }];
 
         let mc_options = super::MultipleChoiceOptions { options };

--- a/typescript/contracts/cwd-pre-propose-multiple/CwdPreProposeMultiple.types.ts
+++ b/typescript/contracts/cwd-pre-propose-multiple/CwdPreProposeMultiple.types.ts
@@ -204,6 +204,7 @@ export interface MultipleChoiceOptions {
 export interface MultipleChoiceOption {
   description: string;
   msgs: CosmosMsgForEmpty[];
+  title: string;
 }
 export interface Coin {
   amount: Uint128;

--- a/typescript/contracts/cwd-pre-propose-multiple/CwdPreProposeMultiple.types.ts
+++ b/typescript/contracts/cwd-pre-propose-multiple/CwdPreProposeMultiple.types.ts
@@ -203,7 +203,7 @@ export interface MultipleChoiceOptions {
 }
 export interface MultipleChoiceOption {
   description: string;
-  msgs?: CosmosMsgForEmpty[] | null;
+  msgs: CosmosMsgForEmpty[];
 }
 export interface Coin {
   amount: Uint128;

--- a/typescript/contracts/cwd-proposal-multiple/CwdProposalMultiple.client.ts
+++ b/typescript/contracts/cwd-proposal-multiple/CwdProposalMultiple.client.ts
@@ -14,7 +14,7 @@ export interface CwdProposalMultipleReadOnlyInterface {
     proposalId
   }: {
     proposalId: number;
-  }) => Promise<MultipleChoiceProposal>;
+  }) => Promise<ProposalResponse>;
   listProposals: ({
     limit,
     startAfter
@@ -82,7 +82,7 @@ export class CwdProposalMultipleQueryClient implements CwdProposalMultipleReadOn
     proposalId
   }: {
     proposalId: number;
-  }): Promise<MultipleChoiceProposal> => {
+  }): Promise<ProposalResponse> => {
     return this.client.queryContractSmart(this.contractAddress, {
       proposal: {
         proposal_id: proposalId

--- a/typescript/contracts/cwd-proposal-multiple/CwdProposalMultiple.types.ts
+++ b/typescript/contracts/cwd-proposal-multiple/CwdProposalMultiple.types.ts
@@ -238,6 +238,7 @@ export interface MultipleChoiceOptions {
 export interface MultipleChoiceOption {
   description: string;
   msgs: CosmosMsgForEmpty[];
+  title: string;
 }
 export interface Coin {
   amount: Uint128;
@@ -368,6 +369,7 @@ export interface CheckedMultipleChoiceOption {
   index: number;
   msgs: CosmosMsgForEmpty[];
   option_type: MultipleChoiceOptionType;
+  title: string;
   vote_count: Uint128;
 }
 export interface MultipleChoiceVotes {

--- a/typescript/contracts/cwd-proposal-multiple/CwdProposalMultiple.types.ts
+++ b/typescript/contracts/cwd-proposal-multiple/CwdProposalMultiple.types.ts
@@ -237,7 +237,7 @@ export interface MultipleChoiceOptions {
 }
 export interface MultipleChoiceOption {
   description: string;
-  msgs?: CosmosMsgForEmpty[] | null;
+  msgs: CosmosMsgForEmpty[];
 }
 export interface Coin {
   amount: Uint128;
@@ -366,7 +366,7 @@ export interface MultipleChoiceProposal {
 export interface CheckedMultipleChoiceOption {
   description: string;
   index: number;
-  msgs?: CosmosMsgForEmpty[] | null;
+  msgs: CosmosMsgForEmpty[];
   option_type: MultipleChoiceOptionType;
   vote_count: Uint128;
 }

--- a/typescript/contracts/cwd-proposal-single/CwdProposalSingle.client.ts
+++ b/typescript/contracts/cwd-proposal-single/CwdProposalSingle.client.ts
@@ -14,7 +14,7 @@ export interface CwdProposalSingleReadOnlyInterface {
     proposalId
   }: {
     proposalId: number;
-  }) => Promise<SingleChoiceProposal>;
+  }) => Promise<ProposalResponse>;
   listProposals: ({
     limit,
     startAfter
@@ -82,7 +82,7 @@ export class CwdProposalSingleQueryClient implements CwdProposalSingleReadOnlyIn
     proposalId
   }: {
     proposalId: number;
-  }): Promise<SingleChoiceProposal> => {
+  }): Promise<ProposalResponse> => {
     return this.client.queryContractSmart(this.contractAddress, {
       proposal: {
         proposal_id: proposalId


### PR DESCRIPTION
Some stuff that is coming up as I work on the frontend (there may be more, but want to get this in)

- fix a couple return type annotations
- simplify proposal.msgs type
- allow multiple choice options to have their own titles
- increase the max number of options