### PR TITLE
Two-step ownership transfer for staking contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,6 +906,7 @@ dependencies = [
  "cosmwasm-storage",
  "cw-controllers 0.16.0",
  "cw-multi-test",
+ "cw-ownable",
  "cw-paginate 2.0.0-beta",
  "cw-storage-plus 0.16.0",
  "cw-utils 0.16.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw20-stake-external-rewards"
+version = "2.0.0-beta"
+dependencies = [
+ "anyhow",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-controllers 0.16.0",
+ "cw-multi-test",
+ "cw-ownable",
+ "cw-storage-plus 0.16.0",
+ "cw-utils 0.16.0",
+ "cw2 0.16.0",
+ "cw20 0.13.4",
+ "cw20 0.16.0",
+ "cw20-base 0.16.0",
+ "cw20-stake 2.0.0-beta",
+ "stake-cw20-external-rewards",
+ "thiserror",
+]
+
+[[package]]
 name = "cw20-stake-reward-distributor"
 version = "2.0.0-beta"
 dependencies = [
@@ -2934,21 +2956,20 @@ dependencies = [
 
 [[package]]
 name = "stake-cw20-external-rewards"
-version = "2.0.0-beta"
+version = "0.2.6"
+source = "git+https://github.com/DA0-DA0/dao-contracts.git?tag=v1.0.0#e531c760a5d057329afd98d62567aaa4dca2c96f"
 dependencies = [
- "anyhow",
- "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-controllers 0.16.0",
- "cw-multi-test",
- "cw-ownable",
- "cw-storage-plus 0.16.0",
- "cw-utils 0.16.0",
- "cw2 0.16.0",
- "cw20 0.16.0",
- "cw20-base 0.16.0",
- "cw20-stake 2.0.0-beta",
+ "cw-controllers 0.13.4",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
+ "cw20 0.13.4",
+ "cw20-base 0.13.4",
+ "cw20-stake 0.2.6",
+ "schemars",
+ "serde",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -199,7 +199,7 @@ dependencies = [
  "cw-admin-factory",
  "cw-utils 0.16.0",
  "cw20 0.16.0",
- "cw20-stake",
+ "cw20-stake 2.0.0-beta",
  "dao-core",
  "dao-interface",
  "dao-pre-propose-single",
@@ -332,7 +332,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673d31bd830c0772d78545de20d975129b6ab2f7db4e4e9313c3b8777d319194"
 dependencies = [
- "prost 0.11.3",
+ "prost 0.11.5",
  "prost-types",
  "tendermint-proto",
  "tonic",
@@ -504,9 +504,23 @@ dependencies = [
  "cw-storage-plus 0.16.0",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
- "cw20-base",
+ "cw20-base 0.16.0",
  "dao-core",
  "dao-interface",
+ "thiserror",
+]
+
+[[package]]
+name = "cw-controllers"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f0bc6019b4d3d81e11f5c384bcce7173e2210bd654d75c6c9668e12cca05dfa"
+dependencies = [
+ "cosmwasm-std",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "schemars",
+ "serde",
  "thiserror",
 ]
 
@@ -575,7 +589,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
  "cw20 0.16.0",
- "cw20-base",
+ "cw20-base 0.16.0",
  "thiserror",
 ]
 
@@ -721,7 +735,7 @@ dependencies = [
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
- "cw20-base",
+ "cw20-base 0.16.0",
  "thiserror",
 ]
 
@@ -760,7 +774,7 @@ checksum = "c80e93d1deccb8588db03945016a292c3c631e6325d349ebb35d2db6f4f946f7"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2 1.0.0",
+ "cw2 1.0.1",
  "schemars",
  "semver",
  "serde",
@@ -794,13 +808,13 @@ dependencies = [
 
 [[package]]
 name = "cw2"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03bdf3747540b47bc1bdaf50ba3aa5e4276ab0c2ce73e8b367ebe260cc37ff9c"
+checksum = "8fb70cee2cf0b4a8ff7253e6bc6647107905e8eb37208f87d54f67810faa62f8"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 0.16.0",
+ "cw-storage-plus 1.0.1",
  "schemars",
  "serde",
 ]
@@ -832,6 +846,22 @@ dependencies = [
 
 [[package]]
 name = "cw20-base"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0306e606581f4fb45e82bcbb7f0333179ed53dd949c6523f01a99b4bfc1475a0"
+dependencies = [
+ "cosmwasm-std",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
+ "cw20 0.13.4",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw20-base"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61d826fa1084d026d0abdb54faa5956972efa3a9053473bfcefb5388960aab69"
@@ -850,20 +880,56 @@ dependencies = [
 
 [[package]]
 name = "cw20-stake"
+version = "0.2.6"
+source = "git+https://github.com/DA0-DA0/dao-contracts.git?tag=v1.0.0#e531c760a5d057329afd98d62567aaa4dca2c96f"
+dependencies = [
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw-controllers 0.13.4",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
+ "cw20 0.13.4",
+ "cw20-base 0.13.4",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw20-stake"
 version = "2.0.0-beta"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-controllers",
+ "cw-controllers 0.16.0",
  "cw-multi-test",
  "cw-paginate 2.0.0-beta",
  "cw-storage-plus 0.16.0",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
- "cw20-base",
+ "cw20-base 0.16.0",
+ "thiserror",
+]
+
+[[package]]
+name = "cw20-stake-reward-distributor"
+version = "2.0.0-beta"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-multi-test",
+ "cw-ownable",
+ "cw-storage-plus 0.16.0",
+ "cw-utils 0.16.0",
+ "cw2 0.16.0",
+ "cw20 0.16.0",
+ "cw20-base 0.16.0",
+ "cw20-stake 2.0.0-beta",
+ "stake-cw20-reward-distributor",
  "thiserror",
 ]
 
@@ -913,7 +979,7 @@ checksum = "dba1d15bff40b97bde05f36a0d44ac3369a085a4bda6c4673e33a9359513fdd2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-controllers",
+ "cw-controllers 0.16.0",
  "cw-storage-plus 0.16.0",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
@@ -982,7 +1048,6 @@ version = "2.0.0-beta"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-core",
  "cw-multi-test",
  "cw-paginate 2.0.0-beta",
@@ -990,7 +1055,7 @@ dependencies = [
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
- "cw20-base",
+ "cw20-base 0.16.0",
  "cw721 0.16.0",
  "cw721-base",
  "dao-interface",
@@ -1038,7 +1103,7 @@ dependencies = [
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
- "cw20-base",
+ "cw20-base 0.16.0",
  "cw4-group",
  "dao-core",
  "dao-interface",
@@ -1064,7 +1129,7 @@ dependencies = [
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
- "cw20-base",
+ "cw20-base 0.16.0",
  "cw4-group",
  "dao-core",
  "dao-interface",
@@ -1108,7 +1173,7 @@ dependencies = [
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
- "cw20-base",
+ "cw20-base 0.16.0",
  "cw4-group",
  "dao-core",
  "dao-interface",
@@ -1133,7 +1198,7 @@ dependencies = [
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
- "cw20-base",
+ "cw20-base 0.16.0",
  "cw4-group",
  "dao-core",
  "dao-interface",
@@ -1158,7 +1223,7 @@ dependencies = [
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
- "cw20-base",
+ "cw20-base 0.16.0",
  "dao-core",
  "dao-interface",
  "dao-proposal-hooks",
@@ -1193,8 +1258,8 @@ dependencies = [
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
- "cw20-base",
- "cw20-stake",
+ "cw20-base 0.16.0",
+ "cw20-stake 2.0.0-beta",
  "cw3 0.16.0",
  "cw4",
  "cw4-group",
@@ -1234,8 +1299,8 @@ dependencies = [
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
- "cw20-base",
- "cw20-stake",
+ "cw20-base 0.16.0",
+ "cw20-stake 2.0.0-beta",
  "cw3 0.16.0",
  "cw4",
  "cw4-group",
@@ -1285,8 +1350,8 @@ dependencies = [
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
- "cw20-base",
- "cw20-stake",
+ "cw20-base 0.16.0",
+ "cw20-stake 2.0.0-beta",
  "cw4",
  "cw4-group",
  "cw721-base",
@@ -1342,7 +1407,7 @@ dependencies = [
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
- "cw20-base",
+ "cw20-base 0.16.0",
  "dao-interface",
  "dao-macros",
  "thiserror",
@@ -1360,8 +1425,8 @@ dependencies = [
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
- "cw20-base",
- "cw20-stake",
+ "cw20-base 0.16.0",
+ "cw20-stake 2.0.0-beta",
  "dao-interface",
  "dao-macros",
  "thiserror",
@@ -1392,7 +1457,7 @@ dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-controllers",
+ "cw-controllers 0.16.0",
  "cw-multi-test",
  "cw-paginate 2.0.0-beta",
  "cw-storage-plus 0.16.0",
@@ -1415,7 +1480,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-controllers",
+ "cw-controllers 0.16.0",
  "cw-multi-test",
  "cw-paginate 2.0.0-beta",
  "cw-storage-plus 0.16.0",
@@ -1812,6 +1877,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1993,8 +2067,8 @@ dependencies = [
  "cosmwasm-std",
  "cw-utils 0.16.0",
  "cw20 0.16.0",
- "cw20-base",
- "cw20-stake",
+ "cw20-base 0.16.0",
+ "cw20-stake 2.0.0-beta",
  "cw721 0.16.0",
  "cw721-base",
  "dao-core",
@@ -2077,9 +2151,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "linked-hash-map"
@@ -2164,19 +2238,19 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opaque-debug"
@@ -2256,9 +2330,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc8bed3549e0f9b0a2a78bf7c0018237a2cdf085eecbbc048e52612438e4e9d0"
+checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2266,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc078600d06ff90d4ed238f0119d84ab5d43dbaad278b0e33a8820293b32344"
+checksum = "96504449aa860c8dcde14f9fba5c58dc6658688ca1fe363589d6327b8662c603"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2276,9 +2350,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a1af60b1c4148bb269006a750cff8e2ea36aff34d2d96cf7be0b14d1bed23c"
+checksum = "798e0220d1111ae63d66cb66a5dcb3fc2d986d520b98e49e1852bfdb11d7c5e7"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2289,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec8605d59fc2ae0c6c1aefc0c7c7a9769732017c0ce07f7a9cfffa7b4404f20"
+checksum = "984298b75898e30a843e278a9f2452c31e349a073a0ce6fd950a12a74464e065"
 dependencies = [
  "once_cell",
  "pest",
@@ -2378,12 +2452,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b18e655c21ff5ac2084a5ad0611e827b3f92badf79f4910b5a5c58f4d87ff0"
+checksum = "c01db6702aa05baa3f57dec92b8eeeeb4cb19e894e73996b32a4093289e54592"
 dependencies = [
  "bytes",
- "prost-derive 0.11.2",
+ "prost-derive 0.11.5",
 ]
 
 [[package]]
@@ -2401,9 +2475,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164ae68b6587001ca506d3bf7f1000bfa248d0e1217b618108fba4ec1d0cc306"
+checksum = "c8842bad1a5419bca14eac663ba798f6bc19c413c2fdceb5f3ba3b0932d96720"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2414,12 +2488,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.2"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
+checksum = "017f79637768cde62820bc2d4fe0e45daaa027755c323ad077767c6c5f173091"
 dependencies = [
  "bytes",
- "prost 0.11.3",
+ "prost 0.11.5",
 ]
 
 [[package]]
@@ -2686,9 +2760,9 @@ checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
@@ -2713,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2866,31 +2940,32 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-controllers",
+ "cw-controllers 0.16.0",
  "cw-multi-test",
  "cw-storage-plus 0.16.0",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
- "cw20-base",
- "cw20-stake",
+ "cw20-base 0.16.0",
+ "cw20-stake 2.0.0-beta",
  "thiserror",
 ]
 
 [[package]]
 name = "stake-cw20-reward-distributor"
-version = "2.0.0-beta"
+version = "0.1.0"
+source = "git+https://github.com/DA0-DA0/dao-contracts.git?tag=v1.0.0#e531c760a5d057329afd98d62567aaa4dca2c96f"
 dependencies = [
- "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test",
- "cw-ownable",
- "cw-storage-plus 0.16.0",
- "cw-utils 0.16.0",
- "cw2 0.16.0",
- "cw20 0.16.0",
- "cw20-base",
- "cw20-stake",
+ "cosmwasm-storage",
+ "cw-storage-plus 0.13.4",
+ "cw-utils 0.13.4",
+ "cw2 0.13.4",
+ "cw20 0.13.4",
+ "cw20-base 0.13.4",
+ "cw20-stake 0.2.6",
+ "schemars",
+ "serde",
  "thiserror",
 ]
 
@@ -2959,7 +3034,7 @@ dependencies = [
  "k256",
  "num-traits",
  "once_cell",
- "prost 0.11.3",
+ "prost 0.11.5",
  "prost-types",
  "ripemd160",
  "serde",
@@ -2999,7 +3074,7 @@ dependencies = [
  "flex-error",
  "num-derive",
  "num-traits",
- "prost 0.11.3",
+ "prost 0.11.5",
  "prost-types",
  "serde",
  "serde_bytes",
@@ -3236,8 +3311,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.11.3",
- "prost-derive 0.11.2",
+ "prost 0.11.5",
+ "prost-derive 0.11.5",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,6 +609,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw-ownable"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af8128a2c83862868f3d576cadde8c0f56b3845d8cb82d0b15b9a3fdbf23690"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-ownable-derive",
+ "cw-storage-plus 1.0.1",
+ "cw-utils 1.0.1",
+ "thiserror",
+]
+
+[[package]]
+name = "cw-ownable-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05415700faa6f47185e9cd30d2ac5d49d872378b3329f07eae80a58c703cb592"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "cw-paginate"
 version = "0.1.0"
 source = "git+https://github.com/DA0-DA0/dao-contracts.git?tag=v1.0.0#e531c760a5d057329afd98d62567aaa4dca2c96f"
@@ -2860,8 +2885,8 @@ version = "2.0.0-beta"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-multi-test",
+ "cw-ownable",
  "cw-storage-plus 0.16.0",
  "cw-utils 0.16.0",
  "cw2 0.16.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,8 +611,7 @@ dependencies = [
 [[package]]
 name = "cw-ownable"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af8128a2c83862868f3d576cadde8c0f56b3845d8cb82d0b15b9a3fdbf23690"
+source = "git+https://github.com/steak-enjoyers/cw-plus-plus?rev=50d4d9333305894457e5028072a0465f4635b15b#50d4d9333305894457e5028072a0465f4635b15b"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -625,8 +624,7 @@ dependencies = [
 [[package]]
 name = "cw-ownable-derive"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05415700faa6f47185e9cd30d2ac5d49d872378b3329f07eae80a58c703cb592"
+source = "git+https://github.com/steak-enjoyers/cw-plus-plus?rev=50d4d9333305894457e5028072a0465f4635b15b#50d4d9333305894457e5028072a0465f4635b15b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2942,6 +2942,7 @@ dependencies = [
  "cosmwasm-storage",
  "cw-controllers 0.16.0",
  "cw-multi-test",
+ "cw-ownable",
  "cw-storage-plus 0.16.0",
  "cw-utils 0.16.0",
  "cw2 0.16.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,10 +909,12 @@ dependencies = [
  "cw-ownable",
  "cw-paginate 2.0.0-beta",
  "cw-storage-plus 0.16.0",
+ "cw-utils 0.13.4",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
  "cw20-base 0.16.0",
+ "cw20-stake 0.2.6",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,4 +87,4 @@ voting-v1 = { package = "voting", version = "0.1.0", git = "https://github.com/D
 cw-utils-v1 = {package = "cw-utils", version = "0.13"}
 
 # https://github.com/steak-enjoyers/cw-plus-plus/tree/main/packages/ownable
-cw-ownable = "0.3.0" 
+cw-ownable = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,6 @@ dao-voting = { path = "./packages/dao-voting" }
 cw-proposal-single-v1 = { package = "cw-proposal-single", version = "0.1.0", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }
 voting-v1 = { package = "voting", version = "0.1.0", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }
 cw-utils-v1 = {package = "cw-utils", version = "0.13"}
+
+# https://github.com/steak-enjoyers/cw-plus-plus/tree/main/packages/ownable
+cw-ownable = "0.3.0" 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ cw2 = "0.16"
 cw20 = "0.16"
 cw721 = "0.16"
 cw20-base = "0.16"
-cw-core-v1 = { package = "cw-core", version = "0.1.0", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }
 cw-multi-test = "0.16"
 cw721-base = "0.16"
 cw-controllers = "0.16"
@@ -49,15 +48,18 @@ cw4-group = "0.16"
 rand = "0.8"
 cw4 = "0.16"
 cw3 = "0.16"
-indexmap = "1.9"
 serde = "1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["derive"] }
 
+# One commit ahead of version 0.3.0. Allows initialization with an
+# optional owner.
+cw-ownable = { git = "https://github.com/steak-enjoyers/cw-plus-plus", rev = "50d4d9333305894457e5028072a0465f4635b15b" }
+
+
 cw-admin-factory = { path = "./contracts/external/cw-admin-factory" }
 dao-core = { path = "./contracts/dao-core" }
-
 dao-proposal-single = { path = "./contracts/proposal/dao-proposal-single" }
 dao-proposal-multiple = { path = "./contracts/proposal/dao-proposal-multiple" }
 dao-pre-propose-single = { path = "./contracts/pre-propose/dao-pre-propose-single" }
@@ -82,10 +84,10 @@ dao-vote-hooks = { path = "./packages/dao-vote-hooks" }
 cw-paginate = { path = "./packages/cw-paginate" }
 dao-interface = { path = "./packages/dao-interface" }
 dao-voting = { path = "./packages/dao-voting" }
+
+# v1 dependencies. used for state migrations.
+cw-core-v1 = { package = "cw-core", version = "0.1.0", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }
 cw-proposal-single-v1 = { package = "cw-proposal-single", version = "0.1.0", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }
 voting-v1 = { package = "voting", version = "0.1.0", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }
 cw-utils-v1 = {package = "cw-utils", version = "0.13"}
-
-# One commit ahead of version 0.3.0. Allows initialization with an
-# optional owner.
-cw-ownable = { git = "https://github.com/steak-enjoyers/cw-plus-plus", rev = "50d4d9333305894457e5028072a0465f4635b15b" }
+cw20-stake-reward-distributor-v1 = { package = "stake-cw20-reward-distributor", version = "0.1.0", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,3 +91,4 @@ cw-proposal-single-v1 = { package = "cw-proposal-single", version = "0.1.0", git
 voting-v1 = { package = "voting", version = "0.1.0", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }
 cw-utils-v1 = {package = "cw-utils", version = "0.13"}
 cw20-stake-reward-distributor-v1 = { package = "stake-cw20-reward-distributor", version = "0.1.0", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }
+cw20-stake-external-rewards-v1 = { package = "stake-cw20-external-rewards", version = "0.2.6", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,3 +92,4 @@ voting-v1 = { package = "voting", version = "0.1.0", git = "https://github.com/D
 cw-utils-v1 = {package = "cw-utils", version = "0.13"}
 cw20-stake-reward-distributor-v1 = { package = "stake-cw20-reward-distributor", version = "0.1.0", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }
 cw20-stake-external-rewards-v1 = { package = "stake-cw20-external-rewards", version = "0.2.6", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }
+cw20-stake-v1 = { package = "cw20-stake", version = "0.2.6", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,5 +86,6 @@ cw-proposal-single-v1 = { package = "cw-proposal-single", version = "0.1.0", git
 voting-v1 = { package = "voting", version = "0.1.0", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }
 cw-utils-v1 = {package = "cw-utils", version = "0.13"}
 
-# https://github.com/steak-enjoyers/cw-plus-plus/tree/main/packages/ownable
-cw-ownable = "0.3.0"
+# One commit ahead of version 0.3.0. Allows initialization with an
+# optional owner.
+cw-ownable = { git = "https://github.com/steak-enjoyers/cw-plus-plus", rev = "50d4d9333305894457e5028072a0465f4635b15b" }

--- a/ci/integration-tests/src/tests/cw_core_test.rs
+++ b/ci/integration-tests/src/tests/cw_core_test.rs
@@ -299,11 +299,22 @@ fn instantiate_with_admin(chain: &mut Chain) {
         .query("cw20_stake", &cw20_stake::msg::QueryMsg::GetConfig {})
         .unwrap();
     let config_res: cw20_stake::state::Config = res.data().unwrap();
+    assert_eq!(config_res.unstaking_duration, Some(Duration::Time(1209600)));
+
+    let res = chain
+        .orc
+        .query("cw20_stake", &cw20_stake::msg::QueryMsg::Ownership {})
+        .unwrap();
+    let ownership: cw20_stake::msg::Ownership<Addr> = res.data().unwrap();
     assert_eq!(
-        config_res.owner,
-        Some(Addr::unchecked(
-            chain.orc.contract_map.address("dao_core").unwrap()
-        ))
+        ownership,
+        cw20_stake::msg::Ownership::<Addr> {
+            owner: Some(Addr::unchecked(
+                chain.orc.contract_map.address("dao_core").unwrap()
+            )),
+            pending_owner: None,
+            pending_expiry: None
+        }
     );
 
     let res = &chain

--- a/ci/integration-tests/src/tests/cw_core_test.rs
+++ b/ci/integration-tests/src/tests/cw_core_test.rs
@@ -305,7 +305,6 @@ fn instantiate_with_admin(chain: &mut Chain) {
             chain.orc.contract_map.address("dao_core").unwrap()
         ))
     );
-    assert_eq!(config_res.manager, None);
 
     let res = &chain
         .orc

--- a/contracts/dao-core/Cargo.toml
+++ b/contracts/dao-core/Cargo.toml
@@ -17,7 +17,6 @@ library = []
 
 [dependencies]
 cosmwasm-std = { workspace = true, features = ["ibc3"] }
-cosmwasm-storage = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }

--- a/contracts/staking/cw20-stake-external-rewards/Cargo.toml
+++ b/contracts/staking/cw20-stake-external-rewards/Cargo.toml
@@ -25,9 +25,9 @@ cw20 = { workspace = true }
 cw-utils = { workspace = true }
 cw20-base = {  workspace = true, features = ["library"] }
 cw2 = { workspace = true }
-
 thiserror = { workspace = true }
 cw20-stake = { workspace = true, features = ["library"]}
+cw-ownable = { workspace = true }
 
 [dev-dependencies]
 cw-multi-test = { workspace = true }

--- a/contracts/staking/cw20-stake-external-rewards/Cargo.toml
+++ b/contracts/staking/cw20-stake-external-rewards/Cargo.toml
@@ -1,11 +1,8 @@
 [package]
-name = "stake-cw20-external-rewards"
+name = "cw20-stake-external-rewards"
 version = "2.0.0-beta"
-authors = ["Ben2x4 <Ben2x4@tutanota.com>"]
+authors = ["Ben2x4 <Ben2x4@tutanota.com>", "ekez <ekez@withoutdoing.com>"]
 edition = "2018"
-license = "Apache-2.0"
-repository = "https://github.com/DA0-DA0/cw-dao/contracts/cw20-stakeable"
-description = "CW20 token that can be staked and staked balance can be queried at any height"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -28,6 +25,9 @@ cw2 = { workspace = true }
 thiserror = { workspace = true }
 cw20-stake = { workspace = true, features = ["library"]}
 cw-ownable = { workspace = true }
+
+cw20-stake-external-rewards-v1 = { workspace = true }
+cw20-013 = { package = "cw20", version = "0.13" }
 
 [dev-dependencies]
 cw-multi-test = { workspace = true }

--- a/contracts/staking/cw20-stake-external-rewards/examples/schema.rs
+++ b/contracts/staking/cw20-stake-external-rewards/examples/schema.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::write_api;
-use stake_cw20_external_rewards::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use cw20_stake_external_rewards::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 
 fn main() {
     write_api! {

--- a/contracts/staking/cw20-stake-external-rewards/schema/cw20-stake-external-rewards.json
+++ b/contracts/staking/cw20-stake-external-rewards/schema/cw20-stake-external-rewards.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "stake-cw20-external-rewards",
+  "contract_name": "cw20-stake-external-rewards",
   "contract_version": "2.0.0-beta",
   "idl_version": "1.0.0",
   "instantiate": {
@@ -413,8 +413,22 @@
   "migrate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MigrateMsg",
-    "type": "object",
-    "additionalProperties": false
+    "oneOf": [
+      {
+        "description": "Migrates from version 0.2.6 to 2.0.0. The significant changes being the addition of a two-step ownership transfer using `cw_ownable` and the removal of the manager. Migrating will automatically remove the current manager.",
+        "type": "object",
+        "required": [
+          "from_v1"
+        ],
+        "properties": {
+          "from_v1": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
   },
   "sudo": null,
   "responses": {

--- a/contracts/staking/cw20-stake-external-rewards/schema/stake-cw20-external-rewards.json
+++ b/contracts/staking/cw20-stake-external-rewards/schema/stake-cw20-external-rewards.json
@@ -144,28 +144,71 @@
         "additionalProperties": false
       },
       {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
         "required": [
-          "update_owner"
+          "update_ownership"
         ],
         "properties": {
-          "update_owner": {
-            "type": "object",
-            "properties": {
-              "new_owner": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "additionalProperties": false
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
           }
         },
         "additionalProperties": false
       }
     ],
     "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
       "Addr": {
         "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
         "type": "string"
@@ -194,6 +237,53 @@
           }
         },
         "additionalProperties": false
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "StakeChangedHookMsg": {
         "oneOf": [
@@ -249,8 +339,20 @@
           }
         ]
       },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
       "Uint128": {
         "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
         "type": "string"
       }
     }
@@ -288,6 +390,19 @@
                 "type": "string"
               }
             },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
+            "type": "object",
             "additionalProperties": false
           }
         },
@@ -398,16 +513,6 @@
             "staking_contract"
           ],
           "properties": {
-            "owner": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Addr"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
             "reward_token": {
               "$ref": "#/definitions/Denom"
             },
@@ -471,6 +576,113 @@
         },
         "Uint128": {
           "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_Addr",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
           "type": "string"
         }
       }

--- a/contracts/staking/cw20-stake-external-rewards/schema/stake-cw20-external-rewards.json
+++ b/contracts/staking/cw20-stake-external-rewards/schema/stake-cw20-external-rewards.json
@@ -12,12 +12,6 @@
       "staking_contract"
     ],
     "properties": {
-      "manager": {
-        "type": [
-          "string",
-          "null"
-        ]
-      },
       "owner": {
         "type": [
           "string",
@@ -159,27 +153,6 @@
             "type": "object",
             "properties": {
               "new_owner": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
-        "type": "object",
-        "required": [
-          "update_manager"
-        ],
-        "properties": {
-          "update_manager": {
-            "type": "object",
-            "properties": {
-              "new_manager": {
                 "type": [
                   "string",
                   "null"
@@ -425,16 +398,6 @@
             "staking_contract"
           ],
           "properties": {
-            "manager": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/Addr"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
             "owner": {
               "anyOf": [
                 {

--- a/contracts/staking/cw20-stake-external-rewards/src/contract.rs
+++ b/contracts/staking/cw20-stake-external-rewards/src/contract.rs
@@ -359,7 +359,7 @@ pub fn execute_update_reward_duration(
     new_duration: u64,
 ) -> Result<Response<Empty>, ContractError> {
     let config = CONFIG.load(deps.storage)?;
-    if Some(info.sender.clone()) != config.owner {
+    if Some(info.sender) != config.owner {
         return Err(ContractError::Unauthorized {});
     };
 

--- a/contracts/staking/cw20-stake-external-rewards/src/contract.rs
+++ b/contracts/staking/cw20-stake-external-rewards/src/contract.rs
@@ -542,7 +542,6 @@ mod tests {
         let staking_code_id = app.store_code(contract_staking());
         let msg = cw20_stake::msg::InstantiateMsg {
             owner: Some(OWNER.to_string()),
-            manager: Some("manager".to_string()),
             token_address: cw20.to_string(),
             unstaking_duration,
         };

--- a/contracts/staking/cw20-stake-external-rewards/src/error.rs
+++ b/contracts/staking/cw20-stake-external-rewards/src/error.rs
@@ -3,12 +3,14 @@ use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
-    #[error("{0}")]
+    #[error(transparent)]
     Std(#[from] StdError),
-    #[error("{0}")]
+    #[error(transparent)]
+    Ownable(#[from] cw_ownable::OwnershipError),
+    #[error(transparent)]
     Cw20Error(#[from] cw20_base::ContractError),
-    #[error("Unauthorized")]
-    Unauthorized {},
+    #[error("Staking change hook sender is not staking contract")]
+    InvalidHookSender {},
     #[error("No rewards claimable")]
     NoRewardsClaimable {},
     #[error("Reward period not finished")]

--- a/contracts/staking/cw20-stake-external-rewards/src/error.rs
+++ b/contracts/staking/cw20-stake-external-rewards/src/error.rs
@@ -23,4 +23,6 @@ pub enum ContractError {
     RewardRateLessThenOnePerBlock {},
     #[error("Reward duration can not be zero")]
     ZeroRewardDuration {},
+    #[error("can not migrate. current version is up to date")]
+    AlreadyMigrated {},
 }

--- a/contracts/staking/cw20-stake-external-rewards/src/msg.rs
+++ b/contracts/staking/cw20-stake-external-rewards/src/msg.rs
@@ -16,9 +16,6 @@ pub struct InstantiateMsg {
     pub reward_duration: u64,
 }
 
-#[cw_serde]
-pub struct MigrateMsg {}
-
 #[cw_ownable]
 #[cw_serde]
 pub enum ExecuteMsg {
@@ -27,6 +24,15 @@ pub enum ExecuteMsg {
     Receive(Cw20ReceiveMsg),
     Fund {},
     UpdateRewardDuration { new_duration: u64 },
+}
+
+#[cw_serde]
+pub enum MigrateMsg {
+    /// Migrates from version 0.2.6 to 2.0.0. The significant changes
+    /// being the addition of a two-step ownership transfer using
+    /// `cw_ownable` and the removal of the manager. Migrating will
+    /// automatically remove the current manager.
+    FromV1 {},
 }
 
 #[cw_serde]

--- a/contracts/staking/cw20-stake-external-rewards/src/msg.rs
+++ b/contracts/staking/cw20-stake-external-rewards/src/msg.rs
@@ -9,7 +9,6 @@ pub use cw_controllers::ClaimsResponse;
 #[cw_serde]
 pub struct InstantiateMsg {
     pub owner: Option<String>,
-    pub manager: Option<String>,
     pub staking_contract: String,
     pub reward_token: Denom,
     pub reward_duration: u64,
@@ -26,7 +25,6 @@ pub enum ExecuteMsg {
     Fund {},
     UpdateRewardDuration { new_duration: u64 },
     UpdateOwner { new_owner: Option<String> },
-    UpdateManager { new_manager: Option<String> },
 }
 
 #[cw_serde]

--- a/contracts/staking/cw20-stake-external-rewards/src/msg.rs
+++ b/contracts/staking/cw20-stake-external-rewards/src/msg.rs
@@ -6,6 +6,8 @@ use cw20_stake::hooks::StakeChangedHookMsg;
 use crate::state::{Config, RewardConfig};
 pub use cw_controllers::ClaimsResponse;
 
+use cw_ownable::cw_ownable;
+
 #[cw_serde]
 pub struct InstantiateMsg {
     pub owner: Option<String>,
@@ -17,6 +19,7 @@ pub struct InstantiateMsg {
 #[cw_serde]
 pub struct MigrateMsg {}
 
+#[cw_ownable]
 #[cw_serde]
 pub enum ExecuteMsg {
     StakeChangeHook(StakeChangedHookMsg),
@@ -24,7 +27,6 @@ pub enum ExecuteMsg {
     Receive(Cw20ReceiveMsg),
     Fund {},
     UpdateRewardDuration { new_duration: u64 },
-    UpdateOwner { new_owner: Option<String> },
 }
 
 #[cw_serde]
@@ -39,6 +41,8 @@ pub enum QueryMsg {
     Info {},
     #[returns(PendingRewardsResponse)]
     GetPendingRewards { address: String },
+    #[returns(::cw_ownable::Ownership<::cosmwasm_std::Addr>)]
+    Ownership {},
 }
 
 #[cw_serde]

--- a/contracts/staking/cw20-stake-external-rewards/src/msg.rs
+++ b/contracts/staking/cw20-stake-external-rewards/src/msg.rs
@@ -4,7 +4,11 @@ use cw20::{Cw20ReceiveMsg, Denom};
 use cw20_stake::hooks::StakeChangedHookMsg;
 
 use crate::state::{Config, RewardConfig};
+
 pub use cw_controllers::ClaimsResponse;
+// so that consumers don't need a cw_ownable dependency to consume
+// this contract's queries.
+pub use cw_ownable::Ownership;
 
 use cw_ownable::cw_ownable;
 

--- a/contracts/staking/cw20-stake-external-rewards/src/state.rs
+++ b/contracts/staking/cw20-stake-external-rewards/src/state.rs
@@ -9,7 +9,9 @@ pub struct Config {
     pub staking_contract: Addr,
     pub reward_token: Denom,
 }
-pub const CONFIG: Item<Config> = Item::new("config");
+
+// `"config"` key stores v1 configuration.
+pub const CONFIG: Item<Config> = Item::new("config_v2");
 
 #[cw_serde]
 pub struct RewardConfig {

--- a/contracts/staking/cw20-stake-external-rewards/src/state.rs
+++ b/contracts/staking/cw20-stake-external-rewards/src/state.rs
@@ -6,7 +6,6 @@ use cw_storage_plus::{Item, Map};
 
 #[cw_serde]
 pub struct Config {
-    pub owner: Option<Addr>,
     pub staking_contract: Addr,
     pub reward_token: Denom,
 }

--- a/contracts/staking/cw20-stake-external-rewards/src/state.rs
+++ b/contracts/staking/cw20-stake-external-rewards/src/state.rs
@@ -7,7 +7,6 @@ use cw_storage_plus::{Item, Map};
 #[cw_serde]
 pub struct Config {
     pub owner: Option<Addr>,
-    pub manager: Option<Addr>,
     pub staking_contract: Addr,
     pub reward_token: Denom,
 }

--- a/contracts/staking/cw20-stake-reward-distributor/Cargo.toml
+++ b/contracts/staking/cw20-stake-reward-distributor/Cargo.toml
@@ -2,15 +2,7 @@
 name = "stake-cw20-reward-distributor"
 version = "2.0.0-beta"
 edition = "2018"
-authors = ["Vernon Johnson <vtj2105@columbia.edu>"]
-
-exclude = [
-  # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
-  "contract.wasm",
-  "hash.txt",
-]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors = ["Vernon Johnson <vtj2105@columbia.edu>, ekez <ekez@withoutdoing.com>"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -21,25 +13,17 @@ backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
 
-[package.metadata.scripts]
-optimize = """docker run --rm -v "$(pwd)":/code \
-  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
-  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/workspace-optimizer:0.12.6
-"""
-
 [dependencies]
 cosmwasm-std = { workspace = true }
-cosmwasm-storage = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
 cw-utils = { workspace = true }
-
 cw20-base = {  workspace = true, features = ["library"] }
 cw20-stake = { workspace = true, features = ["library"]}
 thiserror = { workspace = true }
+cw-ownable = { workspace = true }
 
 [dev-dependencies]
 cw-multi-test = { workspace = true }

--- a/contracts/staking/cw20-stake-reward-distributor/Cargo.toml
+++ b/contracts/staking/cw20-stake-reward-distributor/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "stake-cw20-reward-distributor"
+name = "cw20-stake-reward-distributor"
 version = "2.0.0-beta"
 edition = "2018"
 authors = ["Vernon Johnson <vtj2105@columbia.edu>, ekez <ekez@withoutdoing.com>"]
@@ -24,6 +24,7 @@ cw20-base = {  workspace = true, features = ["library"] }
 cw20-stake = { workspace = true, features = ["library"]}
 thiserror = { workspace = true }
 cw-ownable = { workspace = true }
+cw20-stake-reward-distributor-v1 = { workspace = true, features = ["library"] }
 
 [dev-dependencies]
 cw-multi-test = { workspace = true }

--- a/contracts/staking/cw20-stake-reward-distributor/examples/schema.rs
+++ b/contracts/staking/cw20-stake-reward-distributor/examples/schema.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::write_api;
-use stake_cw20_reward_distributor::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use cw20_stake_reward_distributor::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
 
 fn main() {
     write_api! {

--- a/contracts/staking/cw20-stake-reward-distributor/schema/cw20-stake-reward-distributor.json
+++ b/contracts/staking/cw20-stake-reward-distributor/schema/cw20-stake-reward-distributor.json
@@ -1,5 +1,5 @@
 {
-  "contract_name": "stake-cw20-reward-distributor",
+  "contract_name": "cw20-stake-reward-distributor",
   "contract_version": "2.0.0-beta",
   "idl_version": "1.0.0",
   "instantiate": {
@@ -259,8 +259,22 @@
   "migrate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MigrateMsg",
-    "type": "object",
-    "additionalProperties": false
+    "oneOf": [
+      {
+        "description": "Updates the contract from v1 -> v2. Version two implements a two step ownership transfer.",
+        "type": "object",
+        "required": [
+          "from_v1"
+        ],
+        "properties": {
+          "from_v1": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
   },
   "sudo": null,
   "responses": {

--- a/contracts/staking/cw20-stake-reward-distributor/schema/stake-cw20-reward-distributor.json
+++ b/contracts/staking/cw20-stake-reward-distributor/schema/stake-cw20-reward-distributor.json
@@ -47,15 +47,11 @@
           "update_config": {
             "type": "object",
             "required": [
-              "owner",
               "reward_rate",
               "reward_token",
               "staking_addr"
             ],
             "properties": {
-              "owner": {
-                "type": "string"
-              },
               "reward_rate": {
                 "$ref": "#/definitions/Uint128"
               },
@@ -96,11 +92,134 @@
           }
         },
         "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
       }
     ],
     "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
       "Uint128": {
         "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
         "type": "string"
       }
     }
@@ -116,6 +235,19 @@
         ],
         "properties": {
           "info": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
             "type": "object",
             "additionalProperties": false
           }
@@ -163,15 +295,11 @@
         "Config": {
           "type": "object",
           "required": [
-            "owner",
             "reward_rate",
             "reward_token",
             "staking_addr"
           ],
           "properties": {
-            "owner": {
-              "$ref": "#/definitions/Addr"
-            },
             "reward_rate": {
               "$ref": "#/definitions/Uint128"
             },
@@ -186,6 +314,113 @@
         },
         "Uint128": {
           "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_Addr",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
           "type": "string"
         }
       }

--- a/contracts/staking/cw20-stake-reward-distributor/src/contract.rs
+++ b/contracts/staking/cw20-stake-reward-distributor/src/contract.rs
@@ -38,7 +38,7 @@ pub fn instantiate(
         reward_rate: msg.reward_rate,
     };
     CONFIG.save(deps.storage, &config)?;
-    cw_ownable::initialize_owner(deps.storage, deps.api, &msg.owner)?;
+    cw_ownable::initialize_owner(deps.storage, deps.api, Some(&msg.owner))?;
 
     // Initialize last payment block
     LAST_PAYMENT_BLOCK.save(deps.storage, &env.block.height)?;

--- a/contracts/staking/cw20-stake-reward-distributor/src/contract.rs
+++ b/contracts/staking/cw20-stake-reward-distributor/src/contract.rs
@@ -233,6 +233,8 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, Co
     use cw20_stake_reward_distributor_v1 as v1;
 
     let ContractVersion { version, .. } = get_contract_version(deps.storage)?;
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
     match msg {
         MigrateMsg::FromV1 {} => {
             if version == CONTRACT_VERSION {

--- a/contracts/staking/cw20-stake-reward-distributor/src/error.rs
+++ b/contracts/staking/cw20-stake-reward-distributor/src/error.rs
@@ -3,11 +3,11 @@ use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
-    #[error("{0}")]
+    #[error(transparent)]
     Std(#[from] StdError),
 
-    #[error("Unauthorized")]
-    Unauthorized {},
+    #[error(transparent)]
+    Ownership(#[from] cw_ownable::OwnershipError),
 
     #[error("Invalid Cw20")]
     InvalidCw20 {},

--- a/contracts/staking/cw20-stake-reward-distributor/src/error.rs
+++ b/contracts/staking/cw20-stake-reward-distributor/src/error.rs
@@ -20,4 +20,7 @@ pub enum ContractError {
 
     #[error("Rewards have already been distributed for this block")]
     RewardsDistributedForBlock {},
+
+    #[error("can not migrate. current version is up to date")]
+    AlreadyMigrated {},
 }

--- a/contracts/staking/cw20-stake-reward-distributor/src/msg.rs
+++ b/contracts/staking/cw20-stake-reward-distributor/src/msg.rs
@@ -4,6 +4,10 @@ use cosmwasm_std::Uint128;
 
 use cw_ownable::cw_ownable;
 
+// so that consumers don't need a cw_ownable dependency to consume
+// this contract's queries.
+pub use cw_ownable::Ownership;
+
 #[cw_serde]
 pub struct InstantiateMsg {
     pub owner: String,

--- a/contracts/staking/cw20-stake-reward-distributor/src/msg.rs
+++ b/contracts/staking/cw20-stake-reward-distributor/src/msg.rs
@@ -2,6 +2,8 @@ use crate::state::Config;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
 
+use cw_ownable::cw_ownable;
+
 #[cw_serde]
 pub struct InstantiateMsg {
     pub owner: String,
@@ -10,10 +12,10 @@ pub struct InstantiateMsg {
     pub reward_token: String,
 }
 
+#[cw_ownable]
 #[cw_serde]
 pub enum ExecuteMsg {
     UpdateConfig {
-        owner: String,
         staking_addr: String,
         reward_rate: Uint128,
         reward_token: String,
@@ -27,6 +29,9 @@ pub enum ExecuteMsg {
 pub enum QueryMsg {
     #[returns(InfoResponse)]
     Info {},
+
+    #[returns(::cw_ownable::Ownership<::cosmwasm_std::Addr>)]
+    Ownership {},
 }
 
 #[cw_serde]

--- a/contracts/staking/cw20-stake-reward-distributor/src/msg.rs
+++ b/contracts/staking/cw20-stake-reward-distributor/src/msg.rs
@@ -42,4 +42,8 @@ pub struct InfoResponse {
 }
 
 #[cw_serde]
-pub struct MigrateMsg {}
+pub enum MigrateMsg {
+    /// Updates the contract from v1 -> v2. Version two implements a
+    /// two step ownership transfer.
+    FromV1 {},
+}

--- a/contracts/staking/cw20-stake-reward-distributor/src/state.rs
+++ b/contracts/staking/cw20-stake-reward-distributor/src/state.rs
@@ -9,6 +9,7 @@ pub struct Config {
     pub reward_token: Addr,
 }
 
-pub const CONFIG: Item<Config> = Item::new("config");
+// `"config"` key stores v1 configuration.
+pub const CONFIG: Item<Config> = Item::new("config_v2");
 
 pub const LAST_PAYMENT_BLOCK: Item<u64> = Item::new("last_payment_block");

--- a/contracts/staking/cw20-stake-reward-distributor/src/state.rs
+++ b/contracts/staking/cw20-stake-reward-distributor/src/state.rs
@@ -4,7 +4,6 @@ use cw_storage_plus::Item;
 
 #[cw_serde]
 pub struct Config {
-    pub owner: Addr,
     pub staking_addr: Addr,
     pub reward_rate: Uint128,
     pub reward_token: Addr,

--- a/contracts/staking/cw20-stake-reward-distributor/src/tests.rs
+++ b/contracts/staking/cw20-stake-reward-distributor/src/tests.rs
@@ -723,7 +723,7 @@ fn test_migrate_from_v1() {
     assert_eq!(
         ownership,
         Ownership::<Addr> {
-            owner: Some(sender),
+            owner: Some(sender.clone()),
             pending_owner: None,
             pending_expiry: None,
         }
@@ -742,4 +742,19 @@ fn test_migrate_from_v1() {
             balance: Uint128::zero()
         }
     );
+
+    let err: ContractError = app
+        .execute(
+            sender,
+            WasmMsg::Migrate {
+                contract_addr: distributor.to_string(),
+                new_code_id: v2_code,
+                msg: to_binary(&MigrateMsg::FromV1 {}).unwrap(),
+            }
+            .into(),
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, ContractError::AlreadyMigrated {});
 }

--- a/contracts/staking/cw20-stake-reward-distributor/src/tests.rs
+++ b/contracts/staking/cw20-stake-reward-distributor/src/tests.rs
@@ -13,7 +13,6 @@ use cw_ownable::{Action, Expiration, Ownership, OwnershipError};
 
 const OWNER: &str = "owner";
 const OWNER2: &str = "owner2";
-const MANAGER: &str = "manager";
 
 pub fn cw20_contract() -> Box<dyn Contract<Empty>> {
     let contract = ContractWrapper::new(
@@ -71,7 +70,6 @@ fn instantiate_staking(app: &mut App, cw20_addr: Addr) -> Addr {
     let staking_id = app.store_code(staking_contract());
     let msg = cw20_stake::msg::InstantiateMsg {
         owner: Some(OWNER.to_string()),
-        manager: Some(MANAGER.to_string()),
         token_address: cw20_addr.to_string(),
         unstaking_duration: None,
     };
@@ -479,7 +477,7 @@ fn test_withdraw() {
     // Unauthorized user cannot withdraw funds
     let err = app
         .execute_contract(
-            Addr::unchecked(MANAGER),
+            Addr::unchecked("notowner"),
             distributor_addr.clone(),
             &ExecuteMsg::Withdraw {},
             &[],

--- a/contracts/staking/cw20-stake/Cargo.toml
+++ b/contracts/staking/cw20-stake/Cargo.toml
@@ -27,6 +27,7 @@ cw20-base = {  workspace = true, features = ["library"] }
 cw2 = { workspace = true }
 thiserror = { workspace = true }
 cw-paginate = { workspace = true }
+cw-ownable = { workspace = true }
 
 [dev-dependencies]
 cw-multi-test = { workspace = true }

--- a/contracts/staking/cw20-stake/Cargo.toml
+++ b/contracts/staking/cw20-stake/Cargo.toml
@@ -29,6 +29,9 @@ thiserror = { workspace = true }
 cw-paginate = { workspace = true }
 cw-ownable = { workspace = true }
 
+cw20-stake-v1 = { workspace = true, features = ["library"] }
+cw-utils-v1 = { workspace = true }
+
 [dev-dependencies]
 cw-multi-test = { workspace = true }
 anyhow = { workspace = true }

--- a/contracts/staking/cw20-stake/schema/cw20-stake.json
+++ b/contracts/staking/cw20-stake/schema/cw20-stake.json
@@ -10,12 +10,6 @@
       "token_address"
     ],
     "properties": {
-      "manager": {
-        "type": [
-          "string",
-          "null"
-        ]
-      },
       "owner": {
         "type": [
           "string",
@@ -141,12 +135,6 @@
                   {
                     "type": "null"
                   }
-                ]
-              },
-              "manager": {
-                "type": [
-                  "string",
-                  "null"
                 ]
               },
               "owner": {
@@ -445,27 +433,6 @@
       {
         "type": "object",
         "required": [
-          "from_beta"
-        ],
-        "properties": {
-          "from_beta": {
-            "type": "object",
-            "properties": {
-              "manager": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              }
-            },
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      },
-      {
-        "type": "object",
-        "required": [
           "from_compatible"
         ],
         "properties": {
@@ -586,16 +553,6 @@
         "token_address"
       ],
       "properties": {
-        "manager": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Addr"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "owner": {
           "anyOf": [
             {

--- a/contracts/staking/cw20-stake/schema/cw20-stake.json
+++ b/contracts/staking/cw20-stake/schema/cw20-stake.json
@@ -561,12 +561,13 @@
     "title": "MigrateMsg",
     "oneOf": [
       {
+        "description": "Migrates the contract from version one to version two. This will remove the contract's current manager, and require a nomination -> acceptance flow for future ownership transfers.",
         "type": "object",
         "required": [
-          "from_compatible"
+          "from_v1"
         ],
         "properties": {
-          "from_compatible": {
+          "from_v1": {
             "type": "object",
             "additionalProperties": false
           }

--- a/contracts/staking/cw20-stake/schema/cw20-stake.json
+++ b/contracts/staking/cw20-stake/schema/cw20-stake.json
@@ -136,12 +136,6 @@
                     "type": "null"
                   }
                 ]
-              },
-              "owner": {
-                "type": [
-                  "string",
-                  "null"
-                ]
               }
             },
             "additionalProperties": false
@@ -190,9 +184,73 @@
           }
         },
         "additionalProperties": false
+      },
+      {
+        "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
+        "type": "object",
+        "required": [
+          "update_ownership"
+        ],
+        "properties": {
+          "update_ownership": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "additionalProperties": false
       }
     ],
     "definitions": {
+      "Action": {
+        "description": "Actions that can be taken to alter the contract's ownership",
+        "oneOf": [
+          {
+            "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
+            "type": "object",
+            "required": [
+              "transfer_ownership"
+            ],
+            "properties": {
+              "transfer_ownership": {
+                "type": "object",
+                "required": [
+                  "new_owner"
+                ],
+                "properties": {
+                  "expiry": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Expiration"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "new_owner": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
+            "type": "string",
+            "enum": [
+              "accept_ownership"
+            ]
+          },
+          {
+            "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
+            "type": "string",
+            "enum": [
+              "renounce_ownership"
+            ]
+          }
+        ]
+      },
       "Binary": {
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
@@ -252,8 +310,67 @@
           }
         ]
       },
+      "Expiration": {
+        "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+        "oneOf": [
+          {
+            "description": "AtHeight will expire when `env.block.height` >= height",
+            "type": "object",
+            "required": [
+              "at_height"
+            ],
+            "properties": {
+              "at_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "AtTime will expire when `env.block.time` >= time",
+            "type": "object",
+            "required": [
+              "at_time"
+            ],
+            "properties": {
+              "at_time": {
+                "$ref": "#/definitions/Timestamp"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Never will never expire. Used to express the empty variant",
+            "type": "object",
+            "required": [
+              "never"
+            ],
+            "properties": {
+              "never": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Timestamp": {
+        "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+        "allOf": [
+          {
+            "$ref": "#/definitions/Uint64"
+          }
+        ]
+      },
       "Uint128": {
         "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      },
+      "Uint64": {
+        "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
         "type": "string"
       }
     }
@@ -423,6 +540,19 @@
           }
         },
         "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "ownership"
+        ],
+        "properties": {
+          "ownership": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
       }
     ]
   },
@@ -553,16 +683,6 @@
         "token_address"
       ],
       "properties": {
-        "owner": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Addr"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "token_address": {
           "$ref": "#/definitions/Addr"
         },
@@ -671,6 +791,113 @@
         },
         "Uint128": {
           "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "ownership": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Ownership_for_Addr",
+      "description": "The contract's ownership info",
+      "type": "object",
+      "properties": {
+        "owner": {
+          "description": "The contract's current owner. `None` if the ownership has been renounced.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_expiry": {
+          "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Expiration"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pending_owner": {
+          "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Addr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Expiration": {
+          "description": "Expiration represents a point in time when some event happens. It can compare with a BlockInfo and will return is_expired() == true once the condition is hit (and for every block in the future)",
+          "oneOf": [
+            {
+              "description": "AtHeight will expire when `env.block.height` >= height",
+              "type": "object",
+              "required": [
+                "at_height"
+              ],
+              "properties": {
+                "at_height": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "AtTime will expire when `env.block.time` >= time",
+              "type": "object",
+              "required": [
+                "at_time"
+              ],
+              "properties": {
+                "at_time": {
+                  "$ref": "#/definitions/Timestamp"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Never will never expire. Used to express the empty variant",
+              "type": "object",
+              "required": [
+                "never"
+              ],
+              "properties": {
+                "never": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
           "type": "string"
         }
       }

--- a/contracts/staking/cw20-stake/src/error.rs
+++ b/contracts/staking/cw20-stake/src/error.rs
@@ -28,4 +28,6 @@ pub enum ContractError {
     TooManyClaims {},
     #[error("Invalid unstaking duration, unstaking duration cannot be 0")]
     InvalidUnstakingDuration {},
+    #[error("can not migrate. current version is up to date")]
+    AlreadyMigrated {},
 }

--- a/contracts/staking/cw20-stake/src/error.rs
+++ b/contracts/staking/cw20-stake/src/error.rs
@@ -3,10 +3,15 @@ use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
-    #[error("{0}")]
+    #[error(transparent)]
     Std(#[from] StdError),
-    #[error("{0}")]
+    #[error(transparent)]
     Cw20Error(#[from] cw20_base::ContractError),
+    #[error(transparent)]
+    Ownership(#[from] cw_ownable::OwnershipError),
+    #[error(transparent)]
+    HookError(#[from] cw_controllers::HookError),
+
     #[error("Provided cw20 errored in response to TokenInfo query")]
     InvalidCw20 {},
     #[error("Nothing to claim")]
@@ -19,16 +24,8 @@ pub enum ContractError {
     ImpossibleUnstake {},
     #[error("Invalid token")]
     InvalidToken { received: Addr, expected: Addr },
-    #[error("Unauthorized")]
-    Unauthorized {},
     #[error("Too many outstanding claims. Claim some tokens before unstaking more.")]
     TooManyClaims {},
-    #[error("No admin configured")]
-    NoAdminConfigured {},
-    #[error("{0}")]
-    HookError(#[from] cw_controllers::HookError),
-    #[error("Only owner can change owner")]
-    OnlyOwnerCanChangeOwner {},
     #[error("Invalid unstaking duration, unstaking duration cannot be 0")]
     InvalidUnstakingDuration {},
 }

--- a/contracts/staking/cw20-stake/src/msg.rs
+++ b/contracts/staking/cw20-stake/src/msg.rs
@@ -1,8 +1,15 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Uint128;
 use cw20::Cw20ReceiveMsg;
-pub use cw_controllers::ClaimsResponse;
+
 use cw_utils::Duration;
+
+use cw_ownable::cw_ownable;
+
+pub use cw_controllers::ClaimsResponse;
+// so that consumers don't need a cw_ownable dependency to consume
+// this contract's queries.
+pub use cw_ownable::Ownership;
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -12,23 +19,15 @@ pub struct InstantiateMsg {
     pub unstaking_duration: Option<Duration>,
 }
 
+#[cw_ownable]
 #[cw_serde]
 pub enum ExecuteMsg {
     Receive(Cw20ReceiveMsg),
-    Unstake {
-        amount: Uint128,
-    },
+    Unstake { amount: Uint128 },
     Claim {},
-    UpdateConfig {
-        owner: Option<String>,
-        duration: Option<Duration>,
-    },
-    AddHook {
-        addr: String,
-    },
-    RemoveHook {
-        addr: String,
-    },
+    UpdateConfig { duration: Option<Duration> },
+    AddHook { addr: String },
+    RemoveHook { addr: String },
 }
 
 #[cw_serde]
@@ -62,6 +61,8 @@ pub enum QueryMsg {
         start_after: Option<String>,
         limit: Option<u32>,
     },
+    #[returns(::cw_ownable::Ownership::<::cosmwasm_std::Addr>)]
+    Ownership {},
 }
 
 #[cw_serde]

--- a/contracts/staking/cw20-stake/src/msg.rs
+++ b/contracts/staking/cw20-stake/src/msg.rs
@@ -67,7 +67,10 @@ pub enum QueryMsg {
 
 #[cw_serde]
 pub enum MigrateMsg {
-    FromCompatible {},
+    /// Migrates the contract from version one to version two. This
+    /// will remove the contract's current manager, and require a
+    /// nomination -> acceptance flow for future ownership transfers.
+    FromV1 {},
 }
 
 #[cw_serde]

--- a/contracts/staking/cw20-stake/src/msg.rs
+++ b/contracts/staking/cw20-stake/src/msg.rs
@@ -8,8 +8,6 @@ use cw_utils::Duration;
 pub struct InstantiateMsg {
     // Owner can update all configs including changing the owner. This will generally be a DAO.
     pub owner: Option<String>,
-    // Manager can update all configs except changing the owner. This will generally be an operations multisig for a DAO.
-    pub manager: Option<String>,
     pub token_address: String,
     pub unstaking_duration: Option<Duration>,
 }
@@ -23,7 +21,6 @@ pub enum ExecuteMsg {
     Claim {},
     UpdateConfig {
         owner: Option<String>,
-        manager: Option<String>,
         duration: Option<Duration>,
     },
     AddHook {
@@ -69,7 +66,6 @@ pub enum QueryMsg {
 
 #[cw_serde]
 pub enum MigrateMsg {
-    FromBeta { manager: Option<String> },
     FromCompatible {},
 }
 

--- a/contracts/staking/cw20-stake/src/state.rs
+++ b/contracts/staking/cw20-stake/src/state.rs
@@ -8,7 +8,6 @@ use cw_utils::Duration;
 #[cw_serde]
 pub struct Config {
     pub owner: Option<Addr>,
-    pub manager: Option<Addr>,
     pub token_address: Addr,
     pub unstaking_duration: Option<Duration>,
 }

--- a/contracts/staking/cw20-stake/src/state.rs
+++ b/contracts/staking/cw20-stake/src/state.rs
@@ -11,7 +11,8 @@ pub struct Config {
     pub unstaking_duration: Option<Duration>,
 }
 
-pub const CONFIG: Item<Config> = Item::new("config");
+// `"config"` key stores v1 configuration.
+pub const CONFIG: Item<Config> = Item::new("config_v2");
 
 pub const STAKED_BALANCES: SnapshotMap<&Addr, Uint128> = SnapshotMap::new(
     "staked_balances",

--- a/contracts/staking/cw20-stake/src/state.rs
+++ b/contracts/staking/cw20-stake/src/state.rs
@@ -7,7 +7,6 @@ use cw_utils::Duration;
 
 #[cw_serde]
 pub struct Config {
-    pub owner: Option<Addr>,
     pub token_address: Addr,
     pub unstaking_duration: Option<Duration>,
 }

--- a/contracts/voting/dao-voting-cw20-staked/src/contract.rs
+++ b/contracts/voting/dao-voting-cw20-staked/src/contract.rs
@@ -95,7 +95,6 @@ pub fn instantiate(
                             owner: Some(info.sender.to_string()),
                             unstaking_duration,
                             token_address: address.to_string(),
-                            manager: None,
                         })?,
                     };
                     let msg = SubMsg::reply_on_success(msg, INSTANTIATE_STAKING_REPLY_ID);
@@ -413,7 +412,6 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                             owner: Some(dao.to_string()),
                             unstaking_duration,
                             token_address: token.to_string(),
-                            manager: None,
                         })?,
                     };
                     let msg = SubMsg::reply_on_success(msg, INSTANTIATE_STAKING_REPLY_ID);

--- a/typescript/contracts/cw20-stake-external-rewards/Cw20StakeExternalRewards.client.ts
+++ b/typescript/contracts/cw20-stake-external-rewards/Cw20StakeExternalRewards.client.ts
@@ -69,11 +69,6 @@ export interface Cw20StakeExternalRewardsInterface extends Cw20StakeExternalRewa
   }: {
     newOwner?: string;
   }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  updateManager: ({
-    newManager
-  }: {
-    newManager?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class Cw20StakeExternalRewardsClient extends Cw20StakeExternalRewardsQueryClient implements Cw20StakeExternalRewardsInterface {
   client: SigningCosmWasmClient;
@@ -91,7 +86,6 @@ export class Cw20StakeExternalRewardsClient extends Cw20StakeExternalRewardsQuer
     this.fund = this.fund.bind(this);
     this.updateRewardDuration = this.updateRewardDuration.bind(this);
     this.updateOwner = this.updateOwner.bind(this);
-    this.updateManager = this.updateManager.bind(this);
   }
 
   stakeChangeHook = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
@@ -145,17 +139,6 @@ export class Cw20StakeExternalRewardsClient extends Cw20StakeExternalRewardsQuer
     return await this.client.execute(this.sender, this.contractAddress, {
       update_owner: {
         new_owner: newOwner
-      }
-    }, fee, memo, funds);
-  };
-  updateManager = async ({
-    newManager
-  }: {
-    newManager?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
-    return await this.client.execute(this.sender, this.contractAddress, {
-      update_manager: {
-        new_manager: newManager
       }
     }, fee, memo, funds);
   };

--- a/typescript/contracts/cw20-stake-external-rewards/Cw20StakeExternalRewards.client.ts
+++ b/typescript/contracts/cw20-stake-external-rewards/Cw20StakeExternalRewards.client.ts
@@ -6,7 +6,7 @@
 
 import { CosmWasmClient, SigningCosmWasmClient, ExecuteResult } from "@cosmjs/cosmwasm-stargate";
 import { Coin, StdFee } from "@cosmjs/amino";
-import { Denom, Addr, InstantiateMsg, ExecuteMsg, StakeChangedHookMsg, Uint128, Binary, Cw20ReceiveMsg, QueryMsg, MigrateMsg, PendingRewardsResponse, InfoResponse, Config, RewardConfig } from "./Cw20StakeExternalRewards.types";
+import { Denom, Addr, InstantiateMsg, ExecuteMsg, StakeChangedHookMsg, Uint128, Binary, Action, Expiration, Timestamp, Uint64, Cw20ReceiveMsg, QueryMsg, MigrateMsg, PendingRewardsResponse, InfoResponse, Config, RewardConfig, OwnershipForAddr } from "./Cw20StakeExternalRewards.types";
 export interface Cw20StakeExternalRewardsReadOnlyInterface {
   contractAddress: string;
   info: () => Promise<InfoResponse>;
@@ -15,6 +15,7 @@ export interface Cw20StakeExternalRewardsReadOnlyInterface {
   }: {
     address: string;
   }) => Promise<PendingRewardsResponse>;
+  ownership: () => Promise<OwnershipForAddr>;
 }
 export class Cw20StakeExternalRewardsQueryClient implements Cw20StakeExternalRewardsReadOnlyInterface {
   client: CosmWasmClient;
@@ -25,6 +26,7 @@ export class Cw20StakeExternalRewardsQueryClient implements Cw20StakeExternalRew
     this.contractAddress = contractAddress;
     this.info = this.info.bind(this);
     this.getPendingRewards = this.getPendingRewards.bind(this);
+    this.ownership = this.ownership.bind(this);
   }
 
   info = async (): Promise<InfoResponse> => {
@@ -41,6 +43,11 @@ export class Cw20StakeExternalRewardsQueryClient implements Cw20StakeExternalRew
       get_pending_rewards: {
         address
       }
+    });
+  };
+  ownership = async (): Promise<OwnershipForAddr> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      ownership: {}
     });
   };
 }
@@ -64,11 +71,7 @@ export interface Cw20StakeExternalRewardsInterface extends Cw20StakeExternalRewa
   }: {
     newDuration: number;
   }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
-  updateOwner: ({
-    newOwner
-  }: {
-    newOwner?: string;
-  }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  updateOwnership: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class Cw20StakeExternalRewardsClient extends Cw20StakeExternalRewardsQueryClient implements Cw20StakeExternalRewardsInterface {
   client: SigningCosmWasmClient;
@@ -85,7 +88,7 @@ export class Cw20StakeExternalRewardsClient extends Cw20StakeExternalRewardsQuer
     this.receive = this.receive.bind(this);
     this.fund = this.fund.bind(this);
     this.updateRewardDuration = this.updateRewardDuration.bind(this);
-    this.updateOwner = this.updateOwner.bind(this);
+    this.updateOwnership = this.updateOwnership.bind(this);
   }
 
   stakeChangeHook = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
@@ -131,15 +134,9 @@ export class Cw20StakeExternalRewardsClient extends Cw20StakeExternalRewardsQuer
       }
     }, fee, memo, funds);
   };
-  updateOwner = async ({
-    newOwner
-  }: {
-    newOwner?: string;
-  }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+  updateOwnership = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
-      update_owner: {
-        new_owner: newOwner
-      }
+      update_ownership: {}
     }, fee, memo, funds);
   };
 }

--- a/typescript/contracts/cw20-stake-external-rewards/Cw20StakeExternalRewards.types.ts
+++ b/typescript/contracts/cw20-stake-external-rewards/Cw20StakeExternalRewards.types.ts
@@ -11,7 +11,6 @@ export type Denom = {
 };
 export type Addr = string;
 export interface InstantiateMsg {
-  manager?: string | null;
   owner?: string | null;
   reward_duration: number;
   reward_token: Denom;
@@ -32,10 +31,6 @@ export type ExecuteMsg = {
 } | {
   update_owner: {
     new_owner?: string | null;
-  };
-} | {
-  update_manager: {
-    new_manager?: string | null;
   };
 };
 export type StakeChangedHookMsg = {
@@ -75,7 +70,6 @@ export interface InfoResponse {
   reward: RewardConfig;
 }
 export interface Config {
-  manager?: Addr | null;
   owner?: Addr | null;
   reward_token: Denom;
   staking_contract: Addr;

--- a/typescript/contracts/cw20-stake-external-rewards/Cw20StakeExternalRewards.types.ts
+++ b/typescript/contracts/cw20-stake-external-rewards/Cw20StakeExternalRewards.types.ts
@@ -29,9 +29,7 @@ export type ExecuteMsg = {
     new_duration: number;
   };
 } | {
-  update_owner: {
-    new_owner?: string | null;
-  };
+  update_ownership: Action;
 };
 export type StakeChangedHookMsg = {
   stake: {
@@ -46,6 +44,21 @@ export type StakeChangedHookMsg = {
 };
 export type Uint128 = string;
 export type Binary = string;
+export type Action = {
+  transfer_ownership: {
+    expiry?: Expiration | null;
+    new_owner: string;
+  };
+} | "accept_ownership" | "renounce_ownership";
+export type Expiration = {
+  at_height: number;
+} | {
+  at_time: Timestamp;
+} | {
+  never: {};
+};
+export type Timestamp = Uint64;
+export type Uint64 = string;
 export interface Cw20ReceiveMsg {
   amount: Uint128;
   msg: Binary;
@@ -57,6 +70,8 @@ export type QueryMsg = {
   get_pending_rewards: {
     address: string;
   };
+} | {
+  ownership: {};
 };
 export interface MigrateMsg {}
 export interface PendingRewardsResponse {
@@ -70,7 +85,6 @@ export interface InfoResponse {
   reward: RewardConfig;
 }
 export interface Config {
-  owner?: Addr | null;
   reward_token: Denom;
   staking_contract: Addr;
 }
@@ -78,4 +92,9 @@ export interface RewardConfig {
   period_finish: number;
   reward_duration: number;
   reward_rate: Uint128;
+}
+export interface OwnershipForAddr {
+  owner?: Addr | null;
+  pending_expiry?: Expiration | null;
+  pending_owner?: Addr | null;
 }

--- a/typescript/contracts/cw20-stake-external-rewards/Cw20StakeExternalRewards.types.ts
+++ b/typescript/contracts/cw20-stake-external-rewards/Cw20StakeExternalRewards.types.ts
@@ -73,7 +73,9 @@ export type QueryMsg = {
 } | {
   ownership: {};
 };
-export interface MigrateMsg {}
+export type MigrateMsg = {
+  from_v1: {};
+};
 export interface PendingRewardsResponse {
   address: string;
   denom: Denom;

--- a/typescript/contracts/cw20-stake-external-rewards/bundle.ts
+++ b/typescript/contracts/cw20-stake-external-rewards/bundle.ts
@@ -4,10 +4,10 @@
 * and run the @cosmwasm/ts-codegen generate command to regenerate this file.
 */
 
-import * as _6 from "./Cw20StakeExternalRewards.types";
-import * as _7 from "./Cw20StakeExternalRewards.client";
+import * as _4 from "./Cw20StakeExternalRewards.types";
+import * as _5 from "./Cw20StakeExternalRewards.client";
 export namespace contracts {
-  export const Cw20StakeExternalRewards = { ..._6,
-    ..._7
+  export const Cw20StakeExternalRewards = { ..._4,
+    ..._5
   };
 }

--- a/typescript/contracts/cw20-stake-external-rewards/bundle.ts
+++ b/typescript/contracts/cw20-stake-external-rewards/bundle.ts
@@ -4,10 +4,10 @@
 * and run the @cosmwasm/ts-codegen generate command to regenerate this file.
 */
 
-import * as _4 from "./Cw20StakeExternalRewards.types";
-import * as _5 from "./Cw20StakeExternalRewards.client";
+import * as _6 from "./Cw20StakeExternalRewards.types";
+import * as _7 from "./Cw20StakeExternalRewards.client";
 export namespace contracts {
-  export const Cw20StakeExternalRewards = { ..._4,
-    ..._5
+  export const Cw20StakeExternalRewards = { ..._6,
+    ..._7
   };
 }

--- a/typescript/contracts/cw20-stake-reward-distributor/Cw20StakeRewardDistributor.types.ts
+++ b/typescript/contracts/cw20-stake-reward-distributor/Cw20StakeRewardDistributor.types.ts
@@ -13,7 +13,6 @@ export interface InstantiateMsg {
 }
 export type ExecuteMsg = {
   update_config: {
-    owner: string;
     reward_rate: Uint128;
     reward_token: string;
     staking_addr: string;
@@ -22,9 +21,28 @@ export type ExecuteMsg = {
   distribute: {};
 } | {
   withdraw: {};
+} | {
+  update_ownership: Action;
 };
+export type Action = {
+  transfer_ownership: {
+    expiry?: Expiration | null;
+    new_owner: string;
+  };
+} | "accept_ownership" | "renounce_ownership";
+export type Expiration = {
+  at_height: number;
+} | {
+  at_time: Timestamp;
+} | {
+  never: {};
+};
+export type Timestamp = Uint64;
+export type Uint64 = string;
 export type QueryMsg = {
   info: {};
+} | {
+  ownership: {};
 };
 export interface MigrateMsg {}
 export type Addr = string;
@@ -34,8 +52,12 @@ export interface InfoResponse {
   last_payment_block: number;
 }
 export interface Config {
-  owner: Addr;
   reward_rate: Uint128;
   reward_token: Addr;
   staking_addr: Addr;
+}
+export interface OwnershipForAddr {
+  owner?: Addr | null;
+  pending_expiry?: Expiration | null;
+  pending_owner?: Addr | null;
 }

--- a/typescript/contracts/cw20-stake-reward-distributor/Cw20StakeRewardDistributor.types.ts
+++ b/typescript/contracts/cw20-stake-reward-distributor/Cw20StakeRewardDistributor.types.ts
@@ -44,7 +44,9 @@ export type QueryMsg = {
 } | {
   ownership: {};
 };
-export interface MigrateMsg {}
+export type MigrateMsg = {
+  from_v1: {};
+};
 export type Addr = string;
 export interface InfoResponse {
   balance: Uint128;

--- a/typescript/contracts/cw20-stake-reward-distributor/bundle.ts
+++ b/typescript/contracts/cw20-stake-reward-distributor/bundle.ts
@@ -4,10 +4,10 @@
 * and run the @cosmwasm/ts-codegen generate command to regenerate this file.
 */
 
-import * as _6 from "./Cw20StakeRewardDistributor.types";
-import * as _7 from "./Cw20StakeRewardDistributor.client";
+import * as _4 from "./Cw20StakeRewardDistributor.types";
+import * as _5 from "./Cw20StakeRewardDistributor.client";
 export namespace contracts {
-  export const Cw20StakeRewardDistributor = { ..._6,
-    ..._7
+  export const Cw20StakeRewardDistributor = { ..._4,
+    ..._5
   };
 }

--- a/typescript/contracts/cw20-stake-reward-distributor/bundle.ts
+++ b/typescript/contracts/cw20-stake-reward-distributor/bundle.ts
@@ -4,10 +4,10 @@
 * and run the @cosmwasm/ts-codegen generate command to regenerate this file.
 */
 
-import * as _4 from "./Cw20StakeRewardDistributor.types";
-import * as _5 from "./Cw20StakeRewardDistributor.client";
+import * as _6 from "./Cw20StakeRewardDistributor.types";
+import * as _7 from "./Cw20StakeRewardDistributor.client";
 export namespace contracts {
-  export const Cw20StakeRewardDistributor = { ..._4,
-    ..._5
+  export const Cw20StakeRewardDistributor = { ..._6,
+    ..._7
   };
 }

--- a/typescript/contracts/cw20-stake/Cw20Stake.client.ts
+++ b/typescript/contracts/cw20-stake/Cw20Stake.client.ts
@@ -156,11 +156,9 @@ export interface Cw20StakeInterface extends Cw20StakeReadOnlyInterface {
   claim: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
   updateConfig: ({
     duration,
-    manager,
     owner
   }: {
     duration?: Duration;
-    manager?: string;
     owner?: string;
   }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
   addHook: ({
@@ -227,17 +225,14 @@ export class Cw20StakeClient extends Cw20StakeQueryClient implements Cw20StakeIn
   };
   updateConfig = async ({
     duration,
-    manager,
     owner
   }: {
     duration?: Duration;
-    manager?: string;
     owner?: string;
   }, fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
     return await this.client.execute(this.sender, this.contractAddress, {
       update_config: {
         duration,
-        manager,
         owner
       }
     }, fee, memo, funds);

--- a/typescript/contracts/cw20-stake/Cw20Stake.types.ts
+++ b/typescript/contracts/cw20-stake/Cw20Stake.types.ts
@@ -10,7 +10,6 @@ export type Duration = {
   time: number;
 };
 export interface InstantiateMsg {
-  manager?: string | null;
   owner?: string | null;
   token_address: string;
   unstaking_duration?: Duration | null;
@@ -26,7 +25,6 @@ export type ExecuteMsg = {
 } | {
   update_config: {
     duration?: Duration | null;
-    manager?: string | null;
     owner?: string | null;
   };
 } | {
@@ -75,10 +73,6 @@ export type QueryMsg = {
   };
 };
 export type MigrateMsg = {
-  from_beta: {
-    manager?: string | null;
-  };
-} | {
   from_compatible: {};
 };
 export type Expiration = {
@@ -99,7 +93,6 @@ export interface Claim {
 }
 export type Addr = string;
 export interface Config {
-  manager?: Addr | null;
   owner?: Addr | null;
   token_address: Addr;
   unstaking_duration?: Duration | null;

--- a/typescript/contracts/cw20-stake/Cw20Stake.types.ts
+++ b/typescript/contracts/cw20-stake/Cw20Stake.types.ts
@@ -91,7 +91,7 @@ export type QueryMsg = {
   ownership: {};
 };
 export type MigrateMsg = {
-  from_compatible: {};
+  from_v1: {};
 };
 export interface ClaimsResponse {
   claims: Claim[];

--- a/typescript/contracts/cw20-stake/Cw20Stake.types.ts
+++ b/typescript/contracts/cw20-stake/Cw20Stake.types.ts
@@ -25,7 +25,6 @@ export type ExecuteMsg = {
 } | {
   update_config: {
     duration?: Duration | null;
-    owner?: string | null;
   };
 } | {
   add_hook: {
@@ -35,9 +34,26 @@ export type ExecuteMsg = {
   remove_hook: {
     addr: string;
   };
+} | {
+  update_ownership: Action;
 };
 export type Uint128 = string;
 export type Binary = string;
+export type Action = {
+  transfer_ownership: {
+    expiry?: Expiration | null;
+    new_owner: string;
+  };
+} | "accept_ownership" | "renounce_ownership";
+export type Expiration = {
+  at_height: number;
+} | {
+  at_time: Timestamp;
+} | {
+  never: {};
+};
+export type Timestamp = Uint64;
+export type Uint64 = string;
 export interface Cw20ReceiveMsg {
   amount: Uint128;
   msg: Binary;
@@ -71,19 +87,12 @@ export type QueryMsg = {
     limit?: number | null;
     start_after?: string | null;
   };
+} | {
+  ownership: {};
 };
 export type MigrateMsg = {
   from_compatible: {};
 };
-export type Expiration = {
-  at_height: number;
-} | {
-  at_time: Timestamp;
-} | {
-  never: {};
-};
-export type Timestamp = Uint64;
-export type Uint64 = string;
 export interface ClaimsResponse {
   claims: Claim[];
 }
@@ -93,7 +102,6 @@ export interface Claim {
 }
 export type Addr = string;
 export interface Config {
-  owner?: Addr | null;
   token_address: Addr;
   unstaking_duration?: Duration | null;
 }
@@ -106,6 +114,11 @@ export interface ListStakersResponse {
 export interface StakerBalanceResponse {
   address: string;
   balance: Uint128;
+}
+export interface OwnershipForAddr {
+  owner?: Addr | null;
+  pending_expiry?: Expiration | null;
+  pending_owner?: Addr | null;
 }
 export interface StakedBalanceAtHeightResponse {
   balance: Uint128;

--- a/typescript/contracts/cw20-stake/bundle.ts
+++ b/typescript/contracts/cw20-stake/bundle.ts
@@ -4,10 +4,10 @@
 * and run the @cosmwasm/ts-codegen generate command to regenerate this file.
 */
 
-import * as _22 from "./Cw20Stake.types";
-import * as _23 from "./Cw20Stake.client";
+import * as _24 from "./Cw20Stake.types";
+import * as _25 from "./Cw20Stake.client";
 export namespace contracts {
-  export const Cw20Stake = { ..._22,
-    ..._23
+  export const Cw20Stake = { ..._24,
+    ..._25
   };
 }

--- a/typescript/contracts/dao-voting-cw20-staked/bundle.ts
+++ b/typescript/contracts/dao-voting-cw20-staked/bundle.ts
@@ -4,10 +4,10 @@
 * and run the @cosmwasm/ts-codegen generate command to regenerate this file.
 */
 
-import * as _24 from "./DaoVotingCw20Staked.types";
-import * as _25 from "./DaoVotingCw20Staked.client";
+import * as _22 from "./DaoVotingCw20Staked.types";
+import * as _23 from "./DaoVotingCw20Staked.client";
 export namespace contracts {
-  export const DaoVotingCw20Staked = { ..._24,
-    ..._25
+  export const DaoVotingCw20Staked = { ..._22,
+    ..._23
   };
 }


### PR DESCRIPTION
this implements a two-step ownership transfer for all of our staking contracts using the [`cw_ownable`](https://crates.io/crates/cw-ownable) crate.

for each contract in `staking/*`:

1. the `manager` is removed
2. `cw_ownable` integrated
3. migration from version one to two is implemented

it is my opinion that having a contract-level owner and CosmWasm-level admin that is a DAO has approximately the same semantics as having an owner and a manager. assuming the admin is a DAO, and the owner an operations multisig:

> the operations multisig has the ability to update unstaking durations, but does not have the ability to update the admin. the admin has the ability to remove the operations multisig and migrate the contract.

that sentence could be reused in a situation where there is an owner, manager, and admin and still be accurate.