### PR TITLE
Allow pre-propose approval contract to be added to a proposal module with pending proposals

### DIFF
--- a/contracts/pre-propose/cwd-pre-propose-approval-single/Cargo.toml
+++ b/contracts/pre-propose/cwd-pre-propose-approval-single/Cargo.toml
@@ -22,6 +22,7 @@ cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
 cw-paginate = { workspace = true }
 cwd-pre-propose-base = { workspace = true }
+cwd-proposal-single = { workspace = true, features = ["library"] }
 cwd-voting = { workspace = true }
 thiserror = { workspace = true }
 
@@ -34,7 +35,6 @@ cw20 = { workspace = true }
 cw20-base = { workspace = true }
 cwd-core = { workspace = true }
 cwd-proposal-hooks = { workspace = true }
-cwd-proposal-single = { workspace = true, features = ["library"] }
 cwd-interface = { workspace = true }
 cwd-testing = { workspace = true }
 cwd-voting = { workspace = true }

--- a/contracts/pre-propose/cwd-pre-propose-approval-single/src/contract.rs
+++ b/contracts/pre-propose/cwd-pre-propose-approval-single/src/contract.rs
@@ -9,13 +9,14 @@ use cw_paginate::paginate_map_values;
 use cwd_pre_propose_base::{
     error::PreProposeError, msg::ExecuteMsg as ExecuteBase, state::PreProposeContract,
 };
+use cwd_proposal_single::msg::ProposeMsg;
 use cwd_voting::deposit::DepositRefundPolicy;
 
 use crate::msg::{
     ApproverProposeMessage, ExecuteExt, ExecuteMsg, InstantiateExt, InstantiateMsg, ProposeMessage,
     ProposeMessageInternal, QueryExt, QueryMsg,
 };
-use crate::state::{PendingProposal, ProposeMsgSingle, APPROVER, CURRENT_ID, PENDING_PROPOSALS};
+use crate::state::{PendingProposal, APPROVER, CURRENT_ID, PENDING_PROPOSALS};
 
 pub(crate) const CONTRACT_NAME: &str = "crates.io:cwd-pre-propose-approval-single";
 pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -90,7 +91,7 @@ pub fn execute_propose(
             title,
             description,
             msgs,
-        } => ProposeMsgSingle {
+        } => ProposeMsg {
             title,
             description,
             msgs,
@@ -168,12 +169,12 @@ pub fn execute_approve(
             let proposal_module = PrePropose::default().proposal_module.load(deps.storage)?;
             let propose_messsage = WasmMsg::Execute {
                 contract_addr: proposal_module.into_string(),
-                msg: to_binary(&ProposeMessageInternal::Propose {
+                msg: to_binary(&ProposeMessageInternal::Propose(ProposeMsg {
                     title: proposal.msg.title,
                     description: proposal.msg.description,
                     msgs: proposal.msg.msgs,
                     proposer: proposal.msg.proposer,
-                })?,
+                }))?,
                 funds: vec![],
             };
 

--- a/contracts/pre-propose/cwd-pre-propose-approval-single/src/contract.rs
+++ b/contracts/pre-propose/cwd-pre-propose-approval-single/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    ensure, to_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Order, Response, StdResult,
-    Storage, SubMsg, WasmMsg,
+    to_binary, Addr, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Order, Response, StdResult,
+    SubMsg, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw_paginate::paginate_map_values;
@@ -16,7 +16,9 @@ use crate::msg::{
     ApproverProposeMessage, ExecuteExt, ExecuteMsg, InstantiateExt, InstantiateMsg, ProposeMessage,
     ProposeMessageInternal, QueryExt, QueryMsg,
 };
-use crate::state::{PendingProposal, APPROVER, CURRENT_ID, PENDING_PROPOSALS};
+use crate::state::{
+    advance_approval_id, PendingProposal, APPROVER, DEPOSIT_SNAPSHOT, PENDING_PROPOSALS,
+};
 
 pub(crate) const CONTRACT_NAME: &str = "crates.io:cwd-pre-propose-approval-single";
 pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -30,12 +32,8 @@ pub fn instantiate(
     info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, PreProposeError> {
-    // Validate and save approver address
     let approver = deps.api.addr_validate(&msg.extension.approver)?;
     APPROVER.save(deps.storage, &approver)?;
-
-    // Initialize first proposal ID
-    CURRENT_ID.save(deps.storage, &0)?;
 
     let resp = PrePropose::default().instantiate(deps.branch(), env, info, msg)?;
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
@@ -50,15 +48,21 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, PreProposeError> {
     match msg {
-        // Override pre-propose-base behavior
         ExecuteMsg::Propose { msg } => execute_propose(deps, env, info, msg),
+        ExecuteMsg::ProposalCreatedHook {
+            proposal_id,
+            proposer,
+        } => execute_proposal_created_hook(deps, info, proposal_id, proposer),
+
+        // TODO(zeke): why not use behavior of base?
         ExecuteMsg::AddProposalSubmittedHook { address } => {
             execute_add_approver_hook(deps, info, address)
         }
+        // TODO(zeke): why not use behavior of base?
         ExecuteMsg::RemoveProposalSubmittedHook { address } => {
             execute_remove_approver_hook(deps, info, address)
         }
-        // Extension
+
         ExecuteMsg::Extension { msg } => match msg {
             ExecuteExt::Approve { id } => execute_approve(deps, info, id),
             ExecuteExt::Reject { id } => execute_reject(deps, info, id),
@@ -75,17 +79,21 @@ pub fn execute_propose(
     info: MessageInfo,
     msg: ProposeMessage,
 ) -> Result<Response, PreProposeError> {
-    // Base pre-propose contract with our configured exetensions
     let pre_propose_base = PrePropose::default();
     let config = pre_propose_base.config.load(deps.storage)?;
 
-    // Check that sender can propose
-    pre_propose_base.check_can_submit(deps.as_ref(), info.clone())?;
+    pre_propose_base.check_can_submit(deps.as_ref(), info.sender.clone())?;
 
-    // Load current id
-    let id = advance_proposal_id(deps.storage)?;
+    // Take deposit, if configured.
+    let deposit_messages = if let Some(ref deposit_info) = config.deposit_info {
+        deposit_info.check_native_deposit_paid(&info)?;
+        deposit_info.get_take_deposit_messages(&info.sender, &env.contract.address)?
+    } else {
+        vec![]
+    };
 
-    // Convert msg to to internal format
+    let approval_id = advance_approval_id(deps.storage)?;
+
     let propose_msg_internal = match msg {
         ProposeMessage::Propose {
             title,
@@ -95,37 +103,16 @@ pub fn execute_propose(
             title,
             description,
             msgs,
-            proposer: Some(info.sender.to_string()),
+            proposer: Some(info.sender.into_string()),
         },
     };
 
-    // Save the proposal as pending
-    PENDING_PROPOSALS.save(
-        deps.storage,
-        id,
-        &PendingProposal {
-            id,
-            msg: propose_msg_internal.clone(),
-        },
-    )?;
+    // Prepare proposal submitted hooks msg to notify approver.  Make
+    // a proposal on the approver DAO to approve this pre-proposal
 
-    // Save info about deposits when this prop was created
-    pre_propose_base.deposits.save(
-        deps.storage,
-        id,
-        &(config.deposit_info.clone(), info.sender.clone()),
-    )?;
-
-    // Handle deposit if configured
-    let deposit_messages = if let Some(ref deposit_info) = config.deposit_info {
-        deposit_info.check_native_deposit_paid(&info)?;
-        deposit_info.get_take_deposit_messages(&info.sender, &env.contract.address)?
-    } else {
-        vec![]
-    };
-
-    // Prepare proposal submitted hooks msg to notify approver
-    // Make a proposal on the approver DAO to approve this pre-proposal
+    // TODO(zeke): is this actually what we should be feeding to the
+    // proposal submitted hooks? this locks them into being an
+    // approver.
     let hooks_msgs =
         pre_propose_base
             .proposal_submitted_hooks
@@ -134,9 +121,9 @@ pub fn execute_propose(
                     contract_addr: a.into_string(),
                     msg: to_binary(&ExecuteBase::<ApproverProposeMessage, Empty>::Propose {
                         msg: ApproverProposeMessage::Propose {
-                            title: propose_msg_internal.clone().title,
-                            description: propose_msg_internal.clone().description,
-                            pre_propose_id: id,
+                            title: propose_msg_internal.title.clone(),
+                            description: propose_msg_internal.description.clone(),
+                            approval_id,
                         },
                     })?,
                     funds: vec![],
@@ -144,11 +131,22 @@ pub fn execute_propose(
                 Ok(SubMsg::new(execute_msg))
             })?;
 
+    // Save the proposal and its information as pending.
+    PENDING_PROPOSALS.save(
+        deps.storage,
+        approval_id,
+        &PendingProposal {
+            approval_id,
+            msg: propose_msg_internal,
+            deposit: config.deposit_info,
+        },
+    )?;
+
     Ok(Response::default()
         .add_messages(deposit_messages)
         .add_submessages(hooks_msgs)
         .add_attribute("method", "pre-propose")
-        .add_attribute("id", id.to_string()))
+        .add_attribute("id", approval_id.to_string()))
 }
 
 pub fn execute_approve(
@@ -169,17 +167,12 @@ pub fn execute_approve(
             let proposal_module = PrePropose::default().proposal_module.load(deps.storage)?;
             let propose_messsage = WasmMsg::Execute {
                 contract_addr: proposal_module.into_string(),
-                msg: to_binary(&ProposeMessageInternal::Propose(ProposeMsg {
-                    title: proposal.msg.title,
-                    description: proposal.msg.description,
-                    msgs: proposal.msg.msgs,
-                    proposer: proposal.msg.proposer,
-                }))?,
+                msg: to_binary(&ProposeMessageInternal::Propose(proposal.msg))?,
                 funds: vec![],
             };
 
-            // Remove proposal
             PENDING_PROPOSALS.remove(deps.storage, id);
+            DEPOSIT_SNAPSHOT.save(deps.storage, &proposal.deposit)?;
 
             Ok(Response::default()
                 .add_message(propose_messsage)
@@ -188,6 +181,31 @@ pub fn execute_approve(
         }
         None => Err(PreProposeError::ProposalNotFound {}),
     }
+}
+
+pub fn execute_proposal_created_hook(
+    deps: DepsMut,
+    info: MessageInfo,
+    id: u64,
+    proposer: String,
+) -> Result<Response, PreProposeError> {
+    let proposer = deps.api.addr_validate(&proposer)?;
+    let pre_propose = PrePropose::default();
+    let proposal_module = pre_propose.proposal_module.load(deps.storage)?;
+    if info.sender != proposal_module {
+        return Err(PreProposeError::NotModule {});
+    }
+
+    let deposit = DEPOSIT_SNAPSHOT.load(deps.storage)?;
+    DEPOSIT_SNAPSHOT.remove(deps.storage);
+
+    pre_propose
+        .deposits
+        .save(deps.storage, id, &(deposit, proposer))?;
+
+    Ok(Response::default()
+        .add_attribute("method", "execute_new_proposal_hook")
+        .add_attribute("proposal_id", id.to_string()))
 }
 
 pub fn execute_reject(
@@ -201,48 +219,57 @@ pub fn execute_reject(
         return Err(PreProposeError::Unauthorized {});
     }
 
-    // Check proposal id exists
-    ensure!(
-        PENDING_PROPOSALS.has(deps.storage, id),
-        PreProposeError::ProposalNotFound {}
-    );
+    let PendingProposal {
+        deposit,
+        msg: ProposeMsg { proposer, .. },
+        ..
+    } = PENDING_PROPOSALS
+        .may_load(deps.storage, id)?
+        .ok_or(PreProposeError::ProposalNotFound {})?;
 
-    // Remove proposal
     PENDING_PROPOSALS.remove(deps.storage, id);
 
-    // Handle deposit logic
-    match PrePropose::default().deposits.may_load(deps.storage, id)? {
-        Some((deposit_info, proposer)) => {
-            let messages = if let Some(ref deposit_info) = deposit_info {
-                // Refund can be issued if proposal if deposits are always refunded
-                // OnlyPassed and Never refund deposit policies do not apply here
-                if deposit_info.refund_policy == DepositRefundPolicy::Always {
-                    deposit_info.get_return_deposit_message(&proposer)?
-                } else {
-                    // If the proposer doesn't get the deposit, the DAO does.
-                    let dao = PrePropose::default().dao.load(deps.storage)?;
-                    deposit_info.get_return_deposit_message(&dao)?
-                }
-            } else {
-                // No deposit info for this proposal. Nothing to do.
-                vec![]
-            };
-
-            Ok(Response::default()
-                .add_attribute("method", "proposal_rejected")
-                .add_attribute("proposal", id.to_string())
-                .add_attribute("deposit_info", to_binary(&deposit_info)?.to_string())
-                .add_messages(messages))
+    let messages = if let Some(ref deposit_info) = deposit {
+        // Refund can be issued if proposal if deposits are always
+        // refunded. `OnlyPassed` and `Never` refund deposit policies
+        // do not apply here.
+        if deposit_info.refund_policy == DepositRefundPolicy::Always {
+            // We'll never put a proposal in the pending map unless we
+            // have set its proposer. Failing to do so would mean the
+            // proposal could never be submitted to the proposal
+            // module as no sender would be specified. Thus, we can
+            // safely unwrap.
+            //
+            // If we're wrong here, worst case is that proposals can't
+            // be rejected and sit in the pending phase forever. This
+            // is effectively rejection, minus you getting your
+            // proposal back, and the DAO could still make a proposal
+            // to do an upgrade.
+            //
+            // We could encode this in the type sytem, but rust being
+            // not able to extend / modify structs from other modules
+            // (the macros just can't access the fields) means that
+            // we'd stop getting the type safety provided by using the
+            // `ProposeMsg` directly from proposal single. IMO, that
+            // type safety is better than rolling our own proposal
+            // type that is a duplicate of the single choice one so
+            // that we can remove this unwrap.
+            let proposer = Addr::unchecked(proposer.unwrap());
+            deposit_info.get_return_deposit_message(&proposer)?
+        } else {
+            // If the proposer doesn't get the deposit, the DAO does.
+            let dao = PrePropose::default().dao.load(deps.storage)?;
+            deposit_info.get_return_deposit_message(&dao)?
         }
+    } else {
+        vec![]
+    };
 
-        // If we do not have a deposit for this proposal it was
-        // likely created before we were added to the proposal
-        // module. In that case, it's not our problem and we just
-        // do nothing.
-        None => Ok(Response::default()
-            .add_attribute("method", "proposal_rejected")
-            .add_attribute("proposal", id.to_string())),
-    }
+    Ok(Response::default()
+        .add_attribute("method", "proposal_rejected")
+        .add_attribute("proposal", id.to_string())
+        .add_attribute("deposit_info", to_binary(&deposit)?.to_string())
+        .add_messages(messages))
 }
 
 pub fn execute_update_approver(
@@ -278,10 +305,7 @@ pub fn execute_add_approver_hook(
         return Err(PreProposeError::Unauthorized {});
     }
 
-    // Validate address
     let addr = deps.api.addr_validate(&address)?;
-
-    // Add hook
     pre_propose_base
         .proposal_submitted_hooks
         .add_hook(deps.storage, addr)?;
@@ -313,12 +337,6 @@ pub fn execute_remove_approver_hook(
         .remove_hook(deps.storage, addr)?;
 
     Ok(Response::default())
-}
-
-pub fn advance_proposal_id(store: &mut dyn Storage) -> StdResult<u64> {
-    let id: u64 = CURRENT_ID.may_load(store)?.unwrap_or_default() + 1;
-    CURRENT_ID.save(store, &id)?;
-    Ok(id)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/contracts/pre-propose/cwd-pre-propose-approval-single/src/msg.rs
+++ b/contracts/pre-propose/cwd-pre-propose-approval-single/src/msg.rs
@@ -11,7 +11,7 @@ pub enum ApproverProposeMessage {
     Propose {
         title: String,
         description: String,
-        pre_propose_id: u64,
+        approval_id: u64,
     },
 }
 

--- a/contracts/pre-propose/cwd-pre-propose-approval-single/src/msg.rs
+++ b/contracts/pre-propose/cwd-pre-propose-approval-single/src/msg.rs
@@ -4,6 +4,7 @@ use cosmwasm_std::{Addr, CosmosMsg, Empty};
 use cwd_pre_propose_base::msg::{
     ExecuteMsg as ExecuteBase, InstantiateMsg as InstantiateBase, QueryMsg as QueryBase,
 };
+use cwd_proposal_single::msg::ProposeMsg;
 
 #[cw_serde]
 pub enum ApproverProposeMessage {
@@ -68,11 +69,6 @@ pub type QueryMsg = QueryBase<QueryExt>;
 /// `proposer` field. The module will fill this in based on the sender
 /// of the external message.
 #[cw_serde]
-pub enum ProposeMessageInternal {
-    Propose {
-        title: String,
-        description: String,
-        msgs: Vec<CosmosMsg<Empty>>,
-        proposer: Option<String>,
-    },
+pub(crate) enum ProposeMessageInternal {
+    Propose(ProposeMsg),
 }

--- a/contracts/pre-propose/cwd-pre-propose-approval-single/src/state.rs
+++ b/contracts/pre-propose/cwd-pre-propose-approval-single/src/state.rs
@@ -1,14 +1,33 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::Addr;
+use cosmwasm_std::{Addr, StdResult, Storage};
 use cw_storage_plus::{Item, Map};
 use cwd_proposal_single::msg::ProposeMsg;
+use cwd_voting::deposit::CheckedDepositInfo;
 
 #[cw_serde]
 pub struct PendingProposal {
-    pub id: u64,
+    /// The approval ID used to identify this pending proposal.
+    pub approval_id: u64,
+    /// The propose message that ought to be executed on the proposal
+    /// message if this proposal is approved.
     pub msg: ProposeMsg,
+    /// Snapshot of the deposit info at the time of proposal
+    /// submission.
+    pub deposit: Option<CheckedDepositInfo>,
 }
 
 pub const APPROVER: Item<Addr> = Item::new("approver");
-pub const CURRENT_ID: Item<u64> = Item::new("current_id");
 pub const PENDING_PROPOSALS: Map<u64, PendingProposal> = Map::new("pending_proposals");
+
+/// Used internally to transition an approval deposit to a proposal
+/// deposit when new proposals are created.
+pub(crate) const DEPOSIT_SNAPSHOT: Item<Option<CheckedDepositInfo>> = Item::new("ds");
+
+/// Used internally to track the current approval_id.
+const CURRENT_ID: Item<u64> = Item::new("current_id");
+
+pub(crate) fn advance_approval_id(store: &mut dyn Storage) -> StdResult<u64> {
+    let id: u64 = CURRENT_ID.may_load(store)?.unwrap_or_default() + 1;
+    CURRENT_ID.save(store, &id)?;
+    Ok(id)
+}

--- a/contracts/pre-propose/cwd-pre-propose-approval-single/src/state.rs
+++ b/contracts/pre-propose/cwd-pre-propose-approval-single/src/state.rs
@@ -1,19 +1,12 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, CosmosMsg, Empty};
+use cosmwasm_std::Addr;
 use cw_storage_plus::{Item, Map};
-
-#[cw_serde]
-pub struct ProposeMsgSingle {
-    pub title: String,
-    pub description: String,
-    pub msgs: Vec<CosmosMsg<Empty>>,
-    pub proposer: Option<String>,
-}
+use cwd_proposal_single::msg::ProposeMsg;
 
 #[cw_serde]
 pub struct PendingProposal {
     pub id: u64,
-    pub msg: ProposeMsgSingle,
+    pub msg: ProposeMsg,
 }
 
 pub const APPROVER: Item<Addr> = Item::new("approver");

--- a/contracts/pre-propose/cwd-pre-propose-approval-single/src/tests.rs
+++ b/contracts/pre-propose/cwd-pre-propose-approval-single/src/tests.rs
@@ -203,7 +203,7 @@ fn make_pre_proposal(app: &mut App, pre_propose: Addr, proposer: &str, funds: &[
         .unwrap();
 
     // Return last item in list, id is first element of tuple
-    pending.pop().unwrap().id
+    pending.pop().unwrap().approval_id
 }
 
 fn mint_natives(app: &mut App, receiver: &str, coins: Vec<Coin>) {
@@ -879,7 +879,7 @@ fn test_pending_proposal_queries() {
             },
         )
         .unwrap();
-    assert_eq!(prop1.id, 1);
+    assert_eq!(prop1.approval_id, 1);
 
     // Query for the pre-propose proposals
     let pre_propose_props: Vec<PendingProposal> = app
@@ -895,7 +895,7 @@ fn test_pending_proposal_queries() {
         )
         .unwrap();
     assert_eq!(pre_propose_props.len(), 2);
-    assert_eq!(pre_propose_props[0].id, 2);
+    assert_eq!(pre_propose_props[0].approval_id, 2);
 
     // Query props in reverse
     let reverse_pre_propose_props: Vec<PendingProposal> = app
@@ -912,7 +912,7 @@ fn test_pending_proposal_queries() {
         .unwrap();
 
     assert_eq!(reverse_pre_propose_props.len(), 2);
-    assert_eq!(reverse_pre_propose_props[0].id, 1);
+    assert_eq!(reverse_pre_propose_props[0].approval_id, 1);
 }
 
 #[test]

--- a/contracts/pre-propose/cwd-pre-propose-approver/schema/cwd-pre-propose-approver.json
+++ b/contracts/pre-propose/cwd-pre-propose-approver/schema/cwd-pre-propose-approver.json
@@ -236,18 +236,18 @@
               "propose": {
                 "type": "object",
                 "required": [
+                  "approval_id",
                   "description",
-                  "pre_propose_id",
                   "title"
                 ],
                 "properties": {
-                  "description": {
-                    "type": "string"
-                  },
-                  "pre_propose_id": {
+                  "approval_id": {
                     "type": "integer",
                     "format": "uint64",
                     "minimum": 0.0
+                  },
+                  "description": {
+                    "type": "string"
                   },
                   "title": {
                     "type": "string"

--- a/contracts/pre-propose/cwd-pre-propose-approver/src/contract.rs
+++ b/contracts/pre-propose/cwd-pre-propose-approver/src/contract.rs
@@ -109,7 +109,7 @@ pub fn execute_propose(
         ApproverProposeMessage::Propose {
             title,
             description,
-            pre_propose_id,
+            approval_id: pre_propose_id,
         } => (
             pre_propose_id,
             ProposeMessageInternal::Propose {

--- a/contracts/pre-propose/cwd-pre-propose-approver/src/tests.rs
+++ b/contracts/pre-propose/cwd-pre-propose-approver/src/tests.rs
@@ -323,7 +323,7 @@ fn make_pre_proposal(app: &mut App, pre_propose: Addr, proposer: &str, funds: &[
         .unwrap();
 
     // Return last item in list, id is first element of tuple
-    pending.pop().unwrap().id
+    pending.pop().unwrap().approval_id
 }
 
 fn mint_natives(app: &mut App, receiver: &str, coins: Vec<Coin>) {

--- a/contracts/pre-propose/cwd-pre-propose-single/Cargo.toml
+++ b/contracts/pre-propose/cwd-pre-propose-single/Cargo.toml
@@ -20,6 +20,7 @@ cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw2 = { workspace = true }
 cwd-pre-propose-base = { workspace = true }
+cwd-proposal-single = { workspace = true, features = ["library"] }
 
 [dev-dependencies]
 cw-multi-test = { workspace = true }
@@ -28,7 +29,6 @@ cw4-group = { workspace = true }
 cw20 = { workspace = true }
 cw20-base = { workspace = true }
 cwd-voting-cw20-staked = { workspace = true }
-cwd-proposal-single = { workspace = true, features = ["library"] }
 cwd-core = { workspace = true }
 cwd-voting-cw4 = { workspace = true }
 cwd-voting = { workspace = true }

--- a/contracts/pre-propose/cwd-pre-propose-single/schema/cwd-pre-propose-single.json
+++ b/contracts/pre-propose/cwd-pre-propose-single/schema/cwd-pre-propose-single.json
@@ -884,6 +884,7 @@
       "ProposeMessage": {
         "oneOf": [
           {
+            "description": "The propose message used to make a proposal to this module. Note that this is identical to the propose message used by cwd-proposal-single, except that it omits the `proposer` field which it fills in for the sender.",
             "type": "object",
             "required": [
               "propose"

--- a/contracts/pre-propose/cwd-pre-propose-single/src/contract.rs
+++ b/contracts/pre-propose/cwd-pre-propose-single/src/contract.rs
@@ -11,12 +11,17 @@ use cwd_pre_propose_base::{
     msg::{ExecuteMsg as ExecuteBase, InstantiateMsg as InstantiateBase, QueryMsg as QueryBase},
     state::PreProposeContract,
 };
+use cwd_proposal_single::msg::ProposeMsg;
 
 pub(crate) const CONTRACT_NAME: &str = "crates.io:cwd-pre-propose-single";
 pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cw_serde]
 pub enum ProposeMessage {
+    /// The propose message used to make a proposal to this
+    /// module. Note that this is identical to the propose message
+    /// used by cwd-proposal-single, except that it omits the
+    /// `proposer` field which it fills in for the sender.
     Propose {
         title: String,
         description: String,
@@ -33,12 +38,7 @@ pub type QueryMsg = QueryBase<Empty>;
 /// of the external message.
 #[cw_serde]
 enum ProposeMessageInternal {
-    Propose {
-        title: String,
-        description: String,
-        msgs: Vec<CosmosMsg<Empty>>,
-        proposer: Option<String>,
-    },
+    Propose(ProposeMsg),
 }
 
 type PrePropose = PreProposeContract<Empty, Empty, Empty, ProposeMessageInternal>;
@@ -76,13 +76,13 @@ pub fn execute(
                     msgs,
                 },
         } => ExecuteInternal::Propose {
-            msg: ProposeMessageInternal::Propose {
+            msg: ProposeMessageInternal::Propose(ProposeMsg {
                 // Fill in proposer based on message sender.
                 proposer: Some(info.sender.to_string()),
                 title,
                 description,
                 msgs,
-            },
+            }),
         },
         ExecuteMsg::Extension { msg } => ExecuteInternal::Extension { msg },
         ExecuteMsg::Withdraw { denom } => ExecuteInternal::Withdraw { denom },

--- a/contracts/proposal/cwd-proposal-single/Cargo.toml
+++ b/contracts/proposal/cwd-proposal-single/Cargo.toml
@@ -28,7 +28,6 @@ thiserror = { workspace = true }
 cwd-core = { workspace = true, features = ["library"] }
 cwd-macros = { workspace = true }
 cwd-pre-propose-base = { workspace = true }
-cwd-pre-propose-single = { workspace = true }
 cwd-interface = { workspace = true }
 cwd-voting = { workspace = true }
 cwd-hooks = { workspace = true }
@@ -47,6 +46,7 @@ cwd-voting-cw20-balance = { workspace = true }
 cwd-voting-cw20-staked = { workspace = true }
 cwd-voting-native-staked = { workspace = true }
 cwd-voting-cw721-staked = { workspace = true }
+cwd-pre-propose-single = { workspace = true }
 cw-denom = { workspace = true }
 cwd-testing = { workspace = true }
 cw20-stake = { workspace = true }

--- a/contracts/proposal/cwd-proposal-single/schema/cwd-proposal-single.json
+++ b/contracts/proposal/cwd-proposal-single/schema/cwd-proposal-single.json
@@ -354,37 +354,7 @@
         ],
         "properties": {
           "propose": {
-            "type": "object",
-            "required": [
-              "description",
-              "msgs",
-              "title"
-            ],
-            "properties": {
-              "description": {
-                "description": "A description of the proposal.",
-                "type": "string"
-              },
-              "msgs": {
-                "description": "The messages that should be executed in response to this proposal passing.",
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/CosmosMsg_for_Empty"
-                }
-              },
-              "proposer": {
-                "description": "The address creating the proposal. If no pre-propose module is attached to this module this must always be None as the proposer is the sender of the propose message. If a pre-propose module is attached, this must be Some and will set the proposer of the proposal it creates.",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "title": {
-                "description": "The title of the proposal.",
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
+            "$ref": "#/definitions/ProposeMsg"
           }
         },
         "additionalProperties": false
@@ -1269,6 +1239,40 @@
             "additionalProperties": false
           }
         ]
+      },
+      "ProposeMsg": {
+        "description": "The contents of a message to create a proposal.",
+        "type": "object",
+        "required": [
+          "description",
+          "msgs",
+          "title"
+        ],
+        "properties": {
+          "description": {
+            "description": "A description of the proposal.",
+            "type": "string"
+          },
+          "msgs": {
+            "description": "The messages that should be executed in response to this proposal passing.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/CosmosMsg_for_Empty"
+            }
+          },
+          "proposer": {
+            "description": "The address creating the proposal. If no pre-propose module is attached to this module this must always be None as the proposer is the sender of the propose message. If a pre-propose module is attached, this must be Some and will set the proposer of the proposal it creates.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "title": {
+            "description": "The title of the proposal.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
       },
       "StakingMsg": {
         "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",

--- a/contracts/proposal/cwd-proposal-single/src/contract.rs
+++ b/contracts/proposal/cwd-proposal-single/src/contract.rs
@@ -10,7 +10,6 @@ use cw_storage_plus::Bound;
 use cw_utils::{parse_reply_instantiate_data, Duration};
 use cwd_hooks::Hooks;
 use cwd_interface::voting::IsActiveResponse;
-use cwd_pre_propose_single::contract::ExecuteMsg as PreProposeMsg;
 use cwd_proposal_hooks::{new_proposal_hooks, proposal_status_changed_hooks};
 use cwd_vote_hooks::new_vote_hooks;
 use cwd_voting::pre_propose::{PreProposeInfo, ProposalCreationPolicy};
@@ -22,7 +21,7 @@ use cwd_voting::status::Status;
 use cwd_voting::threshold::Threshold;
 use cwd_voting::voting::{get_total_power, get_voting_power, validate_voting_period, Vote, Votes};
 
-use crate::msg::MigrateMsg;
+use crate::msg::{MigrateMsg, ProposeMsg};
 use crate::proposal::SingleChoiceProposal;
 use crate::state::{Config, CREATION_POLICY};
 
@@ -40,6 +39,10 @@ use crate::{
 
 pub(crate) const CONTRACT_NAME: &str = "crates.io:cwd-proposal-single";
 pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Message type used for firing hooks to this module's pre-propose
+/// module, if one is installed.
+type PreProposeHookMsg = cwd_pre_propose_base::msg::ExecuteMsg<Empty, Empty>;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
@@ -91,12 +94,12 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     match msg {
-        ExecuteMsg::Propose {
+        ExecuteMsg::Propose(ProposeMsg {
             title,
             description,
             msgs,
             proposer,
-        } => execute_propose(deps, env, info.sender, title, description, msgs, proposer),
+        }) => execute_propose(deps, env, info.sender, title, description, msgs, proposer),
         ExecuteMsg::Vote { proposal_id, vote } => execute_vote(deps, env, info, proposal_id, vote),
         ExecuteMsg::Execute { proposal_id } => execute_execute(deps, env, info, proposal_id),
         ExecuteMsg::Close { proposal_id } => execute_close(deps, env, info, proposal_id),
@@ -240,7 +243,7 @@ pub fn execute_propose(
     let hooks = match proposal_creation_policy {
         ProposalCreationPolicy::Anyone {} => hooks,
         ProposalCreationPolicy::Module { addr } => {
-            let msg = to_binary(&PreProposeMsg::ProposalCreatedHook {
+            let msg = to_binary(&PreProposeHookMsg::ProposalCreatedHook {
                 proposal_id: id,
                 proposer: proposer.into_string(),
             })?;
@@ -331,7 +334,7 @@ pub fn execute_execute(
     let hooks = match proposal_creation_policy {
         ProposalCreationPolicy::Anyone {} => hooks,
         ProposalCreationPolicy::Module { addr } => {
-            let msg = to_binary(&PreProposeMsg::ProposalCompletedHook {
+            let msg = to_binary(&PreProposeHookMsg::ProposalCompletedHook {
                 proposal_id,
                 new_status: prop.status,
             })?;
@@ -479,7 +482,7 @@ pub fn execute_close(
     let hooks = match proposal_creation_policy {
         ProposalCreationPolicy::Anyone {} => hooks,
         ProposalCreationPolicy::Module { addr } => {
-            let msg = to_binary(&PreProposeMsg::ProposalCompletedHook {
+            let msg = to_binary(&PreProposeHookMsg::ProposalCompletedHook {
                 proposal_id,
                 new_status: prop.status,
             })?;

--- a/contracts/proposal/cwd-proposal-single/src/msg.rs
+++ b/contracts/proposal/cwd-proposal-single/src/msg.rs
@@ -38,24 +38,31 @@ pub struct InstantiateMsg {
     pub close_proposal_on_execution_failure: bool,
 }
 
+/// The contents of a message to create a proposal.
+// We break this type out of `ExecuteMsg` because we want pre-propose
+// modules that interact with this contract to be able to get type
+// checking on their propose messages.
+#[cw_serde]
+pub struct ProposeMsg {
+    /// The title of the proposal.
+    pub title: String,
+    /// A description of the proposal.
+    pub description: String,
+    /// The messages that should be executed in response to this
+    /// proposal passing.
+    pub msgs: Vec<CosmosMsg<Empty>>,
+    /// The address creating the proposal. If no pre-propose
+    /// module is attached to this module this must always be None
+    /// as the proposer is the sender of the propose message. If a
+    /// pre-propose module is attached, this must be Some and will
+    /// set the proposer of the proposal it creates.
+    pub proposer: Option<String>,
+}
+
 #[cw_serde]
 pub enum ExecuteMsg {
     /// Creates a proposal in the module.
-    Propose {
-        /// The title of the proposal.
-        title: String,
-        /// A description of the proposal.
-        description: String,
-        /// The messages that should be executed in response to this
-        /// proposal passing.
-        msgs: Vec<CosmosMsg<Empty>>,
-        /// The address creating the proposal. If no pre-propose
-        /// module is attached to this module this must always be None
-        /// as the proposer is the sender of the propose message. If a
-        /// pre-propose module is attached, this must be Some and will
-        /// set the proposer of the proposal it creates.
-        proposer: Option<String>,
-    },
+    Propose(ProposeMsg),
     /// Votes on a proposal. Voting power is determined by the DAO's
     /// voting power module.
     Vote {

--- a/contracts/proposal/cwd-proposal-single/src/testing/execute.rs
+++ b/contracts/proposal/cwd-proposal-single/src/testing/execute.rs
@@ -6,7 +6,7 @@ use cwd_pre_propose_single as cppbps;
 use cwd_voting::{deposit::CheckedDepositInfo, pre_propose::ProposalCreationPolicy, voting::Vote};
 
 use crate::{
-    msg::{ExecuteMsg, QueryMsg},
+    msg::{ExecuteMsg, ProposeMsg, QueryMsg},
     query::ProposalResponse,
     testing::queries::query_creation_policy,
     ContractError,
@@ -70,12 +70,12 @@ pub(crate) fn make_proposal(
             .execute_contract(
                 Addr::unchecked(proposer),
                 proposal_single.clone(),
-                &ExecuteMsg::Propose {
+                &ExecuteMsg::Propose(ProposeMsg {
                     title: "title".to_string(),
                     description: "description".to_string(),
                     msgs: msgs.clone(),
                     proposer: None,
-                },
+                }),
                 &[],
             )
             .unwrap(),

--- a/contracts/proposal/cwd-proposal-single/src/testing/tests.rs
+++ b/contracts/proposal/cwd-proposal-single/src/testing/tests.rs
@@ -28,7 +28,7 @@ use cwd_voting_cw20_staked::msg::ActiveThreshold;
 
 use crate::{
     contract::{migrate, CONTRACT_NAME, CONTRACT_VERSION},
-    msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg},
+    msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, ProposeMsg, QueryMsg},
     proposal::SingleChoiceProposal,
     query::{ProposalResponse, VoteInfo},
     state::Config,
@@ -813,12 +813,12 @@ fn test_active_threshold_absolute() {
         .execute_contract(
             Addr::unchecked(CREATOR_ADDR),
             proposal_module.clone(),
-            &ExecuteMsg::Propose {
+            &ExecuteMsg::Propose(ProposeMsg {
                 title: "title".to_string(),
                 description: "description".to_string(),
                 msgs: vec![],
                 proposer: None,
-            },
+            }),
             &[],
         )
         .unwrap_err()
@@ -851,12 +851,12 @@ fn test_active_threshold_absolute() {
         .execute_contract(
             Addr::unchecked(CREATOR_ADDR),
             proposal_module.clone(),
-            &ExecuteMsg::Propose {
+            &ExecuteMsg::Propose(ProposeMsg {
                 title: "title".to_string(),
                 description: "description".to_string(),
                 msgs: vec![],
                 proposer: None,
-            },
+            }),
             &[],
         )
         .unwrap_err()
@@ -894,12 +894,12 @@ fn test_active_threshold_percent() {
         .execute_contract(
             Addr::unchecked(CREATOR_ADDR),
             proposal_module.clone(),
-            &ExecuteMsg::Propose {
+            &ExecuteMsg::Propose(ProposeMsg {
                 title: "title".to_string(),
                 description: "description".to_string(),
                 msgs: vec![],
                 proposer: None,
-            },
+            }),
             &[],
         )
         .unwrap_err()
@@ -933,12 +933,12 @@ fn test_active_threshold_percent() {
         .execute_contract(
             Addr::unchecked(CREATOR_ADDR),
             proposal_module.clone(),
-            &ExecuteMsg::Propose {
+            &ExecuteMsg::Propose(ProposeMsg {
                 title: "title".to_string(),
                 description: "description".to_string(),
                 msgs: vec![],
                 proposer: None,
-            },
+            }),
             &[],
         )
         .unwrap_err()
@@ -1934,12 +1934,12 @@ fn test_proposal_too_large() {
         .execute_contract(
             Addr::unchecked(CREATOR_ADDR),
             proposal_module,
-            &ExecuteMsg::Propose {
+            &ExecuteMsg::Propose(ProposeMsg {
                 title: "".to_string(),
                 description: "a".repeat(MAX_PROPOSAL_SIZE as usize),
                 msgs: vec![],
                 proposer: None,
-            },
+            }),
             &[],
         )
         .unwrap_err()
@@ -1985,12 +1985,12 @@ fn test_proposal_creation_permissions() {
         .execute_contract(
             Addr::unchecked("notprepropose"),
             proposal_module.clone(),
-            &ExecuteMsg::Propose {
+            &ExecuteMsg::Propose(ProposeMsg {
                 title: "title".to_string(),
                 description: "description".to_string(),
                 msgs: vec![],
                 proposer: None,
-            },
+            }),
             &[],
         )
         .unwrap_err()
@@ -2010,12 +2010,12 @@ fn test_proposal_creation_permissions() {
         .execute_contract(
             pre_propose,
             proposal_module.clone(),
-            &ExecuteMsg::Propose {
+            &ExecuteMsg::Propose(ProposeMsg {
                 title: "title".to_string(),
                 description: "description".to_string(),
                 msgs: vec![],
                 proposer: None,
-            },
+            }),
             &[],
         )
         .unwrap_err()
@@ -2040,12 +2040,12 @@ fn test_proposal_creation_permissions() {
         .execute_contract(
             Addr::unchecked("ekez"),
             proposal_module.clone(),
-            &ExecuteMsg::Propose {
+            &ExecuteMsg::Propose(ProposeMsg {
                 title: "title".to_string(),
                 description: "description".to_string(),
                 msgs: vec![],
                 proposer: Some("ekez".to_string()),
-            },
+            }),
             &[],
         )
         .unwrap_err()

--- a/test-contracts/cwd-proposal-hook-counter/src/tests.rs
+++ b/test-contracts/cwd-proposal-hook-counter/src/tests.rs
@@ -12,7 +12,7 @@ use cwd_voting::{
 };
 
 use crate::msg::{CountResponse, InstantiateMsg, QueryMsg};
-use cwd_proposal_single::state::Config;
+use cwd_proposal_single::{msg::ProposeMsg, state::Config};
 
 const CREATOR_ADDR: &str = "creator";
 
@@ -247,12 +247,12 @@ fn test_counters() {
     app.execute_contract(
         Addr::unchecked(CREATOR_ADDR),
         govmod_single.clone(),
-        &cwd_proposal_single::msg::ExecuteMsg::Propose {
+        &cwd_proposal_single::msg::ExecuteMsg::Propose(ProposeMsg {
             title: "A simple text proposal".to_string(),
             description: "This is a simple text proposal".to_string(),
             msgs: vec![],
             proposer: None,
-        },
+        }),
         &[],
     )
     .unwrap();
@@ -346,12 +346,12 @@ fn test_counters() {
     app.execute_contract(
         Addr::unchecked(CREATOR_ADDR),
         govmod_single.clone(),
-        &cwd_proposal_single::msg::ExecuteMsg::Propose {
+        &cwd_proposal_single::msg::ExecuteMsg::Propose(ProposeMsg {
             title: "A simple text proposal 2nd".to_string(),
             description: "This is a simple text proposal 2nd".to_string(),
             msgs: vec![],
             proposer: None,
-        },
+        }),
         &[],
     )
     .unwrap();

--- a/typescript/contracts/cwd-pre-propose-approver/CwdPreProposeApprover.types.ts
+++ b/typescript/contracts/cwd-pre-propose-approver/CwdPreProposeApprover.types.ts
@@ -45,8 +45,8 @@ export type ExecuteMsg = {
 };
 export type ApproverProposeMessage = {
   propose: {
+    approval_id: number;
     description: string;
-    pre_propose_id: number;
     title: string;
   };
 };

--- a/typescript/contracts/cwd-proposal-single/CwdProposalSingle.client.ts
+++ b/typescript/contracts/cwd-proposal-single/CwdProposalSingle.client.ts
@@ -6,7 +6,7 @@
 
 import { CosmWasmClient, SigningCosmWasmClient, ExecuteResult } from "@cosmjs/cosmwasm-stargate";
 import { StdFee } from "@cosmjs/amino";
-import { Duration, PreProposeInfo, Admin, Binary, Threshold, PercentageThreshold, Decimal, Uint128, InstantiateMsg, ModuleInstantiateInfo, ExecuteMsg, CosmosMsgForEmpty, BankMsg, StakingMsg, DistributionMsg, IbcMsg, Timestamp, Uint64, WasmMsg, GovMsg, VoteOption, Vote, Coin, Empty, IbcTimeout, IbcTimeoutBlock, QueryMsg, MigrateMsg, Addr, Config, VoteResponse, VoteInfo, InfoResponse, ContractVersion, Expiration, Status, ProposalListResponse, ProposalResponse, SingleChoiceProposal, Votes, VoteListResponse, ProposalCreationPolicy, HooksResponse } from "./CwdProposalSingle.types";
+import { Duration, PreProposeInfo, Admin, Binary, Threshold, PercentageThreshold, Decimal, Uint128, InstantiateMsg, ModuleInstantiateInfo, ExecuteMsg, CosmosMsgForEmpty, BankMsg, StakingMsg, DistributionMsg, IbcMsg, Timestamp, Uint64, WasmMsg, GovMsg, VoteOption, Vote, ProposeMsg, Coin, Empty, IbcTimeout, IbcTimeoutBlock, QueryMsg, MigrateMsg, Addr, Config, VoteResponse, VoteInfo, InfoResponse, ContractVersion, Expiration, Status, ProposalListResponse, ProposalResponse, SingleChoiceProposal, Votes, VoteListResponse, ProposalCreationPolicy, HooksResponse } from "./CwdProposalSingle.types";
 export interface CwdProposalSingleReadOnlyInterface {
   contractAddress: string;
   config: () => Promise<Config>;

--- a/typescript/contracts/cwd-proposal-single/CwdProposalSingle.types.ts
+++ b/typescript/contracts/cwd-proposal-single/CwdProposalSingle.types.ts
@@ -61,12 +61,7 @@ export interface ModuleInstantiateInfo {
   msg: Binary;
 }
 export type ExecuteMsg = {
-  propose: {
-    description: string;
-    msgs: CosmosMsgForEmpty[];
-    proposer?: string | null;
-    title: string;
-  };
+  propose: ProposeMsg;
 } | {
   vote: {
     proposal_id: number;
@@ -242,6 +237,12 @@ export type GovMsg = {
 };
 export type VoteOption = "yes" | "no" | "abstain" | "no_with_veto";
 export type Vote = "yes" | "no" | "abstain";
+export interface ProposeMsg {
+  description: string;
+  msgs: CosmosMsgForEmpty[];
+  proposer?: string | null;
+  title: string;
+}
 export interface Coin {
   amount: Uint128;
   denom: string;


### PR DESCRIPTION
This resolves a bug where if the approval pre-propose contract was added to a proposal module with pending proposals it would cause the wrong deposits to get refunded. The bug is discussed in detail in https://github.com/DA0-DA0/dao-contracts/pull/536#discussion_r1028507568.

Still WIP because I want to write a couple more tests.

### How deposits now work

There are two phases:

1. The approval phase. If the proposal is approved, the deposit moves to phase 2. If the proposal is rejected, unless all deposits are being refunded, the deposit is sent to the DAO.
2. The deposit phase. This works like the proposal deposit system we are familiar with and is the one implemented in cwd-pre-propose-base.

To create a new proposal:

1. Make sure the deposit has been paid.
2. Generate a new approval ID.
3. Map that approval ID to a snapshot of the paid deposit.

When a proposal is approved:

1. Get the pending proposal based on the approval ID.
2. Store the deposit snapshot for the approved proposal in a singleton.
3. Make the proposal to the proposal module.

When a proposal created hook is received:

1. Get the deposit snapshot from the singleton.
2. Associated that deposit snapshot with the newly created proposal.

This differs from the base behavior in that it gets the deposit snapshot from the singleton, and not from the current config.