### PR TITLE
Don't allow vesting agreements that would complete instantly.

### DIFF
--- a/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
+++ b/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
@@ -276,7 +276,7 @@
             ]
           },
           "start_time": {
-            "description": "The time to start vesting, or None to start vesting when the contract is instantiated.",
+            "description": "The time to start vesting, or None to start vesting when the contract is instantiated. This may be a time in the past, though it is checked that `start_time + vesting_duration_seconds > now` as a vest that completes instantly is equivalent to a regular fund transfer, but with a lot of extra code.",
             "anyOf": [
               {
                 "$ref": "#/definitions/Timestamp"

--- a/contracts/external/cw-vesting/schema/cw-vesting.json
+++ b/contracts/external/cw-vesting/schema/cw-vesting.json
@@ -51,7 +51,7 @@
         ]
       },
       "start_time": {
-        "description": "The time to start vesting, or None to start vesting when the contract is instantiated.",
+        "description": "The time to start vesting, or None to start vesting when the contract is instantiated. This may be a time in the past, though it is checked that `start_time + vesting_duration_seconds > now` as a vest that completes instantly is equivalent to a regular fund transfer, but with a lot of extra code.",
         "anyOf": [
           {
             "$ref": "#/definitions/Timestamp"

--- a/contracts/external/cw-vesting/src/contract.rs
+++ b/contracts/external/cw-vesting/src/contract.rs
@@ -32,6 +32,11 @@ pub fn instantiate(
     let denom = msg.denom.into_checked(deps.as_ref())?;
     let recipient = deps.api.addr_validate(&msg.recipient)?;
     let start_time = msg.start_time.unwrap_or(env.block.time);
+
+    if start_time.plus_seconds(msg.vesting_duration_seconds) <= env.block.time {
+        return Err(ContractError::Instavest);
+    }
+
     let vest = PAYMENT.initialize(
         deps.storage,
         VestInit {

--- a/contracts/external/cw-vesting/src/error.rs
+++ b/contracts/external/cw-vesting/src/error.rs
@@ -34,6 +34,9 @@ pub enum ContractError {
     #[error("total amount to vest must be non-zero")]
     ZeroVest,
 
+    #[error("this vesting contract would complete instantly")]
+    Instavest,
+
     #[error("payment is cancelled")]
     Cancelled,
 

--- a/contracts/external/cw-vesting/src/msg.rs
+++ b/contracts/external/cw-vesting/src/msg.rs
@@ -30,7 +30,11 @@ pub struct InstantiateMsg {
     /// represent a more complicated vesting schedule.
     pub schedule: Schedule,
     /// The time to start vesting, or None to start vesting when the
-    /// contract is instantiated.
+    /// contract is instantiated. This may be a time in the past,
+    /// though it is checked that `start_time +
+    /// vesting_duration_seconds > now` as a vest that completes
+    /// instantly is equivalent to a regular fund transfer, but with a
+    /// lot of extra code.
     pub start_time: Option<Timestamp>,
     /// The length of the vesting schedule in seconds.
     pub vesting_duration_seconds: u64,

--- a/contracts/external/cw-vesting/src/suite_tests/suite.rs
+++ b/contracts/external/cw-vesting/src/suite_tests/suite.rs
@@ -114,6 +114,11 @@ impl SuiteBuilder {
         self.instantiate.start_time = Some(t);
         self
     }
+
+    pub fn with_vesting_duration(mut self, duration_seconds: u64) -> Self {
+        self.instantiate.vesting_duration_seconds = duration_seconds;
+        self
+    }
 }
 
 impl Suite {


### PR DESCRIPTION
Resolves the third issue in the Oak Security audit report for `cw-vesting`.