### PR TITLE
fix bug on bounty update

### DIFF
--- a/contracts/external/cw-bounties/src/tests.rs
+++ b/contracts/external/cw-bounties/src/tests.rs
@@ -2,14 +2,21 @@ use cosmwasm_std::{coin, Addr, Coin, Empty, StdResult, Uint128};
 use cw_multi_test::{App, AppResponse, Contract, ContractWrapper, Executor};
 use cw_utils::PaymentError;
 
-use crate::{msg::InstantiateMsg, state::BountyStatus, ContractError};
+use crate::{
+    msg::InstantiateMsg,
+    state::{Bounty, BountyStatus},
+    ContractError,
+};
 
 pub struct Test {
     pub app: App,
-    pub addr: Addr,
+    pub contract: Addr,
     pub owner: Addr,
     pub recipient: Addr,
 }
+
+const ATOM_DENOM: &str = "uatom";
+const JUNO_DENOM: &str = "ujuno";
 
 impl Test {
     pub fn new() -> Self {
@@ -21,7 +28,7 @@ impl Test {
                 .init_balance(
                     storage,
                     &owner,
-                    vec![coin(10000, "ujuno"), coin(10000, "uatom")],
+                    vec![coin(10000, JUNO_DENOM), coin(10000, ATOM_DENOM)],
                 )
                 .unwrap();
             router
@@ -29,12 +36,12 @@ impl Test {
                 .init_balance(
                     storage,
                     &recipient,
-                    vec![coin(10000, "ujuno"), coin(10000, "uatom")],
+                    vec![coin(10000, JUNO_DENOM), coin(10000, ATOM_DENOM)],
                 )
                 .unwrap();
         });
         let code_id = app.store_code(bounty_countract());
-        let addr = app
+        let contract = app
             .instantiate_contract(
                 code_id,
                 owner.clone(),
@@ -48,7 +55,7 @@ impl Test {
             .unwrap();
         Self {
             app,
-            addr,
+            contract,
             owner,
             recipient,
         }
@@ -66,17 +73,20 @@ impl Test {
             title,
             description,
         };
-        let res =
-            self.app
-                .execute_contract(self.owner.clone(), self.addr.clone(), &msg, send_funds)?;
+        let res = self.app.execute_contract(
+            self.owner.clone(),
+            self.contract.clone(),
+            &msg,
+            send_funds,
+        )?;
         Ok(res)
     }
 
     pub fn close(&mut self, id: u64) -> Result<AppResponse, anyhow::Error> {
         let msg = crate::msg::ExecuteMsg::Close { id };
-        let res = self
-            .app
-            .execute_contract(self.owner.clone(), self.addr.clone(), &msg, &[])?;
+        let res =
+            self.app
+                .execute_contract(self.owner.clone(), self.contract.clone(), &msg, &[])?;
         Ok(res)
     }
 
@@ -94,9 +104,12 @@ impl Test {
             title,
             description,
         };
-        let res =
-            self.app
-                .execute_contract(self.owner.clone(), self.addr.clone(), &msg, send_funds)?;
+        let res = self.app.execute_contract(
+            self.owner.clone(),
+            self.contract.clone(),
+            &msg,
+            send_funds,
+        )?;
         Ok(res)
     }
 
@@ -105,15 +118,15 @@ impl Test {
             id,
             recipient: self.recipient.to_string(),
         };
-        let res = self
-            .app
-            .execute_contract(self.owner.clone(), self.addr.clone(), &msg, &[])?;
+        let res =
+            self.app
+                .execute_contract(self.owner.clone(), self.contract.clone(), &msg, &[])?;
         Ok(res)
     }
 
     pub fn query(&self, id: u64) -> StdResult<crate::state::Bounty> {
         let msg = crate::msg::QueryMsg::Bounty { id };
-        self.app.wrap().query_wasm_smart(&self.addr, &msg)
+        self.app.wrap().query_wasm_smart(&self.contract, &msg)
     }
 }
 
@@ -130,27 +143,42 @@ fn bounty_countract() -> Box<dyn Contract<Empty>> {
 pub fn test_create_bounty() {
     let mut test = Test::new();
 
+    let bounty_amount = 100;
     let balance_before = test
         .app
         .wrap()
-        .query_balance(test.owner.clone(), "ujuno")
+        .query_balance(test.owner.clone(), JUNO_DENOM)
         .unwrap();
     // create bounty
     test.create(
-        coin(100, "ujuno"),
+        coin(bounty_amount, JUNO_DENOM),
         "title".to_string(),
         Some("description".to_string()),
-        &[coin(100, "ujuno")],
+        &[coin(bounty_amount, JUNO_DENOM)],
     )
     .unwrap();
+    // - assert bounty
+    let bounty = test.query(1).unwrap();
+    assert_eq!(
+        bounty,
+        Bounty {
+            id: 1,
+            amount: coin(bounty_amount, JUNO_DENOM),
+            title: "title".to_string(),
+            description: Some("description".to_string()),
+            status: BountyStatus::Open,
+            created_at: test.app.block_info().time.seconds(),
+            updated_at: None,
+        }
+    );
     // assert balance
     let balance_after = test
         .app
         .wrap()
-        .query_balance(test.owner.clone(), "ujuno")
+        .query_balance(test.owner.clone(), JUNO_DENOM)
         .unwrap();
     assert!(
-        balance_before.amount.u128() == (balance_after.amount.u128() + 100),
+        balance_before.amount.u128() == (balance_after.amount.u128() + bounty_amount),
         "before: {}, after: {}",
         balance_before.amount.u128(),
         balance_after.amount.u128()
@@ -159,7 +187,7 @@ pub fn test_create_bounty() {
     // create bounty without sending funds
     let err: ContractError = test
         .create(
-            coin(100, "ujuno"),
+            coin(bounty_amount, JUNO_DENOM),
             "title".to_string(),
             Some("description".to_string()),
             &[],
@@ -172,10 +200,10 @@ pub fn test_create_bounty() {
     // create bounty with lower amount
     let err: ContractError = test
         .create(
-            coin(100, "ujuno"),
+            coin(bounty_amount, JUNO_DENOM),
             "title".to_string(),
             Some("description".to_string()),
-            &[coin(50, "ujuno")],
+            &[coin(bounty_amount / 2, JUNO_DENOM)],
         )
         .unwrap_err()
         .downcast()
@@ -183,18 +211,18 @@ pub fn test_create_bounty() {
     assert_eq!(
         err,
         ContractError::InvalidAmount {
-            expected: Uint128::new(100),
-            actual: Uint128::new(50)
+            expected: Uint128::new(bounty_amount),
+            actual: Uint128::new(bounty_amount / 2)
         }
     );
 
     // create bounty with bigger amount
     let err: ContractError = test
         .create(
-            coin(100, "ujuno"),
+            coin(bounty_amount, JUNO_DENOM),
             "title".to_string(),
             Some("description".to_string()),
-            &[coin(150, "ujuno")],
+            &[coin(2 * bounty_amount, JUNO_DENOM)],
         )
         .unwrap_err()
         .downcast()
@@ -202,8 +230,8 @@ pub fn test_create_bounty() {
     assert_eq!(
         err,
         ContractError::InvalidAmount {
-            expected: Uint128::new(100),
-            actual: Uint128::new(150)
+            expected: Uint128::new(bounty_amount),
+            actual: Uint128::new(2 * bounty_amount)
         }
     );
 }
@@ -211,18 +239,27 @@ pub fn test_create_bounty() {
 #[test]
 pub fn test_close_bounty() {
     let mut test = Test::new();
+    let bounty_amount = 100;
 
     // create bounty
     test.create(
-        coin(100, "ujuno"),
+        coin(bounty_amount, JUNO_DENOM),
         "title".to_string(),
         Some("description".to_string()),
-        &[coin(100, "ujuno")],
+        &[coin(bounty_amount, JUNO_DENOM)],
     )
     .unwrap();
 
     // close bounty
     test.close(1).unwrap();
+    // - assert bounty status
+    let bounty = test.query(1).unwrap();
+    assert_eq!(
+        bounty.status,
+        BountyStatus::Closed {
+            closed_at: test.app.block_info().time.seconds(),
+        }
+    );
 
     // close bounty again
     let err: ContractError = test.close(1).unwrap_err().downcast().unwrap();
@@ -231,195 +268,293 @@ pub fn test_close_bounty() {
 
 #[test]
 pub fn test_update_bounty() {
-    let mut test = Test::new();
-
-    let initial_juno_balance = test
-        .app
-        .wrap()
-        .query_balance(test.owner.clone(), "ujuno")
-        .unwrap();
-    let initial_atom_balance = test
-        .app
-        .wrap()
-        .query_balance(test.owner.clone(), "uatom")
-        .unwrap();
-    // create bounty
-    test.create(
-        coin(100, "ujuno"),
-        "title".to_string(),
-        Some("description".to_string()),
-        &[coin(100, "ujuno")],
-    )
-    .unwrap();
-
-    // update bounty
-    test.update(
-        1,
-        coin(200, "ujuno"),
-        "title".to_string(),
-        Some("description".to_string()),
-        &[coin(100, "ujuno")],
-    )
-    .unwrap();
-    // assert balance
-    let balance_after = test
-        .app
-        .wrap()
-        .query_balance(test.owner.clone(), "ujuno")
-        .unwrap();
-    assert!(
-        initial_juno_balance.amount.u128() == (balance_after.amount.u128() + 200),
-        "before: {}, after: {}",
-        initial_juno_balance.amount.u128(),
-        balance_after.amount.u128()
-    );
-
-    // update bounty without sending funds
-    let err: ContractError = test
-        .update(
-            1,
-            coin(300, "ujuno"),
+    let bounty_amount = 100;
+    // case: update bounty
+    {
+        let mut test = Test::new();
+        let initial_juno_balance = test
+            .app
+            .wrap()
+            .query_balance(test.owner.clone(), JUNO_DENOM)
+            .unwrap();
+        // create bounty
+        test.create(
+            coin(bounty_amount, JUNO_DENOM),
             "title".to_string(),
             Some("description".to_string()),
-            &[],
+            &[coin(bounty_amount, JUNO_DENOM)],
         )
-        .unwrap_err()
-        .downcast()
         .unwrap();
-    assert_eq!(err, ContractError::PaymentError(PaymentError::NoFunds {}));
 
-    // update bounty with lower amount
-    let err: ContractError = test
-        .update(
+        test.update(
             1,
-            coin(300, "ujuno"),
+            coin(2 * bounty_amount, JUNO_DENOM),
             "title".to_string(),
             Some("description".to_string()),
-            &[coin(50, "ujuno")],
+            &[coin(bounty_amount, JUNO_DENOM)],
         )
-        .unwrap_err()
-        .downcast()
         .unwrap();
-    assert_eq!(
-        err,
-        ContractError::InvalidAmount {
-            expected: Uint128::new(100),
-            actual: Uint128::new(250)
-        }
-    );
+        // - assert bounty
+        let bounty = test.query(1).unwrap();
+        assert_eq!(
+            bounty,
+            Bounty {
+                id: 1,
+                amount: coin(2 * bounty_amount, JUNO_DENOM),
+                title: "title".to_string(),
+                description: Some("description".to_string()),
+                status: BountyStatus::Open,
+                created_at: test.app.block_info().time.seconds(),
+                updated_at: Some(test.app.block_info().time.seconds()),
+            }
+        );
+        // assert balance
+        let balance_after = test
+            .app
+            .wrap()
+            .query_balance(test.owner.clone(), JUNO_DENOM)
+            .unwrap();
+        assert!(
+            initial_juno_balance.amount.u128() == (balance_after.amount.u128() + 200),
+            "before: {}, after: {}",
+            initial_juno_balance.amount.u128(),
+            balance_after.amount.u128()
+        );
+    }
 
-    // update bounty with bigger amount
-    let err: ContractError = test
-        .update(
-            1,
-            coin(300, "ujuno"),
+    // case: update bounty sending incorrect funds
+    {
+        let mut test = Test::new();
+        // create bounty
+        test.create(
+            coin(bounty_amount, JUNO_DENOM),
             "title".to_string(),
             Some("description".to_string()),
-            &[coin(150, "ujuno")],
+            &[coin(bounty_amount, JUNO_DENOM)],
         )
-        .unwrap_err()
-        .downcast()
         .unwrap();
-    assert_eq!(
-        err,
-        ContractError::InvalidAmount {
-            expected: Uint128::new(100),
-            actual: Uint128::new(350)
-        }
-    );
+        let err: ContractError = test
+            .update(
+                1,
+                coin(3 * bounty_amount, JUNO_DENOM),
+                "title".to_string(),
+                Some("description".to_string()),
+                &[],
+            )
+            .unwrap_err()
+            .downcast()
+            .unwrap();
+        assert_eq!(err, ContractError::PaymentError(PaymentError::NoFunds {}));
 
-    // update bounty with different denom
-    test.update(
-        1,
-        coin(200, "uatom"),
-        "title".to_string(),
-        Some("description".to_string()),
-        &[coin(200, "uatom")],
-    )
-    .unwrap();
-    // assert juno balance
-    let juno_balance_after = test
-        .app
-        .wrap()
-        .query_balance(test.owner.clone(), "ujuno")
-        .unwrap();
-    assert!(
-        juno_balance_after.amount == initial_juno_balance.amount,
-        "before: {}, after: {}",
-        initial_juno_balance.amount.u128(),
-        balance_after.amount.u128()
-    );
-    let atom_balance_after = test
-        .app
-        .wrap()
-        .query_balance(test.owner.clone(), "uatom")
-        .unwrap();
-    assert!(
-        atom_balance_after.amount.u128() == (initial_atom_balance.amount.u128() - 200),
-        "before: {}, after: {}",
-        initial_atom_balance.amount.u128(),
-        atom_balance_after.amount.u128()
-    );
+        // update bounty with lower amount
+        let err: ContractError = test
+            .update(
+                1,
+                coin(2 * bounty_amount, JUNO_DENOM),
+                "title".to_string(),
+                Some("description".to_string()),
+                &[coin(bounty_amount / 2, JUNO_DENOM)],
+            )
+            .unwrap_err()
+            .downcast()
+            .unwrap();
+        assert_eq!(
+            err,
+            ContractError::InvalidAmount {
+                expected: Uint128::new(bounty_amount),
+                actual: Uint128::new(bounty_amount + bounty_amount / 2)
+            }
+        );
 
-    // test closed bounty
-    test.close(1).unwrap();
-    let err: ContractError = test
-        .update(
-            1,
-            coin(200, "ujuno"),
+        // update bounty with bigger amount
+        let err: ContractError = test
+            .update(
+                1,
+                coin(2 * bounty_amount, JUNO_DENOM),
+                "title".to_string(),
+                Some("description".to_string()),
+                &[coin(2 * bounty_amount, JUNO_DENOM)], // 100 already in bounty, now sending 200
+            )
+            .unwrap_err()
+            .downcast()
+            .unwrap();
+        assert_eq!(
+            err,
+            ContractError::InvalidAmount {
+                expected: Uint128::new(bounty_amount),
+                actual: Uint128::new(3 * bounty_amount)
+            }
+        );
+    }
+
+    // case: update bounty with different denom
+    {
+        let mut test = Test::new();
+        let initial_juno_balance = test
+            .app
+            .wrap()
+            .query_balance(test.owner.clone(), JUNO_DENOM)
+            .unwrap();
+        let initial_atom_balance = test
+            .app
+            .wrap()
+            .query_balance(test.owner.clone(), ATOM_DENOM)
+            .unwrap();
+        // create bounty
+        test.create(
+            coin(bounty_amount, JUNO_DENOM),
             "title".to_string(),
             Some("description".to_string()),
-            &[coin(200, "ujuno")],
+            &[coin(bounty_amount, JUNO_DENOM)],
         )
-        .unwrap_err()
-        .downcast()
         .unwrap();
-    assert_eq!(err, ContractError::NotOpen {});
+
+        test.update(
+            1,
+            coin(200, ATOM_DENOM),
+            "title".to_string(),
+            Some("description".to_string()),
+            &[coin(200, ATOM_DENOM)],
+        )
+        .unwrap();
+        // - assert bounty
+        let bounty = test.query(1).unwrap();
+        assert_eq!(
+            bounty,
+            Bounty {
+                id: 1,
+                amount: coin(2 * bounty_amount, ATOM_DENOM),
+                title: "title".to_string(),
+                description: Some("description".to_string()),
+                status: BountyStatus::Open,
+                created_at: test.app.block_info().time.seconds(),
+                updated_at: Some(test.app.block_info().time.seconds()),
+            }
+        );
+        // assert juno balance
+        let juno_balance_after = test
+            .app
+            .wrap()
+            .query_balance(test.owner.clone(), JUNO_DENOM)
+            .unwrap();
+        assert!(
+            juno_balance_after.amount == initial_juno_balance.amount,
+            "before: {}, after: {}",
+            initial_juno_balance.amount.u128(),
+            juno_balance_after.amount.u128()
+        );
+        // assert atom balance
+        let atom_balance_after = test
+            .app
+            .wrap()
+            .query_balance(test.owner.clone(), ATOM_DENOM)
+            .unwrap();
+        assert!(
+            atom_balance_after.amount.u128() == (initial_atom_balance.amount.u128() - 200),
+            "before: {}, after: {}",
+            initial_atom_balance.amount.u128(),
+            atom_balance_after.amount.u128()
+        );
+    }
+
+    // case: update on closed bounty
+    {
+        let mut test = Test::new();
+        // create bounty
+        test.create(
+            coin(bounty_amount, JUNO_DENOM),
+            "title".to_string(),
+            Some("description".to_string()),
+            &[coin(bounty_amount, JUNO_DENOM)],
+        )
+        .unwrap();
+
+        test.close(1).unwrap();
+        let err: ContractError = test
+            .update(
+                1,
+                coin(2 * bounty_amount, JUNO_DENOM),
+                "title".to_string(),
+                Some("description".to_string()),
+                &[coin(2 * bounty_amount, JUNO_DENOM)],
+            )
+            .unwrap_err()
+            .downcast()
+            .unwrap();
+        assert_eq!(err, ContractError::NotOpen {});
+    }
 }
 
 #[test]
 pub fn test_pay_out_bounty() {
-    let mut test = Test::new();
-
-    // create bounty
-    test.create(
-        coin(100, "ujuno"),
-        "title".to_string(),
-        Some("description".to_string()),
-        &[coin(100, "ujuno")],
-    )
-    .unwrap();
-
-    let initial_juno_balance = test
-        .app
-        .wrap()
-        .query_balance(test.recipient.clone(), "ujuno")
+    let bounty_amount = 100;
+    // case: payout
+    {
+        let mut test = Test::new();
+        test.create(
+            coin(bounty_amount, JUNO_DENOM),
+            "title".to_string(),
+            Some("description".to_string()),
+            &[coin(bounty_amount, JUNO_DENOM)],
+        )
         .unwrap();
-    // pay out bounty
-    test.pay_out(1).unwrap();
-    // assert balance
-    let balance_after = test
-        .app
-        .wrap()
-        .query_balance(test.recipient.clone(), "ujuno")
-        .unwrap();
-    assert!(
-        initial_juno_balance.amount.u128() + 100 == (balance_after.amount.u128()),
-        "before: {}, after: {}",
-        initial_juno_balance.amount.u128(),
-        balance_after.amount.u128()
-    );
-    // assert bounty claimed
-    let bounty = test.query(1).unwrap();
-    assert_eq!(
-        bounty.status,
-        BountyStatus::Claimed {
-            claimed_by: test.recipient.to_string(),
-            claimed_at: test.app.block_info().time.seconds()
-        }
-    );
 
-    // test bounty already claimed
-    let err: ContractError = test.pay_out(1).unwrap_err().downcast().unwrap();
-    assert_eq!(err, ContractError::NotOpen {});
+        let initial_juno_balance = test
+            .app
+            .wrap()
+            .query_balance(test.recipient.clone(), JUNO_DENOM)
+            .unwrap();
+
+        test.pay_out(1).unwrap();
+        // assert balance
+        let balance_after = test
+            .app
+            .wrap()
+            .query_balance(test.recipient.clone(), JUNO_DENOM)
+            .unwrap();
+        assert!(
+            initial_juno_balance.amount.u128() + bounty_amount == (balance_after.amount.u128()),
+            "before: {}, after: {}",
+            initial_juno_balance.amount.u128(),
+            balance_after.amount.u128()
+        );
+        // assert bounty
+        let bounty = test.query(1).unwrap();
+        assert_eq!(
+            bounty,
+            Bounty {
+                id: 1,
+                amount: coin(bounty_amount, JUNO_DENOM),
+                title: "title".to_string(),
+                description: Some("description".to_string()),
+                status: BountyStatus::Claimed {
+                    claimed_by: test.recipient.to_string(),
+                    claimed_at: test.app.block_info().time.seconds()
+                },
+                created_at: test.app.block_info().time.seconds(),
+                updated_at: None,
+            }
+        );
+
+        // - test bounty already claimed
+        let err: ContractError = test.pay_out(1).unwrap_err().downcast().unwrap();
+        assert_eq!(err, ContractError::NotOpen {});
+    }
+
+    // case: payout of closed bounty, this covered above, but just to be sure and test on manual close
+    {
+        let mut test = Test::new();
+        test.create(
+            coin(bounty_amount, JUNO_DENOM),
+            "title".to_string(),
+            Some("description".to_string()),
+            &[coin(bounty_amount, JUNO_DENOM)],
+        )
+        .unwrap();
+        test.close(1).unwrap();
+
+        // - test bounty already claimed
+        let err: ContractError = test.pay_out(1).unwrap_err().downcast().unwrap();
+        assert_eq!(err, ContractError::NotOpen {});
+    }
 }


### PR DESCRIPTION
Bug in contract:
- bounty with e.g. 100 Juno
- owner updates to 50 Juno
- owner gets 50 Juno returned
- if owner accidentally sends 50 Juno on update, then 100 Juno needs to be send back - not 50