### PR TITLE
cw-abc: Updated hatch phase mechanics, donations, queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 [[package]]
 name = "boot-core"
 version = "0.10.0"
-source = "git+https://github.com/Abstract-OS/BOOT?branch=fix/custom_binding_contract_wrapper#7a0c9f67ce1dfaf11aba7b1ac48e08e66fb3db0c"
+source = "git+https://github.com/AbstractSDK/BOOT?branch=fix/custom_binding_contract_wrapper#7a0c9f67ce1dfaf11aba7b1ac48e08e66fb3db0c"
 dependencies = [
  "anyhow",
  "base16",
@@ -5262,13 +5262,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,10 +14,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.20"
+name = "ahash"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -42,9 +53,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-stream"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad445822218ce64be7a341abfb0b1ea43b5c23aa83902542a4542e78309d8e5e"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -53,24 +64,24 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4655ae1a7b0cdf149156f780c5bf3f1352bc53cbd9e0a361a7ef7b22947e965"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.67"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.5",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -92,9 +103,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.12"
+version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f8ccfd9221ee7d1f3d4b33e1f8319b3a81ed8f61f2ea40b37b859794b4491"
+checksum = "113713495a32dd0ab52baf5c10044725aa3aec00b31beda84218e469029b72a3"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -120,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -225,7 +236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive",
- "hashbrown",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -274,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
 name = "bytecheck"
@@ -364,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cosm-orc"
@@ -406,7 +417,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673d31bd830c0772d78545de20d975129b6ab2f7db4e4e9313c3b8777d319194"
 dependencies = [
- "prost 0.11.8",
+ "prost 0.11.9",
  "prost-types",
  "tendermint-proto 0.26.0",
  "tonic",
@@ -418,7 +429,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4776e787b24d9568dd61d3237eeb4eb321d622fb881b858c7b82806420e87d4"
 dependencies = [
- "prost 0.11.8",
+ "prost 0.11.9",
  "prost-types",
  "tendermint-proto 0.27.0",
  "tonic",
@@ -447,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22add0f9b2a5416df98c1d0248a8d8eedb882c38fbf0c5052b64eebe865df6d"
+checksum = "b76d2207945b8aa3ce0735da53ab9a74f75fe3e7794754c216a9edfa04e1e627"
 dependencies = [
  "digest 0.10.6",
  "ed25519-zebra",
@@ -460,18 +471,18 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e64f710a18ef90d0a632cf27842e98ffc2d005a38a6f76c12fd0bc03bc1a2d"
+checksum = "1dd07af7736164d2d8126dc67fdb33b1b5c54fb5a3190395c47f46d24fc6d592"
 dependencies = [
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5ad2e23a971b9e4cd57b20cee3e2e79c33799bed4b128e473aca3702bfe5dd"
+checksum = "3e9e92cdce475a91659d0dc4d17836a484fc534e80e787281aa4adde4cb1798b"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -482,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2926d159a9bb1a716a592b40280f1663f2491a9de3b6da77c0933cee2a2655b8"
+checksum = "69681bac3dbeb0b00990279e3ed39e3d4406b29f538b16b712f6771322a45048"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -493,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76fee88ff5bf7bef55bd37ac0619974701b99bf6bd4b16cf56ee8810718abd71"
+checksum = "8d39f20967baeb94709123f7bba13a25ae2fa166bc5e7813f734914df3f8f6a1"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -513,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639bc36408bc1ac45e3323166ceeb8f0b91b55a941c4ad59d389829002fbbd94"
+checksum = "88f7944b5204c3a998f73248925a097ace887bdf01c2f70de00d8b92cd69e807"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -523,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -588,6 +599,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-address-like",
  "cw-ownable",
+ "cw-paginate 2.1.0",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
@@ -2024,7 +2036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c24f403d068ad0b359e577a77f92392118be3f3c927538f2bb544a5ecd828c6"
 dependencies = [
  "curve25519-dalek",
- "hashbrown",
+ "hashbrown 0.12.3",
  "hex",
  "rand_core 0.6.4",
  "serde",
@@ -2133,9 +2145,9 @@ checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
 name = "futures"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2148,9 +2160,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2158,15 +2170,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2175,38 +2187,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2222,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -2232,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2256,9 +2268,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",
@@ -2279,7 +2291,16 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
 ]
 
 [[package]]
@@ -2382,9 +2403,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2483,12 +2504,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2606,9 +2627,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "linked-hash-map"
@@ -2793,7 +2814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2852,9 +2873,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbd939b234e95d72bc393d51788aec68aeeb5d51e748ca08ff3aad58cb722f7"
+checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2862,9 +2883,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a81186863f3d0a27340815be8f2078dd8050b14cd71913db9fbda795e5f707d7"
+checksum = "be99c4c1d2fc2769b1d00239431d711d08f6efedcecb8b6e30707160aee99c15"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2872,22 +2893,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a1ef20bf3193c15ac345acb32e26b3dc3223aff4d77ae4fc5359567683796b"
+checksum = "e56094789873daa36164de2e822b3888c6ae4b4f9da555a1103587658c805b1e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3b284b1f13a20dc5ebc90aff59a51b8d7137c221131b52a7260c08cbc1cc80"
+checksum = "6733073c7cff3d8459fda0e42f13a047870242aed8b509fe98000928975f359e"
 dependencies = [
  "once_cell",
  "pest",
@@ -2953,9 +2974,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -2983,12 +3004,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
- "prost-derive 0.11.8",
+ "prost-derive 0.11.9",
 ]
 
 [[package]]
@@ -3006,9 +3027,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -3019,11 +3040,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost 0.11.8",
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -3093,9 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.2"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3104,9 +3125,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "rend"
@@ -3170,7 +3191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21499ed91807f07ae081880aabb2ccc0235e9d88011867d984525e9a4c3cfa3e"
 dependencies = [
  "bytecheck",
- "hashbrown",
+ "hashbrown 0.12.3",
  "ptr_meta",
  "rend",
  "rkyv_derive",
@@ -3367,18 +3388,18 @@ checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
-version = "1.0.158"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15bee9b04dd165c3f4e142628982ddde884c2022a89e8ddf99c4829bf2c3a58"
+checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
 dependencies = [
  "serde",
 ]
@@ -3394,13 +3415,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.158"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.5",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -3416,9 +3437,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -3433,14 +3454,14 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.5",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.19"
+version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82e6c8c047aa50a7328632d067bcae6ef38772a79e28daf32f735e0e4f3dd10"
+checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3486,9 +3507,9 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
+checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
 dependencies = [
  "digest 0.10.6",
  "keccak",
@@ -3643,9 +3664,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.5"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c2d1c76a26822187a1fbb5964e3fff108bc208f02e820ab9dac1234f6b388a"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3657,18 +3678,6 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
 
 [[package]]
 name = "tendermint"
@@ -3685,7 +3694,7 @@ dependencies = [
  "k256",
  "num-traits",
  "once_cell",
- "prost 0.11.8",
+ "prost 0.11.9",
  "prost-types",
  "ripemd160",
  "serde",
@@ -3725,7 +3734,7 @@ dependencies = [
  "flex-error",
  "num-derive",
  "num-traits",
- "prost 0.11.8",
+ "prost 0.11.9",
  "prost-types",
  "serde",
  "serde_bytes",
@@ -3743,7 +3752,7 @@ dependencies = [
  "flex-error",
  "num-derive",
  "num-traits",
- "prost 0.11.8",
+ "prost 0.11.9",
  "prost-types",
  "serde",
  "serde_bytes",
@@ -3832,7 +3841,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.5",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -3889,14 +3898,13 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "pin-project-lite",
@@ -3917,13 +3925,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -3991,8 +3999,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.11.8",
- "prost-derive 0.11.8",
+ "prost 0.11.9",
+ "prost-derive 0.11.9",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4129,16 +4137,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
 name = "unsafe-libyaml"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2024452afd3874bf539695e04af6732ba06517424dbf958fdb16a01f3bef6c"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
 name = "untrusted"
@@ -4435,21 +4437,20 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.3"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "synstructure",
+ "syn 2.0.15",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 [[package]]
 name = "boot-core"
 version = "0.10.0"
-source = "git+https://github.com/Abstract-OS/BOOT?branch=fix/custom_binding_contract_wrapper#2c1d9806a9782ece8f14107efa886eab12a1abdc"
+source = "git+https://github.com/Abstract-OS/BOOT?branch=fix/custom_binding_contract_wrapper#7a0c9f67ce1dfaf11aba7b1ac48e08e66fb3db0c"
 dependencies = [
  "anyhow",
  "base16",
@@ -807,9 +807,11 @@ dependencies = [
 name = "cw-abc"
 version = "0.0.1"
 dependencies = [
+ "anyhow",
  "boot-core",
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-abc",
  "cw-address-like",
  "cw-ownable",
  "cw-paginate 2.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.9",
  "once_cell",
  "version_check",
 ]
@@ -31,6 +31,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -82,6 +91,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
+]
+
+[[package]]
+name = "async-tungstenite"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0388bb7a400072bbb41ceb75d65c3baefb2ea99672fa22e85278452cd9b58b"
+dependencies = [
+ "futures-io",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "rustls-native-certs 0.6.2",
+ "tokio",
+ "tokio-rustls 0.23.4",
+ "tungstenite",
 ]
 
 [[package]]
@@ -147,6 +172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
+
+[[package]]
 name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,10 +190,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bip32"
@@ -180,6 +223,34 @@ dependencies = [
  "sha2 0.10.6",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b36f4c848f6bd9ff208128f08751135846cc23ae57d66ab10a22efff1c675f3c"
+dependencies = [
+ "bech32",
+ "bitcoin-private",
+ "bitcoin_hashes",
+ "hex_lit",
+ "secp256k1",
+]
+
+[[package]]
+name = "bitcoin-private"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
 ]
 
 [[package]]
@@ -204,6 +275,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "boot-contract-derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d5010efb5d2f121985dca0aa92acd3fce48bcdfc99f6b11a0464e8aeaf717d"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "boot-core"
+version = "0.10.0"
+source = "git+https://github.com/Abstract-OS/BOOT?branch=fix/custom_binding_contract_wrapper#2c1d9806a9782ece8f14107efa886eab12a1abdc"
+dependencies = [
+ "anyhow",
+ "base16",
+ "base64 0.21.0",
+ "bitcoin",
+ "boot-contract-derive",
+ "boot-fns-derive",
+ "chrono",
+ "cosmrs 0.12.0",
+ "cosmwasm-std",
+ "cw-multi-test 0.16.4",
+ "derive_builder",
+ "ed25519-dalek",
+ "eyre",
+ "hex",
+ "hkd32",
+ "ibc-chain-registry",
+ "ibc-relayer-types",
+ "log",
+ "prost 0.11.9",
+ "rand_core 0.6.4",
+ "reqwest",
+ "ring",
+ "ripemd",
+ "schemars",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "sha256",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "boot-fns-derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d393ab931ab528220197c7fe9bfc361f0a0459743d4dd49211cec86ee1d70232"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -339,6 +470,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "time 0.1.45",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "config"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +518,15 @@ name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -402,7 +567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "596064e3608349aa302eb68b2df8ed3a66bbb51d9b470dbd9afff70843e44642"
 dependencies = [
  "async-trait",
- "cosmrs",
+ "cosmrs 0.10.0",
  "regex",
  "schemars",
  "serde",
@@ -436,6 +601,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmos-sdk-proto"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade369159e0256ae10c6fb5f16decc37129d6b2416710456185daacfa65bdfae"
+dependencies = [
+ "prost 0.11.9",
+ "prost-types",
+ "tendermint-proto 0.30.0",
+ "tonic",
+]
+
+[[package]]
 name = "cosmrs"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,15 +622,37 @@ dependencies = [
  "cosmos-sdk-proto 0.15.0",
  "ecdsa",
  "eyre",
- "getrandom",
+ "getrandom 0.2.9",
  "k256",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
  "subtle-encoding",
- "tendermint",
- "tendermint-rpc",
+ "tendermint 0.26.0",
+ "tendermint-rpc 0.26.0",
  "thiserror",
+]
+
+[[package]]
+name = "cosmrs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "466426988551efa4cce46bac51ce6b6e047ea7b76086ac5e47bffad90a3c093e"
+dependencies = [
+ "bip32",
+ "cosmos-sdk-proto 0.17.0",
+ "ecdsa",
+ "eyre",
+ "getrandom 0.2.9",
+ "k256",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "subtle-encoding",
+ "tendermint 0.30.0",
+ "tendermint-rpc 0.30.0",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -508,7 +707,7 @@ version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d39f20967baeb94709123f7bba13a25ae2fa166bc5e7813f734914df3f8f6a1"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "derivative",
@@ -575,7 +774,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
 dependencies = [
- "sct",
+ "sct 0.6.1",
 ]
 
 [[package]]
@@ -592,9 +791,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.6.4",
+ "subtle-ng",
+ "zeroize",
+]
+
+[[package]]
 name = "cw-abc"
 version = "0.0.1"
 dependencies = [
+ "boot-core",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-address-like",
@@ -627,7 +840,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
@@ -728,7 +941,7 @@ version = "2.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw20 0.16.0",
  "cw20-base 0.16.0",
  "thiserror",
@@ -740,7 +953,7 @@ version = "0.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-paginate 2.1.0",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
@@ -768,6 +981,25 @@ dependencies = [
 name = "cw-multi-test"
 version = "0.16.2"
 source = "git+https://github.com/CosmWasm/cw-multi-test?rev=9af32fd42efcf28e9a79987f2c2036f879cd5331#9af32fd42efcf28e9a79987f2c2036f879cd5331"
+dependencies = [
+ "anyhow",
+ "cosmwasm-std",
+ "cw-storage-plus 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-utils 1.0.1",
+ "derivative",
+ "itertools",
+ "k256",
+ "prost 0.9.0",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw-multi-test"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a18afd2e201221c6d72a57f0886ef2a22151bbc9e6db7af276fde8a91081042"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -825,7 +1057,7 @@ version = "2.1.0"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "serde",
 ]
@@ -837,7 +1069,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-denom",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-ownable",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
@@ -942,7 +1174,7 @@ version = "2.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
@@ -1013,7 +1245,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-denom",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-ownable",
  "cw-paginate 2.1.0",
  "cw-stake-tracker",
@@ -1203,7 +1435,7 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-controllers 0.16.0",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-ownable",
  "cw-paginate 2.1.0",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
@@ -1225,7 +1457,7 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-controllers 0.16.0",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-ownable",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
@@ -1244,7 +1476,7 @@ version = "2.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-ownable",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
@@ -1434,13 +1666,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "cxx"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "dao-core"
 version = "2.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-core",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-paginate 2.1.0",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
@@ -1490,7 +1766,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-core",
  "cw-core-interface",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-proposal-single",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.13.4",
@@ -1522,7 +1798,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-denom",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-paginate 2.1.0",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
@@ -1549,7 +1825,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-denom",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
@@ -1576,7 +1852,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-denom",
  "cw-hooks",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
@@ -1594,7 +1870,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-denom",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
@@ -1619,7 +1895,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-denom",
  "cw-hooks",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
@@ -1643,7 +1919,7 @@ dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
@@ -1665,7 +1941,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-hooks",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
@@ -1700,7 +1976,7 @@ dependencies = [
  "cosmwasm-storage",
  "cw-denom",
  "cw-hooks",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
@@ -1725,7 +2001,7 @@ dependencies = [
  "dao-voting-cw4",
  "dao-voting-cw721-staked",
  "dao-voting-native-staked",
- "rand",
+ "rand 0.8.5",
  "thiserror",
  "voting",
 ]
@@ -1740,7 +2016,7 @@ dependencies = [
  "cw-core",
  "cw-denom",
  "cw-hooks",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-proposal-single",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.13.4",
@@ -1778,7 +2054,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw2 0.16.0",
  "dao-interface",
@@ -1794,7 +2070,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-core",
  "cw-hooks",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-proposal-single",
  "cw-utils 0.16.0",
  "cw-vesting",
@@ -1817,7 +2093,7 @@ dependencies = [
  "dao-voting-cw4",
  "dao-voting-cw721-staked",
  "dao-voting-native-staked",
- "rand",
+ "rand 0.8.5",
  "stake-cw20",
  "voting",
 ]
@@ -1854,7 +2130,7 @@ version = "2.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
@@ -1872,7 +2148,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
@@ -1891,7 +2167,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
  "cw2 0.16.0",
@@ -1910,7 +2186,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 0.16.0",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-paginate 2.1.0",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
@@ -1933,7 +2209,7 @@ dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-controllers 0.16.0",
- "cw-multi-test",
+ "cw-multi-test 0.16.2",
  "cw-paginate 2.1.0",
  "cw-storage-plus 1.0.1 (git+https://github.com/CosmWasm/cw-storage-plus?rev=6db957ce730a95141a3ab4dc5ab76fb38e8c0c42)",
  "cw-utils 0.16.0",
@@ -1941,6 +2217,41 @@ dependencies = [
  "dao-interface",
  "dao-macros",
  "thiserror",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1958,6 +2269,48 @@ name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2014,7 +2367,21 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
+ "serde",
  "signature",
+]
+
+[[package]]
+name = "ed25519-consensus"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
+dependencies = [
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core 0.6.4",
+ "sha2 0.9.9",
+ "zeroize",
 ]
 
 [[package]]
@@ -2025,6 +2392,9 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "rand 0.7.3",
+ "serde",
+ "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -2071,6 +2441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,6 +2472,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,6 +2503,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,6 +2519,15 @@ checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "static_assertions",
 ]
 
 [[package]]
@@ -2127,6 +2545,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2244,6 +2677,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
@@ -2251,7 +2695,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2309,7 +2753,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "headers-core",
@@ -2347,10 +2791,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "hkd32"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e013a4f0b8772418eee1fc462e74017aba13c364a7b61bd3df1ddcbfe47b065"
+dependencies = [
+ "hmac",
+ "once_cell",
+ "pbkdf2",
+ "rand_core 0.6.4",
+ "sha2 0.10.6",
+ "subtle-encoding",
+ "zeroize",
+]
 
 [[package]]
 name = "hmac"
@@ -2436,12 +2907,12 @@ dependencies = [
  "headers",
  "http",
  "hyper",
- "hyper-rustls",
- "rustls-native-certs",
+ "hyper-rustls 0.22.1",
+ "rustls-native-certs 0.5.0",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.22.0",
  "tower-service",
- "webpki",
+ "webpki 0.21.4",
 ]
 
 [[package]]
@@ -2454,12 +2925,25 @@ dependencies = [
  "futures-util",
  "hyper",
  "log",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.19.1",
+ "rustls-native-certs 0.5.0",
  "tokio",
- "tokio-rustls",
- "webpki",
- "webpki-roots",
+ "tokio-rustls 0.22.0",
+ "webpki 0.21.4",
+ "webpki-roots 0.21.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls 0.20.8",
+ "tokio",
+ "tokio-rustls 0.23.4",
 ]
 
 [[package]]
@@ -2475,6 +2959,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
+name = "ibc-chain-registry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c61ec20f3a311c7e7088f5726c1101d105523f04ef50561df0b5742d18b259"
+dependencies = [
+ "async-trait",
+ "flex-error",
+ "futures",
+ "http",
+ "ibc-proto",
+ "ibc-relayer-types",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tendermint-rpc 0.30.0",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "ibc-proto"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a2d356a360473d212dd20779b11ce858e35ac5509c7e1953002fa247780759"
+dependencies = [
+ "base64 0.13.1",
+ "bytes",
+ "flex-error",
+ "prost 0.11.9",
+ "serde",
+ "subtle-encoding",
+ "tendermint-proto 0.30.0",
+ "tonic",
+]
+
+[[package]]
+name = "ibc-relayer-types"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05064fd47044b1de6e6dbf18389dbbb460664ce8d9f1ab1067e1fb5eb163854c"
+dependencies = [
+ "bytes",
+ "derive_more",
+ "dyn-clone",
+ "erased-serde",
+ "flex-error",
+ "ibc-proto",
+ "ics23",
+ "itertools",
+ "num-rational",
+ "primitive-types",
+ "prost 0.11.9",
+ "safe-regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "subtle-encoding",
+ "tendermint 0.30.0",
+ "tendermint-light-client-verifier",
+ "tendermint-proto 0.30.0",
+ "time 0.3.20",
+ "uint",
+]
+
+[[package]]
+name = "ics23"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca44b684ce1859cff746ff46f5765ab72e12e3c06f76a8356db8f9a2ecf43f17"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "hex",
+ "prost 0.11.9",
+ "ripemd",
+ "sha2 0.10.6",
+ "sha3",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2482,6 +3089,15 @@ checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2510,6 +3126,15 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2556,11 +3181,28 @@ dependencies = [
  "dao-voting-cw721-staked",
  "env_logger",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "test-context",
 ]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "itertools"
@@ -2632,10 +3274,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
+
+[[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -2678,8 +3345,26 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2802,10 +3487,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl"
+version = "0.10.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ea2d98598bf9ada7ea6ee8a30fb74f9156b63bbe495d64ec2b87c269d2dda3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "992bac49bdbab4423199c654a5515bd2a6c6a23bf03f2dd3bdb7e5ae6259bc69"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-multimap"
@@ -2815,6 +3538,29 @@ checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2958,10 +3704,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "primitive-types"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
+dependencies = [
+ "fixed-hash",
+ "impl-serde",
+ "uint",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -3078,13 +3841,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3102,6 +3888,9 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
+]
 
 [[package]]
 name = "rand_core"
@@ -3109,7 +3898,34 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.9",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -3136,6 +3952,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581008d2099240d37fb08d77ad713bcaec2c4d89d50b5b21a8bb1996bbab68ab"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+dependencies = [
+ "base64 0.21.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls 0.23.2",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.20.8",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-rustls 0.23.4",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.22.6",
+ "winreg",
 ]
 
 [[package]]
@@ -3215,7 +4073,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags",
  "serde",
 ]
@@ -3242,10 +4100,24 @@ dependencies = [
  "byteorder",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3254,11 +4126,23 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "log",
  "ring",
- "sct",
- "webpki",
+ "sct 0.6.1",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct 0.7.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -3268,9 +4152,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
 dependencies = [
  "openssl-probe",
- "rustls",
+ "rustls 0.19.1",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -3284,6 +4189,53 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "safe-proc-macro2"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "814c536dcd27acf03296c618dab7ad62d28e70abd7ba41d3f34a2ce707a2c666"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "safe-quote"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e530f7831f3feafcd5f1aae406ac205dd998436b4007c8e80f03eca78a88f7"
+dependencies = [
+ "safe-proc-macro2",
+]
+
+[[package]]
+name = "safe-regex"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15289bf322e0673d52756a18194167f2378ec1a15fe884af6e2d2cb934822b0"
+dependencies = [
+ "safe-regex-macro",
+]
+
+[[package]]
+name = "safe-regex-compiler"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba76fae590a2aa665279deb1f57b5098cbace01a0c5e60e262fcf55f7c51542"
+dependencies = [
+ "safe-proc-macro2",
+ "safe-quote",
+]
+
+[[package]]
+name = "safe-regex-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c2e96b5c03f158d1b16ba79af515137795f4ad4e8de3f790518aae91f1d127"
+dependencies = [
+ "safe-proc-macro2",
+ "safe-regex-compiler",
+]
 
 [[package]]
 name = "same-file"
@@ -3328,10 +4280,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scratch"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+
+[[package]]
 name = "sct"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -3355,6 +4329,25 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+dependencies = [
+ "bitcoin_hashes",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3458,6 +4451,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3506,6 +4511,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha256"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f8b5de2bac3a4ae28e9b611072a8e326d9b26c8189c0972d4c321fa684f1f"
+dependencies = [
+ "hex",
+ "sha2 0.10.6",
+]
+
+[[package]]
 name = "sha3"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3513,6 +4528,15 @@ checksum = "54c2bb1a323307527314a36bfb73f24febb08ce2b8a554bf4ffd6f51ad15198c"
 dependencies = [
  "digest 0.10.6",
  "keccak",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3539,6 +4563,12 @@ checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
@@ -3637,6 +4667,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3650,6 +4686,12 @@ checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
@@ -3680,6 +4722,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "tendermint"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3706,7 +4761,38 @@ dependencies = [
  "subtle",
  "subtle-encoding",
  "tendermint-proto 0.26.0",
- "time",
+ "time 0.3.20",
+ "zeroize",
+]
+
+[[package]]
+name = "tendermint"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90c3c1e32352551f0f1639ce765e4c66ce250c733d4b9ba1aff81130437465c"
+dependencies = [
+ "bytes",
+ "digest 0.10.6",
+ "ed25519",
+ "ed25519-consensus",
+ "flex-error",
+ "futures",
+ "k256",
+ "num-traits",
+ "once_cell",
+ "prost 0.11.9",
+ "prost-types",
+ "ripemd",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2 0.10.6",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto 0.30.0",
+ "time 0.3.20",
  "zeroize",
 ]
 
@@ -3719,9 +4805,36 @@ dependencies = [
  "flex-error",
  "serde",
  "serde_json",
- "tendermint",
+ "tendermint 0.26.0",
  "toml",
  "url",
+]
+
+[[package]]
+name = "tendermint-config"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74efd33bcb53413b77cbe90ccb2cf0403930a5c1f300725deb87a61f7c4fab90"
+dependencies = [
+ "flex-error",
+ "serde",
+ "serde_json",
+ "tendermint 0.30.0",
+ "toml",
+ "url",
+]
+
+[[package]]
+name = "tendermint-light-client-verifier"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36e9193521a81e4c824faedc5eb31926f8918ebb21a1fa9cee9b3dbe5164a93"
+dependencies = [
+ "derive_more",
+ "flex-error",
+ "serde",
+ "tendermint 0.30.0",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -3739,7 +4852,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "subtle-encoding",
- "time",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -3757,7 +4870,25 @@ dependencies = [
  "serde",
  "serde_bytes",
  "subtle-encoding",
- "time",
+ "time 0.3.20",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e553ed65874c3f35a71eb60d255edfea956274b5af37a0297d54bba039fe45e3"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "num-derive",
+ "num-traits",
+ "prost 0.11.9",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -3770,11 +4901,11 @@ dependencies = [
  "bytes",
  "flex-error",
  "futures",
- "getrandom",
+ "getrandom 0.2.9",
  "http",
  "hyper",
  "hyper-proxy",
- "hyper-rustls",
+ "hyper-rustls 0.22.1",
  "peg",
  "pin-project",
  "serde",
@@ -3782,11 +4913,46 @@ dependencies = [
  "serde_json",
  "subtle",
  "subtle-encoding",
- "tendermint",
- "tendermint-config",
+ "tendermint 0.26.0",
+ "tendermint-config 0.26.0",
  "tendermint-proto 0.26.0",
  "thiserror",
- "time",
+ "time 0.3.20",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
+name = "tendermint-rpc"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d79bd426571d6a805be5c0b6749707ede6c6ee5e55dd45baef46857a1baa9f54"
+dependencies = [
+ "async-trait",
+ "async-tungstenite",
+ "bytes",
+ "flex-error",
+ "futures",
+ "getrandom 0.2.9",
+ "http",
+ "hyper",
+ "hyper-proxy",
+ "hyper-rustls 0.22.1",
+ "peg",
+ "pin-project",
+ "semver",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "subtle",
+ "subtle-encoding",
+ "tendermint 0.30.0",
+ "tendermint-config 0.30.0",
+ "thiserror",
+ "time 0.3.20",
  "tokio",
  "tracing",
  "url",
@@ -3842,6 +5008,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -3907,7 +5084,9 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.45.0",
@@ -3935,14 +5114,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "rustls",
+ "rustls 0.19.1",
  "tokio",
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls 0.20.8",
+ "tokio",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -3988,7 +5188,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4001,7 +5201,10 @@ dependencies = [
  "pin-project",
  "prost 0.11.9",
  "prost-derive 0.11.9",
+ "rustls-native-certs 0.6.2",
+ "rustls-pemfile",
  "tokio",
+ "tokio-rustls 0.23.4",
  "tokio-stream",
  "tokio-util",
  "tower",
@@ -4022,7 +5225,7 @@ dependencies = [
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -4092,6 +5295,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "tungstenite"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "rustls 0.20.8",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+ "webpki 0.22.0",
+]
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4137,6 +5361,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4160,10 +5402,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -4215,6 +5469,18 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -4242,6 +5508,18 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -4294,12 +5572,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
- "webpki",
+ "webpki 0.21.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -4334,18 +5631,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4354,7 +5660,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -4363,13 +5678,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -4379,10 +5709,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4391,10 +5733,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4403,16 +5757,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "wynd-utils"

--- a/contracts/external/cw-abc/Cargo.toml
+++ b/contracts/external/cw-abc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cw-abc"
 version = "0.0.1"
-authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>", "Jake Hartnell"]
+authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>", "Jake Hartnell", "Adair <adairrr@users.noreply.github.com>"]
 edition = { workspace = true }
 description = "Implements an Augmented Bonding Curve"
 license = "Apache-2.0"

--- a/contracts/external/cw-abc/Cargo.toml
+++ b/contracts/external/cw-abc/Cargo.toml
@@ -30,6 +30,7 @@ integer-cbrt = "0.1.2"
 token-bindings = { git = "https://github.com/CosmosContracts/token-bindings", rev = "1412b94" }
 cw-address-like = "1.0.4"
 cw-ownable = { workspace = true }
+cw-paginate = { workspace = true }
 
 [dev-dependencies]
 speculoos = "0.11.0"

--- a/contracts/external/cw-abc/Cargo.toml
+++ b/contracts/external/cw-abc/Cargo.toml
@@ -36,3 +36,20 @@ boot-core = { version = "0.10.0", optional = true, git = "https://github.com/Abs
 
 [dev-dependencies]
 speculoos = "0.11.0"
+#cw-multi-test = { version = "0.16.0" }
+anyhow = { workspace = true }
+cw-abc = { path = ".", features = ["boot"] }
+
+
+
+
+[profile.release]
+rpath = false
+lto = true
+overflow-checks = true
+opt-level = 3
+debug = false
+debug-assertions = false
+codegen-units = 1
+panic = 'abort'
+incremental = false

--- a/contracts/external/cw-abc/Cargo.toml
+++ b/contracts/external/cw-abc/Cargo.toml
@@ -32,7 +32,7 @@ token-bindings = { git = "https://github.com/CosmosContracts/token-bindings", re
 cw-address-like = "1.0.4"
 cw-ownable = { workspace = true }
 cw-paginate = { workspace = true }
-boot-core = { version = "0.10.0", optional = true, git = "https://github.com/Abstract-OS/BOOT", branch = "fix/custom_binding_contract_wrapper" }
+boot-core = { version = "0.10.0", optional = true, git = "https://github.com/AbstractSDK/BOOT", branch = "fix/custom_binding_contract_wrapper" }
 
 [dev-dependencies]
 speculoos = "0.11.0"

--- a/contracts/external/cw-abc/Cargo.toml
+++ b/contracts/external/cw-abc/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
+boot = ["dep:boot-core"]
 
 [dependencies]
 cw-utils = { workspace = true }
@@ -31,6 +32,7 @@ token-bindings = { git = "https://github.com/CosmosContracts/token-bindings", re
 cw-address-like = "1.0.4"
 cw-ownable = { workspace = true }
 cw-paginate = { workspace = true }
+boot-core = { version = "0.10.0", optional = true, git = "https://github.com/Abstract-OS/BOOT", branch = "fix/custom_binding_contract_wrapper" }
 
 [dev-dependencies]
 speculoos = "0.11.0"

--- a/contracts/external/cw-abc/src/abc.rs
+++ b/contracts/external/cw-abc/src/abc.rs
@@ -64,10 +64,19 @@ impl HatchConfig {
             )
         );
 
+        // TODO: define better values
         ensure!(
             self.initial_allocation_ratio <= StdDecimal::percent(100u64),
             ContractError::HatchPhaseConfigError(
                 "Initial allocation percentage must be between 0 and 100.".to_string()
+            )
+        );
+
+        // TODO: define better values
+        ensure!(
+            self.exit_tax <= StdDecimal::percent(100u64),
+            ContractError::HatchPhaseConfigError(
+                "Exit taxation percentage must be between 0 and 100.".to_string()
             )
         );
 
@@ -107,6 +116,13 @@ impl OpenConfig {
 #[cw_serde]
 pub struct ClosedConfig {}
 
+impl ClosedConfig {
+    /// Validate the closed config
+    pub fn validate(&self) -> Result<(), ContractError> {
+        Ok(())
+    }
+}
+
 #[cw_serde]
 pub struct CommonsPhaseConfig {
     // The Hatch phase where initial contributors (Hatchers) participate in a hatch sale.
@@ -144,11 +160,47 @@ pub enum CommonsPhase {
     Closed,
 }
 
+impl CommonsPhase {
+    pub fn expect_hatch(&self) -> Result<(), ContractError> {
+        ensure!(
+            matches!(self, CommonsPhase::Hatch),
+            ContractError::InvalidPhase {
+                expected: "Hatch".to_string(),
+                actual: format!("{:?}", self)
+            }
+        );
+        Ok(())
+    }
+
+    pub fn expect_open(&self) -> Result<(), ContractError> {
+        ensure!(
+            matches!(self, CommonsPhase::Open),
+            ContractError::InvalidPhase {
+                expected: "Open".to_string(),
+                actual: format!("{:?}", self)
+            }
+        );
+        Ok(())
+    }
+
+    pub fn expect_closed(&self) -> Result<(), ContractError> {
+        ensure!(
+            matches!(self, CommonsPhase::Closed),
+            ContractError::InvalidPhase {
+                expected: "Closed".to_string(),
+                actual: format!("{:?}", self)
+            }
+        );
+        Ok(())
+    }
+}
+
 impl CommonsPhaseConfig {
     /// Validate that the commons configuration is valid
     pub fn validate(&self) -> Result<(), ContractError> {
         self.hatch.validate()?;
         self.open.validate()?;
+        self.closed.validate()?;
 
         Ok(())
     }

--- a/contracts/external/cw-abc/src/abc.rs
+++ b/contracts/external/cw-abc/src/abc.rs
@@ -44,6 +44,8 @@ pub struct HatchConfig {
     pub initial_price: Uint128,
     // The initial allocation (θ), percentage of the initial raise allocated to the Funding Pool
     pub initial_allocation_ratio: StdDecimal,
+    // Exit tax for the hatch phase
+    pub exit_tax: StdDecimal,
 }
 
 impl HatchConfig {

--- a/contracts/external/cw-abc/src/abc.rs
+++ b/contracts/external/cw-abc/src/abc.rs
@@ -1,10 +1,9 @@
-
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Decimal as StdDecimal, ensure, Uint128};
+use cosmwasm_std::{ensure, Decimal as StdDecimal, Uint128};
 
-use token_bindings::Metadata;
-use crate::curves::{Constant, Curve, decimal, DecimalPlaces, Linear, SquareRoot};
+use crate::curves::{decimal, Constant, Curve, DecimalPlaces, Linear, SquareRoot};
 use crate::ContractError;
+use token_bindings::Metadata;
 
 #[cw_serde]
 pub struct SupplyToken {
@@ -53,23 +52,28 @@ impl HatchConfig {
     pub fn validate(&self) -> Result<(), ContractError> {
         ensure!(
             self.initial_raise.min < self.initial_raise.max,
-            ContractError::HatchPhaseConfigError("Initial raise minimum value must be less than maximum value.".to_string())
+            ContractError::HatchPhaseConfigError(
+                "Initial raise minimum value must be less than maximum value.".to_string()
+            )
         );
 
         ensure!(
             !self.initial_price.is_zero(),
-            ContractError::HatchPhaseConfigError("Initial price must be greater than zero.".to_string())
+            ContractError::HatchPhaseConfigError(
+                "Initial price must be greater than zero.".to_string()
+            )
         );
 
         ensure!(
             self.initial_allocation_ratio <= StdDecimal::percent(100u64),
-            ContractError::HatchPhaseConfigError("Initial allocation percentage must be between 0 and 100.".to_string())
+            ContractError::HatchPhaseConfigError(
+                "Initial allocation percentage must be between 0 and 100.".to_string()
+            )
         );
 
         Ok(())
     }
 }
-
 
 #[cw_serde]
 pub struct OpenConfig {
@@ -82,15 +86,18 @@ pub struct OpenConfig {
 impl OpenConfig {
     /// Validate the open config
     pub fn validate(&self) -> Result<(), ContractError> {
-
         ensure!(
             self.allocation_percentage <= StdDecimal::percent(100u64),
-            ContractError::OpenPhaseConfigError("Reserve percentage must be between 0 and 100.".to_string())
+            ContractError::OpenPhaseConfigError(
+                "Reserve percentage must be between 0 and 100.".to_string()
+            )
         );
 
         ensure!(
             self.exit_tax <= StdDecimal::percent(100u64),
-            ContractError::OpenPhaseConfigError("Exit taxation percentage must be between 0 and 100.".to_string())
+            ContractError::OpenPhaseConfigError(
+                "Exit taxation percentage must be between 0 and 100.".to_string()
+            )
         );
 
         Ok(())
@@ -99,7 +106,6 @@ impl OpenConfig {
 
 #[cw_serde]
 pub struct ClosedConfig {}
-
 
 #[cw_serde]
 pub struct CommonsPhaseConfig {
@@ -135,7 +141,7 @@ pub enum CommonsPhase {
     Hatch,
     Open,
     // TODO: should we allow for a closed phase?
-    Closed
+    Closed,
 }
 
 impl CommonsPhaseConfig {
@@ -147,7 +153,6 @@ impl CommonsPhaseConfig {
         Ok(())
     }
 }
-
 
 pub type CurveFn = Box<dyn Fn(DecimalPlaces) -> Box<dyn Curve>>;
 
@@ -185,4 +190,3 @@ impl CurveType {
         }
     }
 }
-

--- a/contracts/external/cw-abc/src/boot.rs
+++ b/contracts/external/cw-abc/src/boot.rs
@@ -1,6 +1,8 @@
 use crate::msg::*;
-use boot_core::{ArtifactsDir, ContractWrapper, Daemon, Mock, MockState, TxHandler, Uploadable, WasmPath};
 use boot_core::{contract, Contract, CwEnv};
+#[cfg(feature = "daemon")]
+use boot_core::{ArtifactsDir, Daemon, WasmPath};
+use boot_core::{ContractWrapper, Mock, MockState, TxHandler, Uploadable};
 use cosmwasm_std::Empty;
 use token_bindings::{TokenFactoryMsg, TokenFactoryQuery};
 
@@ -9,10 +11,14 @@ pub struct CwAbc<Chain>;
 
 impl<Chain: CwEnv> CwAbc<Chain> {
     pub fn new(name: &str, chain: Chain) -> Self {
-        let mut contract = Contract::new(name, chain);
+        let contract = Contract::new(name, chain);
         Self(contract)
     }
 }
+
+/// Basic app for the token factory contract
+/// TODO: should be in the bindings, along with custom handler for multi-test
+pub(crate) type TokenFactoryBasicApp = boot_core::BasicApp<TokenFactoryMsg, TokenFactoryQuery>;
 
 type TokenFactoryMock = Mock<MockState, TokenFactoryMsg, TokenFactoryQuery>;
 
@@ -26,8 +32,12 @@ impl Uploadable<TokenFactoryMock> for CwAbc<TokenFactoryMock> {
     }
 }
 
+#[cfg(feature = "daemon")]
 impl Uploadable<Daemon> for CwAbc<Daemon> {
     fn source(&self) -> <Daemon as TxHandler>::ContractSource {
-        ArtifactsDir::env().expect("Expected ARTIFACTS_DIR in env").find_wasm_path("cw_abc").unwrap()
+        ArtifactsDir::env()
+            .expect("Expected ARTIFACTS_DIR in env")
+            .find_wasm_path("cw_abc")
+            .unwrap()
     }
 }

--- a/contracts/external/cw-abc/src/boot.rs
+++ b/contracts/external/cw-abc/src/boot.rs
@@ -1,0 +1,33 @@
+use crate::msg::*;
+use boot_core::{ArtifactsDir, ContractWrapper, Daemon, Mock, MockState, TxHandler, Uploadable, WasmPath};
+use boot_core::{contract, Contract, CwEnv};
+use cosmwasm_std::Empty;
+use token_bindings::{TokenFactoryMsg, TokenFactoryQuery};
+
+#[contract(InstantiateMsg, ExecuteMsg, QueryMsg, Empty)]
+pub struct CwAbc<Chain>;
+
+impl<Chain: CwEnv> CwAbc<Chain> {
+    pub fn new(name: &str, chain: Chain) -> Self {
+        let mut contract = Contract::new(name, chain);
+        Self(contract)
+    }
+}
+
+type TokenFactoryMock = Mock<MockState, TokenFactoryMsg, TokenFactoryQuery>;
+
+impl Uploadable<TokenFactoryMock> for CwAbc<TokenFactoryMock> {
+    fn source(&self) -> <TokenFactoryMock as TxHandler>::ContractSource {
+        Box::new(ContractWrapper::new(
+            crate::contract::execute,
+            crate::contract::instantiate,
+            crate::contract::query,
+        ))
+    }
+}
+
+impl Uploadable<Daemon> for CwAbc<Daemon> {
+    fn source(&self) -> <Daemon as TxHandler>::ContractSource {
+        ArtifactsDir::env().expect("Expected ARTIFACTS_DIR in env").find_wasm_path("cw_abc").unwrap()
+    }
+}

--- a/contracts/external/cw-abc/src/commands.rs
+++ b/contracts/external/cw-abc/src/commands.rs
@@ -82,11 +82,11 @@ pub fn execute_buy(
 
     let denom = SUPPLY_DENOM.load(deps.storage)?;
     // mint supply token
-    let mint_msg = TokenMsg::MintTokens {
+    let mint_msg = TokenMsg::mint_contract_tokens(
         denom,
-        amount: minted,
-        mint_to_address: info.sender.to_string(),
-    };
+        minted,
+        info.sender.to_string(),
+    );
 
     Ok(Response::new()
         .add_message(mint_msg)
@@ -161,11 +161,11 @@ pub fn execute_sell(
     CURVE_STATE.save(deps.storage, &state)?;
 
     // Burn the tokens
-    let burn_msg = TokenMsg::BurnTokens {
+    let burn_msg = TokenMsg::burn_contract_tokens(
         denom,
-        amount: payment,
-        burn_from_address: info.sender.to_string(),
-    };
+        payment,
+        info.sender.to_string(),
+    );
 
     // now send the tokens to the sender (TODO: for sell_from we do something else, right???)
     let msg = BankMsg::Send {

--- a/contracts/external/cw-abc/src/commands.rs
+++ b/contracts/external/cw-abc/src/commands.rs
@@ -28,9 +28,14 @@ pub fn execute_buy(
 
             // Check that the potential hatcher is allowlisted
             assert_allowlisted(deps.storage, &info.sender)?;
-            HATCHERS.update(deps.storage, |mut hatchers| -> StdResult<_>{
-                hatchers.insert(info.sender.clone());
-                Ok(hatchers)
+            HATCHERS.update(deps.storage, &info.sender, |amount| -> StdResult<_> {
+                match amount {
+                    Some(mut amount) => {
+                        amount += payment;
+                        Ok(amount)
+                    }
+                    None => Ok(payment),
+                }
             })?;
 
             // Check if the initial_raise max has been met

--- a/contracts/external/cw-abc/src/commands.rs
+++ b/contracts/external/cw-abc/src/commands.rs
@@ -2,8 +2,8 @@ use crate::abc::{CommonsPhase, CurveFn, MinMax};
 use crate::contract::CwAbcResult;
 use crate::ContractError;
 use cosmwasm_std::{
-    coins, ensure, Addr, BankMsg, Decimal as StdDecimal, DepsMut, Env, MessageInfo,
-    QuerierWrapper, Response, StdError, StdResult, Storage, Uint128,
+    coins, ensure, Addr, BankMsg, Decimal as StdDecimal, DepsMut, Env, MessageInfo, QuerierWrapper,
+    Response, StdError, StdResult, Storage, Uint128,
 };
 use cw_utils::must_pay;
 use std::collections::HashSet;

--- a/contracts/external/cw-abc/src/contract.rs
+++ b/contracts/external/cw-abc/src/contract.rs
@@ -116,6 +116,7 @@ pub fn do_execute(
     match msg {
         ExecuteMsg::Buy {} => commands::execute_buy(deps, env, info, curve_fn),
         ExecuteMsg::Burn { amount } => commands::execute_sell(deps, env, info, curve_fn, amount),
+        ExecuteMsg::Donate {} => commands::execute_donate(deps, env, info),
         ExecuteMsg::UpdateHatchAllowlist { to_add, to_remove } => {
             cw_ownable::assert_owner(deps.storage, &info.sender)?;
             commands::update_hatch_allowlist(deps, to_add, to_remove)
@@ -159,6 +160,9 @@ pub fn do_query(
         // custom queries
         QueryMsg::CurveInfo {} => to_binary(&queries::query_curve_info(deps, curve_fn)?),
         QueryMsg::PhaseConfig {} => to_binary(&queries::query_phase_config(deps)?),
+        QueryMsg::Donations { start_after, limit } => {
+            to_binary(&queries::query_donations(deps, start_after, limit)?)
+        }
         QueryMsg::Ownership {} => to_binary(&cw_ownable::get_ownership(deps.storage)?),
         // QueryMsg::GetDenom {
         //     creator_address,

--- a/contracts/external/cw-abc/src/contract.rs
+++ b/contracts/external/cw-abc/src/contract.rs
@@ -9,7 +9,7 @@ use token_bindings::{TokenFactoryMsg, TokenFactoryQuery, TokenMsg};
 use crate::curves::DecimalPlaces;
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use crate::state::{CURVE_STATE, CURVE_TYPE, CurveState, HATCHER_ALLOWLIST, HATCHERS, PHASE_CONFIG, SUPPLY_DENOM};
+use crate::state::{CURVE_STATE, CURVE_TYPE, CurveState, HATCHER_ALLOWLIST, PHASE_CONFIG, SUPPLY_DENOM};
 use cw_utils::nonpayable;
 use crate::abc::CurveFn;
 use crate::{commands, queries};
@@ -73,7 +73,6 @@ pub fn instantiate(
     let curve_state = CurveState::new(reserve.denom, normalization_places);
     CURVE_STATE.save(deps.storage, &curve_state)?;
     CURVE_TYPE.save(deps.storage, &curve_type)?;
-    HATCHERS.save(deps.storage, &HashSet::new())?;
 
     if let Some(allowlist) = hatcher_allowlist {
         let allowlist = allowlist.into_iter()

--- a/contracts/external/cw-abc/src/contract.rs
+++ b/contracts/external/cw-abc/src/contract.rs
@@ -1,8 +1,6 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{
-    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
-};
+use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 use cw2::set_contract_version;
 use std::collections::HashSet;
 
@@ -11,7 +9,7 @@ use token_bindings::{TokenFactoryMsg, TokenFactoryQuery, TokenMsg};
 use crate::abc::CurveFn;
 use crate::curves::DecimalPlaces;
 use crate::error::ContractError;
-use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, UpdatePhaseConfigMsg};
 use crate::state::{
     CurveState, CURVE_STATE, CURVE_TYPE, HATCHER_ALLOWLIST, PHASE_CONFIG, SUPPLY_DENOM,
 };
@@ -124,12 +122,19 @@ pub fn do_execute(
         ExecuteMsg::UpdateHatchAllowlist { to_add, to_remove } => {
             commands::update_hatch_allowlist(deps, info, to_add, to_remove)
         }
-        ExecuteMsg::UpdateHatchConfig {
-            initial_raise,
-            initial_allocation_ratio,
-        } => {
-            commands::update_hatch_config(deps, env, info, initial_raise, initial_allocation_ratio)
-        }
+        ExecuteMsg::UpdatePhaseConfig(update) => match update {
+            UpdatePhaseConfigMsg::Hatch {
+                initial_raise,
+                initial_allocation_ratio,
+            } => commands::update_hatch_config(
+                deps,
+                env,
+                info,
+                initial_raise,
+                initial_allocation_ratio,
+            ),
+            _ => todo!(),
+        },
         ExecuteMsg::UpdateOwnership(action) => {
             commands::update_ownership(deps, &env, &info, action)
         }

--- a/contracts/external/cw-abc/src/contract.rs
+++ b/contracts/external/cw-abc/src/contract.rs
@@ -171,6 +171,9 @@ pub fn do_query(
         QueryMsg::Donations { start_after, limit } => {
             to_binary(&queries::query_donations(deps, start_after, limit)?)
         }
+        QueryMsg::Hatchers { start_after, limit } => {
+            to_binary(&queries::query_hatchers(deps, start_after, limit)?)
+        }
         QueryMsg::Ownership {} => to_binary(&cw_ownable::get_ownership(deps.storage)?),
         // QueryMsg::GetDenom {
         //     creator_address,

--- a/contracts/external/cw-abc/src/contract.rs
+++ b/contracts/external/cw-abc/src/contract.rs
@@ -266,6 +266,7 @@ mod tests {
                     },
                     initial_price: Uint128::one(),
                     initial_allocation_ratio: Decimal::percent(10u64),
+                    exit_tax: Decimal::zero(),
                 },
                 open: OpenConfig {
                     allocation_percentage: Decimal::percent(10u64),

--- a/contracts/external/cw-abc/src/contract.rs
+++ b/contracts/external/cw-abc/src/contract.rs
@@ -119,7 +119,7 @@ pub fn do_execute(
 ) -> CwAbcResult {
     match msg {
         ExecuteMsg::Buy {} => commands::execute_buy(deps, env, info, curve_fn),
-        ExecuteMsg::Burn { amount } => commands::execute_sell(deps, env, info, curve_fn, amount),
+        ExecuteMsg::Burn {} => commands::execute_sell(deps, env, info, curve_fn),
         ExecuteMsg::Donate {} => commands::execute_donate(deps, env, info),
         ExecuteMsg::UpdateHatchAllowlist { to_add, to_remove } => {
             cw_ownable::assert_owner(deps.storage, &info.sender)?;

--- a/contracts/external/cw-abc/src/contract.rs
+++ b/contracts/external/cw-abc/src/contract.rs
@@ -1,18 +1,22 @@
-use std::collections::HashSet;
-use std::ops::Deref;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
-use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, Response, StdResult, to_binary};
+use cosmwasm_std::{
+    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, QuerierWrapper, Response, StdResult,
+};
 use cw2::set_contract_version;
+use std::collections::HashSet;
+use std::ops::Deref;
 use token_bindings::{TokenFactoryMsg, TokenFactoryQuery, TokenMsg};
 
+use crate::abc::CurveFn;
 use crate::curves::DecimalPlaces;
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use crate::state::{CURVE_STATE, CURVE_TYPE, CurveState, HATCHER_ALLOWLIST, PHASE_CONFIG, SUPPLY_DENOM};
-use cw_utils::nonpayable;
-use crate::abc::CurveFn;
+use crate::state::{
+    CurveState, CURVE_STATE, CURVE_TYPE, HATCHER_ALLOWLIST, PHASE_CONFIG, SUPPLY_DENOM,
+};
 use crate::{commands, queries};
+use cw_utils::nonpayable;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:cw20-abc";
@@ -33,7 +37,6 @@ pub fn instantiate(
     nonpayable(&info)?;
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
-
     let InstantiateMsg {
         supply,
         reserve,
@@ -42,9 +45,10 @@ pub fn instantiate(
         hatcher_allowlist,
     } = msg;
 
-
     if supply.subdenom.is_empty() {
-        return Err(ContractError::SupplyTokenError("Token subdenom must not be empty.".to_string()));
+        return Err(ContractError::SupplyTokenError(
+            "Token subdenom must not be empty.".to_string(),
+        ));
     }
 
     phase_config.validate()?;
@@ -75,8 +79,10 @@ pub fn instantiate(
     CURVE_TYPE.save(deps.storage, &curve_type)?;
 
     if let Some(allowlist) = hatcher_allowlist {
-        let allowlist = allowlist.into_iter()
-            .map(|addr| deps.api.addr_validate(addr.as_str())).collect::<StdResult<HashSet<_>>>()?;
+        let allowlist = allowlist
+            .into_iter()
+            .map(|addr| deps.api.addr_validate(addr.as_str()))
+            .collect::<StdResult<HashSet<_>>>()?;
         HATCHER_ALLOWLIST.save(deps.storage, &allowlist)?;
     }
 
@@ -86,7 +92,6 @@ pub fn instantiate(
 
     Ok(Response::default().add_message(create_supply_denom_msg))
 }
-
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
@@ -123,19 +128,23 @@ pub fn do_execute(
         ExecuteMsg::UpdateHatchConfig { .. } => {
             cw_ownable::assert_owner(deps.storage, &info.sender)?;
             todo!()
-        },
+        }
         ExecuteMsg::UpdateOwnership(action) => {
-            let ownership = cw_ownable::update_ownership(DepsMut {
-                storage: deps.storage,
-                api: deps.api,
-                querier: QuerierWrapper::new(deps.querier.deref()),
-            }, &env.block, &info.sender, action)?;
+            let ownership = cw_ownable::update_ownership(
+                DepsMut {
+                    storage: deps.storage,
+                    api: deps.api,
+                    querier: QuerierWrapper::new(deps.querier.deref()),
+                },
+                &env.block,
+                &info.sender,
+                action,
+            )?;
 
             Ok(Response::default().add_attributes(ownership.into_attributes()))
         }
     }
 }
-
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps<TokenFactoryQuery>, env: Env, msg: QueryMsg) -> StdResult<Binary> {
@@ -214,13 +223,19 @@ pub fn do_query(
 // this is poor man's "skip" flag
 #[cfg(test)]
 mod tests {
-    use std::marker::PhantomData;
-    use cosmwasm_std::{CosmosMsg, Decimal, OwnedDeps, testing::{mock_env, mock_info, MockApi, MockQuerier, MockStorage}, Uint128};
-    use token_bindings::Metadata;
-    use crate::abc::{ClosedConfig, CommonsPhaseConfig, CurveType, HatchConfig, MinMax, OpenConfig, ReserveToken, SupplyToken};
     use super::*;
-    use speculoos::prelude::*;
+    use crate::abc::{
+        ClosedConfig, CommonsPhaseConfig, CurveType, HatchConfig, MinMax, OpenConfig, ReserveToken,
+        SupplyToken,
+    };
     use crate::queries::query_curve_info;
+    use cosmwasm_std::{
+        testing::{mock_env, mock_info, MockApi, MockQuerier, MockStorage},
+        CosmosMsg, Decimal, OwnedDeps, Uint128,
+    };
+    use speculoos::prelude::*;
+    use std::marker::PhantomData;
+    use token_bindings::Metadata;
 
     const DENOM: &str = "satoshi";
     const CREATOR: &str = "creator";
@@ -228,8 +243,6 @@ mod tests {
     const BUYER: &str = "buyer";
 
     const SUPPLY_DENOM: &str = "subdenom";
-
-
 
     fn default_supply_metadata() -> Metadata {
         Metadata {
@@ -278,23 +291,24 @@ mod tests {
         }
     }
 
-//     fn get_balance<U: Into<String>>(deps: Deps, addr: U) -> Uint128 {
-//         query_balance(deps, addr.into()).unwrap().balance
-//     }
+    //     fn get_balance<U: Into<String>>(deps: Deps, addr: U) -> Uint128 {
+    //         query_balance(deps, addr.into()).unwrap().balance
+    //     }
 
-//     fn setup_test(deps: DepsMut, decimals: u8, reserve_decimals: u8, curve_type: CurveType) {
-//         // this matches `linear_curve` test case from curves.rs
-//         let creator = String::from(CREATOR);
-//         let msg = default_instantiate(decimals, reserve_decimals, curve_type);
-//         let info = mock_info(&creator, &[]);
+    //     fn setup_test(deps: DepsMut, decimals: u8, reserve_decimals: u8, curve_type: CurveType) {
+    //         // this matches `linear_curve` test case from curves.rs
+    //         let creator = String::from(CREATOR);
+    //         let msg = default_instantiate(decimals, reserve_decimals, curve_type);
+    //         let info = mock_info(&creator, &[]);
 
-//         // make sure we can instantiate with this
-//         let res = instantiate(deps, mock_env(), info, msg).unwrap();
-//         assert_eq!(0, res.messages.len());
-//     }
+    //         // make sure we can instantiate with this
+    //         let res = instantiate(deps, mock_env(), info, msg).unwrap();
+    //         assert_eq!(0, res.messages.len());
+    //     }
 
     /// Mock token factory querier dependencies
-    fn mock_tf_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier<TokenFactoryQuery>, TokenFactoryQuery> {
+    fn mock_tf_dependencies(
+    ) -> OwnedDeps<MockStorage, MockApi, MockQuerier<TokenFactoryQuery>, TokenFactoryQuery> {
         OwnedDeps {
             storage: MockStorage::default(),
             api: MockApi::default(),
@@ -320,10 +334,12 @@ mod tests {
         let res = instantiate(deps.as_mut(), mock_env(), info, msg)?;
         assert_that!(res.messages.len()).is_equal_to(1);
         let submsg = res.messages.get(0).unwrap();
-        assert_that!(submsg.msg).is_equal_to(CosmosMsg::Custom(TokenFactoryMsg::Token(TokenMsg::CreateDenom {
-            subdenom: SUPPLY_DENOM.to_string(),
-            metadata: Some(default_supply_metadata()),
-        })));
+        assert_that!(submsg.msg).is_equal_to(CosmosMsg::Custom(TokenFactoryMsg::Token(
+            TokenMsg::CreateDenom {
+                subdenom: SUPPLY_DENOM.to_string(),
+                metadata: Some(default_supply_metadata()),
+            },
+        )));
 
         // TODO!
         // // token info is proper
@@ -351,136 +367,136 @@ mod tests {
         Ok(())
     }
 
-//     #[test]
-//     fn buy_issues_tokens() {
-//         let mut deps = mock_dependencies();
-//         let curve_type = CurveType::Linear {
-//             slope: Uint128::new(1),
-//             scale: 1,
-//         };
-//         setup_test(deps.as_mut(), 2, 8, curve_type.clone());
+    //     #[test]
+    //     fn buy_issues_tokens() {
+    //         let mut deps = mock_dependencies();
+    //         let curve_type = CurveType::Linear {
+    //             slope: Uint128::new(1),
+    //             scale: 1,
+    //         };
+    //         setup_test(deps.as_mut(), 2, 8, curve_type.clone());
 
-//         // succeeds with proper token (5 BTC = 5*10^8 satoshi)
-//         let info = mock_info(INVESTOR, &coins(500_000_000, DENOM));
-//         let buy = ExecuteMsg::Buy {};
-//         execute(deps.as_mut(), mock_env(), info, buy.clone()).unwrap();
+    //         // succeeds with proper token (5 BTC = 5*10^8 satoshi)
+    //         let info = mock_info(INVESTOR, &coins(500_000_000, DENOM));
+    //         let buy = ExecuteMsg::Buy {};
+    //         execute(deps.as_mut(), mock_env(), info, buy.clone()).unwrap();
 
-//         // bob got 1000 EPOXY (10.00)
-//         assert_eq!(get_balance(deps.as_ref(), INVESTOR), Uint128::new(1000));
-//         assert_eq!(get_balance(deps.as_ref(), BUYER), Uint128::zero());
+    //         // bob got 1000 EPOXY (10.00)
+    //         assert_eq!(get_balance(deps.as_ref(), INVESTOR), Uint128::new(1000));
+    //         assert_eq!(get_balance(deps.as_ref(), BUYER), Uint128::zero());
 
-//         // send them all to buyer
-//         let info = mock_info(INVESTOR, &[]);
-//         let send = ExecuteMsg::Transfer {
-//             recipient: BUYER.into(),
-//             amount: Uint128::new(1000),
-//         };
-//         execute(deps.as_mut(), mock_env(), info, send).unwrap();
+    //         // send them all to buyer
+    //         let info = mock_info(INVESTOR, &[]);
+    //         let send = ExecuteMsg::Transfer {
+    //             recipient: BUYER.into(),
+    //             amount: Uint128::new(1000),
+    //         };
+    //         execute(deps.as_mut(), mock_env(), info, send).unwrap();
 
-//         // ensure balances updated
-//         assert_eq!(get_balance(deps.as_ref(), INVESTOR), Uint128::zero());
-//         assert_eq!(get_balance(deps.as_ref(), BUYER), Uint128::new(1000));
+    //         // ensure balances updated
+    //         assert_eq!(get_balance(deps.as_ref(), INVESTOR), Uint128::zero());
+    //         assert_eq!(get_balance(deps.as_ref(), BUYER), Uint128::new(1000));
 
-//         // second stake needs more to get next 1000 EPOXY
-//         let info = mock_info(INVESTOR, &coins(1_500_000_000, DENOM));
-//         execute(deps.as_mut(), mock_env(), info, buy).unwrap();
+    //         // second stake needs more to get next 1000 EPOXY
+    //         let info = mock_info(INVESTOR, &coins(1_500_000_000, DENOM));
+    //         execute(deps.as_mut(), mock_env(), info, buy).unwrap();
 
-//         // ensure balances updated
-//         assert_eq!(get_balance(deps.as_ref(), INVESTOR), Uint128::new(1000));
-//         assert_eq!(get_balance(deps.as_ref(), BUYER), Uint128::new(1000));
+    //         // ensure balances updated
+    //         assert_eq!(get_balance(deps.as_ref(), INVESTOR), Uint128::new(1000));
+    //         assert_eq!(get_balance(deps.as_ref(), BUYER), Uint128::new(1000));
 
-//         // check curve info updated
-//         let curve = query_curve_info(deps.as_ref(), curve_type.to_curve_fn()).unwrap();
-//         assert_eq!(curve.reserve, Uint128::new(2_000_000_000));
-//         assert_eq!(curve.supply, Uint128::new(2000));
-//         assert_eq!(curve.spot_price, Decimal::percent(200));
+    //         // check curve info updated
+    //         let curve = query_curve_info(deps.as_ref(), curve_type.to_curve_fn()).unwrap();
+    //         assert_eq!(curve.reserve, Uint128::new(2_000_000_000));
+    //         assert_eq!(curve.supply, Uint128::new(2000));
+    //         assert_eq!(curve.spot_price, Decimal::percent(200));
 
-//         // check token info updated
-//         let token = query_token_info(deps.as_ref()).unwrap();
-//         assert_eq!(token.decimals, 2);
-//         assert_eq!(token.total_supply, Uint128::new(2000));
-//     }
+    //         // check token info updated
+    //         let token = query_token_info(deps.as_ref()).unwrap();
+    //         assert_eq!(token.decimals, 2);
+    //         assert_eq!(token.total_supply, Uint128::new(2000));
+    //     }
 
-//     #[test]
-//     fn bonding_fails_with_wrong_denom() {
-//         let mut deps = mock_dependencies();
-//         let curve_type = CurveType::Linear {
-//             slope: Uint128::new(1),
-//             scale: 1,
-//         };
-//         setup_test(deps.as_mut(), 2, 8, curve_type);
+    //     #[test]
+    //     fn bonding_fails_with_wrong_denom() {
+    //         let mut deps = mock_dependencies();
+    //         let curve_type = CurveType::Linear {
+    //             slope: Uint128::new(1),
+    //             scale: 1,
+    //         };
+    //         setup_test(deps.as_mut(), 2, 8, curve_type);
 
-//         // fails when no tokens sent
-//         let info = mock_info(INVESTOR, &[]);
-//         let buy = ExecuteMsg::Buy {};
-//         let err = execute(deps.as_mut(), mock_env(), info, buy.clone()).unwrap_err();
-//         assert_eq!(err, PaymentError::NoFunds {}.into());
+    //         // fails when no tokens sent
+    //         let info = mock_info(INVESTOR, &[]);
+    //         let buy = ExecuteMsg::Buy {};
+    //         let err = execute(deps.as_mut(), mock_env(), info, buy.clone()).unwrap_err();
+    //         assert_eq!(err, PaymentError::NoFunds {}.into());
 
-//         // fails when wrong tokens sent
-//         let info = mock_info(INVESTOR, &coins(1234567, "wei"));
-//         let err = execute(deps.as_mut(), mock_env(), info, buy.clone()).unwrap_err();
-//         assert_eq!(err, PaymentError::MissingDenom(DENOM.into()).into());
+    //         // fails when wrong tokens sent
+    //         let info = mock_info(INVESTOR, &coins(1234567, "wei"));
+    //         let err = execute(deps.as_mut(), mock_env(), info, buy.clone()).unwrap_err();
+    //         assert_eq!(err, PaymentError::MissingDenom(DENOM.into()).into());
 
-//         // fails when too many tokens sent
-//         let info = mock_info(INVESTOR, &[coin(3400022, DENOM), coin(1234567, "wei")]);
-//         let err = execute(deps.as_mut(), mock_env(), info, buy).unwrap_err();
-//         assert_eq!(err, PaymentError::MultipleDenoms {}.into());
-//     }
+    //         // fails when too many tokens sent
+    //         let info = mock_info(INVESTOR, &[coin(3400022, DENOM), coin(1234567, "wei")]);
+    //         let err = execute(deps.as_mut(), mock_env(), info, buy).unwrap_err();
+    //         assert_eq!(err, PaymentError::MultipleDenoms {}.into());
+    //     }
 
-//     #[test]
-//     fn burning_sends_reserve() {
-//         let mut deps = mock_dependencies();
-//         let curve_type = CurveType::Linear {
-//             slope: Uint128::new(1),
-//             scale: 1,
-//         };
-//         setup_test(deps.as_mut(), 2, 8, curve_type.clone());
+    //     #[test]
+    //     fn burning_sends_reserve() {
+    //         let mut deps = mock_dependencies();
+    //         let curve_type = CurveType::Linear {
+    //             slope: Uint128::new(1),
+    //             scale: 1,
+    //         };
+    //         setup_test(deps.as_mut(), 2, 8, curve_type.clone());
 
-//         // succeeds with proper token (20 BTC = 20*10^8 satoshi)
-//         let info = mock_info(INVESTOR, &coins(2_000_000_000, DENOM));
-//         let buy = ExecuteMsg::Buy {};
-//         execute(deps.as_mut(), mock_env(), info, buy).unwrap();
+    //         // succeeds with proper token (20 BTC = 20*10^8 satoshi)
+    //         let info = mock_info(INVESTOR, &coins(2_000_000_000, DENOM));
+    //         let buy = ExecuteMsg::Buy {};
+    //         execute(deps.as_mut(), mock_env(), info, buy).unwrap();
 
-//         // bob got 2000 EPOXY (20.00)
-//         assert_eq!(get_balance(deps.as_ref(), INVESTOR), Uint128::new(2000));
+    //         // bob got 2000 EPOXY (20.00)
+    //         assert_eq!(get_balance(deps.as_ref(), INVESTOR), Uint128::new(2000));
 
-//         // cannot burn too much
-//         let info = mock_info(INVESTOR, &[]);
-//         let burn = ExecuteMsg::Burn {
-//             amount: Uint128::new(3000),
-//         };
-//         let err = execute(deps.as_mut(), mock_env(), info, burn).unwrap_err();
-//         // TODO check error
+    //         // cannot burn too much
+    //         let info = mock_info(INVESTOR, &[]);
+    //         let burn = ExecuteMsg::Burn {
+    //             amount: Uint128::new(3000),
+    //         };
+    //         let err = execute(deps.as_mut(), mock_env(), info, burn).unwrap_err();
+    //         // TODO check error
 
-//         // burn 1000 EPOXY to get back 15BTC (*10^8)
-//         let info = mock_info(INVESTOR, &[]);
-//         let burn = ExecuteMsg::Burn {
-//             amount: Uint128::new(1000),
-//         };
-//         let res = execute(deps.as_mut(), mock_env(), info, burn).unwrap();
+    //         // burn 1000 EPOXY to get back 15BTC (*10^8)
+    //         let info = mock_info(INVESTOR, &[]);
+    //         let burn = ExecuteMsg::Burn {
+    //             amount: Uint128::new(1000),
+    //         };
+    //         let res = execute(deps.as_mut(), mock_env(), info, burn).unwrap();
 
-//         // balance is lower
-//         assert_eq!(get_balance(deps.as_ref(), INVESTOR), Uint128::new(1000));
+    //         // balance is lower
+    //         assert_eq!(get_balance(deps.as_ref(), INVESTOR), Uint128::new(1000));
 
-//         // ensure we got our money back
-//         assert_eq!(1, res.messages.len());
-//         assert_eq!(
-//             &res.messages[0],
-//             &SubMsg::new(BankMsg::Send {
-//                 to_address: INVESTOR.into(),
-//                 amount: coins(1_500_000_000, DENOM),
-//             })
-//         );
+    //         // ensure we got our money back
+    //         assert_eq!(1, res.messages.len());
+    //         assert_eq!(
+    //             &res.messages[0],
+    //             &SubMsg::new(BankMsg::Send {
+    //                 to_address: INVESTOR.into(),
+    //                 amount: coins(1_500_000_000, DENOM),
+    //             })
+    //         );
 
-//         // check curve info updated
-//         let curve = query_curve_info(deps.as_ref(), curve_type.to_curve_fn()).unwrap();
-//         assert_eq!(curve.reserve, Uint128::new(500_000_000));
-//         assert_eq!(curve.supply, Uint128::new(1000));
-//         assert_eq!(curve.spot_price, Decimal::percent(100));
+    //         // check curve info updated
+    //         let curve = query_curve_info(deps.as_ref(), curve_type.to_curve_fn()).unwrap();
+    //         assert_eq!(curve.reserve, Uint128::new(500_000_000));
+    //         assert_eq!(curve.supply, Uint128::new(1000));
+    //         assert_eq!(curve.spot_price, Decimal::percent(100));
 
-//         // check token info updated
-//         let token = query_token_info(deps.as_ref()).unwrap();
-//         assert_eq!(token.decimals, 2);
-//         assert_eq!(token.total_supply, Uint128::new(1000));
-//     }
+    //         // check token info updated
+    //         let token = query_token_info(deps.as_ref()).unwrap();
+    //         assert_eq!(token.decimals, 2);
+    //         assert_eq!(token.total_supply, Uint128::new(1000));
+    //     }
 }

--- a/contracts/external/cw-abc/src/error.rs
+++ b/contracts/external/cw-abc/src/error.rs
@@ -36,4 +36,7 @@ pub enum ContractError {
 
     #[error("Selling is disabled during the hatch phase")]
     HatchSellingDisabled {},
+
+    #[error("Invalid sell amount")]
+    MismatchedSellAmount {},
 }

--- a/contracts/external/cw-abc/src/error.rs
+++ b/contracts/external/cw-abc/src/error.rs
@@ -39,4 +39,7 @@ pub enum ContractError {
 
     #[error("Invalid sell amount")]
     MismatchedSellAmount {},
+
+    #[error("Invalid phase, expected {expected:?}, actual {actual:?}")]
+    InvalidPhase { expected: String, actual: String },
 }

--- a/contracts/external/cw-abc/src/error.rs
+++ b/contracts/external/cw-abc/src/error.rs
@@ -33,4 +33,7 @@ pub enum ContractError {
 
     #[error("The commons is closed to new contributions")]
     CommonsClosed {},
+
+    #[error("Selling is disabled during the hatch phase")]
+    HatchSellingDisabled {},
 }

--- a/contracts/external/cw-abc/src/integration.rs
+++ b/contracts/external/cw-abc/src/integration.rs
@@ -1,0 +1,38 @@
+use crate::{abc::CurveType, boot::CwAbc};
+use boot_core::{BootUpload, Mock};
+use cosmwasm_std::{Addr, Uint128};
+
+use crate::testing::prelude::*;
+
+type AResult = anyhow::Result<()>; // alias for Result<(), anyhow::Error>
+
+// TODO: we need to make a PR to token factory bindings for the CustomHandler so that messages will actually execute
+#[test]
+fn instantiate() -> AResult {
+    let sender = Addr::unchecked(TEST_CREATOR);
+    let chain = Mock::new(&sender)?;
+
+    let abc = CwAbc::new("cw:abc", chain);
+    abc.upload()?;
+
+    let curve_type = CurveType::SquareRoot {
+        slope: Uint128::new(1),
+        scale: 1,
+    };
+
+    let _init_msg = default_instantiate_msg(5u8, 5u8, curve_type);
+    // abc.instantiate(&init_msg, None, None)?;
+    //
+    // let expected_config = msg::CurveInfoResponse {
+    //     reserve: Default::default(),
+    //     supply: Default::default(),
+    //     funding: Default::default(),
+    //     spot_price: Default::default(),
+    //     reserve_denom: "".to_string(),
+    // };
+    //
+    // let actual_config = abc.curve_info()?;
+    //
+    // assert_that!(&actual_config).is_equal_to(&expected_config);
+    Ok(())
+}

--- a/contracts/external/cw-abc/src/lib.rs
+++ b/contracts/external/cw-abc/src/lib.rs
@@ -6,5 +6,7 @@ mod error;
 pub mod msg;
 mod queries;
 pub mod state;
+#[cfg(feature = "boot")]
+pub mod boot;
 
 pub use crate::error::ContractError;

--- a/contracts/external/cw-abc/src/lib.rs
+++ b/contracts/external/cw-abc/src/lib.rs
@@ -1,12 +1,112 @@
 pub mod abc;
+#[cfg(feature = "boot")]
+pub mod boot;
 pub(crate) mod commands;
 pub mod contract;
 pub mod curves;
 mod error;
+#[cfg(test)]
+mod integration;
 pub mod msg;
 mod queries;
 pub mod state;
-#[cfg(feature = "boot")]
-pub mod boot;
 
 pub use crate::error::ContractError;
+
+#[cfg(test)]
+pub(crate) mod testing {
+    use crate::abc::{
+        ClosedConfig, CommonsPhaseConfig, CurveType, HatchConfig, MinMax, OpenConfig, ReserveToken,
+        SupplyToken,
+    };
+    use crate::msg::InstantiateMsg;
+    use cosmwasm_std::{
+        testing::{mock_env, mock_info, MockApi, MockQuerier, MockStorage},
+        Decimal, OwnedDeps, Uint128,
+    };
+
+    use crate::contract;
+    use crate::contract::CwAbcResult;
+    use cosmwasm_std::DepsMut;
+    use std::marker::PhantomData;
+    use token_bindings::{Metadata, TokenFactoryQuery};
+
+    pub(crate) mod prelude {
+        pub use super::{
+            default_instantiate_msg, default_supply_metadata, mock_tf_dependencies, TEST_BUYER,
+            TEST_CREATOR, TEST_INVESTOR, TEST_RESERVE_DENOM, TEST_SUPPLY_DENOM,
+        };
+        pub use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+        pub use speculoos::prelude::*;
+    }
+
+    pub const TEST_RESERVE_DENOM: &str = "satoshi";
+    pub const TEST_CREATOR: &str = "creator";
+    pub const TEST_INVESTOR: &str = "investor";
+    pub const TEST_BUYER: &str = "buyer";
+
+    pub const TEST_SUPPLY_DENOM: &str = "subdenom";
+
+    pub fn default_supply_metadata() -> Metadata {
+        Metadata {
+            name: Some("Bonded".to_string()),
+            symbol: Some("EPOXY".to_string()),
+            description: None,
+            denom_units: vec![],
+            base: None,
+            display: None,
+        }
+    }
+
+    pub fn default_instantiate_msg(
+        decimals: u8,
+        reserve_decimals: u8,
+        curve_type: CurveType,
+    ) -> InstantiateMsg {
+        InstantiateMsg {
+            supply: SupplyToken {
+                subdenom: TEST_SUPPLY_DENOM.to_string(),
+                metadata: default_supply_metadata(),
+                decimals,
+            },
+            reserve: ReserveToken {
+                denom: TEST_RESERVE_DENOM.to_string(),
+                decimals: reserve_decimals,
+            },
+            phase_config: CommonsPhaseConfig {
+                hatch: HatchConfig {
+                    initial_raise: MinMax {
+                        min: Uint128::one(),
+                        max: Uint128::from(1000000u128),
+                    },
+                    initial_price: Uint128::one(),
+                    initial_allocation_ratio: Decimal::percent(10u64),
+                    exit_tax: Decimal::zero(),
+                },
+                open: OpenConfig {
+                    allocation_percentage: Decimal::percent(10u64),
+                    exit_tax: Decimal::percent(10u64),
+                },
+                closed: ClosedConfig {},
+            },
+            hatcher_allowlist: None,
+            curve_type,
+        }
+    }
+
+    pub fn mock_init(deps: DepsMut<TokenFactoryQuery>, init_msg: InstantiateMsg) -> CwAbcResult {
+        let info = mock_info(TEST_CREATOR, &[]);
+        let env = mock_env();
+        contract::instantiate(deps, env, info, init_msg)
+    }
+
+    pub fn mock_tf_dependencies(
+    ) -> OwnedDeps<MockStorage, MockApi, MockQuerier<TokenFactoryQuery>, TokenFactoryQuery> {
+        OwnedDeps {
+            storage: MockStorage::default(),
+            api: MockApi::default(),
+            querier: MockQuerier::<TokenFactoryQuery>::new(&[]),
+            custom_query_type: PhantomData::<TokenFactoryQuery>,
+        }
+    }
+}

--- a/contracts/external/cw-abc/src/lib.rs
+++ b/contracts/external/cw-abc/src/lib.rs
@@ -1,10 +1,10 @@
+pub mod abc;
+pub(crate) mod commands;
 pub mod contract;
 pub mod curves;
 mod error;
 pub mod msg;
-pub mod state;
-pub mod abc;
-pub(crate) mod commands;
 mod queries;
+pub mod state;
 
 pub use crate::error::ContractError;

--- a/contracts/external/cw-abc/src/msg.rs
+++ b/contracts/external/cw-abc/src/msg.rs
@@ -21,6 +21,24 @@ pub struct InstantiateMsg {
     pub hatcher_allowlist: Option<Vec<String>>,
 }
 
+/// Update the phase configurations.
+/// These can only be called by the admin and only before or during each phase
+#[cw_serde]
+pub enum UpdatePhaseConfigMsg {
+    /// Update the hatch phase configuration
+    Hatch {
+        initial_raise: Option<MinMax>,
+        initial_allocation_ratio: Option<StdDecimal>,
+    },
+    /// Update the open phase configuration
+    Open {
+        exit_tax: Option<StdDecimal>,
+        reserve_ratio: Option<StdDecimal>,
+    },
+    /// Update the closed phase configuration
+    Closed {},
+}
+
 #[cw_ownable::cw_ownable_execute]
 #[cw_serde]
 pub enum ExecuteMsg {
@@ -38,10 +56,7 @@ pub enum ExecuteMsg {
     },
     /// Update the hatch phase configuration
     /// This can only be called by the admin and only during the hatch phase
-    UpdateHatchConfig {
-        initial_raise: Option<MinMax>,
-        initial_allocation_ratio: Option<StdDecimal>,
-    },
+    UpdatePhaseConfig(UpdatePhaseConfigMsg),
 }
 
 #[cw_ownable::cw_ownable_query]

--- a/contracts/external/cw-abc/src/msg.rs
+++ b/contracts/external/cw-abc/src/msg.rs
@@ -41,6 +41,7 @@ pub enum UpdatePhaseConfigMsg {
 
 #[cw_ownable::cw_ownable_execute]
 #[cw_serde]
+#[cfg_attr(feature = "boot", derive(boot_core::ExecuteFns))]
 pub enum ExecuteMsg {
     /// Buy will attempt to purchase as many supply tokens as possible.
     /// You must send only reserve tokens in that message
@@ -62,6 +63,7 @@ pub enum ExecuteMsg {
 #[cw_ownable::cw_ownable_query]
 #[cw_serde]
 #[derive(QueryResponses)]
+#[cfg_attr(feature = "boot", derive(boot_core::QueryFns))]
 pub enum QueryMsg {
     /// Returns the reserve and supply quantities, as well as the spot price to buy 1 token
     /// Returns [`CurveInfoResponse`]

--- a/contracts/external/cw-abc/src/msg.rs
+++ b/contracts/external/cw-abc/src/msg.rs
@@ -1,8 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Decimal, Uint128, Decimal as StdDecimal};
+use cosmwasm_std::{Addr, Decimal, Decimal as StdDecimal, Uint128};
 
 use crate::abc::{CommonsPhase, CommonsPhaseConfig, CurveType, MinMax, ReserveToken, SupplyToken};
-
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -21,7 +20,6 @@ pub struct InstantiateMsg {
     // Hatcher allowlist
     pub hatcher_allowlist: Option<Vec<String>>,
 }
-
 
 #[cw_ownable::cw_ownable_execute]
 #[cw_serde]

--- a/contracts/external/cw-abc/src/msg.rs
+++ b/contracts/external/cw-abc/src/msg.rs
@@ -56,10 +56,17 @@ pub enum QueryMsg {
     /// Returns [`CommonsPhaseConfigResponse`]
     #[returns(CommonsPhaseConfigResponse)]
     PhaseConfig {},
-    /// Returns the donators
+    /// Returns a list of the donors and their donations
     /// Returns [`DonationsResponse`]
     #[returns(DonationsResponse)]
     Donations {
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+    /// List the hatchers and their contributions
+    /// Returns [`HatchersResponse`]
+    #[returns(HatchersResponse)]
+    Hatchers {
         start_after: Option<String>,
         limit: Option<u32>,
     },
@@ -98,4 +105,10 @@ pub struct CommonsPhaseConfigResponse {
 pub struct DonationsResponse {
     // the donators mapped to their donation in the reserve token
     pub donations: Vec<(Addr, Uint128)>,
+}
+
+#[cw_serde]
+pub struct HatchersResponse {
+    // the hatchers mapped to their contribution in the reserve token
+    pub hatchers: Vec<(Addr, Uint128)>,
 }

--- a/contracts/external/cw-abc/src/msg.rs
+++ b/contracts/external/cw-abc/src/msg.rs
@@ -31,6 +31,8 @@ pub enum ExecuteMsg {
     Buy {},
     /// Implements CW20. Burn is a base message to destroy tokens forever
     Burn { amount: Uint128 },
+    /// Donate will add reserve tokens to the funding pool
+    Donate {},
     /// Update the hatch phase allowlist
     UpdateHatchAllowlist {
         to_add: Vec<String>,
@@ -55,7 +57,14 @@ pub enum QueryMsg {
     /// Returns the current phase configuration
     /// Returns [`CommonsPhaseConfigResponse`]
     #[returns(CommonsPhaseConfigResponse)]
-    PhaseConfig {}
+    PhaseConfig {},
+    /// Returns the donators
+    /// Returns [`DonationsResponse`]
+    #[returns(DonationsResponse)]
+    Donations {
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
 }
 
 #[cw_serde]
@@ -85,4 +94,10 @@ pub struct CommonsPhaseConfigResponse {
 
     // current phase
     pub phase: CommonsPhase,
+}
+
+#[cw_serde]
+pub struct DonationsResponse {
+    // the donators mapped to their donation in the reserve token
+    pub donations: Vec<(Addr, Uint128)>,
 }

--- a/contracts/external/cw-abc/src/msg.rs
+++ b/contracts/external/cw-abc/src/msg.rs
@@ -45,10 +45,13 @@ pub enum UpdatePhaseConfigMsg {
 pub enum ExecuteMsg {
     /// Buy will attempt to purchase as many supply tokens as possible.
     /// You must send only reserve tokens in that message
+    #[payable]
     Buy {},
     /// Burn is a base message to destroy tokens forever
+    #[payable]
     Burn {},
     /// Donate will add reserve tokens to the funding pool
+    #[payable]
     Donate {},
     /// Update the hatch phase allowlist
     UpdateHatchAllowlist {

--- a/contracts/external/cw-abc/src/msg.rs
+++ b/contracts/external/cw-abc/src/msg.rs
@@ -27,8 +27,8 @@ pub enum ExecuteMsg {
     /// Buy will attempt to purchase as many supply tokens as possible.
     /// You must send only reserve tokens in that message
     Buy {},
-    /// Implements CW20. Burn is a base message to destroy tokens forever
-    Burn { amount: Uint128 },
+    /// Burn is a base message to destroy tokens forever
+    Burn {},
     /// Donate will add reserve tokens to the funding pool
     Donate {},
     /// Update the hatch phase allowlist

--- a/contracts/external/cw-abc/src/msg.rs
+++ b/contracts/external/cw-abc/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Decimal, Uint128, Decimal as StdDecimal};
 
-use crate::abc::{CommonsPhaseConfig, CurveType, MinMax, ReserveToken, SupplyToken};
+use crate::abc::{CommonsPhase, CommonsPhaseConfig, CurveType, MinMax, ReserveToken, SupplyToken};
 
 
 #[cw_serde]
@@ -16,7 +16,10 @@ pub struct InstantiateMsg {
     pub curve_type: CurveType,
 
     // Hatch configuration information
-    pub phase_config: CommonsPhaseConfig<String>,
+    pub phase_config: CommonsPhaseConfig,
+
+    // Hatcher allowlist
+    pub hatcher_allowlist: Option<Vec<String>>,
 }
 
 
@@ -70,7 +73,16 @@ pub struct CurveInfoResponse {
 }
 
 #[cw_serde]
+pub struct HatcherAllowlistResponse {
+    // hatcher allowlist
+    pub allowlist: Option<Vec<Addr>>,
+}
+
+#[cw_serde]
 pub struct CommonsPhaseConfigResponse {
     // the phase configuration
-    pub phase_config: CommonsPhaseConfig<Addr>,
+    pub phase_config: CommonsPhaseConfig,
+
+    // current phase
+    pub phase: CommonsPhase,
 }

--- a/contracts/external/cw-abc/src/queries.rs
+++ b/contracts/external/cw-abc/src/queries.rs
@@ -1,6 +1,8 @@
 use crate::abc::CurveFn;
-use crate::msg::{CommonsPhaseConfigResponse, CurveInfoResponse, DonationsResponse};
-use crate::state::{CurveState, CURVE_STATE, DONATIONS, PHASE, PHASE_CONFIG};
+use crate::msg::{
+    CommonsPhaseConfigResponse, CurveInfoResponse, DonationsResponse, HatchersResponse,
+};
+use crate::state::{CurveState, CURVE_STATE, DONATIONS, HATCHERS, PHASE, PHASE_CONFIG};
 use cosmwasm_std::{Deps, Order, QuerierWrapper, StdResult};
 use std::ops::Deref;
 use token_bindings::TokenFactoryQuery;
@@ -76,4 +78,27 @@ pub fn query_donations(
     )?;
 
     Ok(DonationsResponse { donations })
+}
+
+pub fn query_hatchers(
+    deps: Deps<TokenFactoryQuery>,
+    start_aftor: Option<String>,
+    limit: Option<u32>,
+) -> StdResult<HatchersResponse> {
+    let hatchers = cw_paginate::paginate_map(
+        Deps {
+            storage: deps.storage,
+            api: deps.api,
+            querier: QuerierWrapper::new(deps.querier.deref()),
+        },
+        &HATCHERS,
+        start_aftor
+            .map(|addr| deps.api.addr_validate(&addr))
+            .transpose()?
+            .as_ref(),
+        limit,
+        Order::Descending,
+    )?;
+
+    Ok(HatchersResponse { hatchers })
 }

--- a/contracts/external/cw-abc/src/queries.rs
+++ b/contracts/external/cw-abc/src/queries.rs
@@ -1,9 +1,9 @@
-use std::ops::Deref;
-use cosmwasm_std::{Deps, Order, QuerierWrapper, StdResult};
-use token_bindings::TokenFactoryQuery;
 use crate::abc::CurveFn;
 use crate::msg::{CommonsPhaseConfigResponse, CurveInfoResponse, DonationsResponse};
-use crate::state::{CURVE_STATE, CurveState, DONATIONS, PHASE, PHASE_CONFIG};
+use crate::state::{CurveState, CURVE_STATE, DONATIONS, PHASE, PHASE_CONFIG};
+use cosmwasm_std::{Deps, Order, QuerierWrapper, StdResult};
+use std::ops::Deref;
+use token_bindings::TokenFactoryQuery;
 
 /// Get the current state of the curve
 pub fn query_curve_info(
@@ -41,7 +41,6 @@ pub fn query_phase_config(deps: Deps<TokenFactoryQuery>) -> StdResult<CommonsPha
     })
 }
 
-
 // // TODO, maybe we don't need this
 // pub fn get_denom(
 //     deps: Deps<TokenFactoryQuery>,
@@ -56,20 +55,25 @@ pub fn query_phase_config(deps: Deps<TokenFactoryQuery>) -> StdResult<CommonsPha
 //     }
 // }
 
-pub fn query_donations(deps: Deps<TokenFactoryQuery>, start_aftor: Option<String>, limit: Option<u32>) -> StdResult<DonationsResponse> {
+pub fn query_donations(
+    deps: Deps<TokenFactoryQuery>,
+    start_aftor: Option<String>,
+    limit: Option<u32>,
+) -> StdResult<DonationsResponse> {
     let donations = cw_paginate::paginate_map(
         Deps {
             storage: deps.storage,
             api: deps.api,
-            querier: QuerierWrapper::new(deps.querier.deref())
+            querier: QuerierWrapper::new(deps.querier.deref()),
         },
         &DONATIONS,
-        start_aftor.map(|addr| deps.api.addr_validate(&addr)).transpose()?.as_ref(),
+        start_aftor
+            .map(|addr| deps.api.addr_validate(&addr))
+            .transpose()?
+            .as_ref(),
         limit,
         Order::Descending,
     )?;
 
-    Ok(DonationsResponse {
-        donations,
-    })
+    Ok(DonationsResponse { donations })
 }

--- a/contracts/external/cw-abc/src/queries.rs
+++ b/contracts/external/cw-abc/src/queries.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{Deps, StdResult};
 use token_bindings::TokenFactoryQuery;
 use crate::abc::CurveFn;
 use crate::msg::{CommonsPhaseConfigResponse, CurveInfoResponse};
-use crate::state::{CURVE_STATE, CurveState};
+use crate::state::{CURVE_STATE, CurveState, PHASE, PHASE_CONFIG};
 
 /// Get the current state of the curve
 pub fn query_curve_info(
@@ -31,11 +31,12 @@ pub fn query_curve_info(
 }
 
 /// Load and return the phase config
-/// TODO: the allowlist will need to paged... should it be separate?
 pub fn query_phase_config(deps: Deps<TokenFactoryQuery>) -> StdResult<CommonsPhaseConfigResponse> {
-    let phase_config = crate::state::PHASE_CONFIG.load(deps.storage)?;
+    let phase = PHASE.load(deps.storage)?;
+    let phase_config = PHASE_CONFIG.load(deps.storage)?;
     Ok(CommonsPhaseConfigResponse {
-        phase_config
+        phase_config,
+        phase,
     })
 }
 

--- a/contracts/external/cw-abc/src/queries.rs
+++ b/contracts/external/cw-abc/src/queries.rs
@@ -1,8 +1,9 @@
-use cosmwasm_std::{Deps, StdResult};
+use std::ops::Deref;
+use cosmwasm_std::{Deps, Order, QuerierWrapper, StdResult};
 use token_bindings::TokenFactoryQuery;
 use crate::abc::CurveFn;
-use crate::msg::{CommonsPhaseConfigResponse, CurveInfoResponse};
-use crate::state::{CURVE_STATE, CurveState, PHASE, PHASE_CONFIG};
+use crate::msg::{CommonsPhaseConfigResponse, CurveInfoResponse, DonationsResponse};
+use crate::state::{CURVE_STATE, CurveState, DONATIONS, PHASE, PHASE_CONFIG};
 
 /// Get the current state of the curve
 pub fn query_curve_info(
@@ -54,3 +55,21 @@ pub fn query_phase_config(deps: Deps<TokenFactoryQuery>) -> StdResult<CommonsPha
 //         denom: response.denom,
 //     }
 // }
+
+pub fn query_donations(deps: Deps<TokenFactoryQuery>, start_aftor: Option<String>, limit: Option<u32>) -> StdResult<DonationsResponse> {
+    let donations = cw_paginate::paginate_map(
+        Deps {
+            storage: deps.storage,
+            api: deps.api,
+            querier: QuerierWrapper::new(deps.querier.deref())
+        },
+        &DONATIONS,
+        start_aftor.map(|addr| deps.api.addr_validate(&addr)).transpose()?.as_ref(),
+        limit,
+        Order::Descending,
+    )?;
+
+    Ok(DonationsResponse {
+        donations,
+    })
+}

--- a/contracts/external/cw-abc/src/state.rs
+++ b/contracts/external/cw-abc/src/state.rs
@@ -43,12 +43,14 @@ pub const CURVE_TYPE: Item<CurveType> = Item::new("curve_type");
 /// The denom used for the supply token
 pub const SUPPLY_DENOM: Item<String> = Item::new("denom");
 
+pub static HATCHER_ALLOWLIST: Item<HashSet<Addr>> = Item::new("hatch_allowlist");
+
 /// Keep track of who has contributed to the hatch phase
 /// TODO: cw-set?
 pub static HATCHERS: Item<HashSet<Addr>> = Item::new("hatchers");
 
 /// The phase configuration of the Augmented Bonding Curve
-pub static PHASE_CONFIG: Item<CommonsPhaseConfig<Addr>> = Item::new("phase_config");
+pub static PHASE_CONFIG: Item<CommonsPhaseConfig> = Item::new("phase_config");
 
 /// The phase state of the Augmented Bonding Curve
 pub static PHASE: Item<CommonsPhase> = Item::new("phase");

--- a/contracts/external/cw-abc/src/state.rs
+++ b/contracts/external/cw-abc/src/state.rs
@@ -43,12 +43,14 @@ pub const CURVE_TYPE: Item<CurveType> = Item::new("curve_type");
 /// The denom used for the supply token
 pub const SUPPLY_DENOM: Item<String> = Item::new("denom");
 
+/// Hatcher phase allowlist
+/// TODO: we could use the keys for the [`HATCHERS`] map instead setting them to 0 at the beginning, though existing hatchers would not be able to be removed
 pub static HATCHER_ALLOWLIST: Item<HashSet<Addr>> = Item::new("hatch_allowlist");
 
 /// Keep track of who has contributed to the hatch phase
 /// TODO: cw-set? This should be a map because in the open-phase we need to be able
 /// to ascertain the amount contributed by a user
-pub static HATCHERS: Item<HashSet<Addr>> = Item::new("hatchers");
+pub static HATCHERS: Map<&Addr, Uint128> = Map::new("hatchers");
 
 /// Keep track of the donated amounts per user
 pub static DONATIONS: Map<&Addr, Uint128> = Map::new("donations");

--- a/contracts/external/cw-abc/src/state.rs
+++ b/contracts/external/cw-abc/src/state.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use cosmwasm_schema::cw_serde;
 
 use cosmwasm_std::{Addr, Uint128};
-use cw_storage_plus::Item;
+use cw_storage_plus::{Item, Map};
 use crate::abc::{ CommonsPhaseConfig, CurveType, CommonsPhase};
 
 use crate::curves::DecimalPlaces;
@@ -46,8 +46,12 @@ pub const SUPPLY_DENOM: Item<String> = Item::new("denom");
 pub static HATCHER_ALLOWLIST: Item<HashSet<Addr>> = Item::new("hatch_allowlist");
 
 /// Keep track of who has contributed to the hatch phase
-/// TODO: cw-set?
+/// TODO: cw-set? This should be a map because in the open-phase we need to be able
+/// to ascertain the amount contributed by a user
 pub static HATCHERS: Item<HashSet<Addr>> = Item::new("hatchers");
+
+/// Keep track of the donated amounts per user
+pub static DONATIONS: Map<&Addr, Uint128> = Map::new("donations");
 
 /// The phase configuration of the Augmented Bonding Curve
 pub static PHASE_CONFIG: Item<CommonsPhaseConfig> = Item::new("phase_config");

--- a/contracts/external/cw-abc/src/state.rs
+++ b/contracts/external/cw-abc/src/state.rs
@@ -1,9 +1,9 @@
-use std::collections::HashSet;
 use cosmwasm_schema::cw_serde;
+use std::collections::HashSet;
 
+use crate::abc::{CommonsPhase, CommonsPhaseConfig, CurveType};
 use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::{Item, Map};
-use crate::abc::{ CommonsPhaseConfig, CurveType, CommonsPhase};
 
 use crate::curves::DecimalPlaces;
 
@@ -60,4 +60,3 @@ pub static PHASE_CONFIG: Item<CommonsPhaseConfig> = Item::new("phase_config");
 
 /// The phase state of the Augmented Bonding Curve
 pub static PHASE: Item<CommonsPhase> = Item::new("phase");
-


### PR DESCRIPTION
This change implements the following:
1) Donation feature for donating tokens directly to the funding pool
- Keeps track of donations and is queryable
2) Initial sell exit-tax implementation 
- Q: do we want hatchers to be able to sell their tokens at all? Right now there is an exit tax functionality but it would allow early investors to dump on later investors. Maybe we should require it to be > 50%?
3) Hatchers are tracked in a `Map` to allow for vesting schedule checking, otherwise their tokens bought afterwards would be stuck in their same vesting schedule
- Queryable
4) Update phase config
5) Initial boot integration and testing infra setup
- TODO: we need to make a PR to the `token-bindings` so that we can have a custom handler for the TokenFactory.