### PR TITLE
Initial phase integration to cw-abc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-address-like",
+ "cw-ownable",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
  "cw2 0.16.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,7 @@ version = "0.0.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-address-like",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
  "cw2 0.16.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,6 +592,7 @@ dependencies = [
  "integer-cbrt",
  "integer-sqrt",
  "rust_decimal",
+ "speculoos",
  "thiserror",
  "token-bindings",
 ]
@@ -2669,6 +2670,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2677,6 +2712,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -3457,6 +3525,15 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "speculoos"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65881c9270d6157f30a09233305da51bed97eef9192d0ea21e57b1c8f05c3620"
+dependencies = [
+ "num",
 ]
 
 [[package]]

--- a/contracts/external/cw-abc/Cargo.toml
+++ b/contracts/external/cw-abc/Cargo.toml
@@ -30,4 +30,4 @@ integer-cbrt = "0.1.2"
 token-bindings = { git = "https://github.com/CosmosContracts/token-bindings", rev = "1412b94" }
 
 [dev-dependencies]
-
+speculoos = "0.11.0"

--- a/contracts/external/cw-abc/Cargo.toml
+++ b/contracts/external/cw-abc/Cargo.toml
@@ -29,5 +29,7 @@ integer-sqrt = "0.1.5"
 integer-cbrt = "0.1.2"
 token-bindings = { git = "https://github.com/CosmosContracts/token-bindings", rev = "1412b94" }
 cw-address-like = "1.0.4"
+cw-ownable = { workspace = true }
+
 [dev-dependencies]
 speculoos = "0.11.0"

--- a/contracts/external/cw-abc/Cargo.toml
+++ b/contracts/external/cw-abc/Cargo.toml
@@ -28,6 +28,6 @@ rust_decimal = "1.14.3"
 integer-sqrt = "0.1.5"
 integer-cbrt = "0.1.2"
 token-bindings = { git = "https://github.com/CosmosContracts/token-bindings", rev = "1412b94" }
-
+cw-address-like = "1.0.4"
 [dev-dependencies]
 speculoos = "0.11.0"

--- a/contracts/external/cw-abc/src/abc.rs
+++ b/contracts/external/cw-abc/src/abc.rs
@@ -1,0 +1,123 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{ensure, Uint128};
+use token_bindings::Metadata;
+use crate::curves::{Constant, Curve, decimal, DecimalPlaces, Linear, SquareRoot};
+use crate::ContractError;
+
+#[cw_serde]
+pub struct SupplyToken {
+    // The denom to create for the supply token
+    pub subdenom: String,
+    // Metadata for the supply token to create
+    pub metadata: Metadata,
+    // Number of decimal places for the reserve token, needed for proper curve math.
+    // Same format as decimals above, eg. if it is uatom, where 1 unit is 10^-6 ATOM, use 6 here
+    pub decimals: u8,
+}
+
+#[cw_serde]
+pub struct ReserveToken {
+    // Reserve token denom (only support native for now)
+    pub denom: String,
+    // Number of decimal places for the reserve token, needed for proper curve math.
+    // Same format as decimals above, eg. if it is uatom, where 1 unit is 10^-6 ATOM, use 6 here
+    pub decimals: u8,
+}
+
+
+#[cw_serde]
+pub enum CommonsPhase {
+    // The Hatch phase where initial contributors (Hatchers) participate in a hatch sale.
+    Hatch(HatchConfig),
+    // The Vesting phase where tokens minted during the Hatch phase are locked (burning is disabled) to combat early speculation/arbitrage.
+    Vesting {
+        // The start timestamp of the vesting process.
+        vesting_start: u64,
+        // The end timestamp of the vesting process.
+        vesting_end: u64,
+    },
+    // The Open phase where anyone can mint tokens by contributing DAI into the curve and becoming members of the Commons.
+    Open,
+}
+
+
+#[cw_serde]
+pub struct HatchConfig {
+    // Initial contributors (Hatchers) list
+    // pub hatchers: Vec<Addr>,
+    // The initial raise range (min, max) in the reserve token
+    pub initial_raise: (Uint128, Uint128),
+    // The initial price (p0) per reserve token
+    pub initial_price: Uint128,
+    // The initial allocation (θ), percentage of the initial raise allocated to the Funding Pool
+    pub initial_allocation: u8,
+    // Percentage of capital put into the Reserve Pool during the Hatch phase
+    pub reserve_percentage: u8,
+}
+
+impl HatchConfig {
+    pub fn validate(&self) -> Result<(), ContractError> {
+        // ensure!(!self.hatchers.is_empty(), ContractError::HatchConfigError("Hatchers list must not be empty."));
+
+        ensure!(
+            self.initial_raise.0 < self.initial_raise.1,
+            ContractError::HatchConfigError("Initial raise minimum value must be less than maximum value.".to_string())
+        );
+
+        ensure!(
+            !self.initial_price.is_zero(),
+            ContractError::HatchConfigError("Initial price must be greater than zero.".to_string())
+        );
+
+        ensure!(
+            self.initial_allocation <= 100,
+            ContractError::HatchConfigError("Initial allocation percentage must be between 0 and 100.".to_string())
+        );
+
+        ensure!(
+            self.reserve_percentage <= 100,
+            ContractError::HatchConfigError("Reserve percentage must be between 0 and 100.".to_string())
+        );
+
+        Ok(())
+    }
+}
+
+
+pub type CurveFn = Box<dyn Fn(DecimalPlaces) -> Box<dyn Curve>>;
+
+#[cw_serde]
+pub enum CurveType {
+    /// Constant always returns `value * 10^-scale` as spot price
+    Constant { value: Uint128, scale: u32 },
+    /// Linear returns `slope * 10^-scale * supply` as spot price
+    Linear { slope: Uint128, scale: u32 },
+    /// SquareRoot returns `slope * 10^-scale * supply^0.5` as spot price
+    SquareRoot { slope: Uint128, scale: u32 },
+}
+
+impl CurveType {
+    pub fn to_curve_fn(&self) -> CurveFn {
+        match self.clone() {
+            CurveType::Constant { value, scale } => {
+                let calc = move |places| -> Box<dyn Curve> {
+                    Box::new(Constant::new(decimal(value, scale), places))
+                };
+                Box::new(calc)
+            }
+            CurveType::Linear { slope, scale } => {
+                let calc = move |places| -> Box<dyn Curve> {
+                    Box::new(Linear::new(decimal(slope, scale), places))
+                };
+                Box::new(calc)
+            }
+            CurveType::SquareRoot { slope, scale } => {
+                let calc = move |places| -> Box<dyn Curve> {
+                    Box::new(SquareRoot::new(decimal(slope, scale), places))
+                };
+                Box::new(calc)
+            }
+        }
+    }
+}
+

--- a/contracts/external/cw-abc/src/abc.rs
+++ b/contracts/external/cw-abc/src/abc.rs
@@ -42,6 +42,7 @@ pub struct HatchConfig<T: AddressLike> {
     // The initial raise range (min, max) in the reserve token
     pub initial_raise: MinMax,
     // The initial price (p0) per reserve token
+    // TODO: initial price is not implemented yet
     pub initial_price: Uint128,
     // The initial allocation (θ), percentage of the initial raise allocated to the Funding Pool
     pub initial_allocation_ratio: StdDecimal,

--- a/contracts/external/cw-abc/src/commands.rs
+++ b/contracts/external/cw-abc/src/commands.rs
@@ -1,0 +1,157 @@
+use cosmwasm_std::{BankMsg, coins, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Uint128};
+use token_bindings::{TokenFactoryQuery, TokenMsg};
+use cw_utils::must_pay;
+use crate::abc::{CommonsPhase, CurveFn};
+use crate::{ContractError};
+use crate::contract::CwAbcResult;
+use crate::msg::ExecuteMsg;
+use crate::state::{CURVE_STATE, HATCHERS, PHASE, PHASE_CONFIG, SUPPLY_DENOM};
+
+/// We pull out logic here, so we can import this from another contract and set a different Curve.
+/// This contacts sets a curve with an enum in InstantiateMsg and stored in state, but you may want
+/// to use custom math not included - make this easily reusable
+pub fn do_execute(
+    deps: DepsMut<TokenFactoryQuery>,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+    curve_fn: CurveFn,
+) -> CwAbcResult {
+    match msg {
+        ExecuteMsg::Buy {} => execute_buy(deps, env, info, curve_fn),
+        ExecuteMsg::Burn { amount } => Ok(execute_sell(deps, env, info, curve_fn, amount)?),
+    }
+}
+
+pub fn execute_buy(
+    deps: DepsMut<TokenFactoryQuery>,
+    _env: Env,
+    info: MessageInfo,
+    curve_fn: CurveFn,
+) -> CwAbcResult {
+    let mut curve_state = CURVE_STATE.load(deps.storage)?;
+
+    let payment = must_pay(&info, &curve_state.reserve_denom)?;
+
+    // Load the phase config and phase
+    let phase_config = PHASE_CONFIG.load(deps.storage)?;
+    let mut phase = PHASE.load(deps.storage)?;
+
+    let (reserved, funded) = match phase {
+        CommonsPhase::Hatch => {
+            let hatch_config = &phase_config.hatch;
+
+            // Check that the potential hatcher is allowlisted
+            hatch_config.assert_allowlisted(&info.sender)?;
+            HATCHERS.update(deps.storage, |mut hatchers| -> StdResult<_>{
+                hatchers.insert(info.sender.clone());
+                Ok(hatchers)
+            })?;
+
+            // Check if the initial_raise max has been met
+            if curve_state.reserve + payment >= hatch_config.initial_raise.1 {
+                // Transition to the Open phase, the hatchers' tokens are now vesting
+                phase = CommonsPhase::Open;
+                PHASE.save(deps.storage, &phase)?;
+            }
+
+            // Calculate the number of tokens sent to the funding pool using the initial allocation percentage
+            // TODO: is it safe to multiply a Decimal with a Uint128?
+            let funded = payment * hatch_config.initial_allocation_percentage;
+            // Calculate the number of tokens sent to the reserve
+            let reserved = payment - funded;
+
+            (reserved, funded)
+        }
+        CommonsPhase::Open => {
+            let hatch_config = &phase_config.open;
+
+            // Calculate the number of tokens sent to the funding pool using the allocation percentage
+            let funded = payment * hatch_config.allocation_percentage;
+            // Calculate the number of tokens sent to the reserve
+            let reserved = payment - funded;
+
+            (reserved, funded)
+        }
+        CommonsPhase::Closed => {
+            // TODO: what to do here?
+            return Err(ContractError::CommonsClosed {});
+        }
+    };
+
+    // calculate how many tokens can be purchased with this and mint them
+    let curve = curve_fn(curve_state.clone().decimals);
+    curve_state.reserve += reserved;
+    curve_state.funding += funded;
+    let new_supply = curve.supply(curve_state.reserve);
+    let minted = new_supply
+        .checked_sub(curve_state.supply)
+        .map_err(StdError::overflow)?;
+    curve_state.supply = new_supply;
+    CURVE_STATE.save(deps.storage, &curve_state)?;
+
+    let denom = SUPPLY_DENOM.load(deps.storage)?;
+    // mint supply token
+    let mint_msg = TokenMsg::MintTokens {
+        denom,
+        amount: minted,
+        mint_to_address: info.sender.to_string(),
+    };
+
+    Ok(Response::new()
+        .add_message(mint_msg)
+        .add_attribute("action", "buy")
+        .add_attribute("from", info.sender)
+        .add_attribute("reserved", reserved)
+        .add_attribute("funded", funded)
+        .add_attribute("supply", minted))
+}
+
+pub fn execute_sell(
+    deps: DepsMut<TokenFactoryQuery>,
+    _env: Env,
+    info: MessageInfo,
+    curve_fn: CurveFn,
+    amount: Uint128,
+) -> CwAbcResult {
+    let receiver = info.sender.clone();
+
+    let denom = SUPPLY_DENOM.load(deps.storage)?;
+    let payment = must_pay(&info, &denom)?;
+
+    // calculate how many tokens can be purchased with this and mint them
+    let mut state = CURVE_STATE.load(deps.storage)?;
+    let curve = curve_fn(state.clone().decimals);
+    state.supply = state
+        .supply
+        .checked_sub(amount)
+        .map_err(StdError::overflow)?;
+    let new_reserve = curve.reserve(state.supply);
+    let released = state
+        .reserve
+        .checked_sub(new_reserve)
+        .map_err(StdError::overflow)?;
+    state.reserve = new_reserve;
+    CURVE_STATE.save(deps.storage, &state)?;
+
+    // Burn the tokens
+    let burn_msg = TokenMsg::BurnTokens {
+        denom,
+        amount: payment,
+        burn_from_address: info.sender.to_string(),
+    };
+
+    // now send the tokens to the sender (TODO: for sell_from we do something else, right???)
+    let msg = BankMsg::Send {
+        to_address: receiver.to_string(),
+        amount: coins(released.u128(), state.reserve_denom),
+    };
+
+    Ok(Response::new()
+        .add_message(msg)
+        .add_message(burn_msg)
+        .add_attribute("action", "burn")
+        .add_attribute("from", info.sender)
+        .add_attribute("supply", amount)
+        .add_attribute("reserve", released))
+}

--- a/contracts/external/cw-abc/src/contract.rs
+++ b/contracts/external/cw-abc/src/contract.rs
@@ -35,7 +35,6 @@ pub fn instantiate(
     nonpayable(&info)?;
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
-    msg.validate()?;
 
     let InstantiateMsg {
         supply,
@@ -43,6 +42,13 @@ pub fn instantiate(
         curve_type,
         phase_config,
     } = msg;
+
+
+    if supply.subdenom.is_empty() {
+        return Err(ContractError::SupplyTokenError("Token subdenom must not be empty.".to_string()));
+    }
+
+    let phase_config = phase_config.validate(deps.api)?;
 
     // Create supply denom with metadata
     let create_supply_denom_msg = TokenMsg::CreateDenom {
@@ -169,10 +175,6 @@ mod tests {
     use super::*;
     use speculoos::prelude::*;
     use crate::queries::query_curve_info;
-//     use crate::msg::CurveType;
-//     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-//     use cosmwasm_std::{coin, Decimal, OverflowError, OverflowOperation, StdError, SubMsg};
-//     use cw_utils::PaymentError;
 
     const DENOM: &str = "satoshi";
     const CREATOR: &str = "creator";

--- a/contracts/external/cw-abc/src/contract.rs
+++ b/contracts/external/cw-abc/src/contract.rs
@@ -14,11 +14,13 @@ use crate::state::{CurveState, CURVE_STATE, CURVE_TYPE, DENOM};
 use cw_utils::{must_pay, nonpayable};
 
 // version info for migration info
-const CONTRACT_NAME: &str = "crates.io:cw20-bonding";
+const CONTRACT_NAME: &str = "crates.io:cw20-abc";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // By default, the prefix for token factory tokens is "factory"
 const DENOM_PREFIX: &str = "factory";
+
+type CwAbcResult<T = Response<TokenFactoryMsg>> = Result<T, ContractError>;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
@@ -26,7 +28,7 @@ pub fn instantiate(
     env: Env,
     info: MessageInfo,
     msg: InstantiateMsg,
-) -> Result<Response<TokenFactoryMsg>, ContractError> {
+) -> CwAbcResult {
     nonpayable(&info)?;
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
@@ -65,13 +67,14 @@ pub fn instantiate(
     Ok(Response::default().add_message(create_denom_msg))
 }
 
+
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut<TokenFactoryQuery>,
     env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
-) -> Result<Response<TokenFactoryMsg>, ContractError> {
+) -> CwAbcResult {
     // default implementation stores curve info as enum, you can do something else in a derived
     // contract and just pass in your custom curve to do_execute
     let curve_type = CURVE_TYPE.load(deps.storage)?;
@@ -88,7 +91,7 @@ pub fn do_execute(
     info: MessageInfo,
     msg: ExecuteMsg,
     curve_fn: CurveFn,
-) -> Result<Response<TokenFactoryMsg>, ContractError> {
+) -> CwAbcResult {
     match msg {
         ExecuteMsg::Buy {} => execute_buy(deps, env, info, curve_fn),
         ExecuteMsg::Burn { amount } => Ok(execute_sell(deps, env, info, curve_fn, amount)?),
@@ -100,7 +103,7 @@ pub fn execute_buy(
     env: Env,
     info: MessageInfo,
     curve_fn: CurveFn,
-) -> Result<Response<TokenFactoryMsg>, ContractError> {
+) -> CwAbcResult {
     let mut state = CURVE_STATE.load(deps.storage)?;
 
     let denom = DENOM.load(deps.storage)?;
@@ -137,7 +140,7 @@ pub fn execute_sell(
     info: MessageInfo,
     curve_fn: CurveFn,
     amount: Uint128,
-) -> Result<Response<TokenFactoryMsg>, ContractError> {
+) -> CwAbcResult {
     let receiver = info.sender.clone();
 
     let denom = DENOM.load(deps.storage)?;

--- a/contracts/external/cw-abc/src/contract.rs
+++ b/contracts/external/cw-abc/src/contract.rs
@@ -128,7 +128,7 @@ pub fn query(deps: Deps<TokenFactoryQuery>, env: Env, msg: QueryMsg) -> StdResul
 }
 
 /// We pull out logic here, so we can import this from another contract and set a different Curve.
-/// This contacts sets a curve with an enum in InstantitateMsg and stored in state, but you may want
+/// This contacts sets a curve with an enum in [`InstantiateMsg`] and stored in state, but you may want
 /// to use custom math not included - make this easily reusable
 pub fn do_query(
     deps: Deps<TokenFactoryQuery>,

--- a/contracts/external/cw-abc/src/contract.rs
+++ b/contracts/external/cw-abc/src/contract.rs
@@ -117,6 +117,7 @@ pub fn do_query(
     match msg {
         // custom queries
         QueryMsg::CurveInfo {} => to_binary(&queries::query_curve_info(deps, curve_fn)?),
+        QueryMsg::PhaseConfig {} => to_binary(&queries::query_phase_config(deps)?),
         // QueryMsg::GetDenom {
         //     creator_address,
         //     subdenom,

--- a/contracts/external/cw-abc/src/error.rs
+++ b/contracts/external/cw-abc/src/error.rs
@@ -16,12 +16,18 @@ pub enum ContractError {
     #[error("Unauthorized")]
     Unauthorized {},
 
-    #[error("Hatch config error {0}")]
-    HatchConfigError(String),
+    #[error("Hatch phase config error {0}")]
+    HatchPhaseConfigError(String),
+
+    #[error("Open phase config error {0}")]
+    OpenPhaseConfigError(String),
 
     #[error("Supply token error {0}")]
     SupplyTokenError(String),
 
     #[error("Sender {sender:?} is not in the hatcher allowlist.")]
     SenderNotAllowlisted { sender: String },
+
+    #[error("The commons is closed to new contributions")]
+    CommonsClosed {},
 }

--- a/contracts/external/cw-abc/src/error.rs
+++ b/contracts/external/cw-abc/src/error.rs
@@ -21,4 +21,7 @@ pub enum ContractError {
 
     #[error("Supply token error {0}")]
     SupplyTokenError(String),
+
+    #[error("Sender {sender:?} is not in the hatcher allowlist.")]
+    SenderNotAllowlisted { sender: String },
 }

--- a/contracts/external/cw-abc/src/error.rs
+++ b/contracts/external/cw-abc/src/error.rs
@@ -13,6 +13,9 @@ pub enum ContractError {
     #[error("Invalid subdenom: {subdenom:?}")]
     InvalidSubdenom { subdenom: String },
 
+    #[error("{0}")]
+    Ownership(#[from] cw_ownable::OwnershipError),
+
     #[error("Unauthorized")]
     Unauthorized {},
 

--- a/contracts/external/cw-abc/src/error.rs
+++ b/contracts/external/cw-abc/src/error.rs
@@ -15,4 +15,10 @@ pub enum ContractError {
 
     #[error("Unauthorized")]
     Unauthorized {},
+
+    #[error("Hatch config error {0}")]
+    HatchConfigError(String),
+
+    #[error("Supply token error {0}")]
+    SupplyTokenError(String),
 }

--- a/contracts/external/cw-abc/src/lib.rs
+++ b/contracts/external/cw-abc/src/lib.rs
@@ -3,5 +3,6 @@ pub mod curves;
 mod error;
 pub mod msg;
 pub mod state;
+pub mod abc;
 
 pub use crate::error::ContractError;

--- a/contracts/external/cw-abc/src/lib.rs
+++ b/contracts/external/cw-abc/src/lib.rs
@@ -4,5 +4,7 @@ mod error;
 pub mod msg;
 pub mod state;
 pub mod abc;
+pub(crate) mod commands;
+mod queries;
 
 pub use crate::error::ContractError;

--- a/contracts/external/cw-abc/src/msg.rs
+++ b/contracts/external/cw-abc/src/msg.rs
@@ -20,6 +20,7 @@ pub struct InstantiateMsg {
 }
 
 
+#[cw_ownable::cw_ownable_execute]
 #[cw_serde]
 pub enum ExecuteMsg {
     /// Buy will attempt to purchase as many supply tokens as possible.
@@ -40,6 +41,7 @@ pub enum ExecuteMsg {
     },
 }
 
+#[cw_ownable::cw_ownable_query]
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum QueryMsg {

--- a/contracts/external/cw-abc/src/msg.rs
+++ b/contracts/external/cw-abc/src/msg.rs
@@ -2,7 +2,7 @@ use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Decimal, Uint128};
 
 use crate::abc::{CommonsPhaseConfig, CurveType, ReserveToken, SupplyToken};
-use crate::ContractError;
+
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -16,18 +16,7 @@ pub struct InstantiateMsg {
     pub curve_type: CurveType,
 
     // Hatch configuration information
-    pub phase_config: CommonsPhaseConfig,
-}
-
-impl InstantiateMsg {
-    /// Validate the instantiate message
-    pub fn validate(&self) -> Result<(), ContractError> {
-        if self.supply.subdenom.is_empty() {
-            return Err(ContractError::SupplyTokenError("Token subdenom must not be empty.".to_string()));
-        }
-
-        self.phase_config.validate()
-    }
+    pub phase_config: CommonsPhaseConfig<String>,
 }
 
 
@@ -60,4 +49,9 @@ pub struct CurveInfoResponse {
     pub spot_price: Decimal,
     // current reserve denom
     pub reserve_denom: String,
+}
+
+#[cw_serde]
+pub struct CommonsPhaseConfigResponse {
+
 }

--- a/contracts/external/cw-abc/src/msg.rs
+++ b/contracts/external/cw-abc/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Decimal, Uint128};
 
-use crate::abc::{CurveType, HatchConfig, ReserveToken, SupplyToken};
+use crate::abc::{CommonsPhaseConfig, CurveType, HatchConfig, ReserveToken, SupplyToken};
 use crate::ContractError;
 
 #[cw_serde]
@@ -16,7 +16,7 @@ pub struct InstantiateMsg {
     pub curve_type: CurveType,
 
     // Hatch configuration information
-    pub hatch_config: HatchConfig,
+    pub phase_config: CommonsPhaseConfig,
 }
 
 impl InstantiateMsg {
@@ -26,7 +26,7 @@ impl InstantiateMsg {
             return Err(ContractError::SupplyTokenError("Token subdenom must not be empty.".to_string()));
         }
 
-        self.hatch_config.validate()
+        self.phase_config.validate()
     }
 }
 

--- a/contracts/external/cw-abc/src/msg.rs
+++ b/contracts/external/cw-abc/src/msg.rs
@@ -1,68 +1,35 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Decimal, Uint128};
-use token_bindings::Metadata;
 
-use crate::curves::{decimal, Constant, Curve, DecimalPlaces, Linear, SquareRoot};
+use crate::abc::{CurveType, HatchConfig, ReserveToken, SupplyToken};
+use crate::ContractError;
 
 #[cw_serde]
 pub struct InstantiateMsg {
-    /// The denom to create
-    pub subdenom: String,
-    /// Metadata for the token to create
-    pub metadata: Metadata,
+    // Supply token information
+    pub supply: SupplyToken,
 
-    /// TODO maybe we don't need this
-    pub decimals: u8,
+    // Reserve token information
+    pub reserve: ReserveToken,
 
-    /// this is the reserve token denom (only support native for now)
-    pub reserve_denom: String,
-    /// number of decimal places for the reserve token, needed for proper curve math.
-    /// Same format as decimals above, eg. if it is uatom, where 1 unit is 10^-6 ATOM, use 6 here
-    pub reserve_decimals: u8,
-
-    /// enum to store the curve parameters used for this contract
-    /// if you want to add a custom Curve, you should make a new contract that imports this one.
-    /// write a custom `instantiate`, and then dispatch `your::execute` -> `cw20_bonding::do_execute`
-    /// with your custom curve as a parameter (and same with `query` -> `do_query`)
+    // Curve type for this contract
     pub curve_type: CurveType,
+
+    // Hatch configuration information
+    pub hatch_config: HatchConfig,
 }
 
-pub type CurveFn = Box<dyn Fn(DecimalPlaces) -> Box<dyn Curve>>;
-
-#[cw_serde]
-pub enum CurveType {
-    /// Constant always returns `value * 10^-scale` as spot price
-    Constant { value: Uint128, scale: u32 },
-    /// Linear returns `slope * 10^-scale * supply` as spot price
-    Linear { slope: Uint128, scale: u32 },
-    /// SquareRoot returns `slope * 10^-scale * supply^0.5` as spot price
-    SquareRoot { slope: Uint128, scale: u32 },
-}
-
-impl CurveType {
-    pub fn to_curve_fn(&self) -> CurveFn {
-        match self.clone() {
-            CurveType::Constant { value, scale } => {
-                let calc = move |places| -> Box<dyn Curve> {
-                    Box::new(Constant::new(decimal(value, scale), places))
-                };
-                Box::new(calc)
-            }
-            CurveType::Linear { slope, scale } => {
-                let calc = move |places| -> Box<dyn Curve> {
-                    Box::new(Linear::new(decimal(slope, scale), places))
-                };
-                Box::new(calc)
-            }
-            CurveType::SquareRoot { slope, scale } => {
-                let calc = move |places| -> Box<dyn Curve> {
-                    Box::new(SquareRoot::new(decimal(slope, scale), places))
-                };
-                Box::new(calc)
-            }
+impl InstantiateMsg {
+    /// Validate the instantiate message
+    pub fn validate(&self) -> Result<(), ContractError> {
+        if self.supply.subdenom.is_empty() {
+            return Err(ContractError::SupplyTokenError("Token subdenom must not be empty.".to_string()));
         }
+
+        self.hatch_config.validate()
     }
 }
+
 
 #[cw_serde]
 pub enum ExecuteMsg {

--- a/contracts/external/cw-abc/src/msg.rs
+++ b/contracts/external/cw-abc/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Decimal, Uint128};
+use cosmwasm_std::{Addr, Decimal, Uint128};
 
 use crate::abc::{CommonsPhaseConfig, CurveType, ReserveToken, SupplyToken};
 
@@ -33,8 +33,13 @@ pub enum ExecuteMsg {
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     /// Returns the reserve and supply quantities, as well as the spot price to buy 1 token
+    /// Returns [`CurveInfoResponse`]
     #[returns(CurveInfoResponse)]
     CurveInfo {},
+    /// Returns the current phase configuration
+    /// Returns [`CommonsPhaseConfigResponse`]
+    #[returns(CommonsPhaseConfigResponse)]
+    PhaseConfig {}
 }
 
 #[cw_serde]
@@ -53,5 +58,6 @@ pub struct CurveInfoResponse {
 
 #[cw_serde]
 pub struct CommonsPhaseConfigResponse {
-
+    // the phase configuration
+    pub phase_config: CommonsPhaseConfig<Addr>,
 }

--- a/contracts/external/cw-abc/src/msg.rs
+++ b/contracts/external/cw-abc/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Decimal, Uint128};
 
-use crate::abc::{CommonsPhaseConfig, CurveType, HatchConfig, ReserveToken, SupplyToken};
+use crate::abc::{CommonsPhaseConfig, CurveType, ReserveToken, SupplyToken};
 use crate::ContractError;
 
 #[cw_serde]
@@ -54,6 +54,10 @@ pub struct CurveInfoResponse {
     pub reserve: Uint128,
     // how many supply tokens have been issued
     pub supply: Uint128,
+    // the amount of tokens in the funding pool
+    pub funding: Uint128,
+    // current spot price of the token
     pub spot_price: Decimal,
+    // current reserve denom
     pub reserve_denom: String,
 }

--- a/contracts/external/cw-abc/src/msg.rs
+++ b/contracts/external/cw-abc/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Decimal, Uint128};
+use cosmwasm_std::{Addr, Decimal, Uint128, Decimal as StdDecimal};
 
-use crate::abc::{CommonsPhaseConfig, CurveType, ReserveToken, SupplyToken};
+use crate::abc::{CommonsPhaseConfig, CurveType, MinMax, ReserveToken, SupplyToken};
 
 
 #[cw_serde]
@@ -27,6 +27,17 @@ pub enum ExecuteMsg {
     Buy {},
     /// Implements CW20. Burn is a base message to destroy tokens forever
     Burn { amount: Uint128 },
+    /// Update the hatch phase allowlist
+    UpdateHatchAllowlist {
+        to_add: Vec<String>,
+        to_remove: Vec<String>,
+    },
+    /// Update the hatch phase configuration
+    /// This can only be called by the admin and only during the hatch phase
+    UpdateHatchConfig {
+        initial_raise: Option<MinMax>,
+        initial_allocation_ratio: Option<StdDecimal>,
+    },
 }
 
 #[cw_serde]

--- a/contracts/external/cw-abc/src/queries.rs
+++ b/contracts/external/cw-abc/src/queries.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{Deps, StdResult};
 use token_bindings::TokenFactoryQuery;
 use crate::abc::CurveFn;
-use crate::msg::CurveInfoResponse;
+use crate::msg::{CommonsPhaseConfigResponse, CurveInfoResponse};
 use crate::state::{CURVE_STATE, CurveState};
 
 /// Get the current state of the curve
@@ -27,6 +27,14 @@ pub fn query_curve_info(
         funding,
         spot_price,
         reserve_denom,
+    })
+}
+
+/// Load and return the phase config
+pub fn query_phase_config(deps: Deps<TokenFactoryQuery>) -> StdResult<CommonsPhaseConfigResponse> {
+    let phase_config = crate::state::PHASE_CONFIG.load(deps.storage)?;
+    Ok(CommonsPhaseConfigResponse {
+        phase_config
     })
 }
 

--- a/contracts/external/cw-abc/src/queries.rs
+++ b/contracts/external/cw-abc/src/queries.rs
@@ -1,0 +1,46 @@
+use cosmwasm_std::{Deps, StdResult};
+use token_bindings::TokenFactoryQuery;
+use crate::abc::CurveFn;
+use crate::msg::CurveInfoResponse;
+use crate::state::{CURVE_STATE, CurveState};
+
+/// Get the current state of the curve
+pub fn query_curve_info(
+    deps: Deps<TokenFactoryQuery>,
+    curve_fn: CurveFn,
+) -> StdResult<CurveInfoResponse> {
+    let CurveState {
+        reserve,
+        supply,
+        reserve_denom,
+        decimals,
+        funding,
+    } = CURVE_STATE.load(deps.storage)?;
+
+    // This we can get from the local digits stored in instantiate
+    let curve = curve_fn(decimals);
+    let spot_price = curve.spot_price(supply);
+
+    Ok(CurveInfoResponse {
+        reserve,
+        supply,
+        funding,
+        spot_price,
+        reserve_denom,
+    })
+}
+
+
+// // TODO, maybe we don't need this
+// pub fn get_denom(
+//     deps: Deps<TokenFactoryQuery>,
+//     creator_addr: String,
+//     subdenom: String,
+// ) -> GetDenomResponse {
+//     let querier = TokenQuerier::new(&deps.querier);
+//     let response = querier.full_denom(creator_addr, subdenom).unwrap();
+
+//     GetDenomResponse {
+//         denom: response.denom,
+//     }
+// }

--- a/contracts/external/cw-abc/src/queries.rs
+++ b/contracts/external/cw-abc/src/queries.rs
@@ -31,6 +31,7 @@ pub fn query_curve_info(
 }
 
 /// Load and return the phase config
+/// TODO: the allowlist will need to paged... should it be separate?
 pub fn query_phase_config(deps: Deps<TokenFactoryQuery>) -> StdResult<CommonsPhaseConfigResponse> {
     let phase_config = crate::state::PHASE_CONFIG.load(deps.storage)?;
     Ok(CommonsPhaseConfigResponse {

--- a/contracts/external/cw-abc/src/state.rs
+++ b/contracts/external/cw-abc/src/state.rs
@@ -1,8 +1,9 @@
+use std::collections::HashSet;
 use cosmwasm_schema::cw_serde;
 
-use cosmwasm_std::Uint128;
+use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::Item;
-use crate::abc::{CommonsPhase, CommonsPhaseConfig, CurveType};
+use crate::abc::{ CommonsPhaseConfig, CurveType, CommonsPhase};
 
 use crate::curves::DecimalPlaces;
 
@@ -11,6 +12,8 @@ use crate::curves::DecimalPlaces;
 pub struct CurveState {
     /// reserve is how many native tokens exist bonded to the validator
     pub reserve: Uint128,
+    /// funding is how many native tokens exist unbonded and in the contract
+    pub funding: Uint128,
     /// supply is how many tokens this contract has issued
     pub supply: Uint128,
 
@@ -25,6 +28,7 @@ impl CurveState {
     pub fn new(reserve_denom: String, decimals: DecimalPlaces) -> Self {
         CurveState {
             reserve: Uint128::zero(),
+            funding: Uint128::zero(),
             supply: Uint128::zero(),
             reserve_denom,
             decimals,
@@ -39,8 +43,12 @@ pub const CURVE_TYPE: Item<CurveType> = Item::new("curve_type");
 /// The denom used for the supply token
 pub const SUPPLY_DENOM: Item<String> = Item::new("denom");
 
+/// Keep track of who has contributed to the hatch phase
+pub static HATCHERS: Item<HashSet<Addr>> = Item::new("hatchers");
+
 /// The phase configuration of the Augmented Bonding Curve
 pub static PHASE_CONFIG: Item<CommonsPhaseConfig> = Item::new("phase_config");
 
-/// The phase of the Augmented Bonding Curve
+/// The phase state of the Augmented Bonding Curve
 pub static PHASE: Item<CommonsPhase> = Item::new("phase");
+

--- a/contracts/external/cw-abc/src/state.rs
+++ b/contracts/external/cw-abc/src/state.rs
@@ -47,7 +47,7 @@ pub const SUPPLY_DENOM: Item<String> = Item::new("denom");
 pub static HATCHERS: Item<HashSet<Addr>> = Item::new("hatchers");
 
 /// The phase configuration of the Augmented Bonding Curve
-pub static PHASE_CONFIG: Item<CommonsPhaseConfig> = Item::new("phase_config");
+pub static PHASE_CONFIG: Item<CommonsPhaseConfig<Addr>> = Item::new("phase_config");
 
 /// The phase state of the Augmented Bonding Curve
 pub static PHASE: Item<CommonsPhase> = Item::new("phase");

--- a/contracts/external/cw-abc/src/state.rs
+++ b/contracts/external/cw-abc/src/state.rs
@@ -2,7 +2,7 @@ use cosmwasm_schema::cw_serde;
 
 use cosmwasm_std::Uint128;
 use cw_storage_plus::Item;
-use crate::abc::{CommonsPhase, CurveType};
+use crate::abc::{CommonsPhase, CommonsPhaseConfig, CurveType};
 
 use crate::curves::DecimalPlaces;
 
@@ -38,6 +38,9 @@ pub const CURVE_TYPE: Item<CurveType> = Item::new("curve_type");
 
 /// The denom used for the supply token
 pub const SUPPLY_DENOM: Item<String> = Item::new("denom");
+
+/// The phase configuration of the Augmented Bonding Curve
+pub static PHASE_CONFIG: Item<CommonsPhaseConfig> = Item::new("phase_config");
 
 /// The phase of the Augmented Bonding Curve
 pub static PHASE: Item<CommonsPhase> = Item::new("phase");

--- a/contracts/external/cw-abc/src/state.rs
+++ b/contracts/external/cw-abc/src/state.rs
@@ -44,6 +44,7 @@ pub const CURVE_TYPE: Item<CurveType> = Item::new("curve_type");
 pub const SUPPLY_DENOM: Item<String> = Item::new("denom");
 
 /// Keep track of who has contributed to the hatch phase
+/// TODO: cw-set?
 pub static HATCHERS: Item<HashSet<Addr>> = Item::new("hatchers");
 
 /// The phase configuration of the Augmented Bonding Curve

--- a/contracts/external/cw-abc/src/state.rs
+++ b/contracts/external/cw-abc/src/state.rs
@@ -2,9 +2,9 @@ use cosmwasm_schema::cw_serde;
 
 use cosmwasm_std::Uint128;
 use cw_storage_plus::Item;
+use crate::abc::{CommonsPhase, CurveType};
 
 use crate::curves::DecimalPlaces;
-use crate::msg::CurveType;
 
 /// Supply is dynamic and tracks the current supply of staked and ERC20 tokens.
 #[cw_serde]
@@ -36,4 +36,8 @@ pub const CURVE_STATE: Item<CurveState> = Item::new("curve_state");
 
 pub const CURVE_TYPE: Item<CurveType> = Item::new("curve_type");
 
-pub const DENOM: Item<String> = Item::new("denom");
+/// The denom used for the supply token
+pub const SUPPLY_DENOM: Item<String> = Item::new("denom");
+
+/// The phase of the Augmented Bonding Curve
+pub static PHASE: Item<CommonsPhase> = Item::new("phase");


### PR DESCRIPTION
This change does the following:
- initial phase configuration setup for cw-abc
 - phase configurations and current phase stored in state
 - Hatch phase has an allowlist
 - Basic phase queries
- cw-ownable integration
- Move queries & commands to `queries` and `commands` respectively
- Addition of `funding` pool to the curve state

There are TODOs where functionality is still missing. The burn mechanism was left untouched.


Questions: 
1) Do we want to have a `PreHatch` phase where the configuration can be changed freely? Hatch configuration for the `initialPrice` should NOT be changed after the phase has begun, though the `min` and `max` `initialRaise` should be able to be changed (like in traditional fundraising)
2) Do we want to separate the phase configurations into their own states so that there's not unnecessary loading of state? 
3) Closed phase? Necessary? 
4) Testing - BOOT will be updated to work with custom messages shortly, so should be able to integrate soon.