### PR TITLE
Add missing query to dao-pre-propose-approver

### DIFF
--- a/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
+++ b/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
@@ -547,10 +547,10 @@
           {
             "type": "object",
             "required": [
-              "pending_proposal_id_for_approval_proposal_id"
+              "pre_propose_approval_id_for_approver_proposal_id"
             ],
             "properties": {
-              "pending_proposal_id_for_approval_proposal_id": {
+              "pre_propose_approval_id_for_approver_proposal_id": {
                 "type": "object",
                 "required": [
                   "id"

--- a/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
+++ b/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
@@ -543,6 +543,29 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "pending_proposal_id_for_approval_proposal_id"
+            ],
+            "properties": {
+              "pending_proposal_id_for_approval_proposal_id": {
+                "type": "object",
+                "required": [
+                  "id"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
           }
         ]
       }

--- a/contracts/pre-propose/dao-pre-propose-approver/src/contract.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/contract.rs
@@ -188,6 +188,9 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             QueryExt::PreProposeApprovalContract {} => {
                 to_binary(&PRE_PROPOSE_APPROVAL_CONTRACT.load(deps.storage)?)
             }
+            QueryExt::PendingProposalIdForApprovalProposalId { id } => {
+                to_binary(&PROPOSAL_IDS.load(deps.storage, id)?)
+            }
         },
         _ => PrePropose::default().query(deps, env, msg),
     }

--- a/contracts/pre-propose/dao-pre-propose-approver/src/contract.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/contract.rs
@@ -188,7 +188,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             QueryExt::PreProposeApprovalContract {} => {
                 to_binary(&PRE_PROPOSE_APPROVAL_CONTRACT.load(deps.storage)?)
             }
-            QueryExt::PendingProposalIdForApprovalProposalId { id } => {
+            QueryExt::PreProposeApprovalIdForApproverProposalId { id } => {
                 to_binary(&PROPOSAL_ID_TO_PRE_PROPOSE_ID.may_load(deps.storage, id)?)
             }
         },

--- a/contracts/pre-propose/dao-pre-propose-approver/src/msg.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/msg.rs
@@ -15,6 +15,8 @@ pub struct InstantiateMsg {
 pub enum QueryExt {
     #[returns(cosmwasm_std::Addr)]
     PreProposeApprovalContract {},
+    #[returns(u64)]
+    PendingProposalIdForApprovalProposalId { id: u64 },
 }
 
 pub type BaseInstantiateMsg = InstantiateBase<Empty>;

--- a/contracts/pre-propose/dao-pre-propose-approver/src/msg.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/msg.rs
@@ -15,7 +15,7 @@ pub struct InstantiateMsg {
 pub enum QueryExt {
     #[returns(cosmwasm_std::Addr)]
     PreProposeApprovalContract {},
-    #[returns(u64)]
+    #[returns(Option<u64>)]
     PendingProposalIdForApprovalProposalId { id: u64 },
 }
 

--- a/contracts/pre-propose/dao-pre-propose-approver/src/msg.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/msg.rs
@@ -16,7 +16,7 @@ pub enum QueryExt {
     #[returns(cosmwasm_std::Addr)]
     PreProposeApprovalContract {},
     #[returns(Option<u64>)]
-    PendingProposalIdForApprovalProposalId { id: u64 },
+    PreProposeApprovalIdForApproverProposalId { id: u64 },
 }
 
 pub type BaseInstantiateMsg = InstantiateBase<Empty>;

--- a/contracts/pre-propose/dao-pre-propose-approver/src/msg.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/msg.rs
@@ -15,7 +15,7 @@ pub struct InstantiateMsg {
 pub enum QueryExt {
     #[returns(cosmwasm_std::Addr)]
     PreProposeApprovalContract {},
-    #[returns(Option<u64>)]
+    #[returns(::std::option::Option<u64>)]
     PreProposeApprovalIdForApproverProposalId { id: u64 },
 }
 

--- a/contracts/pre-propose/dao-pre-propose-approver/src/state.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/state.rs
@@ -4,4 +4,4 @@ use cw_storage_plus::{Item, Map};
 // Stores the address of the pre-propose approval contract
 pub const PRE_PROPOSE_APPROVAL_CONTRACT: Item<Addr> = Item::new("pre_propose_approval_contract");
 // Maps proposal ids to pre-propose ids
-pub const PROPOSAL_IDS: Map<u64, u64> = Map::new("proposal_ids");
+pub const PROPOSAL_ID_TO_PRE_PROPOSE_ID: Map<u64, u64> = Map::new("proposal_ids");

--- a/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
@@ -26,6 +26,7 @@ use dao_voting::{
 
 use crate::contract::{CONTRACT_NAME, CONTRACT_VERSION};
 use crate::msg::InstantiateMsg as ApproverInstantiateMsg;
+use crate::msg::{QueryExt as ApproverQueryExt, QueryMsg as ApproverQueryMsg};
 
 // The approver dao contract is the 6th contract instantiated
 const APPROVER: &str = "contract6";
@@ -1234,7 +1235,7 @@ fn test_propose_open_proposal_submission() {
         pre_propose,
         _approver_core_addr: _,
         proposal_single_approver,
-        pre_propose_approver: _,
+        pre_propose_approver,
     } = setup_default_test(
         &mut app,
         Some(UncheckedDepositInfo {
@@ -1249,11 +1250,23 @@ fn test_propose_open_proposal_submission() {
 
     // Non-member proposes.
     mint_natives(&mut app, "nonmember", coins(10, "ujuno"));
-    let _pre_propose_id =
-        make_pre_proposal(&mut app, pre_propose, "nonmember", &coins(10, "ujuno"));
+    let pre_propose_id = make_pre_proposal(&mut app, pre_propose, "nonmember", &coins(10, "ujuno"));
+
+    let approver_prop_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+    let pre_propose_id_from_proposal: u64 = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose_approver.clone(),
+            &ApproverQueryMsg::QueryExtension {
+                msg: ApproverQueryExt::PendingProposalIdForApprovalProposalId {
+                    id: approver_prop_id,
+                },
+            },
+        )
+        .unwrap();
+    assert_eq!(pre_propose_id, pre_propose_id_from_proposal);
 
     // Approver DAO votes to approves
-    let approver_prop_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
     approve_proposal(&mut app, proposal_single_approver, "ekez", approver_prop_id);
     let id = get_latest_proposal_id(&app, proposal_single.clone());
 

--- a/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
@@ -1258,7 +1258,7 @@ fn test_propose_open_proposal_submission() {
         .query_wasm_smart(
             pre_propose_approver.clone(),
             &ApproverQueryMsg::QueryExtension {
-                msg: ApproverQueryExt::PendingProposalIdForApprovalProposalId {
+                msg: ApproverQueryExt::PreProposeApprovalIdForApproverProposalId {
                     id: approver_prop_id,
                 },
             },


### PR DESCRIPTION
The `dao-pre-propose-approver` contract does not currently provide any query to determine which pre-propose ID corresponds with a given proposal. In other words, you cannot check which pending proposal an approval proposal was made for.

This PR adds a query `PendingProposalIdForApprovalProposalId` which takes the `id` of the approval proposal being voted on by the approval DAO and returns the `id` of the pending proposal in the `dao-pre-propose-single` contract on the DAO waiting for proposal approval.