### PR TITLE
Update macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,9 @@ version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cwd-hooks",
  "cwd-interface",
+ "cwd-voting",
  "proc-macro2",
  "quote",
  "syn",

--- a/contracts/cwd-core/schema/cwd-core.json
+++ b/contracts/cwd-core/schema/cwd-core.json
@@ -31,7 +31,7 @@
         "type": "boolean"
       },
       "dao_uri": {
-        "description": "Implements the DAO Star standard: https://daostar.one/EIP",
+        "description": "Implements the DAO Star standard: <https://daostar.one/EIP>",
         "type": [
           "string",
           "null"
@@ -63,7 +63,7 @@
         "type": "string"
       },
       "proposal_modules_instantiate_info": {
-        "description": "Instantiate information for the core contract's proposal modules.",
+        "description": "Instantiate information for the core contract's proposal modules. NOTE: the pre-propose-base package depends on it being the case that the core module instantiates its proposal module.",
         "type": "array",
         "items": {
           "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -488,6 +488,7 @@
             ],
             "properties": {
               "to_add": {
+                "description": "NOTE: the pre-propose-base package depends on it being the case that the core module instantiates its proposal module.",
                 "type": "array",
                 "items": {
                   "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -697,7 +698,7 @@
             "type": "boolean"
           },
           "dao_uri": {
-            "description": "The URI for the DAO as defined by the DAOstar standard https://daostar.one/EIP",
+            "description": "The URI for the DAO as defined by the DAOstar standard <https://daostar.one/EIP>",
             "type": [
               "string",
               "null"
@@ -1697,6 +1698,20 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns contract version info",
+        "type": "object",
+        "required": [
+          "info"
+        ],
+        "properties": {
+          "info": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Gets all proposal modules associated with the contract.",
         "type": "object",
         "required": [
@@ -1815,7 +1830,7 @@
         "additionalProperties": false
       },
       {
-        "description": "Implements the DAO Star standard: https://daostar.one/EIP",
+        "description": "Implements the DAO Star standard: <https://daostar.one/EIP>",
         "type": "object",
         "required": [
           "dao_u_r_i"
@@ -1829,6 +1844,7 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the voting power for an address at a given height.",
         "type": "object",
         "required": [
           "voting_power_at_height"
@@ -1858,6 +1874,7 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the total voting power at a given block height.",
         "type": "object",
         "required": [
           "total_power_at_height"
@@ -1875,19 +1892,6 @@
                 "minimum": 0.0
               }
             },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
-        "type": "object",
-        "required": [
-          "info"
-        ],
-        "properties": {
-          "info": {
-            "type": "object",
             "additionalProperties": false
           }
         },
@@ -2044,7 +2048,7 @@
           "type": "boolean"
         },
         "dao_uri": {
-          "description": "The URI for the DAO as defined by the DAOstar standard https://daostar.one/EIP",
+          "description": "The URI for the DAO as defined by the DAOstar standard <https://daostar.one/EIP>",
           "type": [
             "string",
             "null"
@@ -2245,7 +2249,7 @@
               "type": "boolean"
             },
             "dao_uri": {
-              "description": "The URI for the DAO as defined by the DAOstar standard https://daostar.one/EIP",
+              "description": "The URI for the DAO as defined by the DAOstar standard <https://daostar.one/EIP>",
               "type": [
                 "string",
                 "null"

--- a/contracts/cwd-core/src/msg.rs
+++ b/contracts/cwd-core/src/msg.rs
@@ -4,7 +4,6 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{CosmosMsg, Empty};
 use cw_utils::Duration;
 use cwd_interface::ModuleInstantiateInfo;
-use cwd_macros::{info_query, voting_query};
 
 /// Information about an item to be stored in the items list.
 #[cw_serde]
@@ -39,10 +38,9 @@ pub struct InstantiateMsg {
     /// Instantiate information for the core contract's voting
     /// power module.
     pub voting_module_instantiate_info: ModuleInstantiateInfo,
-    /// Instantiate information for the core contract's
-    /// proposal modules.
-    // NOTE: the pre-propose-base package depends on it being the case
-    // that the core module instantiates its proposal module.
+    /// Instantiate information for the core contract's proposal modules.
+    /// NOTE: the pre-propose-base package depends on it being the case
+    /// that the core module instantiates its proposal module.
     pub proposal_modules_instantiate_info: Vec<ModuleInstantiateInfo>,
 
     /// Initial information for arbitrary contract addresses to be
@@ -50,7 +48,7 @@ pub struct InstantiateMsg {
     /// items map. The value is an enum that either uses an existing
     /// address or instantiates a new contract.
     pub initial_items: Option<Vec<InitialItem>>,
-    /// Implements the DAO Star standard: https://daostar.one/EIP
+    /// Implements the DAO Star standard: <https://daostar.one/EIP>
     pub dao_uri: Option<String>,
 }
 
@@ -117,8 +115,8 @@ pub enum ExecuteMsg {
     /// instantiate info in `to_add` is used to create new modules and
     /// install them.
     UpdateProposalModules {
-        // NOTE: the pre-propose-base package depends on it being the
-        // case that the core module instantiates its proposal module.
+        /// NOTE: the pre-propose-base package depends on it being the
+        /// case that the core module instantiates its proposal module.
         to_add: Vec<ModuleInstantiateInfo>,
         to_disable: Vec<String>,
     },
@@ -133,8 +131,6 @@ pub enum ExecuteMsg {
     },
 }
 
-#[voting_query]
-#[info_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
@@ -185,6 +181,9 @@ pub enum QueryMsg {
         start_after: Option<String>,
         limit: Option<u32>,
     },
+    /// Returns contract version info
+    #[returns(cwd_interface::voting::InfoResponse)]
+    Info {},
     /// Gets all proposal modules associated with the
     /// contract.
     #[returns(Vec<crate::state::ProposalModule>)]
@@ -212,9 +211,18 @@ pub enum QueryMsg {
         start_after: Option<String>,
         limit: Option<u32>,
     },
-    /// Implements the DAO Star standard: https://daostar.one/EIP
+    /// Implements the DAO Star standard: <https://daostar.one/EIP>
     #[returns(crate::query::DaoURIResponse)]
     DaoURI {},
+    /// Returns the voting power for an address at a given height.
+    #[returns(cwd_interface::voting::VotingPowerAtHeightResponse)]
+    VotingPowerAtHeight {
+        address: String,
+        height: Option<u64>,
+    },
+    /// Returns the total voting power at a given block height.
+    #[returns(cwd_interface::voting::TotalPowerAtHeightResponse)]
+    TotalPowerAtHeight { height: Option<u64> },
 }
 
 #[cw_serde]

--- a/contracts/cwd-core/src/state.rs
+++ b/contracts/cwd-core/src/state.rs
@@ -20,7 +20,7 @@ pub struct Config {
     /// tokens to its treasury.
     pub automatically_add_cw721s: bool,
     /// The URI for the DAO as defined by the DAOstar standard
-    /// https://daostar.one/EIP
+    /// <https://daostar.one/EIP>
     pub dao_uri: Option<String>,
 }
 

--- a/contracts/proposal/cwd-proposal-multiple/schema/cwd-proposal-multiple.json
+++ b/contracts/proposal/cwd-proposal-multiple/schema/cwd-proposal-multiple.json
@@ -1824,7 +1824,7 @@
         "additionalProperties": false
       },
       {
-        "description": "Lists all of the consumers of vote hooks for thismodule.",
+        "description": "Lists all of the consumers of vote hooks for this module.",
         "type": "object",
         "required": [
           "vote_hooks"

--- a/contracts/proposal/cwd-proposal-multiple/schema/cwd-proposal-multiple.json
+++ b/contracts/proposal/cwd-proposal-multiple/schema/cwd-proposal-multiple.json
@@ -1688,20 +1688,6 @@
         "additionalProperties": false
       },
       {
-        "description": "Returns the number of proposals that have been created in this module.",
-        "type": "object",
-        "required": [
-          "proposal_count"
-        ],
-        "properties": {
-          "proposal_count": {
-            "type": "object",
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
         "description": "Returns a voters position on a proposal.",
         "type": "object",
         "required": [
@@ -1768,6 +1754,48 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the address of the DAO this module belongs to",
+        "type": "object",
+        "required": [
+          "dao"
+        ],
+        "properties": {
+          "dao": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns contract version info",
+        "type": "object",
+        "required": [
+          "info"
+        ],
+        "properties": {
+          "info": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the number of proposals that have been created in this module.",
+        "type": "object",
+        "required": [
+          "proposal_count"
+        ],
+        "properties": {
+          "proposal_count": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Gets the current proposal creation policy for this module.",
         "type": "object",
         "required": [
@@ -1796,39 +1824,13 @@
         "additionalProperties": false
       },
       {
-        "description": "Lists all of the consumers of vote hooks for this module.",
+        "description": "Lists all of the consumers of vote hooks for thismodule.",
         "type": "object",
         "required": [
           "vote_hooks"
         ],
         "properties": {
           "vote_hooks": {
-            "type": "object",
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
-        "type": "object",
-        "required": [
-          "dao"
-        ],
-        "properties": {
-          "dao": {
-            "type": "object",
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
-        "type": "object",
-        "required": [
-          "info"
-        ],
-        "properties": {
-          "info": {
             "type": "object",
             "additionalProperties": false
           }

--- a/contracts/proposal/cwd-proposal-multiple/src/msg.rs
+++ b/contracts/proposal/cwd-proposal-multiple/src/msg.rs
@@ -1,6 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cw_utils::Duration;
-use cwd_macros::{info_query, proposal_module_query};
+use cwd_macros::proposal_module_query;
 use cwd_voting::{
     multiple_choice::{MultipleChoiceOptions, MultipleChoiceVote, VotingStrategy},
     pre_propose::PreProposeInfo,
@@ -133,7 +133,6 @@ pub enum ExecuteMsg {
 }
 
 #[proposal_module_query]
-#[info_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
@@ -143,8 +142,7 @@ pub enum QueryMsg {
     /// Gets information about a proposal.
     #[returns(crate::query::ProposalResponse)]
     Proposal { proposal_id: u64 },
-    /// Lists all the proposals that have been cast in this
-    /// module.
+    /// Lists all the proposals that have been cast in this module.
     #[returns(crate::query::ProposalListResponse)]
     ListProposals {
         start_after: Option<u64>,
@@ -157,32 +155,16 @@ pub enum QueryMsg {
         start_before: Option<u64>,
         limit: Option<u64>,
     },
-    /// Returns the number of proposals that have been created in this
-    /// module.
-    #[returns(u64)]
-    ProposalCount {},
     /// Returns a voters position on a proposal.
     #[returns(crate::query::VoteResponse)]
     GetVote { proposal_id: u64, voter: String },
-    /// Lists all of the votes that have been cast on a
-    /// proposal.
+    /// Lists all of the votes that have been cast on a proposal.
     #[returns(crate::query::VoteListResponse)]
     ListVotes {
         proposal_id: u64,
         start_after: Option<String>,
         limit: Option<u64>,
     },
-    /// Gets the current proposal creation policy for this
-    /// module.
-    #[returns(cwd_voting::pre_propose::ProposalCreationPolicy)]
-    ProposalCreationPolicy {},
-    /// Lists all of the consumers of proposal hooks for this module.
-    #[returns(cwd_hooks::HooksResponse)]
-    ProposalHooks {},
-    /// Lists all of the consumers of vote hooks for this
-    /// module.
-    #[returns(cwd_hooks::HooksResponse)]
-    VoteHooks {},
 }
 
 #[cw_serde]

--- a/contracts/proposal/cwd-proposal-single/schema/cwd-proposal-single.json
+++ b/contracts/proposal/cwd-proposal-single/schema/cwd-proposal-single.json
@@ -1943,7 +1943,7 @@
         "additionalProperties": false
       },
       {
-        "description": "Lists all of the consumers of vote hooks for thismodule.",
+        "description": "Lists all of the consumers of vote hooks for this module.",
         "type": "object",
         "required": [
           "vote_hooks"

--- a/contracts/proposal/cwd-proposal-single/schema/cwd-proposal-single.json
+++ b/contracts/proposal/cwd-proposal-single/schema/cwd-proposal-single.json
@@ -1804,20 +1804,6 @@
         "additionalProperties": false
       },
       {
-        "description": "Returns the number of proposals that have been created in this module.",
-        "type": "object",
-        "required": [
-          "proposal_count"
-        ],
-        "properties": {
-          "proposal_count": {
-            "type": "object",
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
         "description": "Returns a voters position on a propsal.",
         "type": "object",
         "required": [
@@ -1887,6 +1873,48 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the address of the DAO this module belongs to",
+        "type": "object",
+        "required": [
+          "dao"
+        ],
+        "properties": {
+          "dao": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns contract version info",
+        "type": "object",
+        "required": [
+          "info"
+        ],
+        "properties": {
+          "info": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the number of proposals that have been created in this module.",
+        "type": "object",
+        "required": [
+          "proposal_count"
+        ],
+        "properties": {
+          "proposal_count": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Gets the current proposal creation policy for this module.",
         "type": "object",
         "required": [
@@ -1915,39 +1943,13 @@
         "additionalProperties": false
       },
       {
-        "description": "Lists all of the consumers of vote hooks for this module.",
+        "description": "Lists all of the consumers of vote hooks for thismodule.",
         "type": "object",
         "required": [
           "vote_hooks"
         ],
         "properties": {
           "vote_hooks": {
-            "type": "object",
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
-        "type": "object",
-        "required": [
-          "dao"
-        ],
-        "properties": {
-          "dao": {
-            "type": "object",
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
-        "type": "object",
-        "required": [
-          "info"
-        ],
-        "properties": {
-          "info": {
             "type": "object",
             "additionalProperties": false
           }

--- a/contracts/proposal/cwd-proposal-single/src/msg.rs
+++ b/contracts/proposal/cwd-proposal-single/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{CosmosMsg, Empty};
 use cw_utils::Duration;
-use cwd_macros::{info_query, proposal_module_query};
+use cwd_macros::proposal_module_query;
 use cwd_voting::{pre_propose::PreProposeInfo, threshold::Threshold, voting::Vote};
 
 #[cw_serde]
@@ -144,7 +144,6 @@ pub enum ExecuteMsg {
 }
 
 #[proposal_module_query]
-#[info_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
@@ -180,10 +179,6 @@ pub enum QueryMsg {
         /// returned.
         limit: Option<u64>,
     },
-    /// Returns the number of proposals that have been created in this
-    /// module.
-    #[returns(u64)]
-    ProposalCount {},
     /// Returns a voters position on a propsal.
     #[returns(crate::query::VoteResponse)]
     GetVote { proposal_id: u64, voter: String },
@@ -200,17 +195,6 @@ pub enum QueryMsg {
         /// query. If no limit is specified a max of 30 are returned.
         limit: Option<u64>,
     },
-    /// Gets the current proposal creation policy for this
-    /// module.
-    #[returns(cwd_voting::pre_propose::ProposalCreationPolicy)]
-    ProposalCreationPolicy {},
-    /// Lists all of the consumers of proposal hooks for this module.
-    #[returns(cwd_hooks::HooksResponse)]
-    ProposalHooks {},
-    /// Lists all of the consumers of vote hooks for this
-    /// module.
-    #[returns(cwd_hooks::HooksResponse)]
-    VoteHooks {},
 }
 
 #[cw_serde]

--- a/contracts/voting/cwd-voting-cw20-staked/schema/cwd-voting-cw20-staked.json
+++ b/contracts/voting/cwd-voting-cw20-staked/schema/cwd-voting-cw20-staked.json
@@ -528,21 +528,6 @@
         "additionalProperties": false
       },
       {
-        "description": "Gets the address that instantiated this module.",
-        "type": "object",
-        "required": [
-          "dao"
-        ],
-        "properties": {
-          "dao": {
-            "type": "object",
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
-        "description": "Gets the active threshold for this module.",
         "type": "object",
         "required": [
           "active_threshold"
@@ -556,6 +541,7 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the voting power for an address at a given height.",
         "type": "object",
         "required": [
           "voting_power_at_height"
@@ -585,6 +571,7 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
         "required": [
           "total_power_at_height"
@@ -608,6 +595,21 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the address of the DAO this module belongs to.",
+        "type": "object",
+        "required": [
+          "dao"
+        ],
+        "properties": {
+          "dao": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns contract version info.",
         "type": "object",
         "required": [
           "info"

--- a/contracts/voting/cwd-voting-cw20-staked/src/msg.rs
+++ b/contracts/voting/cwd-voting-cw20-staked/src/msg.rs
@@ -4,7 +4,7 @@ use cw20::Cw20Coin;
 use cw20_base::msg::InstantiateMarketingInfo;
 use cw_utils::Duration;
 
-use cwd_macros::{active_query, token_query, voting_query};
+use cwd_macros::{active_query, token_query, voting_module_query};
 
 /// Information about the staking contract to be used with this voting
 /// module.
@@ -82,7 +82,7 @@ pub enum ExecuteMsg {
     },
 }
 
-#[voting_query]
+#[voting_module_query]
 #[token_query]
 #[active_query]
 #[cw_serde]

--- a/contracts/voting/cwd-voting-cw20-staked/src/msg.rs
+++ b/contracts/voting/cwd-voting-cw20-staked/src/msg.rs
@@ -4,7 +4,7 @@ use cw20::Cw20Coin;
 use cw20_base::msg::InstantiateMarketingInfo;
 use cw_utils::Duration;
 
-use cwd_macros::{active_query, info_query, token_query, voting_query};
+use cwd_macros::{active_query, token_query, voting_query};
 
 /// Information about the staking contract to be used with this voting
 /// module.
@@ -83,7 +83,6 @@ pub enum ExecuteMsg {
 }
 
 #[voting_query]
-#[info_query]
 #[token_query]
 #[active_query]
 #[cw_serde]
@@ -93,10 +92,6 @@ pub enum QueryMsg {
     /// is wrapping.
     #[returns(cosmwasm_std::Addr)]
     StakingContract {},
-    /// Gets the address that instantiated this module.
-    #[returns(cosmwasm_std::Addr)]
-    Dao {},
-    /// Gets the active threshold for this module.
     #[returns(ActiveThresholdResponse)]
     ActiveThreshold {},
 }

--- a/contracts/voting/cwd-voting-cw4/schema/cwd-voting-cw4.json
+++ b/contracts/voting/cwd-voting-cw4/schema/cwd-voting-cw4.json
@@ -125,19 +125,7 @@
         "additionalProperties": false
       },
       {
-        "type": "object",
-        "required": [
-          "dao"
-        ],
-        "properties": {
-          "dao": {
-            "type": "object",
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
+        "description": "Returns the voting power for an address at a given height.",
         "type": "object",
         "required": [
           "voting_power_at_height"
@@ -167,6 +155,7 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
         "required": [
           "total_power_at_height"
@@ -190,6 +179,21 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the address of the DAO this module belongs to.",
+        "type": "object",
+        "required": [
+          "dao"
+        ],
+        "properties": {
+          "dao": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns contract version info.",
         "type": "object",
         "required": [
           "info"

--- a/contracts/voting/cwd-voting-cw4/src/msg.rs
+++ b/contracts/voting/cwd-voting-cw4/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cwd_macros::{info_query, voting_query};
+use cwd_macros::voting_query;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -13,14 +13,11 @@ pub enum ExecuteMsg {
 }
 
 #[voting_query]
-#[info_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(cosmwasm_std::Addr)]
     GroupContract {},
-    #[returns(cosmwasm_std::Addr)]
-    Dao {},
 }
 
 #[cw_serde]

--- a/contracts/voting/cwd-voting-cw4/src/msg.rs
+++ b/contracts/voting/cwd-voting-cw4/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cwd_macros::voting_query;
+use cwd_macros::voting_module_query;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -12,7 +12,7 @@ pub enum ExecuteMsg {
     MemberChangedHook { diffs: Vec<cw4::MemberDiff> },
 }
 
-#[voting_query]
+#[voting_module_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {

--- a/contracts/voting/cwd-voting-cw4/src/state.rs
+++ b/contracts/voting/cwd-voting-cw4/src/state.rs
@@ -16,4 +16,4 @@ pub const TOTAL_WEIGHT: SnapshotItem<Uint128> = SnapshotItem::new(
 );
 
 pub const GROUP_CONTRACT: Item<Addr> = Item::new("group_contract");
-pub const DAO: Item<Addr> = Item::new("dao");
+pub const DAO: Item<Addr> = Item::new("dao_address");

--- a/contracts/voting/cwd-voting-cw4/src/state.rs
+++ b/contracts/voting/cwd-voting-cw4/src/state.rs
@@ -16,4 +16,4 @@ pub const TOTAL_WEIGHT: SnapshotItem<Uint128> = SnapshotItem::new(
 );
 
 pub const GROUP_CONTRACT: Item<Addr> = Item::new("group_contract");
-pub const DAO_ADDRESS: Item<Addr> = Item::new("dao_address");
+pub const DAO: Item<Addr> = Item::new("dao");

--- a/contracts/voting/cwd-voting-cw721-staked/schema/cwd-voting-cw721-staked.json
+++ b/contracts/voting/cwd-voting-cw721-staked/schema/cwd-voting-cw721-staked.json
@@ -394,6 +394,7 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the voting power for an address at a given height.",
         "type": "object",
         "required": [
           "voting_power_at_height"
@@ -423,6 +424,7 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
         "required": [
           "total_power_at_height"
@@ -446,6 +448,21 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the address of the DAO this module belongs to.",
+        "type": "object",
+        "required": [
+          "dao"
+        ],
+        "properties": {
+          "dao": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns contract version info.",
         "type": "object",
         "required": [
           "info"
@@ -536,6 +553,12 @@
           ]
         }
       }
+    },
+    "dao": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
     },
     "hooks": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/cwd-voting-cw721-staked/src/contract.rs
+++ b/contracts/voting/cwd-voting-cw721-staked/src/contract.rs
@@ -267,6 +267,7 @@ pub fn execute_remove_hook(
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Config {} => query_config(deps),
+        QueryMsg::Dao {} => unimplemented!(),
         QueryMsg::NftClaims { address } => query_nft_claims(deps, address),
         QueryMsg::Hooks {} => query_hooks(deps),
         QueryMsg::VotingPowerAtHeight { address, height } => {

--- a/contracts/voting/cwd-voting-cw721-staked/src/msg.rs
+++ b/contracts/voting/cwd-voting-cw721-staked/src/msg.rs
@@ -2,7 +2,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cw721::Cw721ReceiveMsg;
 use cw_utils::Duration;
 use cwd_interface::Admin;
-use cwd_macros::voting_query;
+use cwd_macros::voting_module_query;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -40,7 +40,7 @@ pub enum ExecuteMsg {
     },
 }
 
-#[voting_query]
+#[voting_module_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {

--- a/contracts/voting/cwd-voting-cw721-staked/src/msg.rs
+++ b/contracts/voting/cwd-voting-cw721-staked/src/msg.rs
@@ -2,7 +2,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cw721::Cw721ReceiveMsg;
 use cw_utils::Duration;
 use cwd_interface::Admin;
-use cwd_macros::{info_query, voting_query};
+use cwd_macros::voting_query;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -41,7 +41,6 @@ pub enum ExecuteMsg {
 }
 
 #[voting_query]
-#[info_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {

--- a/contracts/voting/cwd-voting-cw721-staked/src/state.rs
+++ b/contracts/voting/cwd-voting-cw721-staked/src/state.rs
@@ -15,6 +15,7 @@ pub struct Config {
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");
+pub const DAO_ADDRESS: Item<Addr> = Item::new("dao_address");
 
 /// The set of NFTs currently staked by each address. The existence of
 /// an `(address, token_id)` pair implies that `address` has staked

--- a/contracts/voting/cwd-voting-cw721-staked/src/state.rs
+++ b/contracts/voting/cwd-voting-cw721-staked/src/state.rs
@@ -15,7 +15,7 @@ pub struct Config {
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");
-pub const DAO_ADDRESS: Item<Addr> = Item::new("dao_address");
+pub const DAO: Item<Addr> = Item::new("dao");
 
 /// The set of NFTs currently staked by each address. The existence of
 /// an `(address, token_id)` pair implies that `address` has staked

--- a/contracts/voting/cwd-voting-native-staked/schema/cwd-voting-native-staked.json
+++ b/contracts/voting/cwd-voting-native-staked/schema/cwd-voting-native-staked.json
@@ -256,19 +256,6 @@
       {
         "type": "object",
         "required": [
-          "dao"
-        ],
-        "properties": {
-          "dao": {
-            "type": "object",
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
-        "type": "object",
-        "required": [
           "get_config"
         ],
         "properties": {
@@ -330,6 +317,7 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the voting power for an address at a given height.",
         "type": "object",
         "required": [
           "voting_power_at_height"
@@ -359,6 +347,7 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
         "required": [
           "total_power_at_height"
@@ -382,6 +371,21 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the address of the DAO this module belongs to.",
+        "type": "object",
+        "required": [
+          "dao"
+        ],
+        "properties": {
+          "dao": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns contract version info.",
         "type": "object",
         "required": [
           "info"

--- a/contracts/voting/cwd-voting-native-staked/src/msg.rs
+++ b/contracts/voting/cwd-voting-native-staked/src/msg.rs
@@ -2,7 +2,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
 use cw_utils::Duration;
 use cwd_interface::Admin;
-use cwd_macros::voting_query;
+use cwd_macros::voting_module_query;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -30,7 +30,7 @@ pub enum ExecuteMsg {
     Claim {},
 }
 
-#[voting_query]
+#[voting_module_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {

--- a/contracts/voting/cwd-voting-native-staked/src/msg.rs
+++ b/contracts/voting/cwd-voting-native-staked/src/msg.rs
@@ -2,7 +2,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
 use cw_utils::Duration;
 use cwd_interface::Admin;
-use cwd_macros::{info_query, voting_query};
+use cwd_macros::voting_query;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -31,12 +31,9 @@ pub enum ExecuteMsg {
 }
 
 #[voting_query]
-#[info_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
-    #[returns(cosmwasm_std::Addr)]
-    Dao {},
     #[returns(crate::state::Config)]
     GetConfig {},
     #[returns(cw_controllers::ClaimsResponse)]

--- a/contracts/voting/cwd-voting-staking-denom-staked/schema/cwd-voting-staking-denom-staked.json
+++ b/contracts/voting/cwd-voting-staking-denom-staked/schema/cwd-voting-staking-denom-staked.json
@@ -30,19 +30,6 @@
       {
         "type": "object",
         "required": [
-          "dao"
-        ],
-        "properties": {
-          "dao": {
-            "type": "object",
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
-        "type": "object",
-        "required": [
           "staking_module"
         ],
         "properties": {
@@ -54,6 +41,7 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the voting power for an address at a given height.",
         "type": "object",
         "required": [
           "voting_power_at_height"
@@ -83,6 +71,7 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
         "required": [
           "total_power_at_height"
@@ -106,6 +95,21 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns the address of the DAO this module belongs to.",
+        "type": "object",
+        "required": [
+          "dao"
+        ],
+        "properties": {
+          "dao": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns contract version info.",
         "type": "object",
         "required": [
           "info"

--- a/contracts/voting/cwd-voting-staking-denom-staked/src/msg.rs
+++ b/contracts/voting/cwd-voting-staking-denom-staked/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cwd_macros::{info_query, voting_query};
+use cwd_macros::voting_query;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -13,12 +13,9 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {}
 
 #[voting_query]
-#[info_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
-    #[returns(cosmwasm_std::Addr)]
-    Dao {},
     #[returns(cosmwasm_std::Addr)]
     StakingModule {},
 }

--- a/contracts/voting/cwd-voting-staking-denom-staked/src/msg.rs
+++ b/contracts/voting/cwd-voting-staking-denom-staked/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cwd_macros::voting_query;
+use cwd_macros::voting_module_query;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -12,7 +12,7 @@ pub struct InstantiateMsg {
 #[cw_serde]
 pub enum ExecuteMsg {}
 
-#[voting_query]
+#[voting_module_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {

--- a/packages/cw-denom/src/lib.rs
+++ b/packages/cw-denom/src/lib.rs
@@ -79,9 +79,9 @@ impl UncheckedDenom {
 
 impl CheckedDenom {
     /// Queries WHO's balance for the denomination.
-    pub fn query_balance<'a, C: CustomQuery>(
+    pub fn query_balance<C: CustomQuery>(
         &self,
-        querier: &QuerierWrapper<'a, C>,
+        querier: &QuerierWrapper<C>,
         who: &Addr,
     ) -> StdResult<Uint128> {
         match self {

--- a/packages/cwd-interface/src/lib.rs
+++ b/packages/cwd-interface/src/lib.rs
@@ -38,11 +38,11 @@ pub struct ModuleInstantiateInfo {
 }
 
 impl ModuleInstantiateInfo {
-    pub fn into_wasm_msg(self, dao_address: Addr) -> WasmMsg {
+    pub fn into_wasm_msg(self, dao: Addr) -> WasmMsg {
         WasmMsg::Instantiate {
             admin: self.admin.map(|admin| match admin {
                 Admin::Address { addr } => addr,
-                Admin::CoreModule {} => dao_address.into_string(),
+                Admin::CoreModule {} => dao.into_string(),
             }),
             code_id: self.code_id,
             msg: self.msg,

--- a/packages/cwd-interface/src/voting.rs
+++ b/packages/cwd-interface/src/voting.rs
@@ -1,13 +1,11 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
 use cw2::ContractVersion;
-use cwd_macros::{active_query, info_query, proposal_module_query, token_query, voting_query};
+use cwd_macros::{active_query, token_query, voting_query};
 
 #[token_query]
 #[voting_query]
-#[info_query]
 #[active_query]
-#[proposal_module_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum Query {}
@@ -42,12 +40,11 @@ mod tests {
     fn test_macro_expansion() {
         use cosmwasm_schema::{cw_serde, QueryResponses};
 
-        use cwd_macros::{active_query, info_query, token_query, voting_query};
+        use cwd_macros::{active_query, token_query, voting_query};
         let query = Query::TokenContract {};
 
         #[token_query]
         #[voting_query]
-        #[info_query]
         #[active_query]
         #[cw_serde]
         #[derive(QueryResponses)]
@@ -59,6 +56,7 @@ mod tests {
             Query::TotalPowerAtHeight { .. } => (),
             Query::IsActive {} => (),
             Query::Info {} => (),
+            Query::Dao {} => (),
         }
     }
 }

--- a/packages/cwd-interface/src/voting.rs
+++ b/packages/cwd-interface/src/voting.rs
@@ -1,10 +1,10 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
 use cw2::ContractVersion;
-use cwd_macros::{active_query, token_query, voting_query};
+use cwd_macros::{active_query, token_query, voting_module_query};
 
 #[token_query]
-#[voting_query]
+#[voting_module_query]
 #[active_query]
 #[cw_serde]
 #[derive(QueryResponses)]
@@ -40,11 +40,11 @@ mod tests {
     fn test_macro_expansion() {
         use cosmwasm_schema::{cw_serde, QueryResponses};
 
-        use cwd_macros::{active_query, token_query, voting_query};
+        use cwd_macros::{active_query, token_query, voting_module_query};
         let query = Query::TokenContract {};
 
         #[token_query]
-        #[voting_query]
+        #[voting_module_query]
         #[active_query]
         #[cw_serde]
         #[derive(QueryResponses)]

--- a/packages/cwd-macros/Cargo.toml
+++ b/packages/cwd-macros/Cargo.toml
@@ -17,5 +17,6 @@ proc-macro2 = { workspace = true }
 
 [dev-dependencies]
 cwd-interface = { workspace = true }
+cwd-hooks = { workspace = true }
+cwd-voting = { workspace = true }
 cosmwasm-std = { workspace = true }
-

--- a/packages/cwd-macros/README.md
+++ b/packages/cwd-macros/README.md
@@ -6,13 +6,12 @@ the voting module interface on an enum:
 
 ```rust
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cwd_macros::{token_query, voting_module_query, info_query};
+use cwd_macros::{token_query, voting_module_query};
 use cwd_interface::voting::TotalPowerAtHeightResponse;
 use cwd_interface::voting::VotingPowerAtHeightResponse;
 
 #[token_query]
 #[voting_module_query]
-#[info_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum Query {}

--- a/packages/cwd-macros/README.md
+++ b/packages/cwd-macros/README.md
@@ -6,12 +6,12 @@ the voting module interface on an enum:
 
 ```rust
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cwd_macros::{token_query, voting_query, info_query};
+use cwd_macros::{token_query, voting_module_query, info_query};
 use cwd_interface::voting::TotalPowerAtHeightResponse;
 use cwd_interface::voting::VotingPowerAtHeightResponse;
 
 #[token_query]
-#[voting_query]
+#[voting_module_query]
 #[info_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/packages/cwd-macros/src/lib.rs
+++ b/packages/cwd-macros/src/lib.rs
@@ -324,16 +324,16 @@ pub fn proposal_module_query(metadata: TokenStream, input: TokenStream) -> Token
             #[returns(#i)]
             Info { },
             /// Returns the number of proposals that have been created in this module.
-            #[returns(u64)]
+            #[returns(::std::primitive::u64)]
             ProposalCount {},
             /// Gets the current proposal creation policy for this module.
-            #[returns(cwd_voting::pre_propose::ProposalCreationPolicy)]
+            #[returns(::cwd_voting::pre_propose::ProposalCreationPolicy)]
             ProposalCreationPolicy {},
             /// Lists all of the consumers of proposal hooks for this module.
-            #[returns(cwd_hooks::HooksResponse)]
+            #[returns(::cwd_hooks::HooksResponse)]
             ProposalHooks {},
-            /// Lists all of the consumers of vote hooks for thismodule.
-            #[returns(cwd_hooks::HooksResponse)]
+            /// Lists all of the consumers of vote hooks for this module.
+            #[returns(::cwd_hooks::HooksResponse)]
             VoteHooks {},
         }
         }

--- a/packages/cwd-macros/src/lib.rs
+++ b/packages/cwd-macros/src/lib.rs
@@ -81,6 +81,8 @@ fn cwd_interface_path(inside: &str) -> Path {
 ///     TotalPowerAtHeight {
 ///       height: Option<u64>
 ///     },
+///     Dao {},
+///     Info {},
 /// }
 /// ```
 ///
@@ -111,6 +113,7 @@ fn cwd_interface_path(inside: &str) -> Path {
 /// ```
 #[proc_macro_attribute]
 pub fn voting_query(metadata: TokenStream, input: TokenStream) -> TokenStream {
+    let i = cwd_interface_path("voting::InfoResponse");
     let vp = cwd_interface_path("voting::VotingPowerAtHeightResponse");
     let tp = cwd_interface_path("voting::TotalPowerAtHeightResponse");
 
@@ -119,15 +122,23 @@ pub fn voting_query(metadata: TokenStream, input: TokenStream) -> TokenStream {
         input,
         quote! {
         enum Right {
+            /// Returns the voting power for an address at a given height.
             #[returns(#vp)]
             VotingPowerAtHeight {
-            address: ::std::string::String,
-            height: ::std::option::Option<::std::primitive::u64>
+                address: ::std::string::String,
+                height: ::std::option::Option<::std::primitive::u64>
             },
+            /// Returns the total voting power at a given block heigh.
             #[returns(#tp)]
             TotalPowerAtHeight {
-            height: ::std::option::Option<::std::primitive::u64>
+                height: ::std::option::Option<::std::primitive::u64>
             },
+            /// Returns the address of the DAO this module belongs to.
+            #[returns(cosmwasm_std::Addr)]
+            Dao {},
+            /// Returns contract version info.
+            #[returns(#i)]
+            Info {}
         }
         }
         .into(),
@@ -250,65 +261,6 @@ pub fn active_query(metadata: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 /// Adds the necessary fields to an enum such that it implements the
-/// interface needed to be a module that has an
-/// info query.
-///
-/// For example:
-///
-/// ```
-/// use cwd_macros::info_query;
-/// use cosmwasm_schema::{cw_serde, QueryResponses};
-/// use cwd_interface::voting::InfoResponse;
-///
-/// #[info_query]
-/// #[cw_serde]
-/// #[derive(QueryResponses)]
-/// enum QueryMsg {}
-/// ```
-///
-/// Will transform the enum to:
-///
-/// ```
-/// enum QueryMsg {
-///     Info {},
-/// }
-/// ```
-///
-/// Note that other derive macro invocations must occur after this
-/// procedural macro as they may depend on the new fields. For
-/// example, the following will fail becase the `Clone` derivation
-/// occurs before the addition of the field.
-///
-/// ```compile_fail
-/// use cwd_macros::info_query;
-///
-/// #[derive(Clone)]
-/// #[info_query]
-/// #[allow(dead_code)]
-/// enum Test {
-///     Foo,
-///     Bar(u64),
-///     Baz { foo: u64 },
-/// }
-/// ```
-#[proc_macro_attribute]
-pub fn info_query(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    let i = cwd_interface_path("voting::InfoResponse");
-
-    merge_variants(
-        metadata,
-        input,
-        quote! {
-        enum Right {
-            #[returns(#i)]
-            Info { },
-        }
-        }
-        .into(),
-    )
-}
-
-/// Adds the necessary fields to an enum such that it implements the
 /// interface needed to be a proposal module.
 ///
 /// For example:
@@ -329,6 +281,9 @@ pub fn info_query(metadata: TokenStream, input: TokenStream) -> TokenStream {
 /// ```
 /// enum QueryMsg {
 ///     Dao {},
+///     Info {},
+///     ProposalCreationPolicy {},
+///     ProposalHooks {},
 /// }
 /// ```
 ///
@@ -355,13 +310,31 @@ pub fn info_query(metadata: TokenStream, input: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_attribute]
 pub fn proposal_module_query(metadata: TokenStream, input: TokenStream) -> TokenStream {
+    let i = cwd_interface_path("voting::InfoResponse");
+
     merge_variants(
         metadata,
         input,
         quote! {
         enum Right {
+            /// Returns the address of the DAO this module belongs to
             #[returns(::cosmwasm_std::Addr)]
-            Dao {}
+            Dao {},
+            /// Returns contract version info
+            #[returns(#i)]
+            Info { },
+            /// Returns the number of proposals that have been created in this module.
+            #[returns(u64)]
+            ProposalCount {},
+            /// Gets the current proposal creation policy for this module.
+            #[returns(cwd_voting::pre_propose::ProposalCreationPolicy)]
+            ProposalCreationPolicy {},
+            /// Lists all of the consumers of proposal hooks for this module.
+            #[returns(cwd_hooks::HooksResponse)]
+            ProposalHooks {},
+            /// Lists all of the consumers of vote hooks for thismodule.
+            #[returns(cwd_hooks::HooksResponse)]
+            VoteHooks {},
         }
         }
         .into(),

--- a/packages/cwd-macros/src/lib.rs
+++ b/packages/cwd-macros/src/lib.rs
@@ -58,12 +58,12 @@ fn cwd_interface_path(inside: &str) -> Path {
 /// For example:
 ///
 /// ```
-/// use cwd_macros::voting_query;
+/// use cwd_macros::voting_module_query;
 /// use cosmwasm_schema::{cw_serde, QueryResponses};
 /// use cwd_interface::voting::TotalPowerAtHeightResponse;
 /// use cwd_interface::voting::VotingPowerAtHeightResponse;
 ///
-/// #[voting_query]
+/// #[voting_module_query]
 /// #[cw_serde]
 /// #[derive(QueryResponses)]
 /// enum QueryMsg {}
@@ -92,13 +92,13 @@ fn cwd_interface_path(inside: &str) -> Path {
 /// occurs before the addition of the field.
 ///
 /// ```compile_fail
-/// use cwd_macros::voting_query;
+/// use cwd_macros::voting_module_query;
 /// use cosmwasm_schema::{cw_serde, QueryResponses};
 /// use cwd_interface::voting::TotalPowerAtHeightResponse;
 /// use cwd_interface::voting::VotingPowerAtHeightResponse;
 ///
 /// #[derive(Clone)]
-/// #[voting_query]
+/// #[voting_module_query]
 /// #[allow(dead_code)]
 /// #[cw_serde]
 /// #[derive(QueryResponses)]
@@ -112,7 +112,7 @@ fn cwd_interface_path(inside: &str) -> Path {
 /// }
 /// ```
 #[proc_macro_attribute]
-pub fn voting_query(metadata: TokenStream, input: TokenStream) -> TokenStream {
+pub fn voting_module_query(metadata: TokenStream, input: TokenStream) -> TokenStream {
     let i = cwd_interface_path("voting::InfoResponse");
     let vp = cwd_interface_path("voting::VotingPowerAtHeightResponse");
     let tp = cwd_interface_path("voting::TotalPowerAtHeightResponse");

--- a/packages/cwd-macros/tests/govmod.rs
+++ b/packages/cwd-macros/tests/govmod.rs
@@ -22,5 +22,10 @@ fn proposal_module_query_derive() {
     // If this compiles we have won.
     match test {
         Test::Foo | Test::Bar(_) | Test::Baz { .. } | Test::Dao {} => "yay",
+        Test::Info {} => "yay",
+        Test::ProposalCount {} => "yay",
+        Test::ProposalCreationPolicy {} => "yay",
+        Test::ProposalHooks {} => "yay",
+        Test::VoteHooks {} => "yay",
     };
 }

--- a/packages/cwd-macros/tests/voting.rs
+++ b/packages/cwd-macros/tests/voting.rs
@@ -1,11 +1,11 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 
-use cwd_macros::voting_query;
+use cwd_macros::voting_module_query;
 
 /// enum for testing. Important that this derives things / has other
 /// attributes so we can be sure we aren't messing with other macros
 /// with ours.
-#[voting_query]
+#[voting_module_query]
 #[allow(dead_code)]
 #[cw_serde]
 #[derive(QueryResponses)]
@@ -19,7 +19,7 @@ enum Test {
 }
 
 #[test]
-fn voting_query_derive() {
+fn voting_module_query_derive() {
     let _test = Test::VotingPowerAtHeight {
         address: "foo".to_string(),
         height: Some(10),

--- a/packages/cwd-macros/tests/voting.rs
+++ b/packages/cwd-macros/tests/voting.rs
@@ -1,12 +1,11 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 
-use cwd_macros::{info_query, voting_query};
+use cwd_macros::voting_query;
 
 /// enum for testing. Important that this derives things / has other
 /// attributes so we can be sure we aren't messing with other macros
 /// with ours.
 #[voting_query]
-#[info_query]
 #[allow(dead_code)]
 #[cw_serde]
 #[derive(QueryResponses)]
@@ -39,5 +38,6 @@ fn voting_query_derive() {
             address: _,
         }
         | Test::Info {} => "yay",
+        Test::Dao {} => "yay",
     };
 }

--- a/packages/cwd-voting/src/pre_propose.rs
+++ b/packages/cwd-voting/src/pre_propose.rs
@@ -40,7 +40,7 @@ impl ProposalCreationPolicy {
 impl PreProposeInfo {
     pub fn into_initial_policy_and_messages(
         self,
-        dao_address: Addr,
+        dao: Addr,
     ) -> StdResult<(ProposalCreationPolicy, Vec<SubMsg<Empty>>)> {
         Ok(match self {
             Self::AnyoneMayPropose {} => (ProposalCreationPolicy::Anyone {}, vec![]),
@@ -50,7 +50,7 @@ impl PreProposeInfo {
                 // upon instantiation failure.
                 ProposalCreationPolicy::Anyone {},
                 vec![SubMsg::reply_on_success(
-                    info.into_wasm_msg(dao_address),
+                    info.into_wasm_msg(dao),
                     pre_propose_module_instantiation_id(),
                 )],
             ),

--- a/test-contracts/cwd-proposal-sudo/src/msg.rs
+++ b/test-contracts/cwd-proposal-sudo/src/msg.rs
@@ -1,8 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::CosmosMsg;
 
-use cwd_macros::{info_query, proposal_module_query};
-
 #[cw_serde]
 pub struct InstantiateMsg {
     pub root: String,
@@ -13,11 +11,13 @@ pub enum ExecuteMsg {
     Execute { msgs: Vec<CosmosMsg> },
 }
 
-#[proposal_module_query]
-#[info_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     #[returns(cosmwasm_std::Addr)]
     Admin {},
+    #[returns(cosmwasm_std::Addr)]
+    Dao {},
+    #[returns(cwd_interface::voting::InfoResponse)]
+    Info {},
 }

--- a/test-contracts/cwd-voting-cw20-balance/src/contract.rs
+++ b/test-contracts/cwd-voting-cw20-balance/src/contract.rs
@@ -9,7 +9,7 @@ use cw_utils::parse_reply_instantiate_data;
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, TokenInfo};
-use crate::state::TOKEN;
+use crate::state::{DAO_ADDRESS, TOKEN};
 
 const CONTRACT_NAME: &str = "crates.io:cw20-balance-voting";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -24,6 +24,8 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    DAO_ADDRESS.save(deps.storage, &info.sender)?;
 
     match msg.token_info {
         TokenInfo::Existing { address } => {
@@ -96,8 +98,13 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         }
         QueryMsg::TotalPowerAtHeight { height: _ } => query_total_power_at_height(deps, env),
         QueryMsg::Info {} => query_info(deps),
-        QueryMsg::Dao {} => unimplemented!(),
+        QueryMsg::Dao {} => query_dao(deps),
     }
+}
+
+pub fn query_dao(deps: Deps) -> StdResult<Binary> {
+    let dao = DAO_ADDRESS.load(deps.storage)?;
+    to_binary(&dao)
 }
 
 pub fn query_token_contract(deps: Deps) -> StdResult<Binary> {

--- a/test-contracts/cwd-voting-cw20-balance/src/contract.rs
+++ b/test-contracts/cwd-voting-cw20-balance/src/contract.rs
@@ -96,6 +96,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         }
         QueryMsg::TotalPowerAtHeight { height: _ } => query_total_power_at_height(deps, env),
         QueryMsg::Info {} => query_info(deps),
+        QueryMsg::Dao {} => unimplemented!(),
     }
 }
 

--- a/test-contracts/cwd-voting-cw20-balance/src/contract.rs
+++ b/test-contracts/cwd-voting-cw20-balance/src/contract.rs
@@ -9,7 +9,7 @@ use cw_utils::parse_reply_instantiate_data;
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, TokenInfo};
-use crate::state::{DAO_ADDRESS, TOKEN};
+use crate::state::{DAO, TOKEN};
 
 const CONTRACT_NAME: &str = "crates.io:cw20-balance-voting";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -25,7 +25,7 @@ pub fn instantiate(
 ) -> Result<Response, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
-    DAO_ADDRESS.save(deps.storage, &info.sender)?;
+    DAO.save(deps.storage, &info.sender)?;
 
     match msg.token_info {
         TokenInfo::Existing { address } => {
@@ -103,7 +103,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 }
 
 pub fn query_dao(deps: Deps) -> StdResult<Binary> {
-    let dao = DAO_ADDRESS.load(deps.storage)?;
+    let dao = DAO.load(deps.storage)?;
     to_binary(&dao)
 }
 

--- a/test-contracts/cwd-voting-cw20-balance/src/msg.rs
+++ b/test-contracts/cwd-voting-cw20-balance/src/msg.rs
@@ -3,7 +3,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cw20::Cw20Coin;
 use cw20_base::msg::InstantiateMarketingInfo;
 
-use cwd_macros::{token_query, voting_query};
+use cwd_macros::{token_query, voting_module_query};
 
 #[cw_serde]
 pub enum TokenInfo {
@@ -31,7 +31,7 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {}
 
 #[token_query]
-#[voting_query]
+#[voting_module_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {}

--- a/test-contracts/cwd-voting-cw20-balance/src/msg.rs
+++ b/test-contracts/cwd-voting-cw20-balance/src/msg.rs
@@ -3,7 +3,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cw20::Cw20Coin;
 use cw20_base::msg::InstantiateMarketingInfo;
 
-use cwd_macros::{info_query, token_query, voting_query};
+use cwd_macros::{token_query, voting_query};
 
 #[cw_serde]
 pub enum TokenInfo {
@@ -32,7 +32,6 @@ pub enum ExecuteMsg {}
 
 #[token_query]
 #[voting_query]
-#[info_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {}

--- a/test-contracts/cwd-voting-cw20-balance/src/state.rs
+++ b/test-contracts/cwd-voting-cw20-balance/src/state.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::Addr;
 use cw_storage_plus::Item;
 
+pub const DAO_ADDRESS: Item<Addr> = Item::new("dao_address");
 pub const TOKEN: Item<Addr> = Item::new("token");

--- a/test-contracts/cwd-voting-cw20-balance/src/state.rs
+++ b/test-contracts/cwd-voting-cw20-balance/src/state.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::Addr;
 use cw_storage_plus::Item;
 
-pub const DAO_ADDRESS: Item<Addr> = Item::new("dao_address");
+pub const DAO: Item<Addr> = Item::new("dao");
 pub const TOKEN: Item<Addr> = Item::new("token");

--- a/typescript/contracts/cwd-core/CwdCore.client.ts
+++ b/typescript/contracts/cwd-core/CwdCore.client.ts
@@ -46,6 +46,7 @@ export interface CwdCoreReadOnlyInterface {
     limit?: number;
     startAfter?: string;
   }) => Promise<ArrayOfString>;
+  info: () => Promise<InfoResponse>;
   proposalModules: ({
     limit,
     startAfter
@@ -82,7 +83,6 @@ export interface CwdCoreReadOnlyInterface {
   }: {
     height?: number;
   }) => Promise<TotalPowerAtHeightResponse>;
-  info: () => Promise<InfoResponse>;
 }
 export class CwdCoreQueryClient implements CwdCoreReadOnlyInterface {
   client: CosmWasmClient;
@@ -100,6 +100,7 @@ export class CwdCoreQueryClient implements CwdCoreReadOnlyInterface {
     this.dumpState = this.dumpState.bind(this);
     this.getItem = this.getItem.bind(this);
     this.listItems = this.listItems.bind(this);
+    this.info = this.info.bind(this);
     this.proposalModules = this.proposalModules.bind(this);
     this.activeProposalModules = this.activeProposalModules.bind(this);
     this.pauseInfo = this.pauseInfo.bind(this);
@@ -108,7 +109,6 @@ export class CwdCoreQueryClient implements CwdCoreReadOnlyInterface {
     this.daoURI = this.daoURI.bind(this);
     this.votingPowerAtHeight = this.votingPowerAtHeight.bind(this);
     this.totalPowerAtHeight = this.totalPowerAtHeight.bind(this);
-    this.info = this.info.bind(this);
   }
 
   admin = async (): Promise<Addr> => {
@@ -198,6 +198,11 @@ export class CwdCoreQueryClient implements CwdCoreReadOnlyInterface {
       }
     });
   };
+  info = async (): Promise<InfoResponse> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      info: {}
+    });
+  };
   proposalModules = async ({
     limit,
     startAfter
@@ -278,11 +283,6 @@ export class CwdCoreQueryClient implements CwdCoreReadOnlyInterface {
       total_power_at_height: {
         height
       }
-    });
-  };
-  info = async (): Promise<InfoResponse> => {
-    return this.client.queryContractSmart(this.contractAddress, {
-      info: {}
     });
   };
 }

--- a/typescript/contracts/cwd-core/CwdCore.types.ts
+++ b/typescript/contracts/cwd-core/CwdCore.types.ts
@@ -305,6 +305,8 @@ export type QueryMsg = {
     start_after?: string | null;
   };
 } | {
+  info: {};
+} | {
   proposal_modules: {
     limit?: number | null;
     start_after?: string | null;
@@ -334,8 +336,6 @@ export type QueryMsg = {
   total_power_at_height: {
     height?: number | null;
   };
-} | {
-  info: {};
 };
 export type MigrateMsg = {
   from_v1: {

--- a/typescript/contracts/cwd-proposal-multiple/CwdProposalMultiple.client.ts
+++ b/typescript/contracts/cwd-proposal-multiple/CwdProposalMultiple.client.ts
@@ -29,7 +29,6 @@ export interface CwdProposalMultipleReadOnlyInterface {
     limit?: number;
     startBefore?: number;
   }) => Promise<ProposalListResponse>;
-  proposalCount: () => Promise<Uint64>;
   getVote: ({
     proposalId,
     voter
@@ -46,11 +45,12 @@ export interface CwdProposalMultipleReadOnlyInterface {
     proposalId: number;
     startAfter?: string;
   }) => Promise<VoteListResponse>;
+  dao: () => Promise<Addr>;
+  info: () => Promise<InfoResponse>;
+  proposalCount: () => Promise<Uint64>;
   proposalCreationPolicy: () => Promise<ProposalCreationPolicy>;
   proposalHooks: () => Promise<HooksResponse>;
   voteHooks: () => Promise<HooksResponse>;
-  dao: () => Promise<Addr>;
-  info: () => Promise<InfoResponse>;
 }
 export class CwdProposalMultipleQueryClient implements CwdProposalMultipleReadOnlyInterface {
   client: CosmWasmClient;
@@ -63,14 +63,14 @@ export class CwdProposalMultipleQueryClient implements CwdProposalMultipleReadOn
     this.proposal = this.proposal.bind(this);
     this.listProposals = this.listProposals.bind(this);
     this.reverseProposals = this.reverseProposals.bind(this);
-    this.proposalCount = this.proposalCount.bind(this);
     this.getVote = this.getVote.bind(this);
     this.listVotes = this.listVotes.bind(this);
+    this.dao = this.dao.bind(this);
+    this.info = this.info.bind(this);
+    this.proposalCount = this.proposalCount.bind(this);
     this.proposalCreationPolicy = this.proposalCreationPolicy.bind(this);
     this.proposalHooks = this.proposalHooks.bind(this);
     this.voteHooks = this.voteHooks.bind(this);
-    this.dao = this.dao.bind(this);
-    this.info = this.info.bind(this);
   }
 
   config = async (): Promise<Config> => {
@@ -117,11 +117,6 @@ export class CwdProposalMultipleQueryClient implements CwdProposalMultipleReadOn
       }
     });
   };
-  proposalCount = async (): Promise<Uint64> => {
-    return this.client.queryContractSmart(this.contractAddress, {
-      proposal_count: {}
-    });
-  };
   getVote = async ({
     proposalId,
     voter
@@ -153,6 +148,21 @@ export class CwdProposalMultipleQueryClient implements CwdProposalMultipleReadOn
       }
     });
   };
+  dao = async (): Promise<Addr> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      dao: {}
+    });
+  };
+  info = async (): Promise<InfoResponse> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      info: {}
+    });
+  };
+  proposalCount = async (): Promise<Uint64> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      proposal_count: {}
+    });
+  };
   proposalCreationPolicy = async (): Promise<ProposalCreationPolicy> => {
     return this.client.queryContractSmart(this.contractAddress, {
       proposal_creation_policy: {}
@@ -166,16 +176,6 @@ export class CwdProposalMultipleQueryClient implements CwdProposalMultipleReadOn
   voteHooks = async (): Promise<HooksResponse> => {
     return this.client.queryContractSmart(this.contractAddress, {
       vote_hooks: {}
-    });
-  };
-  dao = async (): Promise<Addr> => {
-    return this.client.queryContractSmart(this.contractAddress, {
-      dao: {}
-    });
-  };
-  info = async (): Promise<InfoResponse> => {
-    return this.client.queryContractSmart(this.contractAddress, {
-      info: {}
     });
   };
 }

--- a/typescript/contracts/cwd-proposal-multiple/CwdProposalMultiple.types.ts
+++ b/typescript/contracts/cwd-proposal-multiple/CwdProposalMultiple.types.ts
@@ -278,8 +278,6 @@ export type QueryMsg = {
     start_before?: number | null;
   };
 } | {
-  proposal_count: {};
-} | {
   get_vote: {
     proposal_id: number;
     voter: string;
@@ -291,15 +289,17 @@ export type QueryMsg = {
     start_after?: string | null;
   };
 } | {
+  dao: {};
+} | {
+  info: {};
+} | {
+  proposal_count: {};
+} | {
   proposal_creation_policy: {};
 } | {
   proposal_hooks: {};
 } | {
   vote_hooks: {};
-} | {
-  dao: {};
-} | {
-  info: {};
 };
 export type MigrateMsg = {
   from_v1: {

--- a/typescript/contracts/cwd-proposal-single/CwdProposalSingle.client.ts
+++ b/typescript/contracts/cwd-proposal-single/CwdProposalSingle.client.ts
@@ -29,7 +29,6 @@ export interface CwdProposalSingleReadOnlyInterface {
     limit?: number;
     startBefore?: number;
   }) => Promise<ProposalListResponse>;
-  proposalCount: () => Promise<Uint64>;
   getVote: ({
     proposalId,
     voter
@@ -46,11 +45,12 @@ export interface CwdProposalSingleReadOnlyInterface {
     proposalId: number;
     startAfter?: string;
   }) => Promise<VoteListResponse>;
+  dao: () => Promise<Addr>;
+  info: () => Promise<InfoResponse>;
+  proposalCount: () => Promise<Uint64>;
   proposalCreationPolicy: () => Promise<ProposalCreationPolicy>;
   proposalHooks: () => Promise<HooksResponse>;
   voteHooks: () => Promise<HooksResponse>;
-  dao: () => Promise<Addr>;
-  info: () => Promise<InfoResponse>;
 }
 export class CwdProposalSingleQueryClient implements CwdProposalSingleReadOnlyInterface {
   client: CosmWasmClient;
@@ -63,14 +63,14 @@ export class CwdProposalSingleQueryClient implements CwdProposalSingleReadOnlyIn
     this.proposal = this.proposal.bind(this);
     this.listProposals = this.listProposals.bind(this);
     this.reverseProposals = this.reverseProposals.bind(this);
-    this.proposalCount = this.proposalCount.bind(this);
     this.getVote = this.getVote.bind(this);
     this.listVotes = this.listVotes.bind(this);
+    this.dao = this.dao.bind(this);
+    this.info = this.info.bind(this);
+    this.proposalCount = this.proposalCount.bind(this);
     this.proposalCreationPolicy = this.proposalCreationPolicy.bind(this);
     this.proposalHooks = this.proposalHooks.bind(this);
     this.voteHooks = this.voteHooks.bind(this);
-    this.dao = this.dao.bind(this);
-    this.info = this.info.bind(this);
   }
 
   config = async (): Promise<Config> => {
@@ -117,11 +117,6 @@ export class CwdProposalSingleQueryClient implements CwdProposalSingleReadOnlyIn
       }
     });
   };
-  proposalCount = async (): Promise<Uint64> => {
-    return this.client.queryContractSmart(this.contractAddress, {
-      proposal_count: {}
-    });
-  };
   getVote = async ({
     proposalId,
     voter
@@ -153,6 +148,21 @@ export class CwdProposalSingleQueryClient implements CwdProposalSingleReadOnlyIn
       }
     });
   };
+  dao = async (): Promise<Addr> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      dao: {}
+    });
+  };
+  info = async (): Promise<InfoResponse> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      info: {}
+    });
+  };
+  proposalCount = async (): Promise<Uint64> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      proposal_count: {}
+    });
+  };
   proposalCreationPolicy = async (): Promise<ProposalCreationPolicy> => {
     return this.client.queryContractSmart(this.contractAddress, {
       proposal_creation_policy: {}
@@ -166,16 +176,6 @@ export class CwdProposalSingleQueryClient implements CwdProposalSingleReadOnlyIn
   voteHooks = async (): Promise<HooksResponse> => {
     return this.client.queryContractSmart(this.contractAddress, {
       vote_hooks: {}
-    });
-  };
-  dao = async (): Promise<Addr> => {
-    return this.client.queryContractSmart(this.contractAddress, {
-      dao: {}
-    });
-  };
-  info = async (): Promise<InfoResponse> => {
-    return this.client.queryContractSmart(this.contractAddress, {
-      info: {}
     });
   };
 }

--- a/typescript/contracts/cwd-proposal-single/CwdProposalSingle.types.ts
+++ b/typescript/contracts/cwd-proposal-single/CwdProposalSingle.types.ts
@@ -283,8 +283,6 @@ export type QueryMsg = {
     start_before?: number | null;
   };
 } | {
-  proposal_count: {};
-} | {
   get_vote: {
     proposal_id: number;
     voter: string;
@@ -296,15 +294,17 @@ export type QueryMsg = {
     start_after?: string | null;
   };
 } | {
+  dao: {};
+} | {
+  info: {};
+} | {
+  proposal_count: {};
+} | {
   proposal_creation_policy: {};
 } | {
   proposal_hooks: {};
 } | {
   vote_hooks: {};
-} | {
-  dao: {};
-} | {
-  info: {};
 };
 export type MigrateMsg = {
   from_v1: {

--- a/typescript/contracts/cwd-voting-cw20-staked/CwdVotingCw20Staked.client.ts
+++ b/typescript/contracts/cwd-voting-cw20-staked/CwdVotingCw20Staked.client.ts
@@ -10,7 +10,6 @@ import { ActiveThreshold, Uint128, Decimal, TokenInfo, StakingInfo, Duration, Lo
 export interface CwdVotingCw20StakedReadOnlyInterface {
   contractAddress: string;
   stakingContract: () => Promise<Addr>;
-  dao: () => Promise<Addr>;
   activeThreshold: () => Promise<ActiveThresholdResponse>;
   votingPowerAtHeight: ({
     address,
@@ -24,6 +23,7 @@ export interface CwdVotingCw20StakedReadOnlyInterface {
   }: {
     height?: number;
   }) => Promise<TotalPowerAtHeightResponse>;
+  dao: () => Promise<Addr>;
   info: () => Promise<InfoResponse>;
   tokenContract: () => Promise<Addr>;
   isActive: () => Promise<Boolean>;
@@ -36,10 +36,10 @@ export class CwdVotingCw20StakedQueryClient implements CwdVotingCw20StakedReadOn
     this.client = client;
     this.contractAddress = contractAddress;
     this.stakingContract = this.stakingContract.bind(this);
-    this.dao = this.dao.bind(this);
     this.activeThreshold = this.activeThreshold.bind(this);
     this.votingPowerAtHeight = this.votingPowerAtHeight.bind(this);
     this.totalPowerAtHeight = this.totalPowerAtHeight.bind(this);
+    this.dao = this.dao.bind(this);
     this.info = this.info.bind(this);
     this.tokenContract = this.tokenContract.bind(this);
     this.isActive = this.isActive.bind(this);
@@ -48,11 +48,6 @@ export class CwdVotingCw20StakedQueryClient implements CwdVotingCw20StakedReadOn
   stakingContract = async (): Promise<Addr> => {
     return this.client.queryContractSmart(this.contractAddress, {
       staking_contract: {}
-    });
-  };
-  dao = async (): Promise<Addr> => {
-    return this.client.queryContractSmart(this.contractAddress, {
-      dao: {}
     });
   };
   activeThreshold = async (): Promise<ActiveThresholdResponse> => {
@@ -83,6 +78,11 @@ export class CwdVotingCw20StakedQueryClient implements CwdVotingCw20StakedReadOn
       total_power_at_height: {
         height
       }
+    });
+  };
+  dao = async (): Promise<Addr> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      dao: {}
     });
   };
   info = async (): Promise<InfoResponse> => {

--- a/typescript/contracts/cwd-voting-cw20-staked/CwdVotingCw20Staked.types.ts
+++ b/typescript/contracts/cwd-voting-cw20-staked/CwdVotingCw20Staked.types.ts
@@ -82,8 +82,6 @@ export type ExecuteMsg = {
 export type QueryMsg = {
   staking_contract: {};
 } | {
-  dao: {};
-} | {
   active_threshold: {};
 } | {
   voting_power_at_height: {
@@ -94,6 +92,8 @@ export type QueryMsg = {
   total_power_at_height: {
     height?: number | null;
   };
+} | {
+  dao: {};
 } | {
   info: {};
 } | {

--- a/typescript/contracts/cwd-voting-cw4/CwdVotingCw4.client.ts
+++ b/typescript/contracts/cwd-voting-cw4/CwdVotingCw4.client.ts
@@ -10,7 +10,6 @@ import { InstantiateMsg, Member, ExecuteMsg, MemberDiff, QueryMsg, MigrateMsg, A
 export interface CwdVotingCw4ReadOnlyInterface {
   contractAddress: string;
   groupContract: () => Promise<Addr>;
-  dao: () => Promise<Addr>;
   votingPowerAtHeight: ({
     address,
     height
@@ -23,6 +22,7 @@ export interface CwdVotingCw4ReadOnlyInterface {
   }: {
     height?: number;
   }) => Promise<TotalPowerAtHeightResponse>;
+  dao: () => Promise<Addr>;
   info: () => Promise<InfoResponse>;
 }
 export class CwdVotingCw4QueryClient implements CwdVotingCw4ReadOnlyInterface {
@@ -33,20 +33,15 @@ export class CwdVotingCw4QueryClient implements CwdVotingCw4ReadOnlyInterface {
     this.client = client;
     this.contractAddress = contractAddress;
     this.groupContract = this.groupContract.bind(this);
-    this.dao = this.dao.bind(this);
     this.votingPowerAtHeight = this.votingPowerAtHeight.bind(this);
     this.totalPowerAtHeight = this.totalPowerAtHeight.bind(this);
+    this.dao = this.dao.bind(this);
     this.info = this.info.bind(this);
   }
 
   groupContract = async (): Promise<Addr> => {
     return this.client.queryContractSmart(this.contractAddress, {
       group_contract: {}
-    });
-  };
-  dao = async (): Promise<Addr> => {
-    return this.client.queryContractSmart(this.contractAddress, {
-      dao: {}
     });
   };
   votingPowerAtHeight = async ({
@@ -72,6 +67,11 @@ export class CwdVotingCw4QueryClient implements CwdVotingCw4ReadOnlyInterface {
       total_power_at_height: {
         height
       }
+    });
+  };
+  dao = async (): Promise<Addr> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      dao: {}
     });
   };
   info = async (): Promise<InfoResponse> => {

--- a/typescript/contracts/cwd-voting-cw4/CwdVotingCw4.types.ts
+++ b/typescript/contracts/cwd-voting-cw4/CwdVotingCw4.types.ts
@@ -25,8 +25,6 @@ export interface MemberDiff {
 export type QueryMsg = {
   group_contract: {};
 } | {
-  dao: {};
-} | {
   voting_power_at_height: {
     address: string;
     height?: number | null;
@@ -35,6 +33,8 @@ export type QueryMsg = {
   total_power_at_height: {
     height?: number | null;
   };
+} | {
+  dao: {};
 } | {
   info: {};
 };

--- a/typescript/contracts/cwd-voting-cw721-staked/CwdVotingCw721Staked.client.ts
+++ b/typescript/contracts/cwd-voting-cw721-staked/CwdVotingCw721Staked.client.ts
@@ -37,6 +37,7 @@ export interface CwdVotingCw721StakedReadOnlyInterface {
   }: {
     height?: number;
   }) => Promise<TotalPowerAtHeightResponse>;
+  dao: () => Promise<Addr>;
   info: () => Promise<InfoResponse>;
 }
 export class CwdVotingCw721StakedQueryClient implements CwdVotingCw721StakedReadOnlyInterface {
@@ -52,6 +53,7 @@ export class CwdVotingCw721StakedQueryClient implements CwdVotingCw721StakedRead
     this.stakedNfts = this.stakedNfts.bind(this);
     this.votingPowerAtHeight = this.votingPowerAtHeight.bind(this);
     this.totalPowerAtHeight = this.totalPowerAtHeight.bind(this);
+    this.dao = this.dao.bind(this);
     this.info = this.info.bind(this);
   }
 
@@ -116,6 +118,11 @@ export class CwdVotingCw721StakedQueryClient implements CwdVotingCw721StakedRead
       total_power_at_height: {
         height
       }
+    });
+  };
+  dao = async (): Promise<Addr> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      dao: {}
     });
   };
   info = async (): Promise<InfoResponse> => {

--- a/typescript/contracts/cwd-voting-cw721-staked/CwdVotingCw721Staked.types.ts
+++ b/typescript/contracts/cwd-voting-cw721-staked/CwdVotingCw721Staked.types.ts
@@ -73,6 +73,8 @@ export type QueryMsg = {
     height?: number | null;
   };
 } | {
+  dao: {};
+} | {
   info: {};
 };
 export type Addr = string;

--- a/typescript/contracts/cwd-voting-native-staked/CwdVotingNativeStaked.client.ts
+++ b/typescript/contracts/cwd-voting-native-staked/CwdVotingNativeStaked.client.ts
@@ -9,7 +9,6 @@ import { Coin, StdFee } from "@cosmjs/amino";
 import { Admin, Duration, InstantiateMsg, ExecuteMsg, Uint128, QueryMsg, MigrateMsg, Expiration, Timestamp, Uint64, ClaimsResponse, Claim, Addr, Config, InfoResponse, ContractVersion, ListStakersResponse, StakerBalanceResponse, TotalPowerAtHeightResponse, VotingPowerAtHeightResponse } from "./CwdVotingNativeStaked.types";
 export interface CwdVotingNativeStakedReadOnlyInterface {
   contractAddress: string;
-  dao: () => Promise<Addr>;
   getConfig: () => Promise<Config>;
   claims: ({
     address
@@ -35,6 +34,7 @@ export interface CwdVotingNativeStakedReadOnlyInterface {
   }: {
     height?: number;
   }) => Promise<TotalPowerAtHeightResponse>;
+  dao: () => Promise<Addr>;
   info: () => Promise<InfoResponse>;
 }
 export class CwdVotingNativeStakedQueryClient implements CwdVotingNativeStakedReadOnlyInterface {
@@ -44,20 +44,15 @@ export class CwdVotingNativeStakedQueryClient implements CwdVotingNativeStakedRe
   constructor(client: CosmWasmClient, contractAddress: string) {
     this.client = client;
     this.contractAddress = contractAddress;
-    this.dao = this.dao.bind(this);
     this.getConfig = this.getConfig.bind(this);
     this.claims = this.claims.bind(this);
     this.listStakers = this.listStakers.bind(this);
     this.votingPowerAtHeight = this.votingPowerAtHeight.bind(this);
     this.totalPowerAtHeight = this.totalPowerAtHeight.bind(this);
+    this.dao = this.dao.bind(this);
     this.info = this.info.bind(this);
   }
 
-  dao = async (): Promise<Addr> => {
-    return this.client.queryContractSmart(this.contractAddress, {
-      dao: {}
-    });
-  };
   getConfig = async (): Promise<Config> => {
     return this.client.queryContractSmart(this.contractAddress, {
       get_config: {}
@@ -111,6 +106,11 @@ export class CwdVotingNativeStakedQueryClient implements CwdVotingNativeStakedRe
       total_power_at_height: {
         height
       }
+    });
+  };
+  dao = async (): Promise<Addr> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      dao: {}
     });
   };
   info = async (): Promise<InfoResponse> => {

--- a/typescript/contracts/cwd-voting-native-staked/CwdVotingNativeStaked.types.ts
+++ b/typescript/contracts/cwd-voting-native-staked/CwdVotingNativeStaked.types.ts
@@ -39,8 +39,6 @@ export type ExecuteMsg = {
 };
 export type Uint128 = string;
 export type QueryMsg = {
-  dao: {};
-} | {
   get_config: {};
 } | {
   claims: {
@@ -60,6 +58,8 @@ export type QueryMsg = {
   total_power_at_height: {
     height?: number | null;
   };
+} | {
+  dao: {};
 } | {
   info: {};
 };

--- a/typescript/contracts/cwd-voting-staking-denom-staked/CwdVotingStakingDenomStaked.client.ts
+++ b/typescript/contracts/cwd-voting-staking-denom-staked/CwdVotingStakingDenomStaked.client.ts
@@ -8,7 +8,6 @@ import { CosmWasmClient } from "@cosmjs/cosmwasm-stargate";
 import { InstantiateMsg, ExecuteMsg, QueryMsg, MigrateMsg, Addr, InfoResponse, ContractVersion, Uint128, TotalPowerAtHeightResponse, VotingPowerAtHeightResponse } from "./CwdVotingStakingDenomStaked.types";
 export interface CwdVotingStakingDenomStakedReadOnlyInterface {
   contractAddress: string;
-  dao: () => Promise<Addr>;
   stakingModule: () => Promise<Addr>;
   votingPowerAtHeight: ({
     address,
@@ -22,6 +21,7 @@ export interface CwdVotingStakingDenomStakedReadOnlyInterface {
   }: {
     height?: number;
   }) => Promise<TotalPowerAtHeightResponse>;
+  dao: () => Promise<Addr>;
   info: () => Promise<InfoResponse>;
 }
 export class CwdVotingStakingDenomStakedQueryClient implements CwdVotingStakingDenomStakedReadOnlyInterface {
@@ -31,18 +31,13 @@ export class CwdVotingStakingDenomStakedQueryClient implements CwdVotingStakingD
   constructor(client: CosmWasmClient, contractAddress: string) {
     this.client = client;
     this.contractAddress = contractAddress;
-    this.dao = this.dao.bind(this);
     this.stakingModule = this.stakingModule.bind(this);
     this.votingPowerAtHeight = this.votingPowerAtHeight.bind(this);
     this.totalPowerAtHeight = this.totalPowerAtHeight.bind(this);
+    this.dao = this.dao.bind(this);
     this.info = this.info.bind(this);
   }
 
-  dao = async (): Promise<Addr> => {
-    return this.client.queryContractSmart(this.contractAddress, {
-      dao: {}
-    });
-  };
   stakingModule = async (): Promise<Addr> => {
     return this.client.queryContractSmart(this.contractAddress, {
       staking_module: {}
@@ -71,6 +66,11 @@ export class CwdVotingStakingDenomStakedQueryClient implements CwdVotingStakingD
       total_power_at_height: {
         height
       }
+    });
+  };
+  dao = async (): Promise<Addr> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      dao: {}
     });
   };
   info = async (): Promise<InfoResponse> => {

--- a/typescript/contracts/cwd-voting-staking-denom-staked/CwdVotingStakingDenomStaked.types.ts
+++ b/typescript/contracts/cwd-voting-staking-denom-staked/CwdVotingStakingDenomStaked.types.ts
@@ -9,8 +9,6 @@ export interface InstantiateMsg {
 }
 export type ExecuteMsg = string;
 export type QueryMsg = {
-  dao: {};
-} | {
   staking_module: {};
 } | {
   voting_power_at_height: {
@@ -21,6 +19,8 @@ export type QueryMsg = {
   total_power_at_height: {
     height?: number | null;
   };
+} | {
+  dao: {};
 } | {
   info: {};
 };


### PR DESCRIPTION
- Closes #509
- Closes #459 

Wound up removing the `info_query` macro as it was used for both proposal and voting modules. It's more and helpful IMO to only have to use one macro to implement a module.

Wound up also implementing a missing `Dao { }` query for the cw721 voting contract. This a good example of why it's nice to have everything in a `voting_query` macro... otherwise the developer has to remember which macros to use.