### PR TITLE
use storage instead of deps

### DIFF
--- a/contracts/external/cw-token-swap/src/contract.rs
+++ b/contracts/external/cw-token-swap/src/contract.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult, Uint128,
+    to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult, Storage, Uint128,
 };
 use cw2::set_contract_version;
 use cw_storage_plus::Item;
@@ -232,13 +232,13 @@ pub fn execute_withdraw(deps: DepsMut, info: MessageInfo) -> Result<Response, Co
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::Status {} => query_status(deps),
+        QueryMsg::Status {} => query_status(deps.storage),
     }
 }
 
-pub fn query_status(deps: Deps) -> StdResult<Binary> {
-    let counterparty_one = COUNTERPARTY_ONE.load(deps.storage)?;
-    let counterparty_two = COUNTERPARTY_TWO.load(deps.storage)?;
+pub fn query_status(storage: &dyn Storage) -> StdResult<Binary> {
+    let counterparty_one = COUNTERPARTY_ONE.load(storage)?;
+    let counterparty_two = COUNTERPARTY_TWO.load(storage)?;
 
     to_binary(&StatusResponse {
         counterparty_one,

--- a/contracts/external/cw-tokenfactory-issuer/src/contract.rs
+++ b/contracts/external/cw-tokenfactory-issuer/src/contract.rs
@@ -145,9 +145,9 @@ pub fn sudo(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps<TokenFactoryQuery>, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::IsFrozen {} => to_binary(&queries::query_is_frozen(deps)?),
-        QueryMsg::Denom {} => to_binary(&queries::query_denom(deps)?),
-        QueryMsg::Owner {} => to_binary(&queries::query_owner(deps)?),
+        QueryMsg::IsFrozen {} => to_binary(&queries::query_is_frozen(deps.storage)?),
+        QueryMsg::Denom {} => to_binary(&queries::query_denom(deps.storage)?),
+        QueryMsg::Owner {} => to_binary(&queries::query_owner(deps.storage)?),
         QueryMsg::BurnAllowance { address } => {
             to_binary(&queries::query_burn_allowance(deps, address)?)
         }

--- a/contracts/external/cw-tokenfactory-issuer/src/queries.rs
+++ b/contracts/external/cw-tokenfactory-issuer/src/queries.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, Deps, Order, StdResult, Uint128};
+use cosmwasm_std::{Addr, Deps, Order, StdResult, Storage, Uint128};
 use cw_storage_plus::{Bound, Map};
 use token_bindings::TokenFactoryQuery;
 
@@ -16,18 +16,18 @@ use crate::state::{
 const MAX_LIMIT: u32 = 30;
 const DEFAULT_LIMIT: u32 = 10;
 
-pub fn query_denom(deps: Deps<TokenFactoryQuery>) -> StdResult<DenomResponse> {
-    let denom = DENOM.load(deps.storage)?;
+pub fn query_denom(storage: &dyn Storage) -> StdResult<DenomResponse> {
+    let denom = DENOM.load(storage)?;
     Ok(DenomResponse { denom })
 }
 
-pub fn query_is_frozen(deps: Deps<TokenFactoryQuery>) -> StdResult<IsFrozenResponse> {
-    let is_frozen = IS_FROZEN.load(deps.storage)?;
+pub fn query_is_frozen(storage: &dyn Storage) -> StdResult<IsFrozenResponse> {
+    let is_frozen = IS_FROZEN.load(storage)?;
     Ok(IsFrozenResponse { is_frozen })
 }
 
-pub fn query_owner(deps: Deps<TokenFactoryQuery>) -> StdResult<OwnerResponse> {
-    let owner = OWNER.load(deps.storage)?;
+pub fn query_owner(storage: &dyn Storage) -> StdResult<OwnerResponse> {
+    let owner = OWNER.load(storage)?;
     Ok(OwnerResponse {
         address: owner.into_string(),
     })

--- a/contracts/proposal/dao-proposal-multiple/src/contract.rs
+++ b/contracts/proposal/dao-proposal-multiple/src/contract.rs
@@ -727,48 +727,48 @@ pub fn advance_proposal_id(store: &mut dyn Storage) -> StdResult<u64> {
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::Config {} => query_config(deps),
-        QueryMsg::Proposal { proposal_id } => query_proposal(deps, env, proposal_id),
+        QueryMsg::Config {} => query_config(deps.storage),
+        QueryMsg::Proposal { proposal_id } => query_proposal(deps.storage, env, proposal_id),
         QueryMsg::ListProposals { start_after, limit } => {
             query_list_proposals(deps, env, start_after, limit)
         }
-        QueryMsg::NextProposalId {} => query_next_proposal_id(deps),
-        QueryMsg::ProposalCount {} => query_proposal_count(deps),
+        QueryMsg::NextProposalId {} => query_next_proposal_id(deps.storage),
+        QueryMsg::ProposalCount {} => query_proposal_count(deps.storage),
         QueryMsg::GetVote { proposal_id, voter } => query_vote(deps, proposal_id, voter),
         QueryMsg::ListVotes {
             proposal_id,
             start_after,
             limit,
         } => query_list_votes(deps, proposal_id, start_after, limit),
-        QueryMsg::Info {} => query_info(deps),
+        QueryMsg::Info {} => query_info(deps.storage),
         QueryMsg::ReverseProposals {
             start_before,
             limit,
         } => query_reverse_proposals(deps, env, start_before, limit),
-        QueryMsg::ProposalCreationPolicy {} => query_creation_policy(deps),
-        QueryMsg::ProposalHooks {} => to_binary(&PROPOSAL_HOOKS.query_hooks(deps)?),
-        QueryMsg::VoteHooks {} => to_binary(&VOTE_HOOKS.query_hooks(deps)?),
-        QueryMsg::Dao {} => query_dao(deps),
+        QueryMsg::ProposalCreationPolicy {} => query_creation_policy(deps.storage),
+        QueryMsg::ProposalHooks {} => to_binary(&PROPOSAL_HOOKS.query_hooks(deps.storage)?),
+        QueryMsg::VoteHooks {} => to_binary(&VOTE_HOOKS.query_hooks(deps.storage)?),
+        QueryMsg::Dao {} => query_dao(deps.storage),
     }
 }
 
-pub fn query_config(deps: Deps) -> StdResult<Binary> {
-    let config = CONFIG.load(deps.storage)?;
+pub fn query_config(storage: &dyn Storage) -> StdResult<Binary> {
+    let config = CONFIG.load(storage)?;
     to_binary(&config)
 }
 
-pub fn query_dao(deps: Deps) -> StdResult<Binary> {
-    let config = CONFIG.load(deps.storage)?;
+pub fn query_dao(storage: &dyn Storage) -> StdResult<Binary> {
+    let config = CONFIG.load(storage)?;
     to_binary(&config.dao)
 }
 
-pub fn query_proposal(deps: Deps, env: Env, id: u64) -> StdResult<Binary> {
-    let proposal = PROPOSALS.load(deps.storage, id)?;
+pub fn query_proposal(storage: &dyn Storage, env: Env, id: u64) -> StdResult<Binary> {
+    let proposal = PROPOSALS.load(storage, id)?;
     to_binary(&proposal.into_response(&env.block, id)?)
 }
 
-pub fn query_creation_policy(deps: Deps) -> StdResult<Binary> {
-    let policy = CREATION_POLICY.load(deps.storage)?;
+pub fn query_creation_policy(storage: &dyn Storage) -> StdResult<Binary> {
+    let policy = CREATION_POLICY.load(storage)?;
     to_binary(&policy)
 }
 
@@ -810,12 +810,12 @@ pub fn query_reverse_proposals(
     to_binary(&ProposalListResponse { proposals: props })
 }
 
-pub fn query_next_proposal_id(deps: Deps) -> StdResult<Binary> {
-    to_binary(&next_proposal_id(deps.storage)?)
+pub fn query_next_proposal_id(storage: &dyn Storage) -> StdResult<Binary> {
+    to_binary(&next_proposal_id(storage)?)
 }
 
-pub fn query_proposal_count(deps: Deps) -> StdResult<Binary> {
-    let proposal_count = PROPOSAL_COUNT.load(deps.storage)?;
+pub fn query_proposal_count(storage: &dyn Storage) -> StdResult<Binary> {
+    let proposal_count = PROPOSAL_COUNT.load(storage)?;
     to_binary(&proposal_count)
 }
 
@@ -861,8 +861,8 @@ pub fn query_list_votes(
     to_binary(&VoteListResponse { votes })
 }
 
-pub fn query_info(deps: Deps) -> StdResult<Binary> {
-    let info = cw2::get_contract_version(deps.storage)?;
+pub fn query_info(storage: &dyn Storage) -> StdResult<Binary> {
+    let info = cw2::get_contract_version(storage)?;
     to_binary(&dao_interface::voting::InfoResponse { info })
 }
 

--- a/contracts/proposal/dao-proposal-single/src/contract.rs
+++ b/contracts/proposal/dao-proposal-single/src/contract.rs
@@ -710,48 +710,48 @@ pub fn execute_remove_vote_hook(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::Config {} => query_config(deps),
-        QueryMsg::Dao {} => query_dao(deps),
-        QueryMsg::Proposal { proposal_id } => query_proposal(deps, env, proposal_id),
+        QueryMsg::Config {} => query_config(deps.storage),
+        QueryMsg::Dao {} => query_dao(deps.storage),
+        QueryMsg::Proposal { proposal_id } => query_proposal(deps.storage, env, proposal_id),
         QueryMsg::ListProposals { start_after, limit } => {
             query_list_proposals(deps, env, start_after, limit)
         }
-        QueryMsg::NextProposalId {} => query_next_proposal_id(deps),
-        QueryMsg::ProposalCount {} => query_proposal_count(deps),
+        QueryMsg::NextProposalId {} => query_next_proposal_id(deps.storage),
+        QueryMsg::ProposalCount {} => query_proposal_count(deps.storage),
         QueryMsg::GetVote { proposal_id, voter } => query_vote(deps, proposal_id, voter),
         QueryMsg::ListVotes {
             proposal_id,
             start_after,
             limit,
         } => query_list_votes(deps, proposal_id, start_after, limit),
-        QueryMsg::Info {} => query_info(deps),
+        QueryMsg::Info {} => query_info(deps.storage),
         QueryMsg::ReverseProposals {
             start_before,
             limit,
         } => query_reverse_proposals(deps, env, start_before, limit),
-        QueryMsg::ProposalCreationPolicy {} => query_creation_policy(deps),
-        QueryMsg::ProposalHooks {} => to_binary(&PROPOSAL_HOOKS.query_hooks(deps)?),
-        QueryMsg::VoteHooks {} => to_binary(&VOTE_HOOKS.query_hooks(deps)?),
+        QueryMsg::ProposalCreationPolicy {} => query_creation_policy(deps.storage),
+        QueryMsg::ProposalHooks {} => to_binary(&PROPOSAL_HOOKS.query_hooks(deps.storage)?),
+        QueryMsg::VoteHooks {} => to_binary(&VOTE_HOOKS.query_hooks(deps.storage)?),
     }
 }
 
-pub fn query_config(deps: Deps) -> StdResult<Binary> {
-    let config = CONFIG.load(deps.storage)?;
+pub fn query_config(storage: &dyn Storage) -> StdResult<Binary> {
+    let config = CONFIG.load(storage)?;
     to_binary(&config)
 }
 
-pub fn query_dao(deps: Deps) -> StdResult<Binary> {
-    let config = CONFIG.load(deps.storage)?;
+pub fn query_dao(storage: &dyn Storage) -> StdResult<Binary> {
+    let config = CONFIG.load(storage)?;
     to_binary(&config.dao)
 }
 
-pub fn query_proposal(deps: Deps, env: Env, id: u64) -> StdResult<Binary> {
-    let proposal = PROPOSALS.load(deps.storage, id)?;
+pub fn query_proposal(storage: &dyn Storage, env: Env, id: u64) -> StdResult<Binary> {
+    let proposal = PROPOSALS.load(storage, id)?;
     to_binary(&proposal.into_response(&env.block, id))
 }
 
-pub fn query_creation_policy(deps: Deps) -> StdResult<Binary> {
-    let policy = CREATION_POLICY.load(deps.storage)?;
+pub fn query_creation_policy(storage: &dyn Storage) -> StdResult<Binary> {
+    let policy = CREATION_POLICY.load(storage)?;
     to_binary(&policy)
 }
 
@@ -793,13 +793,13 @@ pub fn query_reverse_proposals(
     to_binary(&ProposalListResponse { proposals: props })
 }
 
-pub fn query_proposal_count(deps: Deps) -> StdResult<Binary> {
-    let proposal_count = PROPOSAL_COUNT.load(deps.storage)?;
+pub fn query_proposal_count(storage: &dyn Storage) -> StdResult<Binary> {
+    let proposal_count = PROPOSAL_COUNT.load(storage)?;
     to_binary(&proposal_count)
 }
 
-pub fn query_next_proposal_id(deps: Deps) -> StdResult<Binary> {
-    to_binary(&next_proposal_id(deps.storage)?)
+pub fn query_next_proposal_id(storage: &dyn Storage) -> StdResult<Binary> {
+    to_binary(&next_proposal_id(storage)?)
 }
 
 pub fn query_vote(deps: Deps, proposal_id: u64, voter: String) -> StdResult<Binary> {
@@ -844,8 +844,8 @@ pub fn query_list_votes(
     to_binary(&VoteListResponse { votes })
 }
 
-pub fn query_info(deps: Deps) -> StdResult<Binary> {
-    let info = cw2::get_contract_version(deps.storage)?;
+pub fn query_info(storage: &dyn Storage) -> StdResult<Binary> {
+    let info = cw2::get_contract_version(storage)?;
     to_binary(&dao_interface::voting::InfoResponse { info })
 }
 

--- a/contracts/staking/cw20-stake/src/contract.rs
+++ b/contracts/staking/cw20-stake/src/contract.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::entry_point;
 
 use cosmwasm_std::{
     from_binary, to_binary, Addr, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response,
-    StdError, StdResult, Uint128,
+    StdError, StdResult, Storage, Uint128,
 };
 
 use cw20::{Cw20ReceiveMsg, TokenInfoResponse};
@@ -354,7 +354,7 @@ pub fn execute_update_owner(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::GetConfig {} => to_binary(&query_config(deps)?),
+        QueryMsg::GetConfig {} => to_binary(&query_config(deps.storage)?),
         QueryMsg::StakedBalanceAtHeight { address, height } => {
             to_binary(&query_staked_balance_at_height(deps, env, address, height)?)
         }
@@ -362,7 +362,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             to_binary(&query_total_staked_at_height(deps, env, height)?)
         }
         QueryMsg::StakedValue { address } => to_binary(&query_staked_value(deps, env, address)?),
-        QueryMsg::TotalValue {} => to_binary(&query_total_value(deps, env)?),
+        QueryMsg::TotalValue {} => to_binary(&query_total_value(deps.storage, env)?),
         QueryMsg::Claims { address } => to_binary(&query_claims(deps, address)?),
         QueryMsg::GetHooks {} => to_binary(&query_hooks(deps)?),
         QueryMsg::ListStakers { start_after, limit } => {
@@ -423,13 +423,13 @@ pub fn query_staked_value(
     }
 }
 
-pub fn query_total_value(deps: Deps, _env: Env) -> StdResult<TotalValueResponse> {
-    let balance = BALANCE.load(deps.storage)?;
+pub fn query_total_value(storage: &dyn Storage, _env: Env) -> StdResult<TotalValueResponse> {
+    let balance = BALANCE.load(storage)?;
     Ok(TotalValueResponse { total: balance })
 }
 
-pub fn query_config(deps: Deps) -> StdResult<Config> {
-    let config = CONFIG.load(deps.storage)?;
+pub fn query_config(storage: &dyn Storage) -> StdResult<Config> {
+    let config = CONFIG.load(storage)?;
     Ok(config)
 }
 

--- a/contracts/voting/dao-voting-cw20-staked/src/contract.rs
+++ b/contracts/voting/dao-voting-cw20-staked/src/contract.rs
@@ -2,7 +2,7 @@
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     to_binary, Addr, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdResult,
-    SubMsg, Uint128, Uint256, WasmMsg,
+    Storage, SubMsg, Uint128, Uint256, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw20::{Cw20Coin, TokenInfoResponse};
@@ -230,26 +230,26 @@ pub fn execute_update_active_threshold(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::TokenContract {} => query_token_contract(deps),
-        QueryMsg::StakingContract {} => query_staking_contract(deps),
+        QueryMsg::TokenContract {} => query_token_contract(deps.storage),
+        QueryMsg::StakingContract {} => query_staking_contract(deps.storage),
         QueryMsg::VotingPowerAtHeight { address, height } => {
             query_voting_power_at_height(deps, env, address, height)
         }
         QueryMsg::TotalPowerAtHeight { height } => query_total_power_at_height(deps, env, height),
-        QueryMsg::Info {} => query_info(deps),
-        QueryMsg::Dao {} => query_dao(deps),
+        QueryMsg::Info {} => query_info(deps.storage),
+        QueryMsg::Dao {} => query_dao(deps.storage),
         QueryMsg::IsActive {} => query_is_active(deps),
         QueryMsg::ActiveThreshold {} => query_active_threshold(deps),
     }
 }
 
-pub fn query_token_contract(deps: Deps) -> StdResult<Binary> {
-    let token = TOKEN.load(deps.storage)?;
+pub fn query_token_contract(storage: &dyn Storage) -> StdResult<Binary> {
+    let token = TOKEN.load(storage)?;
     to_binary(&token)
 }
 
-pub fn query_staking_contract(deps: Deps) -> StdResult<Binary> {
-    let staking_contract = STAKING_CONTRACT.load(deps.storage)?;
+pub fn query_staking_contract(storage: &dyn Storage) -> StdResult<Binary> {
+    let staking_contract = STAKING_CONTRACT.load(storage)?;
     to_binary(&staking_contract)
 }
 
@@ -290,13 +290,13 @@ pub fn query_total_power_at_height(
     })
 }
 
-pub fn query_info(deps: Deps) -> StdResult<Binary> {
-    let info = cw2::get_contract_version(deps.storage)?;
+pub fn query_info(storage: &dyn Storage) -> StdResult<Binary> {
+    let info = cw2::get_contract_version(storage)?;
     to_binary(&dao_interface::voting::InfoResponse { info })
 }
 
-pub fn query_dao(deps: Deps) -> StdResult<Binary> {
-    let dao = DAO.load(deps.storage)?;
+pub fn query_dao(storage: &dyn Storage) -> StdResult<Binary> {
+    let dao = DAO.load(storage)?;
     to_binary(&dao)
 }
 

--- a/contracts/voting/dao-voting-cw4/src/contract.rs
+++ b/contracts/voting/dao-voting-cw4/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdResult, SubMsg,
-    Uint128, WasmMsg,
+    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdResult, Storage,
+    SubMsg, Uint128, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw4::{MemberListResponse, MemberResponse, TotalWeightResponse};
@@ -121,7 +121,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             query_voting_power_at_height(deps, env, address, height)
         }
         QueryMsg::TotalPowerAtHeight { height } => query_total_power_at_height(deps, env, height),
-        QueryMsg::Info {} => query_info(deps),
+        QueryMsg::Info {} => query_info(deps.storage),
         QueryMsg::GroupContract {} => to_binary(&GROUP_CONTRACT.load(deps.storage)?),
         QueryMsg::Dao {} => to_binary(&DAO.load(deps.storage)?),
     }
@@ -161,8 +161,8 @@ pub fn query_total_power_at_height(deps: Deps, env: Env, height: Option<u64>) ->
     })
 }
 
-pub fn query_info(deps: Deps) -> StdResult<Binary> {
-    let info = cw2::get_contract_version(deps.storage)?;
+pub fn query_info(storage: &dyn Storage) -> StdResult<Binary> {
+    let info = cw2::get_contract_version(storage)?;
     to_binary(&dao_interface::voting::InfoResponse { info })
 }
 

--- a/contracts/voting/dao-voting-cw721-roles/src/contract.rs
+++ b/contracts/voting/dao-voting-cw721-roles/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Reply, Response, StdResult, SubMsg,
-    WasmMsg,
+    to_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Reply, Response, StdResult, Storage,
+    SubMsg, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw4::{MemberResponse, TotalWeightResponse};
@@ -94,13 +94,13 @@ pub fn execute(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::Config {} => query_config(deps),
-        QueryMsg::Dao {} => query_dao(deps),
+        QueryMsg::Config {} => query_config(deps.storage),
+        QueryMsg::Dao {} => query_dao(deps.storage),
         QueryMsg::VotingPowerAtHeight { address, height } => {
             query_voting_power_at_height(deps, env, address, height)
         }
         QueryMsg::TotalPowerAtHeight { height } => query_total_power_at_height(deps, env, height),
-        QueryMsg::Info {} => query_info(deps),
+        QueryMsg::Info {} => query_info(deps.storage),
     }
 }
 
@@ -146,18 +146,18 @@ pub fn query_total_power_at_height(
     })
 }
 
-pub fn query_config(deps: Deps) -> StdResult<Binary> {
-    let config = CONFIG.load(deps.storage)?;
+pub fn query_config(storage: &dyn Storage) -> StdResult<Binary> {
+    let config = CONFIG.load(storage)?;
     to_binary(&config)
 }
 
-pub fn query_dao(deps: Deps) -> StdResult<Binary> {
-    let dao = DAO.load(deps.storage)?;
+pub fn query_dao(storage: &dyn Storage) -> StdResult<Binary> {
+    let dao = DAO.load(storage)?;
     to_binary(&dao)
 }
 
-pub fn query_info(deps: Deps) -> StdResult<Binary> {
-    let info = cw2::get_contract_version(deps.storage)?;
+pub fn query_info(storage: &dyn Storage) -> StdResult<Binary> {
+    let info = cw2::get_contract_version(storage)?;
     to_binary(&dao_interface::voting::InfoResponse { info })
 }
 

--- a/contracts/voting/dao-voting-cw721-staked/src/contract.rs
+++ b/contracts/voting/dao-voting-cw721-staked/src/contract.rs
@@ -10,7 +10,7 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     from_binary, to_binary, Addr, Binary, CosmosMsg, Decimal, Deps, DepsMut, Empty, Env,
-    MessageInfo, Reply, Response, StdError, StdResult, SubMsg, Uint128, Uint256, WasmMsg,
+    MessageInfo, Reply, Response, StdError, StdResult, Storage, SubMsg, Uint128, Uint256, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw721::{Cw721ReceiveMsg, NumTokensResponse};
@@ -457,9 +457,9 @@ pub fn execute_update_active_threshold(
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::ActiveThreshold {} => query_active_threshold(deps),
-        QueryMsg::Config {} => query_config(deps),
-        QueryMsg::Dao {} => query_dao(deps),
-        QueryMsg::Info {} => query_info(deps),
+        QueryMsg::Config {} => query_config(deps.storage),
+        QueryMsg::Dao {} => query_dao(deps.storage),
+        QueryMsg::Info {} => query_info(deps.storage),
         QueryMsg::IsActive {} => query_is_active(deps, env),
         QueryMsg::NftClaims { address } => query_nft_claims(deps, address),
         QueryMsg::Hooks {} => query_hooks(deps),
@@ -572,13 +572,13 @@ pub fn query_total_power_at_height(deps: Deps, env: Env, height: Option<u64>) ->
     to_binary(&dao_interface::voting::TotalPowerAtHeightResponse { power, height })
 }
 
-pub fn query_config(deps: Deps) -> StdResult<Binary> {
-    let config = CONFIG.load(deps.storage)?;
+pub fn query_config(storage: &dyn Storage) -> StdResult<Binary> {
+    let config = CONFIG.load(storage)?;
     to_binary(&config)
 }
 
-pub fn query_dao(deps: Deps) -> StdResult<Binary> {
-    let dao = DAO.load(deps.storage)?;
+pub fn query_dao(storage: &dyn Storage) -> StdResult<Binary> {
+    let dao = DAO.load(storage)?;
     to_binary(&dao)
 }
 
@@ -590,8 +590,8 @@ pub fn query_hooks(deps: Deps) -> StdResult<Binary> {
     to_binary(&HOOKS.query_hooks(deps)?)
 }
 
-pub fn query_info(deps: Deps) -> StdResult<Binary> {
-    let info = cw2::get_contract_version(deps.storage)?;
+pub fn query_info(storage: &dyn Storage) -> StdResult<Binary> {
+    let info = cw2::get_contract_version(storage)?;
     to_binary(&dao_interface::voting::InfoResponse { info })
 }
 

--- a/contracts/voting/dao-voting-native-staked/src/contract.rs
+++ b/contracts/voting/dao-voting-native-staked/src/contract.rs
@@ -2,7 +2,7 @@
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     coins, to_binary, BankMsg, BankQuery, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut, Env,
-    MessageInfo, Response, StdResult, Uint128, Uint256,
+    MessageInfo, Response, StdResult, Storage, Uint128, Uint256,
 };
 use cw2::set_contract_version;
 use cw_controllers::ClaimsResponse;
@@ -331,14 +331,14 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::TotalPowerAtHeight { height } => {
             to_binary(&query_total_power_at_height(deps, env, height)?)
         }
-        QueryMsg::Info {} => query_info(deps),
-        QueryMsg::Dao {} => query_dao(deps),
+        QueryMsg::Info {} => query_info(deps.storage),
+        QueryMsg::Dao {} => query_dao(deps.storage),
         QueryMsg::Claims { address } => to_binary(&query_claims(deps, address)?),
         QueryMsg::GetConfig {} => to_binary(&CONFIG.load(deps.storage)?),
         QueryMsg::ListStakers { start_after, limit } => {
             query_list_stakers(deps, start_after, limit)
         }
-        QueryMsg::GetDenom {} => query_denom(deps),
+        QueryMsg::GetDenom {} => query_denom(deps.storage),
         QueryMsg::IsActive {} => query_is_active(deps),
         QueryMsg::ActiveThreshold {} => query_active_threshold(deps),
         QueryMsg::GetHooks {} => to_binary(&query_hooks(deps)?),
@@ -371,18 +371,18 @@ pub fn query_total_power_at_height(
     Ok(TotalPowerAtHeightResponse { power, height })
 }
 
-pub fn query_info(deps: Deps) -> StdResult<Binary> {
-    let info = cw2::get_contract_version(deps.storage)?;
+pub fn query_info(storage: &dyn Storage) -> StdResult<Binary> {
+    let info = cw2::get_contract_version(storage)?;
     to_binary(&dao_interface::voting::InfoResponse { info })
 }
 
-pub fn query_dao(deps: Deps) -> StdResult<Binary> {
-    let dao = DAO.load(deps.storage)?;
+pub fn query_dao(storage: &dyn Storage) -> StdResult<Binary> {
+    let dao = DAO.load(storage)?;
     to_binary(&dao)
 }
 
-pub fn query_denom(deps: Deps) -> StdResult<Binary> {
-    let config = CONFIG.load(deps.storage)?;
+pub fn query_denom(storage: &dyn Storage) -> StdResult<Binary> {
+    let config = CONFIG.load(storage)?;
     to_binary(&DenomResponse {
         denom: config.denom,
     })
@@ -490,7 +490,7 @@ pub fn query_active_threshold(deps: Deps) -> StdResult<Binary> {
 
 pub fn query_hooks(deps: Deps) -> StdResult<GetHooksResponse> {
     Ok(GetHooksResponse {
-        hooks: HOOKS.query_hooks(deps)?.hooks,
+        hooks: HOOKS.query_hooks(deps.storage)?.hooks,
     })
 }
 

--- a/contracts/voting/dao-voting-token-factory-staked/src/contract.rs
+++ b/contracts/voting/dao-voting-token-factory-staked/src/contract.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::entry_point;
 
 use cosmwasm_std::{
     coins, to_binary, BankMsg, BankQuery, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut, Env,
-    MessageInfo, Order, Reply, Response, StdResult, SubMsg, Uint128, Uint256, WasmMsg,
+    MessageInfo, Order, Reply, Response, StdResult, Storage, SubMsg, Uint128, Uint256, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw_controllers::ClaimsResponse;
@@ -397,8 +397,8 @@ pub fn query(deps: Deps<TokenFactoryQuery>, env: Env, msg: QueryMsg) -> StdResul
         QueryMsg::TotalPowerAtHeight { height } => {
             to_binary(&query_total_power_at_height(deps, env, height)?)
         }
-        QueryMsg::Info {} => query_info(deps),
-        QueryMsg::Dao {} => query_dao(deps),
+        QueryMsg::Info {} => query_info(deps.storage),
+        QueryMsg::Dao {} => query_dao(deps.storage),
         QueryMsg::Claims { address } => to_binary(&query_claims(deps, address)?),
         QueryMsg::GetConfig {} => to_binary(&CONFIG.load(deps.storage)?),
         QueryMsg::Denom {} => to_binary(&DenomResponse {
@@ -408,8 +408,8 @@ pub fn query(deps: Deps<TokenFactoryQuery>, env: Env, msg: QueryMsg) -> StdResul
             query_list_stakers(deps, start_after, limit)
         }
         QueryMsg::IsActive {} => query_is_active(deps),
-        QueryMsg::ActiveThreshold {} => query_active_threshold(deps),
-        QueryMsg::GetHooks {} => to_binary(&query_hooks(deps)?),
+        QueryMsg::ActiveThreshold {} => query_active_threshold(deps.storage),
+        QueryMsg::GetHooks {} => to_binary(&query_hooks(deps.storage)?),
         QueryMsg::TokenContract {} => to_binary(&TOKEN_ISSUER_CONTRACT.load(deps.storage)?),
     }
 }
@@ -440,13 +440,13 @@ pub fn query_total_power_at_height(
     Ok(TotalPowerAtHeightResponse { power, height })
 }
 
-pub fn query_info(deps: Deps<TokenFactoryQuery>) -> StdResult<Binary> {
-    let info = cw2::get_contract_version(deps.storage)?;
+pub fn query_info(storage: &dyn Storage) -> StdResult<Binary> {
+    let info = cw2::get_contract_version(storage)?;
     to_binary(&dao_interface::voting::InfoResponse { info })
 }
 
-pub fn query_dao(deps: Deps<TokenFactoryQuery>) -> StdResult<Binary> {
-    let dao = DAO.load(deps.storage)?;
+pub fn query_dao(storage: &dyn Storage) -> StdResult<Binary> {
+    let dao = DAO.load(storage)?;
     to_binary(&dao)
 }
 
@@ -539,15 +539,15 @@ pub fn query_is_active(deps: Deps<TokenFactoryQuery>) -> StdResult<Binary> {
     }
 }
 
-pub fn query_active_threshold(deps: Deps<TokenFactoryQuery>) -> StdResult<Binary> {
+pub fn query_active_threshold(storage: &dyn Storage) -> StdResult<Binary> {
     to_binary(&ActiveThresholdResponse {
-        active_threshold: ACTIVE_THRESHOLD.may_load(deps.storage)?,
+        active_threshold: ACTIVE_THRESHOLD.may_load(storage)?,
     })
 }
 
-pub fn query_hooks(deps: Deps<TokenFactoryQuery>) -> StdResult<GetHooksResponse> {
+pub fn query_hooks(storage: &dyn Storage) -> StdResult<GetHooksResponse> {
     Ok(GetHooksResponse {
-        hooks: HOOKS.query_hooks(deps)?.hooks,
+        hooks: HOOKS.query_hooks(storage)?.hooks,
     })
 }
 

--- a/packages/cw-hooks/src/lib.rs
+++ b/packages/cw-hooks/src/lib.rs
@@ -3,7 +3,7 @@
 use thiserror::Error;
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, CustomQuery, Deps, StdError, StdResult, Storage, SubMsg};
+use cosmwasm_std::{Addr, StdError, StdResult, Storage, SubMsg};
 use cw_storage_plus::Item;
 
 #[cw_serde]
@@ -97,8 +97,8 @@ impl<'a> Hooks<'a> {
         Ok(self.0.may_load(storage)?.unwrap_or_default().len() as u32)
     }
 
-    pub fn query_hooks<Q: CustomQuery>(&self, deps: Deps<Q>) -> StdResult<HooksResponse> {
-        let hooks = self.0.may_load(deps.storage)?.unwrap_or_default();
+    pub fn query_hooks(&self, storage: &dyn Storage) -> StdResult<HooksResponse> {
+        let hooks = self.0.may_load(storage)?.unwrap_or_default();
         let hooks = hooks.into_iter().map(String::from).collect();
         Ok(HooksResponse { hooks })
     }
@@ -190,14 +190,14 @@ mod tests {
         );
 
         // Query hooks returns all hooks added
-        let HooksResponse { hooks: the_hooks } = hooks.query_hooks(deps.as_ref()).unwrap();
+        let HooksResponse { hooks: the_hooks } = hooks.query_hooks(&deps.storage).unwrap();
         assert_eq!(the_hooks, vec![addr!("meow")]);
 
         // Remove last hook
         hooks.remove_hook(&mut deps.storage, addr!("meow")).unwrap();
 
         // Query hooks returns empty vector if no hooks added
-        let HooksResponse { hooks: the_hooks } = hooks.query_hooks(deps.as_ref()).unwrap();
+        let HooksResponse { hooks: the_hooks } = hooks.query_hooks(&deps.storage).unwrap();
         let no_hooks: Vec<String> = vec![];
         assert_eq!(the_hooks, no_hooks);
     }

--- a/packages/cw-paginate-storage/README.md
+++ b/packages/cw-paginate-storage/README.md
@@ -20,7 +20,7 @@ You can use this package to write a query to list it's contents like:
 ```rust
 use cosmwasm_std::{Deps, Binary, to_binary, StdResult};
 use cw_storage_plus::Map;
-use cw_paginate_storage::paginate_map;                         
+use cw_paginate_storage::paginate_map;
 
 pub const ITEMS: Map<String, String> = Map::new("items");
 
@@ -30,7 +30,7 @@ pub fn query_list_items(
     limit: Option<u32>,
 ) -> StdResult<Binary> {
     to_binary(&paginate_map(
-        deps,
+        deps.storage,
         &ITEMS,
         start_after,
         limit,

--- a/packages/dao-pre-propose-base/src/execute.rs
+++ b/packages/dao-pre-propose-base/src/execute.rs
@@ -360,7 +360,7 @@ where
                 })
             }
             QueryMsg::ProposalSubmittedHooks {} => {
-                to_binary(&self.proposal_submitted_hooks.query_hooks(deps)?)
+                to_binary(&self.proposal_submitted_hooks.query_hooks(deps.storage)?)
             }
             QueryMsg::QueryExtension { .. } => Ok(Binary::default()),
         }

--- a/test-contracts/dao-proposal-sudo/src/contract.rs
+++ b/test-contracts/dao-proposal-sudo/src/contract.rs
@@ -2,7 +2,7 @@
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     to_binary, Addr, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
-    WasmMsg,
+    Storage, WasmMsg,
 };
 use cw2::set_contract_version;
 
@@ -71,21 +71,21 @@ pub fn execute_execute(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::Admin {} => query_admin(deps),
-        QueryMsg::Dao {} => query_dao(deps),
-        QueryMsg::Info {} => query_info(deps),
+        QueryMsg::Admin {} => query_admin(deps.storage),
+        QueryMsg::Dao {} => query_dao(deps.storage),
+        QueryMsg::Info {} => query_info(deps.storage),
     }
 }
 
-pub fn query_admin(deps: Deps) -> StdResult<Binary> {
-    to_binary(&ROOT.load(deps.storage)?)
+pub fn query_admin(storage: &dyn Storage) -> StdResult<Binary> {
+    to_binary(&ROOT.load(storage)?)
 }
 
-pub fn query_dao(deps: Deps) -> StdResult<Binary> {
-    to_binary(&DAO.load(deps.storage)?)
+pub fn query_dao(storage: &dyn Storage) -> StdResult<Binary> {
+    to_binary(&DAO.load(storage)?)
 }
 
-pub fn query_info(deps: Deps) -> StdResult<Binary> {
-    let info = cw2::get_contract_version(deps.storage)?;
+pub fn query_info(storage: &dyn Storage) -> StdResult<Binary> {
+    let info = cw2::get_contract_version(storage)?;
     to_binary(&dao_interface::voting::InfoResponse { info })
 }

--- a/test-contracts/dao-voting-cw20-balance/src/contract.rs
+++ b/test-contracts/dao-voting-cw20-balance/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdResult, SubMsg,
-    Uint128, WasmMsg,
+    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdResult, Storage,
+    SubMsg, Uint128, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw_utils::parse_reply_instantiate_data;
@@ -92,23 +92,23 @@ pub fn execute(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::TokenContract {} => query_token_contract(deps),
+        QueryMsg::TokenContract {} => query_token_contract(deps.storage),
         QueryMsg::VotingPowerAtHeight { address, height: _ } => {
             query_voting_power_at_height(deps, env, address)
         }
         QueryMsg::TotalPowerAtHeight { height: _ } => query_total_power_at_height(deps, env),
-        QueryMsg::Info {} => query_info(deps),
-        QueryMsg::Dao {} => query_dao(deps),
+        QueryMsg::Info {} => query_info(deps.storage),
+        QueryMsg::Dao {} => query_dao(deps.storage),
     }
 }
 
-pub fn query_dao(deps: Deps) -> StdResult<Binary> {
-    let dao = DAO.load(deps.storage)?;
+pub fn query_dao(storage: &dyn Storage) -> StdResult<Binary> {
+    let dao = DAO.load(storage)?;
     to_binary(&dao)
 }
 
-pub fn query_token_contract(deps: Deps) -> StdResult<Binary> {
-    let token = TOKEN.load(deps.storage)?;
+pub fn query_token_contract(storage: &dyn Storage) -> StdResult<Binary> {
+    let token = TOKEN.load(storage)?;
     to_binary(&token)
 }
 
@@ -138,8 +138,8 @@ pub fn query_total_power_at_height(deps: Deps, env: Env) -> StdResult<Binary> {
     })
 }
 
-pub fn query_info(deps: Deps) -> StdResult<Binary> {
-    let info = cw2::get_contract_version(deps.storage)?;
+pub fn query_info(storage: &dyn Storage) -> StdResult<Binary> {
+    let info = cw2::get_contract_version(storage)?;
     to_binary(&dao_interface::voting::InfoResponse { info })
 }
 


### PR DESCRIPTION
Here we go #743.
I went over all contracts and packages and checked where storage can be used. Pls have a look.
There are some places where `api` and `querier` are used - I left this untouched and changed only when `storage` is used.