### PR TITLE
Tidy up toml files for publishing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-condorcet"
-version = "2.0.0-beta"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1608,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
  "signature",
 ]
@@ -2258,9 +2258,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.2"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -2380,9 +2380,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
+checksum = "4257b4a04d91f7e9e6290be5d3da4804dd5784fafde3a497d73eb2b4a158c30a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2390,9 +2390,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96504449aa860c8dcde14f9fba5c58dc6658688ca1fe363589d6327b8662c603"
+checksum = "241cda393b0cdd65e62e07e12454f1f25d57017dcc514b1514cd3c4645e3a0a6"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2400,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798e0220d1111ae63d66cb66a5dcb3fc2d986d520b98e49e1852bfdb11d7c5e7"
+checksum = "46b53634d8c8196302953c74d5352f33d0c512a9499bd2ce468fc9f4128fa27c"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2413,13 +2413,13 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "984298b75898e30a843e278a9f2452c31e349a073a0ce6fd950a12a74464e065"
+checksum = "0ef4f1332a8d4678b41966bb4cc1d0676880e84183a1ecc3f4b69f03e99c7a51"
 dependencies = [
  "once_cell",
  "pest",
- "sha1",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -2472,9 +2472,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
  "unicode-ident",
 ]
@@ -2780,9 +2780,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+checksum = "645926f31b250a2dca3c232496c2d898d91036e45ca0e97e0e2390c54e11be36"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2793,9 +2793,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3167,9 +3167,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -3258,9 +3258,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3498,9 +3498,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "0046be40136ef78dc325e0edefccf84ccddacd0afcc1ca54103fa3c61bbdab1d"
 
 [[package]]
 name = "unicode-ident"
@@ -3738,45 +3738,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ members = [
 	]
 exclude = ["ci/configs/"]
 
+[workspace.package]
+license = "BSD-3"
+
 [profile.release.package.stake-cw20-external-rewards]
 codegen-units = 1
 incremental = false
@@ -60,31 +63,31 @@ cw-ownable = { git = "https://github.com/steak-enjoyers/cw-plus-plus", rev = "50
 
 cw-admin-factory = { path = "./contracts/external/cw-admin-factory" }
 dao-core = { path = "./contracts/dao-core" }
-dao-proposal-single = { path = "./contracts/proposal/dao-proposal-single" }
-dao-proposal-multiple = { path = "./contracts/proposal/dao-proposal-multiple" }
-dao-proposal-condorcet = { path = "./contracts/proposal/dao-proposal-condorcet" }
-dao-pre-propose-single = { path = "./contracts/pre-propose/dao-pre-propose-single" }
-dao-pre-propose-multiple = { path = "./contracts/pre-propose/dao-pre-propose-multiple" }
-dao-pre-propose-approval-single = { path = "./contracts/pre-propose/dao-pre-propose-approval-single" }
-dao-pre-propose-approver = { path = "./contracts/pre-propose/dao-pre-propose-approver" }
-cw20-stake = { path = "./contracts/staking/cw20-stake" }
-dao-voting-cw4 = { path = "./contracts/voting/dao-voting-cw4" }
-dao-voting-cw20-staked = { path = "./contracts/voting/dao-voting-cw20-staked" }
-dao-voting-native-staked = { path = "./contracts/voting/dao-voting-native-staked" }
-dao-voting-cw721-staked = { path = "./contracts/voting/dao-voting-cw721-staked" }
-dao-voting-cw20-balance = { path = "./test-contracts/dao-voting-cw20-balance"}
-cw-denom = { path = "./packages/cw-denom" }
-cw-hooks = { path = "./packages/cw-hooks" }
-cw721-controllers = { path = "./packages/cw721-controllers" }
-dao-macros = { path = "./packages/dao-macros" }
-dao-pre-propose-base = { path = "./packages/dao-pre-propose-base" }
-dao-proposal-hooks = { path = "./packages/dao-proposal-hooks" }
-dao-proposal-sudo = { path = "./test-contracts/dao-proposal-sudo" }
-dao-testing = { path = "./packages/dao-testing" }
-dao-vote-hooks = { path = "./packages/dao-vote-hooks" }
-cw-paginate = { path = "./packages/cw-paginate" }
-dao-interface = { path = "./packages/dao-interface" }
-dao-voting = { path = "./packages/dao-voting" }
+dao-proposal-single = { path = "./contracts/proposal/dao-proposal-single", version = "*" }
+dao-proposal-multiple = { path = "./contracts/proposal/dao-proposal-multiple", version = "*" }
+dao-proposal-condorcet = { path = "./contracts/proposal/dao-proposal-condorcet", version = "*" }
+dao-pre-propose-single = { path = "./contracts/pre-propose/dao-pre-propose-single", version = "*" }
+dao-pre-propose-multiple = { path = "./contracts/pre-propose/dao-pre-propose-multiple", version = "*" }
+dao-pre-propose-approval-single = { path = "./contracts/pre-propose/dao-pre-propose-approval-single", version = "*" }
+dao-pre-propose-approver = { path = "./contracts/pre-propose/dao-pre-propose-approver", version = "*" }
+cw20-stake = { path = "./contracts/staking/cw20-stake", version = "*" }
+dao-voting-cw4 = { path = "./contracts/voting/dao-voting-cw4", version = "*" }
+dao-voting-cw20-staked = { path = "./contracts/voting/dao-voting-cw20-staked", version = "*" }
+dao-voting-native-staked = { path = "./contracts/voting/dao-voting-native-staked", version = "*" }
+dao-voting-cw721-staked = { path = "./contracts/voting/dao-voting-cw721-staked", version = "*" }
+dao-voting-cw20-balance = { path = "./test-contracts/dao-voting-cw20-balance", version = "*" }
+cw-denom = { path = "./packages/cw-denom", version = "*" }
+cw-hooks = { path = "./packages/cw-hooks", version = "*" }
+cw721-controllers = { path = "./packages/cw721-controllers", version = "*" }
+dao-macros = { path = "./packages/dao-macros", version = "*" }
+dao-pre-propose-base = { path = "./packages/dao-pre-propose-base", version = "*" }
+dao-proposal-hooks = { path = "./packages/dao-proposal-hooks", version = "*" }
+dao-proposal-sudo = { path = "./test-contracts/dao-proposal-sudo", version = "*" }
+dao-testing = { path = "./packages/dao-testing", version = "*" }
+dao-vote-hooks = { path = "./packages/dao-vote-hooks", version = "*" }
+cw-paginate = { path = "./packages/cw-paginate", version = "*" }
+dao-interface = { path = "./packages/dao-interface", version = "*" }
+dao-voting = { path = "./packages/dao-voting", version = "*" }
 
 # v1 dependencies. used for state migrations.
 cw-core-v1 = { package = "cw-core", version = "0.1.0", git = "https://github.com/DA0-DA0/dao-contracts.git", tag = "v1.0.0" }

--- a/contracts/dao-core/Cargo.toml
+++ b/contracts/dao-core/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["ekez <ekez@withoutdoing.com>"]
 edition = "2021"
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A DAO DAO core module."
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/external/cw-admin-factory/Cargo.toml
+++ b/contracts/external/cw-admin-factory/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["blue-note"]
 edition = "2021"
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A CosmWasm factory contract for instantiating a contract as its own admin."
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/external/cw-token-swap/Cargo.toml
+++ b/contracts/external/cw-token-swap/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["ekez <ekez@withoutdoing.com>"]
 edition = "2021"
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A CosmWasm contract for swapping native and cw20 assets."
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/pre-propose/dao-pre-propose-approval-single/Cargo.toml
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["ekez <ekez@withoutdoing.com>", "Jake Hartnell <no-reply@no-reply.com
 edition = "2021"
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A DAO DAO pre-propose module handling a proposal approval flow for for dao-proposal-single."
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/pre-propose/dao-pre-propose-approver/Cargo.toml
+++ b/contracts/pre-propose/dao-pre-propose-approver/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["ekez <ekez@withoutdoing.com>", "Jake Hartnell <no-reply@no-reply.com
 edition = "2021"
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A DAO DAO pre-propose module for automatically making approval proposals for dao-pre-propose-approval-single."
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/pre-propose/dao-pre-propose-multiple/Cargo.toml
+++ b/contracts/pre-propose/dao-pre-propose-multiple/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["ekez <zekemedley@gmail.com>", "Jake Hartnell <meow@no-reply.com>", "
 edition = "2021"
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A DAO DAO pre-propose module for dao-proposal-multiple for native and cw20 deposits."
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/pre-propose/dao-pre-propose-single/Cargo.toml
+++ b/contracts/pre-propose/dao-pre-propose-single/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["ekez <zekemedley@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A DAO DAO pre-propose module for dao-proposal-single for native and cw20 deposits."
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/proposal/dao-proposal-condorcet/Cargo.toml
+++ b/contracts/proposal/dao-proposal-condorcet/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name ="dao-proposal-condorcet"
-version = "2.0.0-beta"
+version = "0.1.0"
 authors = ["ekez <ekez@withoutdoing.com>"]
 edition = "2021"
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A DAO DAO proposal module with ranked-choice, Condorcet voting."
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
+++ b/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-condorcet",
-  "contract_version": "2.0.0-beta",
+  "contract_version": "0.1.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/dao-proposal-multiple/Cargo.toml
+++ b/contracts/proposal/dao-proposal-multiple/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["blue-note"]
 edition = "2021"
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A DAO DAO proposal module for multiple choice (a or b or c or ...) voting."
+license = { workspace = true }
+
 exclude = [
   # Those files are rust-optimizer artifacts. You might want to commit them for convenience but they should not be part of the source code publication.
   "contract.wasm",

--- a/contracts/proposal/dao-proposal-single/Cargo.toml
+++ b/contracts/proposal/dao-proposal-single/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["ekez <ekez@withoutdoing.com>"]
 edition = "2021"
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A DAO DAO proposal module for single choice (yes / no) voting."
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/staking/cw20-stake-external-rewards/Cargo.toml
+++ b/contracts/staking/cw20-stake-external-rewards/Cargo.toml
@@ -3,6 +3,7 @@ name = "cw20-stake-external-rewards"
 version = "2.0.1"
 authors = ["Ben2x4 <Ben2x4@tutanota.com>", "ekez <ekez@withoutdoing.com>"]
 edition = "2018"
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/staking/cw20-stake-reward-distributor/Cargo.toml
+++ b/contracts/staking/cw20-stake-reward-distributor/Cargo.toml
@@ -3,6 +3,7 @@ name = "cw20-stake-reward-distributor"
 version = "2.0.1"
 edition = "2018"
 authors = ["Vernon Johnson <vtj2105@columbia.edu>, ekez <ekez@withoutdoing.com>"]
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/staking/cw20-stake/Cargo.toml
+++ b/contracts/staking/cw20-stake/Cargo.toml
@@ -3,9 +3,9 @@ name = "cw20-stake"
 version = "2.0.1"
 authors = ["Ben2x4 <Ben2x4@tutanota.com>"]
 edition = "2018"
-license = "Apache-2.0"
 repository = "https://github.com/DA0-DA0/cw-dao/contracts/cw20-stake"
 description = "CW20 token that can be staked and staked balance can be queried at any height"
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/voting/dao-voting-cw20-staked/Cargo.toml
+++ b/contracts/voting/dao-voting-cw20-staked/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Callum Anderson <callumanderson745@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A DAO DAO voting module based on staked cw20 tokens."
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/voting/dao-voting-cw4/Cargo.toml
+++ b/contracts/voting/dao-voting-cw4/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Callum Anderson <callumanderson745@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A DAO DAO voting module based on cw4 membership."
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/voting/dao-voting-cw721-staked/Cargo.toml
+++ b/contracts/voting/dao-voting-cw721-staked/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["CypherApe cypherape@protonmail.com"]
 edition = "2021"
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A DAO DAO voting module based on staked cw721 tokens."
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/voting/dao-voting-native-staked/Cargo.toml
+++ b/contracts/voting/dao-voting-native-staked/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Callum Anderson <callumanderson745@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A DAO DAO voting module based on staked cw721 tokens."
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/packages/cw-denom/Cargo.toml
+++ b/packages/cw-denom/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["ekez ekez@withoutdoing.com"]
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A package for validation and handling of cw20 and native Cosmos SDK denominations."
+license = { workspace = true }
 
 [dependencies]
 cosmwasm-std = { workspace = true }

--- a/packages/cw-hooks/Cargo.toml
+++ b/packages/cw-hooks/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["Callum Anderson <callumanderson745@gmail.com>"]
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A package for managing a set of hooks which can be accessed by their index."
+license = { workspace = true }
 
 [dependencies]
 

--- a/packages/cw-paginate/Cargo.toml
+++ b/packages/cw-paginate/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["ekez ekez@withoutdoing.com"]
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A package for paginating cosmwasm maps."
-
+license = { workspace = true }
 
 [dependencies]
 cosmwasm-std = { workspace = true }

--- a/packages/cw721-controllers/Cargo.toml
+++ b/packages/cw721-controllers/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["CypherApe cypherape@protonmail.com"]
 edition = "2021"
 description = "A package for managing cw721 claims."
 repository = "https://github.com/DA0-DA0/dao-contracts"
+license = { workspace = true }
 
 [dependencies]
 cosmwasm-std = { workspace = true }

--- a/packages/dao-interface/Cargo.toml
+++ b/packages/dao-interface/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["ekez ekez@withoutdoing.com"]
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A package containing interface definitions for DAO DAO DAOs."
+license = { workspace = true }
 
 [dependencies]
 cosmwasm-std = { workspace = true }

--- a/packages/dao-macros/Cargo.toml
+++ b/packages/dao-macros/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["ekez ekez@withoutdoing.com"]
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A package macros for deriving DAO module interfaces."
+license = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/packages/dao-pre-propose-base/Cargo.toml
+++ b/packages/dao-pre-propose-base/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["ekez ekez@withoutdoing.com"]
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A package for implementing pre-propose modules."
+license = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/packages/dao-proposal-hooks/Cargo.toml
+++ b/packages/dao-proposal-hooks/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["Callum Anderson <callumanderson745@gmail.com>"]
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A package for managing proposal hooks."
+license = { workspace = true }
 
 [dependencies]
 cosmwasm-std = { workspace = true }

--- a/packages/dao-testing/Cargo.toml
+++ b/packages/dao-testing/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["ekez ekez@withoutdoing.com"]
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "Testing helper functions and interfaces for testing DAO modules."
+license = { workspace = true }
 
 # This crate depends on multi-test and rand. These are not features in
 # wasm builds of cosmwasm. Despite this crate only being used as a dev

--- a/packages/dao-vote-hooks/Cargo.toml
+++ b/packages/dao-vote-hooks/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["ekez ekez@withoutdoing.com"]
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A package for managing vote hooks."
+license = { workspace = true }
 
 [dependencies]
 cosmwasm-std = { workspace = true }

--- a/packages/dao-voting/Cargo.toml
+++ b/packages/dao-voting/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["ekez ekez@withoutdoing.com"]
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "Types and methods for CosmWasm DAO voting."
+license = { workspace = true }
 
 [dependencies]
 cosmwasm-std = { workspace = true }


### PR DESCRIPTION
This does some basic tidying to our `Cargo.toml` files so that we can publish crates.

Unfortunately it is not possible to [publish a crate with a git dependency](https://github.com/rust-lang/cargo/issues/6738), though we can still publish the good packages.