### PR TITLE
Require that from_v1 migrations are not from v2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,6 +609,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-ownable"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005a42121213990a5cda9ec1db34e27c46dbec679ffa1b0043785d71c015c904"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-ownable-derive",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
+ "thiserror",
+]
+
+[[package]]
+name = "cw-ownable-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05415700faa6f47185e9cd30d2ac5d49d872378b3329f07eae80a58c703cb592"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cw-paginate"
 version = "0.1.0"
 source = "git+https://github.com/DA0-DA0/dao-contracts.git?tag=v1.0.0#e531c760a5d057329afd98d62567aaa4dca2c96f"
@@ -2860,8 +2885,8 @@ version = "2.0.0-beta"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-multi-test",
+ "cw-ownable",
  "cw-storage-plus 0.16.0",
  "cw-utils 0.16.0",
  "cw2 0.16.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,6 @@ dao-voting = { path = "./packages/dao-voting" }
 cw-proposal-single-v1 = { package = "cw-proposal-single", version = "0.1.0", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }
 voting-v1 = { package = "voting", version = "0.1.0", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }
 cw-utils-v1 = {package = "cw-utils", version = "0.13"}
+
+# https://github.com/steak-enjoyers/cw-plus-plus/tree/main/packages/ownable
+cw-ownable = "0.2.0"

--- a/contracts/dao-core/src/error.rs
+++ b/contracts/dao-core/src/error.rs
@@ -50,4 +50,7 @@ pub enum ContractError {
 
     #[error("Proposal module with address is disabled and cannot execute messages.")]
     ModuleDisabledCannotExecute { address: Addr },
+
+    #[error("Can not migrate. Current version is up to date.")]
+    AlreadyMigrated {},
 }

--- a/contracts/dao-core/src/tests.rs
+++ b/contracts/dao-core/src/tests.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{
     testing::{mock_dependencies, mock_env},
     to_binary, Addr, CosmosMsg, Empty, Storage, Uint128, WasmMsg,
 };
-use cw2::ContractVersion;
+use cw2::{set_contract_version, ContractVersion};
 use cw_multi_test::{App, Contract, ContractWrapper, Executor};
 use cw_storage_plus::{Item, Map};
 use cw_utils::{Duration, Expiration};
@@ -2684,7 +2684,7 @@ fn test_migrate_from_beta() {
 
     let new_state: DumpStateResponse = app
         .wrap()
-        .query_wasm_smart(core_addr, &QueryMsg::DumpState {})
+        .query_wasm_smart(&core_addr, &QueryMsg::DumpState {})
         .unwrap();
 
     let proposal_modules = new_state.proposal_modules;
@@ -2694,6 +2694,21 @@ fn test_migrate_from_beta() {
         assert_eq!(prefix, module.prefix);
         assert_eq!(ProposalModuleStatus::Enabled, module.status);
     }
+
+    // Check that we may not migrate more than once.
+    let err: ContractError = app
+        .execute(
+            Addr::unchecked(CREATOR_ADDR),
+            CosmosMsg::Wasm(WasmMsg::Migrate {
+                contract_addr: core_addr.to_string(),
+                new_code_id: core_id,
+                msg: to_binary(&MigrateMsg::FromV1 { dao_uri: None }).unwrap(),
+            }),
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, ContractError::AlreadyMigrated {})
 }
 
 #[test]
@@ -2704,6 +2719,9 @@ fn test_migrate_mock() {
         dao_uri: Some(dao_uri.clone()),
     };
     let env = mock_env();
+
+    // Set starting version to v1.
+    set_contract_version(&mut deps.storage, CONTRACT_NAME, "0.1.0").unwrap();
 
     // Write to storage in old proposal module format
     let proposal_modules_key = Addr::unchecked("addr");

--- a/contracts/proposal/dao-proposal-single/src/error.rs
+++ b/contracts/proposal/dao-proposal-single/src/error.rs
@@ -86,4 +86,7 @@ pub enum ContractError {
 
     #[error("received a reply failure with an invalid ID: ({id})")]
     InvalidReplyID { id: u64 },
+
+    #[error("can not migrate. current version is up to date")]
+    AlreadyMigrated {},
 }

--- a/contracts/proposal/dao-proposal-single/src/testing/tests.rs
+++ b/contracts/proposal/dao-proposal-single/src/testing/tests.rs
@@ -1783,6 +1783,21 @@ fn test_migrate_from_v1() {
         }
     );
 
+    // We can not migrate more than once.
+    let err: ContractError = app
+        .execute(
+            core_addr.clone(),
+            CosmosMsg::Wasm(WasmMsg::Migrate {
+                contract_addr: proposal_module.to_string(),
+                new_code_id: v2_proposal_single,
+                msg: to_binary(&migrate_msg).unwrap(),
+            }),
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert!(matches!(err, ContractError::AlreadyMigrated {}));
+
     // Make sure we can still query for ballots (rationale works post
     // migration).
     let vote = query_vote(&app, &proposal_module, CREATOR_ADDR, 1);

--- a/contracts/staking/cw20-stake-reward-distributor/Cargo.toml
+++ b/contracts/staking/cw20-stake-reward-distributor/Cargo.toml
@@ -2,15 +2,7 @@
 name = "stake-cw20-reward-distributor"
 version = "2.0.0-beta"
 edition = "2018"
-authors = ["Vernon Johnson <vtj2105@columbia.edu>"]
-
-exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "contract.wasm",
-  "hash.txt",
-]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors = ["Vernon Johnson <vtj2105@columbia.edu>, ekez <ekez@withoutdoing.com>"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -21,25 +13,17 @@ backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
 
-[package.metadata.scripts]
-optimize = """docker run --rm -v "$(pwd)":/code \
-  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
-  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/workspace-optimizer:0.12.6
-"""
-
 [dependencies]
 cosmwasm-std = { workspace = true }
-cosmwasm-storage = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
 cw-utils = { workspace = true }
-
 cw20-base = {  workspace = true, features = ["library"] }
 cw20-stake = { workspace = true, features = ["library"]}
 thiserror = { workspace = true }
+cw-ownable = { workspace = true }
 
 [dev-dependencies]
 cw-multi-test = { workspace = true }

--- a/contracts/staking/cw20-stake-reward-distributor/src/error.rs
+++ b/contracts/staking/cw20-stake-reward-distributor/src/error.rs
@@ -3,8 +3,11 @@ use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
-    #[error("{0}")]
+    #[error(transparent)]
     Std(#[from] StdError),
+
+    #[error(transparent)]
+    Ownership(#[from] cw_ownable::OwnershipError),
 
     #[error("Unauthorized")]
     Unauthorized {},

--- a/contracts/staking/cw20-stake-reward-distributor/src/msg.rs
+++ b/contracts/staking/cw20-stake-reward-distributor/src/msg.rs
@@ -2,6 +2,8 @@ use crate::state::Config;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
 
+use cw_ownable::cw_ownable;
+
 #[cw_serde]
 pub struct InstantiateMsg {
     pub owner: String,
@@ -10,10 +12,10 @@ pub struct InstantiateMsg {
     pub reward_token: String,
 }
 
+#[cw_ownable]
 #[cw_serde]
 pub enum ExecuteMsg {
     UpdateConfig {
-        owner: String,
         staking_addr: String,
         reward_rate: Uint128,
         reward_token: String,

--- a/contracts/staking/cw20-stake-reward-distributor/src/state.rs
+++ b/contracts/staking/cw20-stake-reward-distributor/src/state.rs
@@ -4,7 +4,6 @@ use cw_storage_plus::Item;
 
 #[cw_serde]
 pub struct Config {
-    pub owner: Addr,
     pub staking_addr: Addr,
     pub reward_rate: Uint128,
     pub reward_token: Addr,


### PR DESCRIPTION
resolves #578 

this prevents `FromV1` migrations from being used to migrate a contract without a version change, thus preventing a DAO from migrating to v2 from v1 more than once.