### PR TITLE
Add error to FailedProposalExecution response

### DIFF
--- a/contracts/proposal/dao-proposal-condorcet/src/contract.rs
+++ b/contracts/proposal/dao-proposal-condorcet/src/contract.rs
@@ -274,7 +274,7 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
 
             Ok(Response::default()
                 .add_attribute("proposal_execution_failed", proposal_id.to_string())
-                .add_attribute("error", msg.result.unwrap_err()))
+                .add_attribute("error", msg.result.into_result().err().unwrap_or_default()))
         }
         _ => unimplemented!("pre-propose and hooks not yet supported"),
     }

--- a/contracts/proposal/dao-proposal-condorcet/src/contract.rs
+++ b/contracts/proposal/dao-proposal-condorcet/src/contract.rs
@@ -271,8 +271,10 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
             let mut proposal = PROPOSAL.load(deps.storage, proposal_id as u32)?;
             proposal.set_execution_failed();
             PROPOSAL.save(deps.storage, proposal_id as u32, &proposal)?;
+
             Ok(Response::default()
-                .add_attribute("proposal_execution_failed", proposal_id.to_string()))
+                .add_attribute("proposal_execution_failed", proposal_id.to_string())
+                .add_attribute("error", msg.result.unwrap_err()))
         }
         _ => unimplemented!("pre-propose and hooks not yet supported"),
     }

--- a/contracts/proposal/dao-proposal-multiple/src/contract.rs
+++ b/contracts/proposal/dao-proposal-multiple/src/contract.rs
@@ -881,7 +881,7 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
 
             Ok(Response::new()
                 .add_attribute("proposal execution failed", proposal_id.to_string())
-                .add_attribute("error", msg.result.unwrap_err()))
+                .add_attribute("error", msg.result.into_result().err().unwrap_or_default()))
         }
         TaggedReplyId::FailedProposalHook(idx) => {
             let addr = PROPOSAL_HOOKS.remove_hook_by_index(deps.storage, idx)?;

--- a/contracts/proposal/dao-proposal-multiple/src/contract.rs
+++ b/contracts/proposal/dao-proposal-multiple/src/contract.rs
@@ -878,7 +878,10 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
                 }
                 None => Err(ContractError::NoSuchProposal { id: proposal_id }),
             })?;
-            Ok(Response::new().add_attribute("proposal execution failed", proposal_id.to_string()))
+
+            Ok(Response::new()
+                .add_attribute("proposal execution failed", proposal_id.to_string())
+                .add_attribute("error", msg.result.unwrap_err()))
         }
         TaggedReplyId::FailedProposalHook(idx) => {
             let addr = PROPOSAL_HOOKS.remove_hook_by_index(deps.storage, idx)?;

--- a/contracts/proposal/dao-proposal-single/src/contract.rs
+++ b/contracts/proposal/dao-proposal-single/src/contract.rs
@@ -959,7 +959,7 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
 
             Ok(Response::new()
                 .add_attribute("proposal_execution_failed", proposal_id.to_string())
-                .add_attribute("error", msg.result.unwrap_err()))
+                .add_attribute("error", msg.result.into_result().err().unwrap_or_default()))
         }
         TaggedReplyId::FailedProposalHook(idx) => {
             let addr = PROPOSAL_HOOKS.remove_hook_by_index(deps.storage, idx)?;

--- a/contracts/proposal/dao-proposal-single/src/contract.rs
+++ b/contracts/proposal/dao-proposal-single/src/contract.rs
@@ -957,7 +957,9 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
                 None => Err(ContractError::NoSuchProposal { id: proposal_id }),
             })?;
 
-            Ok(Response::new().add_attribute("proposal_execution_failed", proposal_id.to_string()))
+            Ok(Response::new()
+                .add_attribute("proposal_execution_failed", proposal_id.to_string())
+                .add_attribute("error", msg.result.unwrap_err()))
         }
         TaggedReplyId::FailedProposalHook(idx) => {
             let addr = PROPOSAL_HOOKS.remove_hook_by_index(deps.storage, idx)?;


### PR DESCRIPTION
Minimal information is shown when a proposal execution fails, and this could give users a better clue of what went wrong. It should probably be used in all reply_on_error handles.