### PR TITLE
Final CW4 cleanup

### DIFF
--- a/contracts/dao-dao-core/src/tests.rs
+++ b/contracts/dao-dao-core/src/tests.rs
@@ -1148,7 +1148,7 @@ fn test_admin_permissions() {
     );
 
     // DAO unpauses after 10 blocks
-    app.update_block(|mut block| block.height += 11);
+    app.update_block(|block| block.height += 11);
 
     // Admin can nominate a new admin.
     let res = app.execute_contract(
@@ -1414,7 +1414,7 @@ fn test_admin_nomination() {
     );
 
     // DAO unpauses after 10 blocks
-    app.update_block(|mut block| block.height += 11);
+    app.update_block(|block| block.height += 11);
 
     // Remove the admin.
     app.execute_contract(
@@ -2428,7 +2428,7 @@ fn test_pause() {
 
     assert!(matches!(err, ContractError::Paused { .. }));
 
-    app.update_block(|mut block| block.height += 9);
+    app.update_block(|block| block.height += 9);
 
     // Still not unpaused.
     let err: ContractError = app
@@ -2454,7 +2454,7 @@ fn test_pause() {
 
     assert!(matches!(err, ContractError::Paused { .. }));
 
-    app.update_block(|mut block| block.height += 1);
+    app.update_block(|block| block.height += 1);
 
     let paused: PauseInfoResponse = app
         .wrap()

--- a/contracts/external/cw-fund-distributor/src/testing/adversarial_tests.rs
+++ b/contracts/external/cw-fund-distributor/src/testing/adversarial_tests.rs
@@ -203,7 +203,7 @@ pub fn test_claim_lots_of_native_tokens() {
         .unwrap();
     }
 
-    app.update_block(|mut block| block.height += 11);
+    app.update_block(|block| block.height += 11);
 
     app.execute_contract(
         Addr::unchecked("bekauz"),
@@ -276,7 +276,7 @@ pub fn test_claim_lots_of_cw20s() {
         })
         .collect();
 
-    app.update_block(|mut block| block.height += 11);
+    app.update_block(|block| block.height += 11);
 
     app.execute_contract(
         Addr::unchecked("bekauz"),

--- a/contracts/external/cw-fund-distributor/src/testing/tests.rs
+++ b/contracts/external/cw-fund-distributor/src/testing/tests.rs
@@ -583,7 +583,7 @@ pub fn test_claim_cw20() {
     let balance = query_cw20_balance(&mut app, token_address.clone(), distributor_address.clone());
 
     assert_eq!(balance.balance, amount);
-    app.update_block(|mut block| block.height += 11);
+    app.update_block(|block| block.height += 11);
 
     // claim the tokens
     // should result in an entitlement of (10/(10 + 20))%
@@ -654,7 +654,7 @@ pub fn test_claim_cw20_twice() {
 
     assert_eq!(balance.balance, amount);
 
-    app.update_block(|mut block| block.height += 11);
+    app.update_block(|block| block.height += 11);
 
     // claim the tokens twice
     app.execute_contract(
@@ -723,7 +723,7 @@ pub fn test_claim_cw20s_empty_list() {
         Addr::unchecked(CREATOR_ADDR),
     );
 
-    app.update_block(|mut b| b.height += 11);
+    app.update_block(|b| b.height += 11);
 
     let err: ContractError = app
         .execute_contract(
@@ -767,7 +767,7 @@ pub fn test_claim_natives_twice() {
         Addr::unchecked(CREATOR_ADDR),
     );
 
-    app.update_block(|mut block| block.height += 11);
+    app.update_block(|block| block.height += 11);
 
     // claim twice
     app.execute_contract(
@@ -830,7 +830,7 @@ pub fn test_claim_natives() {
         Addr::unchecked(CREATOR_ADDR),
     );
 
-    app.update_block(|mut block| block.height += 11);
+    app.update_block(|block| block.height += 11);
 
     app.execute_contract(
         Addr::unchecked("bekauz"),
@@ -898,7 +898,7 @@ pub fn test_claim_all() {
     );
 
     // claiming period
-    app.update_block(|mut block| block.height += 11);
+    app.update_block(|block| block.height += 11);
 
     app.execute_contract(
         Addr::unchecked("bekauz"),
@@ -963,7 +963,7 @@ pub fn test_claim_natives_empty_list_of_denoms() {
         Addr::unchecked(CREATOR_ADDR),
     );
 
-    app.update_block(|mut block| block.height += 11);
+    app.update_block(|block| block.height += 11);
 
     let err: ContractError = app
         .execute_contract(
@@ -1013,7 +1013,7 @@ pub fn test_redistribute_unclaimed_funds() {
         Addr::unchecked(CREATOR_ADDR),
     );
 
-    app.update_block(|mut block| block.height += 11);
+    app.update_block(|block| block.height += 11);
 
     // claim the initial allocation equal to 1/3rd of 500000
     app.execute_contract(
@@ -1286,7 +1286,7 @@ pub fn test_fund_cw20_during_claiming_period() {
     );
 
     // skip into the claiming period
-    app.update_block(|mut block| block.height += 11);
+    app.update_block(|block| block.height += 11);
 
     // attempt to fund the contract
     let err: ContractError = app
@@ -1323,7 +1323,7 @@ pub fn test_fund_natives_during_claiming_period() {
     mint_natives(&mut app, Addr::unchecked(CREATOR_ADDR), amount);
 
     // skip into the claim period
-    app.update_block(|mut block| block.height += 11);
+    app.update_block(|block| block.height += 11);
 
     // attempt to fund
     let err: ContractError = app

--- a/contracts/proposal/dao-proposal-single/src/testing/tests.rs
+++ b/contracts/proposal/dao-proposal-single/src/testing/tests.rs
@@ -400,7 +400,7 @@ fn test_proposal_close_after_expiry() {
     assert!(matches!(err, ContractError::WrongCloseStatus {}));
 
     // Expire the proposal. Now it should be closable.
-    app.update_block(|mut b| b.time = b.time.plus_seconds(604800));
+    app.update_block(|b| b.time = b.time.plus_seconds(604800));
     close_proposal(&mut app, &proposal_module, CREATOR_ADDR, proposal_id);
     let proposal = query_proposal(&app, &proposal_module, proposal_id);
     assert_eq!(proposal.proposal.status, Status::Closed);
@@ -444,7 +444,7 @@ fn test_proposal_cant_close_after_expiry_is_passed() {
     assert_eq!(proposal.proposal.status, Status::Open);
 
     // Expire the proposal. This should pass it.
-    app.update_block(|mut b| b.time = b.time.plus_seconds(604800));
+    app.update_block(|b| b.time = b.time.plus_seconds(604800));
     let proposal = query_proposal(&app, &proposal_module, proposal_id);
     assert_eq!(proposal.proposal.status, Status::Passed);
 
@@ -481,7 +481,7 @@ fn test_execute_no_non_passed_execution() {
     assert!(matches!(err, ContractError::NotPassed {}));
 
     // Expire the proposal.
-    app.update_block(|mut b| b.time = b.time.plus_seconds(604800));
+    app.update_block(|b| b.time = b.time.plus_seconds(604800));
     let err = execute_proposal_should_fail(&mut app, &proposal_module, CREATOR_ADDR, proposal_id);
     assert!(matches!(err, ContractError::NotPassed {}));
 
@@ -1050,7 +1050,7 @@ fn test_min_voting_period_no_early_pass() {
     let proposal_response = query_proposal(&app, &proposal_module, proposal_id);
     assert_eq!(proposal_response.proposal.status, Status::Open);
 
-    app.update_block(|mut block| block.height += 10);
+    app.update_block(|block| block.height += 10);
     let proposal_response = query_proposal(&app, &proposal_module, proposal_id);
     assert_eq!(proposal_response.proposal.status, Status::Passed);
 }
@@ -1088,7 +1088,7 @@ fn test_min_duration_same_as_proposal_duration() {
     vote_on_proposal(&mut app, &proposal_module, "whale", proposal_id, Vote::Yes);
     vote_on_proposal(&mut app, &proposal_module, "ekez", proposal_id, Vote::No);
 
-    app.update_block(|mut b| b.height += 100);
+    app.update_block(|b| b.height += 100);
     let proposal_response = query_proposal(&app, &proposal_module, proposal_id);
     assert_eq!(proposal_response.proposal.status, Status::Passed);
 }
@@ -1147,7 +1147,7 @@ fn test_revoting_playthrough() {
     assert!(matches!(err, ContractError::AlreadyCast {}));
 
     // Expire the proposal allowing the votes to be tallied.
-    app.update_block(|mut b| b.time = b.time.plus_seconds(604800));
+    app.update_block(|b| b.time = b.time.plus_seconds(604800));
     let proposal_response = query_proposal(&app, &proposal_module, proposal_id);
     assert_eq!(proposal_response.proposal.status, Status::Passed);
     execute_proposal(&mut app, &proposal_module, CREATOR_ADDR, proposal_id);
@@ -1236,7 +1236,7 @@ fn test_allow_revoting_config_changes() {
         Vote::No,
     );
     // Expire the revoting proposal and close it.
-    app.update_block(|mut b| b.time = b.time.plus_seconds(604800));
+    app.update_block(|b| b.time = b.time.plus_seconds(604800));
     close_proposal(&mut app, &proposal_module, CREATOR_ADDR, revoting_proposal);
 }
 
@@ -1393,7 +1393,7 @@ fn test_three_of_five_multisig_revoting() {
     assert!(matches!(err, ContractError::AlreadyCast {}));
 
     // Expire the revoting proposal and close it.
-    app.update_block(|mut b| b.time = b.time.plus_seconds(604800));
+    app.update_block(|b| b.time = b.time.plus_seconds(604800));
     let proposal: ProposalResponse = query_proposal(&app, &proposal_module, proposal_id);
     assert_eq!(proposal.proposal.status, Status::Rejected);
 }
@@ -2635,7 +2635,7 @@ pub fn test_not_allow_voting_on_expired_proposal() {
     } = setup_test(vec![]);
 
     // expire the proposal
-    app.update_block(|mut b| b.time = b.time.plus_seconds(604800));
+    app.update_block(|b| b.time = b.time.plus_seconds(604800));
     let proposal = query_proposal(&app, &proposal_module, proposal_id);
     assert_eq!(proposal.proposal.status, Status::Rejected);
     assert_eq!(proposal.proposal.votes.yes, Uint128::zero());

--- a/contracts/staking/cw20-stake-reward-distributor/src/tests.rs
+++ b/contracts/staking/cw20-stake-reward-distributor/src/tests.rs
@@ -246,7 +246,7 @@ fn test_distribute() {
     app.execute_contract(Addr::unchecked(OWNER), cw20_addr.clone(), &msg, &[])
         .unwrap();
 
-    app.update_block(|mut block| block.height += 10);
+    app.update_block(|block| block.height += 10);
     app.execute_contract(
         Addr::unchecked(OWNER),
         distributor_addr.clone(),
@@ -262,7 +262,7 @@ fn test_distribute() {
     assert_eq!(distributor_info.balance, Uint128::new(990));
     assert_eq!(distributor_info.last_payment_block, app.block_info().height);
 
-    app.update_block(|mut block| block.height += 500);
+    app.update_block(|block| block.height += 500);
     app.execute_contract(
         Addr::unchecked(OWNER),
         distributor_addr.clone(),
@@ -278,7 +278,7 @@ fn test_distribute() {
     assert_eq!(distributor_info.balance, Uint128::new(490));
     assert_eq!(distributor_info.last_payment_block, app.block_info().height);
 
-    app.update_block(|mut block| block.height += 1000);
+    app.update_block(|block| block.height += 1000);
     app.execute_contract(
         Addr::unchecked(OWNER),
         distributor_addr.clone(),
@@ -296,7 +296,7 @@ fn test_distribute() {
     let last_payment_block = distributor_info.last_payment_block;
 
     // Pays out nothing
-    app.update_block(|mut block| block.height += 1100);
+    app.update_block(|block| block.height += 1100);
     let err: ContractError = app
         .execute_contract(
             Addr::unchecked(OWNER),
@@ -318,7 +318,7 @@ fn test_distribute() {
     assert_eq!(distributor_info.last_payment_block, last_payment_block);
 
     // go to a block before the last payment
-    app.update_block(|mut block| block.height -= 2000);
+    app.update_block(|block| block.height -= 2000);
     let err: ContractError = app
         .execute_contract(
             Addr::unchecked(OWNER),
@@ -458,7 +458,7 @@ fn test_withdraw() {
     app.execute_contract(Addr::unchecked(OWNER), cw20_addr.clone(), &msg, &[])
         .unwrap();
 
-    app.update_block(|mut block| block.height += 10);
+    app.update_block(|block| block.height += 10);
     app.execute_contract(
         Addr::unchecked(OWNER),
         distributor_addr.clone(),
@@ -541,7 +541,7 @@ fn test_dao_deploy() {
     app.execute_contract(Addr::unchecked(OWNER), cw20_addr.clone(), &msg, &[])
         .unwrap();
 
-    app.update_block(|mut block| block.height += 10);
+    app.update_block(|block| block.height += 10);
     app.execute_contract(
         Addr::unchecked(OWNER),
         distributor_addr.clone(),

--- a/contracts/voting/dao-voting-cw4/src/contract.rs
+++ b/contracts/voting/dao-voting-cw4/src/contract.rs
@@ -92,7 +92,7 @@ pub fn instantiate(
             )?;
 
             if res.members.is_empty() {
-                return Err(ContractError::ZeroTotalWeight {});
+                return Err(ContractError::NoMembers {});
             }
 
             GROUP_CONTRACT.save(deps.storage, &group_contract)?;

--- a/contracts/voting/dao-voting-cw4/src/error.rs
+++ b/contracts/voting/dao-voting-cw4/src/error.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::StdError;
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum ContractError {
     #[error("{0}")]
     Std(#[from] StdError),
@@ -21,7 +21,7 @@ pub enum ContractError {
     #[error("Contract only supports queries")]
     NoExecute {},
 
-    #[error("Cannot instantiate a group contract with no initial members")]
+    #[error("Cannot instantiate or use a group contract with no initial members")]
     NoMembers {},
 
     #[error("Got a submessage reply with unknown id: {id}")]

--- a/contracts/voting/dao-voting-cw4/src/state.rs
+++ b/contracts/voting/dao-voting-cw4/src/state.rs
@@ -1,19 +1,5 @@
-use cosmwasm_std::{Addr, Uint128};
-use cw_storage_plus::{Item, SnapshotItem, SnapshotMap, Strategy};
-
-pub const USER_WEIGHTS: SnapshotMap<&Addr, Uint128> = SnapshotMap::new(
-    "user_weights",
-    "user_weights__checkpoints",
-    "user_weights__changelog",
-    Strategy::EveryBlock,
-);
-
-pub const TOTAL_WEIGHT: SnapshotItem<Uint128> = SnapshotItem::new(
-    "total_weight",
-    "total_weight__checkpoints",
-    "total_weight__changelog",
-    Strategy::EveryBlock,
-);
+use cosmwasm_std::Addr;
+use cw_storage_plus::Item;
 
 pub const GROUP_CONTRACT: Item<Addr> = Item::new("group_contract");
 pub const DAO: Item<Addr> = Item::new("dao_address");

--- a/contracts/voting/dao-voting-cw721-staked/src/testing/tests.rs
+++ b/contracts/voting/dao-voting-cw721-staked/src/testing/tests.rs
@@ -233,7 +233,7 @@ fn test_update_config() -> anyhow::Result<()> {
     );
 
     let info = app.block_info();
-    app.update_block(|mut block| {
+    app.update_block(|block| {
         block.height += 3;
         block.time = match Duration::Time(1).after(&info) {
             cw_utils::Expiration::AtTime(timestamp) => timestamp,


### PR DESCRIPTION
The other cw4 cleanup PR (#691) was merged a bit too early. It was missing a contract validation and left the unused state variables in. This PR makes these changes.