### PR TITLE
crates.io does not recognize bsd-3.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "cw-denom"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["ci/configs/"]
 
 [workspace.package]
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [profile.release.package.stake-cw20-external-rewards]
 codegen-units = 1

--- a/packages/cw-denom/Cargo.toml
+++ b/packages/cw-denom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-denom"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 authors = ["ekez ekez@withoutdoing.com"]
 repository = "https://github.com/DA0-DA0/dao-contracts"

--- a/packages/cw-denom/Cargo.toml
+++ b/packages/cw-denom/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["ekez ekez@withoutdoing.com"]
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A package for validation and handling of cw20 and native Cosmos SDK denominations."
+documentation = "https://docs.rs/cw-denom"
 license = { workspace = true }
 
 [dependencies]

--- a/packages/cw-hooks/Cargo.toml
+++ b/packages/cw-hooks/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["Callum Anderson <callumanderson745@gmail.com>"]
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A package for managing a set of hooks which can be accessed by their index."
+documentation = "https://docs.rs/cw-hooks"
 license = { workspace = true }
 
 [dependencies]

--- a/packages/cw-paginate/Cargo.toml
+++ b/packages/cw-paginate/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["ekez ekez@withoutdoing.com"]
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A package for paginating cosmwasm maps."
+documentation = "https://docs.rs/cw-paginate"
 license = { workspace = true }
 
 [dependencies]

--- a/packages/cw721-controllers/Cargo.toml
+++ b/packages/cw721-controllers/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["CypherApe cypherape@protonmail.com"]
 edition = "2021"
 description = "A package for managing cw721 claims."
 repository = "https://github.com/DA0-DA0/dao-contracts"
+documentation = "https://docs.rs/cw721-controllers"
 license = { workspace = true }
 
 [dependencies]

--- a/packages/dao-interface/Cargo.toml
+++ b/packages/dao-interface/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["ekez ekez@withoutdoing.com"]
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A package containing interface definitions for DAO DAO DAOs."
+documentation = "https://docs.rs/dao-interface"
 license = { workspace = true }
 
 [dependencies]

--- a/packages/dao-macros/Cargo.toml
+++ b/packages/dao-macros/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["ekez ekez@withoutdoing.com"]
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "A package macros for deriving DAO module interfaces."
+documentation = "https://docs.rs/dao-macros"
 license = { workspace = true }
 
 [lib]

--- a/packages/dao-voting/Cargo.toml
+++ b/packages/dao-voting/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["ekez ekez@withoutdoing.com"]
 repository = "https://github.com/DA0-DA0/dao-contracts"
 description = "Types and methods for CosmWasm DAO voting."
+documentation = "https://docs.rs/dao-voting"
 license = { workspace = true }
 
 [dependencies]


### PR DESCRIPTION
apparently this does not get checked when doing a publish dry run, so here we are.