### PR TITLE
Update URL for cw20-stake-reward-distributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ wiki](https://github.com/DA0-DA0/dao-contracts/wiki/DAO-DAO-Contracts-Design).
 | [dao-voting-cw4](contracts/voting/dao-voting-cw4)                              | A voting power module for multisig-style voting.       |
 | [cw20-stake](contracts/staking/cw20-stake)                                     | A contract for staking cw20 tokens.                    |
 | [cw20-stake-external-rewards](contracts/staking/cw20-stake-external-rewards)   | A contract for providing external staking rewards.     |
-| [cw20-stake-reward-distributor](contracts/staking/cw20-stake-external-rewards) | A contract for distributing rewards via stake-cw20.    |
+| [cw20-stake-reward-distributor](contracts/staking/cw20-stake-reward-distributor) | A contract for distributing rewards via stake-cw20.    |
 
 | Unaudited contracts                                                                      | Description                                                                            |
 | :--------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------- |

--- a/packages/cw-denom/src/lib.rs
+++ b/packages/cw-denom/src/lib.rs
@@ -299,8 +299,8 @@ mod tests {
             "1abc".to_string(),                        // Starts with non alphabetic character.
             "abc~d".to_string(),                       // Contains invalid character.
             "".to_string(),                            // Too short, also empty.
-            "🥵abc".to_string(),                     // Weird unicode start.
-            "ab:12🥵a".to_string(),                  // Weird unocide in non-head position.
+            "🥵abc".to_string(),                       // Weird unicode start.
+            "ab:12🥵a".to_string(),                    // Weird unocide in non-head position.
             "ab,cd".to_string(),                       // Comma is not a valid seperator.
         ];
 


### PR DESCRIPTION
Line 19 - URL was pointing to contracts/staking/cw20-stake-external-rewards Changed to contracts/staking/cw20-stake-reward-distributor