### PR TITLE
Add `NextProposalId` query to proposal module interface.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,6 +1036,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw2 0.16.0",
+ "cwd-hooks",
  "cwd-macros",
 ]
 

--- a/contracts/pre-propose/cwd-pre-propose-approval-single/Cargo.toml
+++ b/contracts/pre-propose/cwd-pre-propose-approval-single/Cargo.toml
@@ -25,6 +25,7 @@ cwd-pre-propose-base = { workspace = true }
 cwd-proposal-single = { workspace = true, features = ["library"] }
 cwd-voting = { workspace = true }
 thiserror = { workspace = true }
+cwd-interface = { workspace = true }
 
 [dev-dependencies]
 cw-denom = { workspace = true }
@@ -35,7 +36,6 @@ cw20 = { workspace = true }
 cw20-base = { workspace = true }
 cwd-core = { workspace = true }
 cwd-proposal-hooks = { workspace = true }
-cwd-interface = { workspace = true }
 cwd-testing = { workspace = true }
 cwd-voting = { workspace = true }
 cwd-voting-cw4 = { workspace = true }

--- a/contracts/pre-propose/cwd-pre-propose-approval-single/schema/cwd-pre-propose-approval-single.json
+++ b/contracts/pre-propose/cwd-pre-propose-approval-single/schema/cwd-pre-propose-approval-single.json
@@ -340,34 +340,6 @@
         "additionalProperties": false
       },
       {
-        "description": "Handles proposal hook fired by the associated proposal module when a proposal is created. By default, the base contract will return deposits proposals, when they are closed, when proposals are executed, or, if it is refunding failed.",
-        "type": "object",
-        "required": [
-          "proposal_created_hook"
-        ],
-        "properties": {
-          "proposal_created_hook": {
-            "type": "object",
-            "required": [
-              "proposal_id",
-              "proposer"
-            ],
-            "properties": {
-              "proposal_id": {
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "proposer": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
         "description": "Handles proposal hook fired by the associated proposal module when a proposal is completed (ie executed or rejected). By default, the base contract will return deposits proposals, when they are closed, when proposals are executed, or, if it is refunding failed.",
         "type": "object",
         "required": [

--- a/contracts/pre-propose/cwd-pre-propose-approval-single/src/state.rs
+++ b/contracts/pre-propose/cwd-pre-propose-approval-single/src/state.rs
@@ -19,10 +19,6 @@ pub struct PendingProposal {
 pub const APPROVER: Item<Addr> = Item::new("approver");
 pub const PENDING_PROPOSALS: Map<u64, PendingProposal> = Map::new("pending_proposals");
 
-/// Used internally to transition an approval deposit to a proposal
-/// deposit when new proposals are created.
-pub(crate) const DEPOSIT_SNAPSHOT: Item<Option<CheckedDepositInfo>> = Item::new("ds");
-
 /// Used internally to track the current approval_id.
 const CURRENT_ID: Item<u64> = Item::new("current_id");
 

--- a/contracts/pre-propose/cwd-pre-propose-approval-single/src/tests.rs
+++ b/contracts/pre-propose/cwd-pre-propose-approval-single/src/tests.rs
@@ -398,7 +398,7 @@ fn approve_proposal(app: &mut App, module: Addr, sender: &str, proposal_id: u64)
     // Parse attrs from approve_proposal response
     let attrs = res.custom_attrs(res.events.len() - 1);
     // Return ID
-    attrs[attrs.len() - 1].value.parse().unwrap()
+    attrs[attrs.len() - 2].value.parse().unwrap()
 }
 
 fn reject_proposal(app: &mut App, module: Addr, sender: &str, proposal_id: u64) {
@@ -971,21 +971,6 @@ fn test_permissions() {
         }),
         false, // no open proposal submission.
     );
-
-    let err: PreProposeError = app
-        .execute_contract(
-            Addr::unchecked("notmodule"),
-            pre_propose.clone(),
-            &ExecuteMsg::ProposalCreatedHook {
-                proposal_id: 1,
-                proposer: "ekez".to_string(),
-            },
-            &[],
-        )
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    assert_eq!(err, PreProposeError::NotModule {});
 
     let err: PreProposeError = app
         .execute_contract(

--- a/contracts/pre-propose/cwd-pre-propose-approver/schema/cwd-pre-propose-approver.json
+++ b/contracts/pre-propose/cwd-pre-propose-approver/schema/cwd-pre-propose-approver.json
@@ -168,34 +168,6 @@
         "additionalProperties": false
       },
       {
-        "description": "Handles proposal hook fired by the associated proposal module when a proposal is created. By default, the base contract will return deposits proposals, when they are closed, when proposals are executed, or, if it is refunding failed.",
-        "type": "object",
-        "required": [
-          "proposal_created_hook"
-        ],
-        "properties": {
-          "proposal_created_hook": {
-            "type": "object",
-            "required": [
-              "proposal_id",
-              "proposer"
-            ],
-            "properties": {
-              "proposal_id": {
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "proposer": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
         "description": "Handles proposal hook fired by the associated proposal module when a proposal is completed (ie executed or rejected). By default, the base contract will return deposits proposals, when they are closed, when proposals are executed, or, if it is refunding failed.",
         "type": "object",
         "required": [

--- a/contracts/pre-propose/cwd-pre-propose-approver/src/state.rs
+++ b/contracts/pre-propose/cwd-pre-propose-approver/src/state.rs
@@ -3,7 +3,5 @@ use cw_storage_plus::{Item, Map};
 
 // Stores the address of the pre-propose approval contract
 pub const PRE_PROPOSE_APPROVAL_CONTRACT: Item<Addr> = Item::new("pre_propose_approval_contract");
-// Stores the current pre-propose-id for use in submessage reply
-pub const CURRENT_PRE_PROPOSE_ID: Item<u64> = Item::new("current_pre_propose_id");
 // Maps proposal ids to pre-propose ids
 pub const PROPOSAL_IDS: Map<u64, u64> = Map::new("proposal_ids");

--- a/contracts/pre-propose/cwd-pre-propose-approver/src/tests.rs
+++ b/contracts/pre-propose/cwd-pre-propose-approver/src/tests.rs
@@ -64,8 +64,7 @@ fn pre_propose_approver_contract() -> Box<dyn Contract<Empty>> {
         crate::contract::execute,
         crate::contract::instantiate,
         crate::contract::query,
-    )
-    .with_reply(crate::contract::reply);
+    );
     Box::new(contract)
 }
 
@@ -1117,21 +1116,6 @@ fn test_permissions() {
         }),
         false, // no open proposal submission.
     );
-
-    let err: PreProposeError = app
-        .execute_contract(
-            Addr::unchecked("notmodule"),
-            pre_propose.clone(),
-            &ExecuteMsg::ProposalCreatedHook {
-                proposal_id: 1,
-                proposer: "ekez".to_string(),
-            },
-            &[],
-        )
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    assert_eq!(err, PreProposeError::NotModule {});
 
     let err: PreProposeError = app
         .execute_contract(

--- a/contracts/pre-propose/cwd-pre-propose-multiple/schema/cwd-pre-propose-multiple.json
+++ b/contracts/pre-propose/cwd-pre-propose-multiple/schema/cwd-pre-propose-multiple.json
@@ -332,34 +332,6 @@
         "additionalProperties": false
       },
       {
-        "description": "Handles proposal hook fired by the associated proposal module when a proposal is created. By default, the base contract will return deposits proposals, when they are closed, when proposals are executed, or, if it is refunding failed.",
-        "type": "object",
-        "required": [
-          "proposal_created_hook"
-        ],
-        "properties": {
-          "proposal_created_hook": {
-            "type": "object",
-            "required": [
-              "proposal_id",
-              "proposer"
-            ],
-            "properties": {
-              "proposal_id": {
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "proposer": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
         "description": "Handles proposal hook fired by the associated proposal module when a proposal is completed (ie executed or rejected). By default, the base contract will return deposits proposals, when they are closed, when proposals are executed, or, if it is refunding failed.",
         "type": "object",
         "required": [

--- a/contracts/pre-propose/cwd-pre-propose-multiple/src/contract.rs
+++ b/contracts/pre-propose/cwd-pre-propose-multiple/src/contract.rs
@@ -97,13 +97,6 @@ pub fn execute(
         ExecuteMsg::RemoveProposalSubmittedHook { address } => {
             ExecuteInternal::RemoveProposalSubmittedHook { address }
         }
-        ExecuteBase::ProposalCreatedHook {
-            proposal_id,
-            proposer,
-        } => ExecuteInternal::ProposalCreatedHook {
-            proposal_id,
-            proposer,
-        },
         ExecuteBase::ProposalCompletedHook {
             proposal_id,
             new_status,

--- a/contracts/pre-propose/cwd-pre-propose-multiple/src/tests.rs
+++ b/contracts/pre-propose/cwd-pre-propose-multiple/src/tests.rs
@@ -180,41 +180,39 @@ fn make_proposal(
     proposer: &str,
     funds: &[Coin],
 ) -> u64 {
-    let res = app
-        .execute_contract(
-            Addr::unchecked(proposer),
-            pre_propose,
-            &ExecuteMsg::Propose {
-                msg: ProposeMessage::Propose {
-                    title: "title".to_string(),
-                    description: "description".to_string(),
-                    choices: MultipleChoiceOptions {
-                        options: vec![
-                            MultipleChoiceOption {
-                                description: "multiple choice option 1".to_string(),
-                                msgs: vec![],
-                                title: "title".to_string(),
-                            },
-                            MultipleChoiceOption {
-                                description: "multiple choice option 2".to_string(),
-                                msgs: vec![],
-                                title: "title".to_string(),
-                            },
-                        ],
-                    },
+    app.execute_contract(
+        Addr::unchecked(proposer),
+        pre_propose,
+        &ExecuteMsg::Propose {
+            msg: ProposeMessage::Propose {
+                title: "title".to_string(),
+                description: "description".to_string(),
+                choices: MultipleChoiceOptions {
+                    options: vec![
+                        MultipleChoiceOption {
+                            description: "multiple choice option 1".to_string(),
+                            msgs: vec![],
+                            title: "title".to_string(),
+                        },
+                        MultipleChoiceOption {
+                            description: "multiple choice option 2".to_string(),
+                            msgs: vec![],
+                            title: "title".to_string(),
+                        },
+                    ],
                 },
             },
-            funds,
-        )
-        .unwrap();
+        },
+        funds,
+    )
+    .unwrap();
 
-    // The new proposal hook is the last message that fires in
-    // this process so we get the proposal ID from it's
-    // attributes. We could do this by looking at the proposal
-    // creation attributes but this changes relative position
-    // depending on if a cw20 or native deposit is being used.
-    let attrs = res.custom_attrs(res.events.len() - 1);
-    let id = attrs[attrs.len() - 1].value.parse().unwrap();
+    let id: u64 = app
+        .wrap()
+        .query_wasm_smart(&proposal_module, &cpm::msg::QueryMsg::NextProposalId {})
+        .unwrap();
+    let id = id - 1;
+
     let proposal: ProposalResponse = app
         .wrap()
         .query_wasm_smart(
@@ -835,21 +833,6 @@ fn test_permissions() {
         }),
         false, // no open proposal submission.
     );
-
-    let err: PreProposeError = app
-        .execute_contract(
-            Addr::unchecked("notmodule"),
-            pre_propose.clone(),
-            &ExecuteMsg::ProposalCreatedHook {
-                proposal_id: 1,
-                proposer: "ekez".to_string(),
-            },
-            &[],
-        )
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    assert_eq!(err, PreProposeError::NotModule {});
 
     let err: PreProposeError = app
         .execute_contract(

--- a/contracts/pre-propose/cwd-pre-propose-single/schema/cwd-pre-propose-single.json
+++ b/contracts/pre-propose/cwd-pre-propose-single/schema/cwd-pre-propose-single.json
@@ -332,34 +332,6 @@
         "additionalProperties": false
       },
       {
-        "description": "Handles proposal hook fired by the associated proposal module when a proposal is created. By default, the base contract will return deposits proposals, when they are closed, when proposals are executed, or, if it is refunding failed.",
-        "type": "object",
-        "required": [
-          "proposal_created_hook"
-        ],
-        "properties": {
-          "proposal_created_hook": {
-            "type": "object",
-            "required": [
-              "proposal_id",
-              "proposer"
-            ],
-            "properties": {
-              "proposal_id": {
-                "type": "integer",
-                "format": "uint64",
-                "minimum": 0.0
-              },
-              "proposer": {
-                "type": "string"
-              }
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
         "description": "Handles proposal hook fired by the associated proposal module when a proposal is completed (ie executed or rejected). By default, the base contract will return deposits proposals, when they are closed, when proposals are executed, or, if it is refunding failed.",
         "type": "object",
         "required": [

--- a/contracts/pre-propose/cwd-pre-propose-single/src/contract.rs
+++ b/contracts/pre-propose/cwd-pre-propose-single/src/contract.rs
@@ -99,13 +99,6 @@ pub fn execute(
         ExecuteMsg::RemoveProposalSubmittedHook { address } => {
             ExecuteInternal::RemoveProposalSubmittedHook { address }
         }
-        ExecuteMsg::ProposalCreatedHook {
-            proposal_id,
-            proposer,
-        } => ExecuteInternal::ProposalCreatedHook {
-            proposal_id,
-            proposer,
-        },
         ExecuteMsg::ProposalCompletedHook {
             proposal_id,
             new_status,

--- a/contracts/proposal/cwd-proposal-multiple/schema/cwd-proposal-multiple.json
+++ b/contracts/proposal/cwd-proposal-multiple/schema/cwd-proposal-multiple.json
@@ -1754,34 +1754,6 @@
         "additionalProperties": false
       },
       {
-        "description": "Returns the address of the DAO this module belongs to",
-        "type": "object",
-        "required": [
-          "dao"
-        ],
-        "properties": {
-          "dao": {
-            "type": "object",
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
-        "description": "Returns contract version info",
-        "type": "object",
-        "required": [
-          "info"
-        ],
-        "properties": {
-          "info": {
-            "type": "object",
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
         "description": "Returns the number of proposals that have been created in this module.",
         "type": "object",
         "required": [
@@ -1831,6 +1803,48 @@
         ],
         "properties": {
           "vote_hooks": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the address of the DAO this module belongs to",
+        "type": "object",
+        "required": [
+          "dao"
+        ],
+        "properties": {
+          "dao": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns contract version info",
+        "type": "object",
+        "required": [
+          "info"
+        ],
+        "properties": {
+          "info": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the proposal ID that will be assigned to the next proposal created.",
+        "type": "object",
+        "required": [
+          "next_proposal_id"
+        ],
+        "properties": {
+          "next_proposal_id": {
             "type": "object",
             "additionalProperties": false
           }
@@ -3460,6 +3474,13 @@
           "additionalProperties": false
         }
       }
+    },
+    "next_proposal_id": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "uint64",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
     },
     "proposal": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/cwd-proposal-multiple/src/contract.rs
+++ b/contracts/proposal/cwd-proposal-multiple/src/contract.rs
@@ -242,28 +242,6 @@ pub fn execute_propose(
     PROPOSALS.save(deps.storage, id, &proposal)?;
 
     let hooks = new_proposal_hooks(PROPOSAL_HOOKS, deps.storage, id, proposer.as_str())?;
-    // Add prepropose / deposit module hook which will save deposit info. This
-    // needs to be called after execute_propose because we don't know the
-    // proposal ID beforehand.
-    let hooks = match proposal_creation_policy {
-        ProposalCreationPolicy::Anyone {} => hooks,
-        ProposalCreationPolicy::Module { addr } => {
-            let msg = to_binary(&PreProposeMsg::ProposalCreatedHook {
-                proposal_id: id,
-                proposer: proposer.into_string(),
-            })?;
-            let mut hooks = hooks;
-            hooks.push(SubMsg::reply_on_error(
-                WasmMsg::Execute {
-                    contract_addr: addr.into_string(),
-                    msg,
-                    funds: vec![],
-                },
-                failed_pre_propose_module_hook_id(),
-            ));
-            hooks
-        }
-    };
 
     Ok(Response::default()
         .add_submessages(hooks)
@@ -692,8 +670,12 @@ pub fn remove_hook(
     Ok(())
 }
 
+pub fn next_proposal_id(store: &dyn Storage) -> StdResult<u64> {
+    Ok(PROPOSAL_COUNT.may_load(store)?.unwrap_or_default() + 1)
+}
+
 pub fn advance_proposal_id(store: &mut dyn Storage) -> StdResult<u64> {
-    let id: u64 = PROPOSAL_COUNT.load(store)? + 1;
+    let id: u64 = next_proposal_id(store)?;
     PROPOSAL_COUNT.save(store, &id)?;
     Ok(id)
 }
@@ -706,6 +688,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::ListProposals { start_after, limit } => {
             query_list_proposals(deps, env, start_after, limit)
         }
+        QueryMsg::NextProposalId {} => query_next_proposal_id(deps),
         QueryMsg::ProposalCount {} => query_proposal_count(deps),
         QueryMsg::GetVote { proposal_id, voter } => query_vote(deps, proposal_id, voter),
         QueryMsg::ListVotes {
@@ -781,6 +764,10 @@ pub fn query_reverse_proposals(
         .collect::<StdResult<Vec<ProposalResponse>>>()?;
 
     to_binary(&ProposalListResponse { proposals: props })
+}
+
+pub fn query_next_proposal_id(deps: Deps) -> StdResult<Binary> {
+    to_binary(&next_proposal_id(deps.storage)?)
 }
 
 pub fn query_proposal_count(deps: Deps) -> StdResult<Binary> {

--- a/contracts/proposal/cwd-proposal-multiple/src/msg.rs
+++ b/contracts/proposal/cwd-proposal-multiple/src/msg.rs
@@ -165,6 +165,18 @@ pub enum QueryMsg {
         start_after: Option<String>,
         limit: Option<u64>,
     },
+    /// Returns the number of proposals that have been created in this module.
+    #[returns(::std::primitive::u64)]
+    ProposalCount {},
+    /// Gets the current proposal creation policy for this module.
+    #[returns(::cwd_voting::pre_propose::ProposalCreationPolicy)]
+    ProposalCreationPolicy {},
+    /// Lists all of the consumers of proposal hooks for this module.
+    #[returns(::cwd_hooks::HooksResponse)]
+    ProposalHooks {},
+    /// Lists all of the consumers of vote hooks for this module.
+    #[returns(::cwd_hooks::HooksResponse)]
+    VoteHooks {},
 }
 
 #[cw_serde]

--- a/contracts/proposal/cwd-proposal-single/schema/cwd-proposal-single.json
+++ b/contracts/proposal/cwd-proposal-single/schema/cwd-proposal-single.json
@@ -1877,34 +1877,6 @@
         "additionalProperties": false
       },
       {
-        "description": "Returns the address of the DAO this module belongs to",
-        "type": "object",
-        "required": [
-          "dao"
-        ],
-        "properties": {
-          "dao": {
-            "type": "object",
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
-        "description": "Returns contract version info",
-        "type": "object",
-        "required": [
-          "info"
-        ],
-        "properties": {
-          "info": {
-            "type": "object",
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
         "description": "Returns the number of proposals that have been created in this module.",
         "type": "object",
         "required": [
@@ -1954,6 +1926,48 @@
         ],
         "properties": {
           "vote_hooks": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the address of the DAO this module belongs to",
+        "type": "object",
+        "required": [
+          "dao"
+        ],
+        "properties": {
+          "dao": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns contract version info",
+        "type": "object",
+        "required": [
+          "info"
+        ],
+        "properties": {
+          "info": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the proposal ID that will be assigned to the next proposal created.",
+        "type": "object",
+        "required": [
+          "next_proposal_id"
+        ],
+        "properties": {
+          "next_proposal_id": {
             "type": "object",
             "additionalProperties": false
           }
@@ -3662,6 +3676,13 @@
           "additionalProperties": false
         }
       }
+    },
+    "next_proposal_id": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "uint64",
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
     },
     "proposal": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/cwd-proposal-single/src/contract.rs
+++ b/contracts/proposal/cwd-proposal-single/src/contract.rs
@@ -22,7 +22,7 @@ use cwd_voting::threshold::Threshold;
 use cwd_voting::voting::{get_total_power, get_voting_power, validate_voting_period, Vote, Votes};
 
 use crate::msg::{MigrateMsg, ProposeMsg};
-use crate::proposal::SingleChoiceProposal;
+use crate::proposal::{next_proposal_id, SingleChoiceProposal};
 use crate::state::{Config, CREATION_POLICY};
 
 use crate::v1_state::{
@@ -244,29 +244,6 @@ pub fn execute_propose(
     PROPOSALS.save(deps.storage, id, &proposal)?;
 
     let hooks = new_proposal_hooks(PROPOSAL_HOOKS, deps.storage, id, proposer.as_str())?;
-
-    // Add prepropose / deposit module hook which will save deposit info. This
-    // needs to be called after execute_propose because we don't know the
-    // proposal ID beforehand.
-    let hooks = match proposal_creation_policy {
-        ProposalCreationPolicy::Anyone {} => hooks,
-        ProposalCreationPolicy::Module { addr } => {
-            let msg = to_binary(&PreProposeHookMsg::ProposalCreatedHook {
-                proposal_id: id,
-                proposer: proposer.into_string(),
-            })?;
-            let mut hooks = hooks;
-            hooks.push(SubMsg::reply_on_error(
-                WasmMsg::Execute {
-                    contract_addr: addr.into_string(),
-                    msg,
-                    funds: vec![],
-                },
-                failed_pre_propose_module_hook_id(),
-            ));
-            hooks
-        }
-    };
 
     Ok(Response::default()
         .add_submessages(hooks)
@@ -725,6 +702,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::ListProposals { start_after, limit } => {
             query_list_proposals(deps, env, start_after, limit)
         }
+        QueryMsg::NextProposalId {} => query_next_proposal_id(deps),
         QueryMsg::ProposalCount {} => query_proposal_count(deps),
         QueryMsg::GetVote { proposal_id, voter } => query_vote(deps, proposal_id, voter),
         QueryMsg::ListVotes {
@@ -804,6 +782,10 @@ pub fn query_reverse_proposals(
 pub fn query_proposal_count(deps: Deps) -> StdResult<Binary> {
     let proposal_count = PROPOSAL_COUNT.load(deps.storage)?;
     to_binary(&proposal_count)
+}
+
+pub fn query_next_proposal_id(deps: Deps) -> StdResult<Binary> {
+    to_binary(&next_proposal_id(deps.storage)?)
 }
 
 pub fn query_vote(deps: Deps, proposal_id: u64, voter: String) -> StdResult<Binary> {

--- a/contracts/proposal/cwd-proposal-single/src/msg.rs
+++ b/contracts/proposal/cwd-proposal-single/src/msg.rs
@@ -202,6 +202,18 @@ pub enum QueryMsg {
         /// query. If no limit is specified a max of 30 are returned.
         limit: Option<u64>,
     },
+    /// Returns the number of proposals that have been created in this module.
+    #[returns(::std::primitive::u64)]
+    ProposalCount {},
+    /// Gets the current proposal creation policy for this module.
+    #[returns(::cwd_voting::pre_propose::ProposalCreationPolicy)]
+    ProposalCreationPolicy {},
+    /// Lists all of the consumers of proposal hooks for this module.
+    #[returns(::cwd_hooks::HooksResponse)]
+    ProposalHooks {},
+    /// Lists all of the consumers of vote hooks for this module.
+    #[returns(::cwd_hooks::HooksResponse)]
+    VoteHooks {},
 }
 
 #[cw_serde]

--- a/contracts/proposal/cwd-proposal-single/src/testing/execute.rs
+++ b/contracts/proposal/cwd-proposal-single/src/testing/execute.rs
@@ -8,7 +8,7 @@ use cwd_voting::{deposit::CheckedDepositInfo, pre_propose::ProposalCreationPolic
 use crate::{
     msg::{ExecuteMsg, ProposeMsg, QueryMsg},
     query::ProposalResponse,
-    testing::queries::query_creation_policy,
+    testing::queries::{query_creation_policy, query_next_proposal_id},
     ContractError,
 };
 
@@ -65,7 +65,7 @@ pub(crate) fn make_proposal(
     };
 
     // Make the proposal.
-    let res = match proposal_creation_policy {
+    match proposal_creation_policy {
         ProposalCreationPolicy::Anyone {} => app
             .execute_contract(
                 Addr::unchecked(proposer),
@@ -94,19 +94,8 @@ pub(crate) fn make_proposal(
             )
             .unwrap(),
     };
-
-    // The new proposal hook is the last message that fires in
-    // this process so we get the proposal ID from it's
-    // attributes. We could do this by looking at the proposal
-    // creation attributes but this changes relative position
-    // depending on if a cw20 or native deposit is being used.
-    let attrs = res.custom_attrs(res.events.len() - 1);
-    let id = attrs[attrs.len() - 1]
-        .value
-        .parse()
-        // If the proposal creation policy doesn't involve a
-        // pre-propose module, no hook so we do it manaually.
-        .unwrap_or_else(|_| res.custom_attrs(1)[2].value.parse().unwrap());
+    let id = query_next_proposal_id(app, proposal_single);
+    let id = id - 1;
 
     // Check that the proposal was created as expected.
     let proposal: ProposalResponse = app

--- a/contracts/proposal/cwd-proposal-single/src/testing/queries.rs
+++ b/contracts/proposal/cwd-proposal-single/src/testing/queries.rs
@@ -200,3 +200,9 @@ pub(crate) fn query_proposal(app: &App, proposal_single: &Addr, id: u64) -> Prop
         .query_wasm_smart(proposal_single, &QueryMsg::Proposal { proposal_id: id })
         .unwrap()
 }
+
+pub(crate) fn query_next_proposal_id(app: &App, proposal_single: &Addr) -> u64 {
+    app.wrap()
+        .query_wasm_smart(proposal_single, &QueryMsg::NextProposalId {})
+        .unwrap()
+}

--- a/contracts/proposal/cwd-proposal-single/src/testing/tests.rs
+++ b/contracts/proposal/cwd-proposal-single/src/testing/tests.rs
@@ -65,8 +65,10 @@ use crate::{
 };
 
 use super::{
-    do_votes::do_votes_staked_balances, execute::vote_on_proposal_with_rationale,
-    queries::query_vote, CREATOR_ADDR,
+    do_votes::do_votes_staked_balances,
+    execute::vote_on_proposal_with_rationale,
+    queries::{query_next_proposal_id, query_vote},
+    CREATOR_ADDR,
 };
 
 struct CommonTest {
@@ -2555,4 +2557,24 @@ fn test_rational_clobbered_on_revote() {
 
     let vote = query_vote(&app, &proposal_module, CREATOR_ADDR, proposal_id);
     assert_eq!(vote.vote.unwrap().rationale, rationale);
+}
+
+#[test]
+fn test_proposal_count_goes_up() {
+    let CommonTest {
+        mut app,
+        proposal_module,
+        gov_token,
+        core_addr,
+        ..
+    } = setup_test(vec![]);
+
+    let next = query_next_proposal_id(&app, &proposal_module);
+    assert_eq!(next, 2);
+
+    mint_cw20s(&mut app, &gov_token, &core_addr, CREATOR_ADDR, 10_000_000);
+    make_proposal(&mut app, &proposal_module, CREATOR_ADDR, vec![]);
+
+    let next = query_next_proposal_id(&app, &proposal_module);
+    assert_eq!(next, 3);
 }

--- a/packages/cwd-interface/Cargo.toml
+++ b/packages/cwd-interface/Cargo.toml
@@ -11,6 +11,7 @@ cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cwd-macros = { workspace = true }
 cw2 = { workspace = true }
+cwd-hooks = { workspace = true }
 
 [dev-dependencies]
 cosmwasm-schema = { workspace = true }

--- a/packages/cwd-interface/src/lib.rs
+++ b/packages/cwd-interface/src/lib.rs
@@ -3,6 +3,7 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Binary, CosmosMsg, Empty, WasmMsg};
 
+pub mod proposal;
 pub mod voting;
 
 /// The cw-core interface.

--- a/packages/cwd-interface/src/proposal.rs
+++ b/packages/cwd-interface/src/proposal.rs
@@ -1,0 +1,24 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cwd_macros::proposal_module_query;
+
+#[proposal_module_query]
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum Query {}
+
+mod tests {
+    /// Make sure the enum has all of the fields we expect. This will
+    /// fail to compile if not.
+    #[test]
+    fn test_macro_expansion() {
+        use super::Query;
+
+        let query = Query::Info {};
+
+        match query {
+            Query::Dao {} => (),
+            Query::Info {} => (),
+            Query::NextProposalId {} => (),
+        }
+    }
+}

--- a/packages/cwd-macros/src/lib.rs
+++ b/packages/cwd-macros/src/lib.rs
@@ -40,6 +40,12 @@ fn merge_variants(metadata: TokenStream, left: TokenStream, right: TokenStream) 
 /// cwd_interface. If we are currently compiling the cwd-interface
 /// crate, `crate::{internal}` is returned. If we are not,
 /// `::cwd_interface::{internal}` is returned.
+///
+/// The this is needed is that cwd_interface both defines types used
+/// in the interfaces here, and uses the macros exported here. At some
+/// point we'll be in a compilation context where we're inside of a
+/// crate as the macro is being expanded, and we need to use types
+/// local to the crate.
 fn cwd_interface_path(inside: &str) -> Path {
     let pkg = std::env::var("CARGO_PKG_NAME").unwrap();
     let base = if pkg == "cwd-interface" {
@@ -323,18 +329,10 @@ pub fn proposal_module_query(metadata: TokenStream, input: TokenStream) -> Token
             /// Returns contract version info
             #[returns(#i)]
             Info { },
-            /// Returns the number of proposals that have been created in this module.
+            /// Returns the proposal ID that will be assigned to the
+            /// next proposal created.
             #[returns(::std::primitive::u64)]
-            ProposalCount {},
-            /// Gets the current proposal creation policy for this module.
-            #[returns(::cwd_voting::pre_propose::ProposalCreationPolicy)]
-            ProposalCreationPolicy {},
-            /// Lists all of the consumers of proposal hooks for this module.
-            #[returns(::cwd_hooks::HooksResponse)]
-            ProposalHooks {},
-            /// Lists all of the consumers of vote hooks for this module.
-            #[returns(::cwd_hooks::HooksResponse)]
-            VoteHooks {},
+            NextProposalId {},
         }
         }
         .into(),

--- a/packages/cwd-macros/tests/govmod.rs
+++ b/packages/cwd-macros/tests/govmod.rs
@@ -23,9 +23,6 @@ fn proposal_module_query_derive() {
     match test {
         Test::Foo | Test::Bar(_) | Test::Baz { .. } | Test::Dao {} => "yay",
         Test::Info {} => "yay",
-        Test::ProposalCount {} => "yay",
-        Test::ProposalCreationPolicy {} => "yay",
-        Test::ProposalHooks {} => "yay",
-        Test::VoteHooks {} => "yay",
+        Test::NextProposalId {} => "yay",
     };
 }

--- a/packages/cwd-pre-propose-base/src/error.rs
+++ b/packages/cwd-pre-propose-base/src/error.rs
@@ -1,5 +1,3 @@
-use std::num::ParseIntError;
-
 use cosmwasm_std::StdError;
 use cw_denom::DenomError;
 use cw_utils::ParseReplyError;
@@ -24,9 +22,6 @@ pub enum PreProposeError {
 
     #[error(transparent)]
     ParseReplyError(#[from] ParseReplyError),
-
-    #[error(transparent)]
-    ParseIntError(#[from] ParseIntError),
 
     #[error("Message sender is not proposal module")]
     NotModule {},

--- a/packages/cwd-pre-propose-base/src/msg.rs
+++ b/packages/cwd-pre-propose-base/src/msg.rs
@@ -77,12 +77,6 @@ pub enum ExecuteMsg<ProposalMessage, ExecuteExt> {
     /// Removes a proposal submitted hook. Only the DAO may call this method.
     RemoveProposalSubmittedHook { address: String },
 
-    /// Handles proposal hook fired by the associated proposal module when a
-    /// proposal is created. By default, the base contract will return deposits
-    /// proposals, when they are closed, when proposals are executed, or,
-    /// if it is refunding failed.
-    ProposalCreatedHook { proposal_id: u64, proposer: String },
-
     /// Handles proposal hook fired by the associated proposal
     /// module when a proposal is completed (ie executed or rejected).
     /// By default, the base contract will return deposits

--- a/typescript/contracts/cwd-pre-propose-approval-single/CwdPreProposeApprovalSingle.client.ts
+++ b/typescript/contracts/cwd-pre-propose-approval-single/CwdPreProposeApprovalSingle.client.ts
@@ -117,13 +117,6 @@ export interface CwdPreProposeApprovalSingleInterface extends CwdPreProposeAppro
   }: {
     address: string;
   }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  proposalCreatedHook: ({
-    proposalId,
-    proposer
-  }: {
-    proposalId: number;
-    proposer: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
   proposalCompletedHook: ({
     newStatus,
     proposalId
@@ -148,7 +141,6 @@ export class CwdPreProposeApprovalSingleClient extends CwdPreProposeApprovalSing
     this.extension = this.extension.bind(this);
     this.addProposalSubmittedHook = this.addProposalSubmittedHook.bind(this);
     this.removeProposalSubmittedHook = this.removeProposalSubmittedHook.bind(this);
-    this.proposalCreatedHook = this.proposalCreatedHook.bind(this);
     this.proposalCompletedHook = this.proposalCompletedHook.bind(this);
   }
 
@@ -218,20 +210,6 @@ export class CwdPreProposeApprovalSingleClient extends CwdPreProposeApprovalSing
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_submitted_hook: {
         address
-      }
-    }, fee, memo, funds);
-  };
-  proposalCreatedHook = async ({
-    proposalId,
-    proposer
-  }: {
-    proposalId: number;
-    proposer: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
-    return await this.client.execute(this.sender, this.contractAddress, {
-      proposal_created_hook: {
-        proposal_id: proposalId,
-        proposer
       }
     }, fee, memo, funds);
   };

--- a/typescript/contracts/cwd-pre-propose-approval-single/CwdPreProposeApprovalSingle.types.ts
+++ b/typescript/contracts/cwd-pre-propose-approval-single/CwdPreProposeApprovalSingle.types.ts
@@ -57,11 +57,6 @@ export type ExecuteMsg = {
     address: string;
   };
 } | {
-  proposal_created_hook: {
-    proposal_id: number;
-    proposer: string;
-  };
-} | {
   proposal_completed_hook: {
     new_status: Status;
     proposal_id: number;

--- a/typescript/contracts/cwd-pre-propose-approver/CwdPreProposeApprover.client.ts
+++ b/typescript/contracts/cwd-pre-propose-approver/CwdPreProposeApprover.client.ts
@@ -117,13 +117,6 @@ export interface CwdPreProposeApproverInterface extends CwdPreProposeApproverRea
   }: {
     address: string;
   }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  proposalCreatedHook: ({
-    proposalId,
-    proposer
-  }: {
-    proposalId: number;
-    proposer: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
   proposalCompletedHook: ({
     newStatus,
     proposalId
@@ -148,7 +141,6 @@ export class CwdPreProposeApproverClient extends CwdPreProposeApproverQueryClien
     this.extension = this.extension.bind(this);
     this.addProposalSubmittedHook = this.addProposalSubmittedHook.bind(this);
     this.removeProposalSubmittedHook = this.removeProposalSubmittedHook.bind(this);
-    this.proposalCreatedHook = this.proposalCreatedHook.bind(this);
     this.proposalCompletedHook = this.proposalCompletedHook.bind(this);
   }
 
@@ -218,20 +210,6 @@ export class CwdPreProposeApproverClient extends CwdPreProposeApproverQueryClien
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_submitted_hook: {
         address
-      }
-    }, fee, memo, funds);
-  };
-  proposalCreatedHook = async ({
-    proposalId,
-    proposer
-  }: {
-    proposalId: number;
-    proposer: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
-    return await this.client.execute(this.sender, this.contractAddress, {
-      proposal_created_hook: {
-        proposal_id: proposalId,
-        proposer
       }
     }, fee, memo, funds);
   };

--- a/typescript/contracts/cwd-pre-propose-approver/CwdPreProposeApprover.types.ts
+++ b/typescript/contracts/cwd-pre-propose-approver/CwdPreProposeApprover.types.ts
@@ -33,11 +33,6 @@ export type ExecuteMsg = {
     address: string;
   };
 } | {
-  proposal_created_hook: {
-    proposal_id: number;
-    proposer: string;
-  };
-} | {
   proposal_completed_hook: {
     new_status: Status;
     proposal_id: number;

--- a/typescript/contracts/cwd-pre-propose-multiple/CwdPreProposeMultiple.client.ts
+++ b/typescript/contracts/cwd-pre-propose-multiple/CwdPreProposeMultiple.client.ts
@@ -117,13 +117,6 @@ export interface CwdPreProposeMultipleInterface extends CwdPreProposeMultipleRea
   }: {
     address: string;
   }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  proposalCreatedHook: ({
-    proposalId,
-    proposer
-  }: {
-    proposalId: number;
-    proposer: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
   proposalCompletedHook: ({
     newStatus,
     proposalId
@@ -148,7 +141,6 @@ export class CwdPreProposeMultipleClient extends CwdPreProposeMultipleQueryClien
     this.extension = this.extension.bind(this);
     this.addProposalSubmittedHook = this.addProposalSubmittedHook.bind(this);
     this.removeProposalSubmittedHook = this.removeProposalSubmittedHook.bind(this);
-    this.proposalCreatedHook = this.proposalCreatedHook.bind(this);
     this.proposalCompletedHook = this.proposalCompletedHook.bind(this);
   }
 
@@ -218,20 +210,6 @@ export class CwdPreProposeMultipleClient extends CwdPreProposeMultipleQueryClien
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_submitted_hook: {
         address
-      }
-    }, fee, memo, funds);
-  };
-  proposalCreatedHook = async ({
-    proposalId,
-    proposer
-  }: {
-    proposalId: number;
-    proposer: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
-    return await this.client.execute(this.sender, this.contractAddress, {
-      proposal_created_hook: {
-        proposal_id: proposalId,
-        proposer
       }
     }, fee, memo, funds);
   };

--- a/typescript/contracts/cwd-pre-propose-multiple/CwdPreProposeMultiple.types.ts
+++ b/typescript/contracts/cwd-pre-propose-multiple/CwdPreProposeMultiple.types.ts
@@ -57,11 +57,6 @@ export type ExecuteMsg = {
     address: string;
   };
 } | {
-  proposal_created_hook: {
-    proposal_id: number;
-    proposer: string;
-  };
-} | {
   proposal_completed_hook: {
     new_status: Status;
     proposal_id: number;

--- a/typescript/contracts/cwd-pre-propose-single/CwdPreProposeSingle.client.ts
+++ b/typescript/contracts/cwd-pre-propose-single/CwdPreProposeSingle.client.ts
@@ -117,13 +117,6 @@ export interface CwdPreProposeSingleInterface extends CwdPreProposeSingleReadOnl
   }: {
     address: string;
   }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  proposalCreatedHook: ({
-    proposalId,
-    proposer
-  }: {
-    proposalId: number;
-    proposer: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
   proposalCompletedHook: ({
     newStatus,
     proposalId
@@ -148,7 +141,6 @@ export class CwdPreProposeSingleClient extends CwdPreProposeSingleQueryClient im
     this.extension = this.extension.bind(this);
     this.addProposalSubmittedHook = this.addProposalSubmittedHook.bind(this);
     this.removeProposalSubmittedHook = this.removeProposalSubmittedHook.bind(this);
-    this.proposalCreatedHook = this.proposalCreatedHook.bind(this);
     this.proposalCompletedHook = this.proposalCompletedHook.bind(this);
   }
 
@@ -218,20 +210,6 @@ export class CwdPreProposeSingleClient extends CwdPreProposeSingleQueryClient im
     return await this.client.execute(this.sender, this.contractAddress, {
       remove_proposal_submitted_hook: {
         address
-      }
-    }, fee, memo, funds);
-  };
-  proposalCreatedHook = async ({
-    proposalId,
-    proposer
-  }: {
-    proposalId: number;
-    proposer: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
-    return await this.client.execute(this.sender, this.contractAddress, {
-      proposal_created_hook: {
-        proposal_id: proposalId,
-        proposer
       }
     }, fee, memo, funds);
   };

--- a/typescript/contracts/cwd-pre-propose-single/CwdPreProposeSingle.types.ts
+++ b/typescript/contracts/cwd-pre-propose-single/CwdPreProposeSingle.types.ts
@@ -57,11 +57,6 @@ export type ExecuteMsg = {
     address: string;
   };
 } | {
-  proposal_created_hook: {
-    proposal_id: number;
-    proposer: string;
-  };
-} | {
   proposal_completed_hook: {
     new_status: Status;
     proposal_id: number;

--- a/typescript/contracts/cwd-proposal-multiple/CwdProposalMultiple.client.ts
+++ b/typescript/contracts/cwd-proposal-multiple/CwdProposalMultiple.client.ts
@@ -45,12 +45,13 @@ export interface CwdProposalMultipleReadOnlyInterface {
     proposalId: number;
     startAfter?: string;
   }) => Promise<VoteListResponse>;
-  dao: () => Promise<Addr>;
-  info: () => Promise<InfoResponse>;
   proposalCount: () => Promise<Uint64>;
   proposalCreationPolicy: () => Promise<ProposalCreationPolicy>;
   proposalHooks: () => Promise<HooksResponse>;
   voteHooks: () => Promise<HooksResponse>;
+  dao: () => Promise<Addr>;
+  info: () => Promise<InfoResponse>;
+  nextProposalId: () => Promise<Uint64>;
 }
 export class CwdProposalMultipleQueryClient implements CwdProposalMultipleReadOnlyInterface {
   client: CosmWasmClient;
@@ -65,12 +66,13 @@ export class CwdProposalMultipleQueryClient implements CwdProposalMultipleReadOn
     this.reverseProposals = this.reverseProposals.bind(this);
     this.getVote = this.getVote.bind(this);
     this.listVotes = this.listVotes.bind(this);
-    this.dao = this.dao.bind(this);
-    this.info = this.info.bind(this);
     this.proposalCount = this.proposalCount.bind(this);
     this.proposalCreationPolicy = this.proposalCreationPolicy.bind(this);
     this.proposalHooks = this.proposalHooks.bind(this);
     this.voteHooks = this.voteHooks.bind(this);
+    this.dao = this.dao.bind(this);
+    this.info = this.info.bind(this);
+    this.nextProposalId = this.nextProposalId.bind(this);
   }
 
   config = async (): Promise<Config> => {
@@ -148,16 +150,6 @@ export class CwdProposalMultipleQueryClient implements CwdProposalMultipleReadOn
       }
     });
   };
-  dao = async (): Promise<Addr> => {
-    return this.client.queryContractSmart(this.contractAddress, {
-      dao: {}
-    });
-  };
-  info = async (): Promise<InfoResponse> => {
-    return this.client.queryContractSmart(this.contractAddress, {
-      info: {}
-    });
-  };
   proposalCount = async (): Promise<Uint64> => {
     return this.client.queryContractSmart(this.contractAddress, {
       proposal_count: {}
@@ -176,6 +168,21 @@ export class CwdProposalMultipleQueryClient implements CwdProposalMultipleReadOn
   voteHooks = async (): Promise<HooksResponse> => {
     return this.client.queryContractSmart(this.contractAddress, {
       vote_hooks: {}
+    });
+  };
+  dao = async (): Promise<Addr> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      dao: {}
+    });
+  };
+  info = async (): Promise<InfoResponse> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      info: {}
+    });
+  };
+  nextProposalId = async (): Promise<Uint64> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      next_proposal_id: {}
     });
   };
 }

--- a/typescript/contracts/cwd-proposal-multiple/CwdProposalMultiple.types.ts
+++ b/typescript/contracts/cwd-proposal-multiple/CwdProposalMultiple.types.ts
@@ -289,10 +289,6 @@ export type QueryMsg = {
     start_after?: string | null;
   };
 } | {
-  dao: {};
-} | {
-  info: {};
-} | {
   proposal_count: {};
 } | {
   proposal_creation_policy: {};
@@ -300,6 +296,12 @@ export type QueryMsg = {
   proposal_hooks: {};
 } | {
   vote_hooks: {};
+} | {
+  dao: {};
+} | {
+  info: {};
+} | {
+  next_proposal_id: {};
 };
 export type MigrateMsg = {
   from_v1: {

--- a/typescript/contracts/cwd-proposal-single/CwdProposalSingle.client.ts
+++ b/typescript/contracts/cwd-proposal-single/CwdProposalSingle.client.ts
@@ -45,12 +45,13 @@ export interface CwdProposalSingleReadOnlyInterface {
     proposalId: number;
     startAfter?: string;
   }) => Promise<VoteListResponse>;
-  dao: () => Promise<Addr>;
-  info: () => Promise<InfoResponse>;
   proposalCount: () => Promise<Uint64>;
   proposalCreationPolicy: () => Promise<ProposalCreationPolicy>;
   proposalHooks: () => Promise<HooksResponse>;
   voteHooks: () => Promise<HooksResponse>;
+  dao: () => Promise<Addr>;
+  info: () => Promise<InfoResponse>;
+  nextProposalId: () => Promise<Uint64>;
 }
 export class CwdProposalSingleQueryClient implements CwdProposalSingleReadOnlyInterface {
   client: CosmWasmClient;
@@ -65,12 +66,13 @@ export class CwdProposalSingleQueryClient implements CwdProposalSingleReadOnlyIn
     this.reverseProposals = this.reverseProposals.bind(this);
     this.getVote = this.getVote.bind(this);
     this.listVotes = this.listVotes.bind(this);
-    this.dao = this.dao.bind(this);
-    this.info = this.info.bind(this);
     this.proposalCount = this.proposalCount.bind(this);
     this.proposalCreationPolicy = this.proposalCreationPolicy.bind(this);
     this.proposalHooks = this.proposalHooks.bind(this);
     this.voteHooks = this.voteHooks.bind(this);
+    this.dao = this.dao.bind(this);
+    this.info = this.info.bind(this);
+    this.nextProposalId = this.nextProposalId.bind(this);
   }
 
   config = async (): Promise<Config> => {
@@ -148,16 +150,6 @@ export class CwdProposalSingleQueryClient implements CwdProposalSingleReadOnlyIn
       }
     });
   };
-  dao = async (): Promise<Addr> => {
-    return this.client.queryContractSmart(this.contractAddress, {
-      dao: {}
-    });
-  };
-  info = async (): Promise<InfoResponse> => {
-    return this.client.queryContractSmart(this.contractAddress, {
-      info: {}
-    });
-  };
   proposalCount = async (): Promise<Uint64> => {
     return this.client.queryContractSmart(this.contractAddress, {
       proposal_count: {}
@@ -176,6 +168,21 @@ export class CwdProposalSingleQueryClient implements CwdProposalSingleReadOnlyIn
   voteHooks = async (): Promise<HooksResponse> => {
     return this.client.queryContractSmart(this.contractAddress, {
       vote_hooks: {}
+    });
+  };
+  dao = async (): Promise<Addr> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      dao: {}
+    });
+  };
+  info = async (): Promise<InfoResponse> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      info: {}
+    });
+  };
+  nextProposalId = async (): Promise<Uint64> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      next_proposal_id: {}
     });
   };
 }

--- a/typescript/contracts/cwd-proposal-single/CwdProposalSingle.types.ts
+++ b/typescript/contracts/cwd-proposal-single/CwdProposalSingle.types.ts
@@ -295,10 +295,6 @@ export type QueryMsg = {
     start_after?: string | null;
   };
 } | {
-  dao: {};
-} | {
-  info: {};
-} | {
   proposal_count: {};
 } | {
   proposal_creation_policy: {};
@@ -306,6 +302,12 @@ export type QueryMsg = {
   proposal_hooks: {};
 } | {
   vote_hooks: {};
+} | {
+  dao: {};
+} | {
+  info: {};
+} | {
+  next_proposal_id: {};
 };
 export type MigrateMsg = {
   from_v1: {


### PR DESCRIPTION
Doing so pretty significantly simplifies pre-propose modules, and makes less compex to write as we can remove the proposal created hook entirely as part of this change.

This also walks back the addition of pre-propose and hooks to the proposal module interface. I think there is beauty in smallness there, and if someone else implements a proposal module they may not want to use our hook and proposal-gating types.