### PR TITLE
Update cardinality when redelegating.

### DIFF
--- a/contracts/external/cw-vesting/src/stake_tracker.rs
+++ b/contracts/external/cw-vesting/src/stake_tracker.rs
@@ -68,10 +68,18 @@ impl<'a> StakeTracker<'a> {
         dst: String,
         amount: Uint128,
     ) -> StdResult<()> {
-        self.validators
+        let new = self
+            .validators
             .decrement(storage, src, t.seconds(), amount)?;
-        self.validators
+        if new.is_zero() {
+            self.cardinality.decrement(storage, (), t.seconds(), 1)?;
+        }
+        let new = self
+            .validators
             .increment(storage, dst, t.seconds(), amount)?;
+        if new == amount {
+            self.cardinality.increment(storage, (), t.seconds(), 1)?;
+        }
         Ok(())
     }
 

--- a/contracts/external/cw-vesting/src/stake_tracker_tests.rs
+++ b/contracts/external/cw-vesting/src/stake_tracker_tests.rs
@@ -392,3 +392,29 @@ fn test_unbonding_slash() {
         .unwrap();
     assert_eq!(cardinality, 0);
 }
+
+/// Redelegating should cause cardinality changes if redelegation
+/// removes all tokens from the source validator, or if it delegates
+/// to a new validator.
+#[test]
+fn test_redelegation_changes_cardinality() {
+    let storage = &mut mock_dependencies().storage;
+    let st = StakeTracker::new("s", "v", "c");
+    let t = Timestamp::default();
+    let amount = Uint128::new(10);
+
+    st.on_delegate(storage, t, "v1".to_string(), amount + amount)
+        .unwrap();
+    let c = st.validator_cardinality(storage, t).unwrap();
+    assert_eq!(c, 1);
+
+    st.on_redelegate(storage, t, "v1".to_string(), "v2".to_string(), amount)
+        .unwrap();
+    let c = st.validator_cardinality(storage, t).unwrap();
+    assert_eq!(c, 2);
+
+    st.on_redelegate(storage, t, "v1".to_string(), "v2".to_string(), amount)
+        .unwrap();
+    let c = st.validator_cardinality(storage, t).unwrap();
+    assert_eq!(c, 1);
+}


### PR DESCRIPTION
Resolves issue one in the cw-vesting Oak Security audit.