### PR TITLE
Use voting power at time of proposal creation for only_members_execute

### DIFF
--- a/contracts/proposal/dao-proposal-multiple/src/contract.rs
+++ b/contracts/proposal/dao-proposal-multiple/src/contract.rs
@@ -356,22 +356,22 @@ pub fn execute_execute(
     info: MessageInfo,
     proposal_id: u64,
 ) -> Result<Response, ContractError> {
+    let mut prop = PROPOSALS
+        .may_load(deps.storage, proposal_id)?
+        .ok_or(ContractError::NoSuchProposal { id: proposal_id })?;
+
     let config = CONFIG.load(deps.storage)?;
     if config.only_members_execute {
         let power = get_voting_power(
             deps.as_ref(),
             info.sender.clone(),
             config.dao.clone(),
-            Some(env.block.height),
+            Some(prop.start_height),
         )?;
         if power.is_zero() {
             return Err(ContractError::Unauthorized {});
         }
     }
-
-    let mut prop = PROPOSALS
-        .may_load(deps.storage, proposal_id)?
-        .ok_or(ContractError::NoSuchProposal { id: proposal_id })?;
 
     // Check here that the proposal is passed. Allow it to be
     // executed even if it is expired so long as it passed during its

--- a/contracts/proposal/dao-proposal-multiple/src/testing/queries.rs
+++ b/contracts/proposal/dao-proposal-multiple/src/testing/queries.rs
@@ -131,6 +131,28 @@ pub fn query_voting_module(app: &App, core_addr: &Addr) -> Addr {
         .unwrap()
 }
 
+pub fn query_cw20_token_staking_contracts(app: &App, core_addr: &Addr) -> (Addr, Addr) {
+    let voting_module: Addr = app
+        .wrap()
+        .query_wasm_smart(core_addr, &dao_core::msg::QueryMsg::VotingModule {})
+        .unwrap();
+    let token_contract: Addr = app
+        .wrap()
+        .query_wasm_smart(
+            voting_module.clone(),
+            &dao_voting_cw20_staked::msg::QueryMsg::TokenContract {},
+        )
+        .unwrap();
+    let staking_contract: Addr = app
+        .wrap()
+        .query_wasm_smart(
+            voting_module,
+            &dao_voting_cw20_staked::msg::QueryMsg::StakingContract {},
+        )
+        .unwrap();
+    (token_contract, staking_contract)
+}
+
 pub fn query_balance_cw20<T: Into<String>, U: Into<String>>(
     app: &App,
     contract_addr: T,

--- a/contracts/proposal/dao-proposal-single/src/contract.rs
+++ b/contracts/proposal/dao-proposal-single/src/contract.rs
@@ -261,17 +261,22 @@ pub fn execute_execute(
     info: MessageInfo,
     proposal_id: u64,
 ) -> Result<Response, ContractError> {
+    let mut prop = PROPOSALS
+        .may_load(deps.storage, proposal_id)?
+        .ok_or(ContractError::NoSuchProposal { id: proposal_id })?;
+
     let config = CONFIG.load(deps.storage)?;
     if config.only_members_execute {
-        let power = get_voting_power(deps.as_ref(), info.sender.clone(), config.dao.clone(), None)?;
+        let power = get_voting_power(
+            deps.as_ref(),
+            info.sender.clone(),
+            config.dao.clone(),
+            Some(prop.start_height),
+        )?;
         if power.is_zero() {
             return Err(ContractError::Unauthorized {});
         }
     }
-
-    let mut prop = PROPOSALS
-        .may_load(deps.storage, proposal_id)?
-        .ok_or(ContractError::NoSuchProposal { id: proposal_id })?;
 
     // Check here that the proposal is passed. Allow it to be executed
     // even if it is expired so long as it passed during its voting


### PR DESCRIPTION
Resolves #575 

This makes it so that `only_members_execute` uses the voting power at time of proposal creation to validate membership during execution instead of at the current time.