### PR TITLE
Don't error if res.data isn't marshallable into a callback.

### DIFF
--- a/contracts/dao-core/src/contract.rs
+++ b/contracts/dao-core/src/contract.rs
@@ -902,7 +902,9 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
 
             // Check for module instantiation callbacks
             let callback_msgs = match res.data {
-                Some(data) => from_binary::<ModuleInstantiateCallback>(&data)?.msgs,
+                Some(data) => from_binary::<ModuleInstantiateCallback>(&data)
+                    .map(|m| m.msgs)
+                    .unwrap_or_else(|_| vec![]),
                 None => vec![],
             };
 
@@ -926,7 +928,9 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
 
             // Check for module instantiation callbacks
             let callback_msgs = match res.data {
-                Some(data) => from_binary::<ModuleInstantiateCallback>(&data)?.msgs,
+                Some(data) => from_binary::<ModuleInstantiateCallback>(&data)
+                    .map(|m| m.msgs)
+                    .unwrap_or_else(|_| vec![]),
                 None => vec![],
             };
 

--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/state.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/state.rs
@@ -8,6 +8,8 @@ use dao_voting::deposit::CheckedDepositInfo;
 pub struct PendingProposal {
     /// The approval ID used to identify this pending proposal.
     pub approval_id: u64,
+    /// The address that created the proposal.
+    pub proposer: Addr,
     /// The propose message that ought to be executed on the proposal
     /// message if this proposal is approved.
     pub msg: ProposeMsg,

--- a/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
+++ b/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
@@ -1278,7 +1278,7 @@
         ]
       },
       "ProposeMsg": {
-        "description": "The contents of a message to create a proposal.",
+        "description": "The contents of a message to create a proposal. We break this type out of `ExecuteMsg` because we want pre-propose modules that interact with this contract to be able to get type checking on their propose messages.",
         "type": "object",
         "required": [
           "description",

--- a/contracts/proposal/dao-proposal-single/src/msg.rs
+++ b/contracts/proposal/dao-proposal-single/src/msg.rs
@@ -39,9 +39,9 @@ pub struct InstantiateMsg {
 }
 
 /// The contents of a message to create a proposal.
-// We break this type out of `ExecuteMsg` because we want pre-propose
-// modules that interact with this contract to be able to get type
-// checking on their propose messages.
+/// We break this type out of `ExecuteMsg` because we want pre-propose
+/// modules that interact with this contract to be able to get type
+/// checking on their propose messages.
 #[cw_serde]
 pub struct ProposeMsg {
     /// The title of the proposal.


### PR DESCRIPTION
it is unclear to me if this would ever be a problem, but i feel it may be best to err on the side of caution here in the event that we ever want to use the data field in a TX that involves instantiating a DAO that doesn't use it itself.