### PR TITLE
Consider unstaking tokens when checking MAX_CLAIMS invariant.

### DIFF
--- a/contracts/voting/dao-voting-cw721-staked/src/contract.rs
+++ b/contracts/voting/dao-voting-cw721-staked/src/contract.rs
@@ -144,7 +144,7 @@ pub fn execute_unstake(
             let outstanding_claims = NFT_CLAIMS
                 .query_claims(deps.as_ref(), &info.sender)?
                 .nft_claims;
-            if outstanding_claims.len() >= MAX_CLAIMS as usize {
+            if outstanding_claims.len() + token_ids.len() > MAX_CLAIMS as usize {
                 return Err(ContractError::TooManyClaims {});
             }
 

--- a/contracts/voting/dao-voting-cw721-staked/src/state.rs
+++ b/contracts/voting/dao-voting-cw721-staked/src/state.rs
@@ -65,7 +65,11 @@ pub fn register_staked_nft(
         .map(|_| ())
 }
 
-pub fn register_unstaked_nft(
+/// Registers the unstaking of TOKEN_IDs in storage. Errors if:
+///
+/// 1. `token_ids` is non-unique.
+/// 2. a NFT being staked has not previously been staked.
+pub fn register_unstaked_nfts(
     storage: &mut dyn Storage,
     height: u64,
     staker: &Addr,

--- a/packages/cw721-controllers/src/nft_claim.rs
+++ b/packages/cw721-controllers/src/nft_claim.rs
@@ -32,6 +32,13 @@ impl<'a> NftClaims<'a> {
 
     /// Creates a number of NFT claims simeltaniously for a given
     /// address.
+    ///
+    /// # Invariants
+    ///
+    /// - token_ids must be deduplicated
+    /// - token_ids must not contain any IDs which are currently in
+    ///   the claims queue for ADDR. This can be ensured by requiring
+    ///   that claims are completed before the tokens may be restaked.
     pub fn create_nft_claims(
         &self,
         storage: &mut dyn Storage,


### PR DESCRIPTION
resolves #580 

Previously one could bypass `MAX_CLAIMS` by unstaking more than one NFT in a single TX.