### PR TITLE
Update title of cw-vesting README

### DIFF
--- a/contracts/external/cw-vesting/README.md
+++ b/contracts/external/cw-vesting/README.md
@@ -1,4 +1,4 @@
-# CW Payroll
+# CW Vesting
 
 This contract enables the creation of native && cw20 token streams, which allows a payment to be vested continuously over time. 
 


### PR DESCRIPTION
Changed `CW Payroll` to `CW Vesting` in line with the contract name.