### PR TITLE
Fix cw-payroll-factory query schema

### DIFF
--- a/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
+++ b/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
@@ -685,85 +685,181 @@
     },
     "list_vesting_contracts": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "Array_of_Addr",
+      "title": "Array_of_VestingContract",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Addr"
+        "$ref": "#/definitions/VestingContract"
       },
       "definitions": {
-        "Addr": {
-          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-          "type": "string"
+        "VestingContract": {
+          "type": "object",
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
+          "properties": {
+            "contract": {
+              "type": "string"
+            },
+            "instantiator": {
+              "type": "string"
+            },
+            "recipient": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       }
     },
     "list_vesting_contracts_by_instantiator": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "Array_of_Addr",
+      "title": "Array_of_VestingContract",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Addr"
+        "$ref": "#/definitions/VestingContract"
       },
       "definitions": {
-        "Addr": {
-          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-          "type": "string"
+        "VestingContract": {
+          "type": "object",
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
+          "properties": {
+            "contract": {
+              "type": "string"
+            },
+            "instantiator": {
+              "type": "string"
+            },
+            "recipient": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       }
     },
     "list_vesting_contracts_by_instantiator_reverse": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "Array_of_Addr",
+      "title": "Array_of_VestingContract",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Addr"
+        "$ref": "#/definitions/VestingContract"
       },
       "definitions": {
-        "Addr": {
-          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-          "type": "string"
+        "VestingContract": {
+          "type": "object",
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
+          "properties": {
+            "contract": {
+              "type": "string"
+            },
+            "instantiator": {
+              "type": "string"
+            },
+            "recipient": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       }
     },
     "list_vesting_contracts_by_recipient": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "Array_of_Addr",
+      "title": "Array_of_VestingContract",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Addr"
+        "$ref": "#/definitions/VestingContract"
       },
       "definitions": {
-        "Addr": {
-          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-          "type": "string"
+        "VestingContract": {
+          "type": "object",
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
+          "properties": {
+            "contract": {
+              "type": "string"
+            },
+            "instantiator": {
+              "type": "string"
+            },
+            "recipient": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       }
     },
     "list_vesting_contracts_by_recipient_reverse": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "Array_of_Addr",
+      "title": "Array_of_VestingContract",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Addr"
+        "$ref": "#/definitions/VestingContract"
       },
       "definitions": {
-        "Addr": {
-          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-          "type": "string"
+        "VestingContract": {
+          "type": "object",
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
+          "properties": {
+            "contract": {
+              "type": "string"
+            },
+            "instantiator": {
+              "type": "string"
+            },
+            "recipient": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       }
     },
     "list_vesting_contracts_reverse": {
       "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "Array_of_Addr",
+      "title": "Array_of_VestingContract",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/Addr"
+        "$ref": "#/definitions/VestingContract"
       },
       "definitions": {
-        "Addr": {
-          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-          "type": "string"
+        "VestingContract": {
+          "type": "object",
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
+          "properties": {
+            "contract": {
+              "type": "string"
+            },
+            "instantiator": {
+              "type": "string"
+            },
+            "recipient": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       }
     },

--- a/contracts/external/cw-payroll-factory/src/msg.rs
+++ b/contracts/external/cw-payroll-factory/src/msg.rs
@@ -3,6 +3,8 @@ use cw20::Cw20ReceiveMsg;
 use cw_ownable::cw_ownable;
 use cw_vesting::msg::InstantiateMsg as PayrollInstantiateMsg;
 
+use crate::state::VestingContract;
+
 #[cw_serde]
 pub struct InstantiateMsg {
     pub owner: Option<String>,
@@ -39,40 +41,40 @@ pub enum ReceiveMsg {
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     /// Returns list of all vesting payment contracts
-    #[returns(Vec<::cosmwasm_std::Addr>)]
+    #[returns(Vec<VestingContract>)]
     ListVestingContracts {
         start_after: Option<String>,
         limit: Option<u32>,
     },
     /// Returns list of all vesting payment contracts in reverse
-    #[returns(Vec<::cosmwasm_std::Addr>)]
+    #[returns(Vec<VestingContract>)]
     ListVestingContractsReverse {
         start_before: Option<String>,
         limit: Option<u32>,
     },
     /// Returns list of all vesting payment contracts by who instantiated them
-    #[returns(Vec<::cosmwasm_std::Addr>)]
+    #[returns(Vec<VestingContract>)]
     ListVestingContractsByInstantiator {
         instantiator: String,
         start_after: Option<String>,
         limit: Option<u32>,
     },
     /// Returns list of all vesting payment contracts by who instantiated them in reverse
-    #[returns(Vec<::cosmwasm_std::Addr>)]
+    #[returns(Vec<VestingContract>)]
     ListVestingContractsByInstantiatorReverse {
         instantiator: String,
         start_before: Option<String>,
         limit: Option<u32>,
     },
     /// Returns list of all vesting payment contracts by recipient
-    #[returns(Vec<::cosmwasm_std::Addr>)]
+    #[returns(Vec<VestingContract>)]
     ListVestingContractsByRecipient {
         recipient: String,
         start_after: Option<String>,
         limit: Option<u32>,
     },
     /// Returns list of all vesting payment contracts by recipient in reverse
-    #[returns(Vec<::cosmwasm_std::Addr>)]
+    #[returns(Vec<VestingContract>)]
     ListVestingContractsByRecipientReverse {
         recipient: String,
         start_before: Option<String>,

--- a/typescript/contracts/cw-payroll-factory/CwPayrollFactory.client.ts
+++ b/typescript/contracts/cw-payroll-factory/CwPayrollFactory.client.ts
@@ -6,7 +6,7 @@
 
 import { CosmWasmClient, SigningCosmWasmClient, ExecuteResult } from "@cosmjs/cosmwasm-stargate";
 import { Coin, StdFee } from "@cosmjs/amino";
-import { InstantiateMsg, ExecuteMsg, Uint128, Binary, UncheckedDenom, Curve, Action, Expiration, Timestamp, Uint64, Cw20ReceiveMsg, UncheckedVestingParams, SaturatingLinear, PiecewiseLinear, QueryMsg, Addr, ArrayOfAddr, OwnershipForAddr } from "./CwPayrollFactory.types";
+import { InstantiateMsg, ExecuteMsg, Uint128, Binary, UncheckedDenom, Curve, Action, Expiration, Timestamp, Uint64, Cw20ReceiveMsg, UncheckedVestingParams, SaturatingLinear, PiecewiseLinear, QueryMsg, ArrayOfVestingContract, VestingContract, Addr, OwnershipForAddr } from "./CwPayrollFactory.types";
 export interface CwPayrollFactoryReadOnlyInterface {
   contractAddress: string;
   listVestingContracts: ({
@@ -15,14 +15,14 @@ export interface CwPayrollFactoryReadOnlyInterface {
   }: {
     limit?: number;
     startAfter?: string;
-  }) => Promise<ArrayOfAddr>;
+  }) => Promise<ArrayOfVestingContract>;
   listVestingContractsReverse: ({
     limit,
     startBefore
   }: {
     limit?: number;
     startBefore?: string;
-  }) => Promise<ArrayOfAddr>;
+  }) => Promise<ArrayOfVestingContract>;
   listVestingContractsByInstantiator: ({
     instantiator,
     limit,
@@ -31,7 +31,7 @@ export interface CwPayrollFactoryReadOnlyInterface {
     instantiator: string;
     limit?: number;
     startAfter?: string;
-  }) => Promise<ArrayOfAddr>;
+  }) => Promise<ArrayOfVestingContract>;
   listVestingContractsByInstantiatorReverse: ({
     instantiator,
     limit,
@@ -40,7 +40,7 @@ export interface CwPayrollFactoryReadOnlyInterface {
     instantiator: string;
     limit?: number;
     startBefore?: string;
-  }) => Promise<ArrayOfAddr>;
+  }) => Promise<ArrayOfVestingContract>;
   listVestingContractsByRecipient: ({
     limit,
     recipient,
@@ -49,7 +49,7 @@ export interface CwPayrollFactoryReadOnlyInterface {
     limit?: number;
     recipient: string;
     startAfter?: string;
-  }) => Promise<ArrayOfAddr>;
+  }) => Promise<ArrayOfVestingContract>;
   listVestingContractsByRecipientReverse: ({
     limit,
     recipient,
@@ -58,7 +58,7 @@ export interface CwPayrollFactoryReadOnlyInterface {
     limit?: number;
     recipient: string;
     startBefore?: string;
-  }) => Promise<ArrayOfAddr>;
+  }) => Promise<ArrayOfVestingContract>;
   ownership: () => Promise<OwnershipForAddr>;
   codeId: () => Promise<Uint64>;
 }
@@ -85,7 +85,7 @@ export class CwPayrollFactoryQueryClient implements CwPayrollFactoryReadOnlyInte
   }: {
     limit?: number;
     startAfter?: string;
-  }): Promise<ArrayOfAddr> => {
+  }): Promise<ArrayOfVestingContract> => {
     return this.client.queryContractSmart(this.contractAddress, {
       list_vesting_contracts: {
         limit,
@@ -99,7 +99,7 @@ export class CwPayrollFactoryQueryClient implements CwPayrollFactoryReadOnlyInte
   }: {
     limit?: number;
     startBefore?: string;
-  }): Promise<ArrayOfAddr> => {
+  }): Promise<ArrayOfVestingContract> => {
     return this.client.queryContractSmart(this.contractAddress, {
       list_vesting_contracts_reverse: {
         limit,
@@ -115,7 +115,7 @@ export class CwPayrollFactoryQueryClient implements CwPayrollFactoryReadOnlyInte
     instantiator: string;
     limit?: number;
     startAfter?: string;
-  }): Promise<ArrayOfAddr> => {
+  }): Promise<ArrayOfVestingContract> => {
     return this.client.queryContractSmart(this.contractAddress, {
       list_vesting_contracts_by_instantiator: {
         instantiator,
@@ -132,7 +132,7 @@ export class CwPayrollFactoryQueryClient implements CwPayrollFactoryReadOnlyInte
     instantiator: string;
     limit?: number;
     startBefore?: string;
-  }): Promise<ArrayOfAddr> => {
+  }): Promise<ArrayOfVestingContract> => {
     return this.client.queryContractSmart(this.contractAddress, {
       list_vesting_contracts_by_instantiator_reverse: {
         instantiator,
@@ -149,7 +149,7 @@ export class CwPayrollFactoryQueryClient implements CwPayrollFactoryReadOnlyInte
     limit?: number;
     recipient: string;
     startAfter?: string;
-  }): Promise<ArrayOfAddr> => {
+  }): Promise<ArrayOfVestingContract> => {
     return this.client.queryContractSmart(this.contractAddress, {
       list_vesting_contracts_by_recipient: {
         limit,
@@ -166,7 +166,7 @@ export class CwPayrollFactoryQueryClient implements CwPayrollFactoryReadOnlyInte
     limit?: number;
     recipient: string;
     startBefore?: string;
-  }): Promise<ArrayOfAddr> => {
+  }): Promise<ArrayOfVestingContract> => {
     return this.client.queryContractSmart(this.contractAddress, {
       list_vesting_contracts_by_recipient_reverse: {
         limit,

--- a/typescript/contracts/cw-payroll-factory/CwPayrollFactory.types.ts
+++ b/typescript/contracts/cw-payroll-factory/CwPayrollFactory.types.ts
@@ -117,8 +117,13 @@ export type QueryMsg = {
 } | {
   code_id: {};
 };
+export type ArrayOfVestingContract = VestingContract[];
+export interface VestingContract {
+  contract: string;
+  instantiator: string;
+  recipient: string;
+}
 export type Addr = string;
-export type ArrayOfAddr = Addr[];
 export interface OwnershipForAddr {
   owner?: Addr | null;
   pending_expiry?: Expiration | null;


### PR DESCRIPTION
The `cw-payroll-factory` list queries seem to return lists of `VestingContract` structs, not `Addr`s. This PR updates the schema to match the queries.