### PR TITLE
Remove requirement that vesting payment owner matches factory

### DIFF
--- a/contracts/external/cw-payroll-factory/src/contract.rs
+++ b/contracts/external/cw-payroll-factory/src/contract.rs
@@ -130,16 +130,6 @@ pub fn instantiate_contract(
     {
         return Err(ContractError::Unauthorized {});
     }
-    // No owner is always allowed. If an owner is specified, it must
-    // exactly match the owner of the contract.
-    if instantiate_msg.owner.as_deref().map_or(false, |i| {
-        ownership.owner.as_ref().map_or(true, |o| o.as_str() != i)
-    }) {
-        return Err(ContractError::OwnerMissmatch {
-            actual: instantiate_msg.owner,
-            expected: ownership.owner.map(|a| a.into_string()),
-        });
-    }
 
     let code_id = VESTING_CODE_ID.load(deps.storage)?;
 

--- a/contracts/external/cw-payroll-factory/src/error.rs
+++ b/contracts/external/cw-payroll-factory/src/error.rs
@@ -17,12 +17,6 @@ pub enum ContractError {
     #[error("Unauthorized")]
     Unauthorized {},
 
-    #[error("instantiate message owner does not match factory owner. got ({actual:?}) expected ({expected:?})")]
-    OwnerMissmatch {
-        actual: Option<String>,
-        expected: Option<String>,
-    },
-
     #[error("{0}")]
     ParseReplyError(#[from] ParseReplyError),
 

--- a/contracts/external/cw-payroll-factory/src/tests.rs
+++ b/contracts/external/cw-payroll-factory/src/tests.rs
@@ -383,40 +383,6 @@ fn test_instantiate_wrong_ownership_native() {
 
     let err: ContractError = app
         .execute_contract(
-            Addr::unchecked(ALICE),
-            factory_addr.clone(),
-            &ExecuteMsg::InstantiateNativePayrollContract {
-                instantiate_msg: PayrollInstantiateMsg {
-                    owner: Some("ekez".to_string()),
-                    recipient: BOB.to_string(),
-                    title: "title".to_string(),
-                    description: Some("desc".to_string()),
-                    total: amount,
-                    denom: unchecked_denom.clone(),
-                    schedule: Schedule::SaturatingLinear,
-                    vesting_duration_seconds: 200,
-                    unbonding_duration_seconds: 2592000, // 30 days
-                    start_time: None,
-                },
-                label: "vesting".to_string(),
-            },
-            &coins(amount.u128(), NATIVE_DENOM),
-        )
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-
-    // Can't instantiate with an owner who is not the factory owner.
-    assert_eq!(
-        err,
-        ContractError::OwnerMissmatch {
-            actual: Some("ekez".to_string()),
-            expected: Some(ALICE.to_string())
-        }
-    );
-
-    let err: ContractError = app
-        .execute_contract(
             Addr::unchecked("ekez"),
             factory_addr,
             &ExecuteMsg::InstantiateNativePayrollContract {
@@ -442,92 +408,6 @@ fn test_instantiate_wrong_ownership_native() {
 
     // Can't instantiate if you are not the owner.
     assert_eq!(err, ContractError::Unauthorized {});
-}
-
-#[test]
-fn test_instantiate_wrong_owner_cw20() {
-    let mut app = App::default();
-    let code_id = app.store_code(factory_contract());
-    let cw20_code_id = app.store_code(cw20_contract());
-    let cw_vesting_code_id = app.store_code(cw_vesting_contract());
-
-    let cw20_addr = app
-        .instantiate_contract(
-            cw20_code_id,
-            Addr::unchecked(ALICE),
-            &cw20_base::msg::InstantiateMsg {
-                name: "cw20 token".to_string(),
-                symbol: "cwtwenty".to_string(),
-                decimals: 6,
-                initial_balances: vec![Cw20Coin {
-                    address: ALICE.to_string(),
-                    amount: Uint128::new(INITIAL_BALANCE),
-                }],
-                mint: None,
-                marketing: None,
-            },
-            &[],
-            "cw20-base",
-            None,
-        )
-        .unwrap();
-
-    let instantiate = InstantiateMsg {
-        owner: Some(ALICE.to_string()),
-        vesting_code_id: cw_vesting_code_id,
-    };
-    let factory_addr = app
-        .instantiate_contract(
-            code_id,
-            Addr::unchecked("CREATOR"),
-            &instantiate,
-            &[],
-            "cw-admin-factory",
-            None,
-        )
-        .unwrap();
-
-    let amount = Uint128::new(1000000);
-    let unchecked_denom = UncheckedDenom::Cw20(cw20_addr.to_string());
-
-    let instantiate_payroll_msg = PayrollInstantiateMsg {
-        owner: Some(BOB.to_string()),
-        recipient: BOB.to_string(),
-        title: "title".to_string(),
-        description: Some("desc".to_string()),
-        total: amount,
-        denom: unchecked_denom,
-        schedule: Schedule::SaturatingLinear,
-        vesting_duration_seconds: 200,
-        unbonding_duration_seconds: 2592000, // 30 days
-        start_time: None,
-    };
-
-    let err: ContractError = app
-        .execute_contract(
-            Addr::unchecked(ALICE),
-            cw20_addr,
-            &Cw20ExecuteMsg::Send {
-                contract: factory_addr.to_string(),
-                amount: instantiate_payroll_msg.total,
-                msg: to_binary(&ReceiveMsg::InstantiatePayrollContract {
-                    instantiate_msg: instantiate_payroll_msg,
-                    label: "Payroll".to_string(),
-                })
-                .unwrap(),
-            },
-            &[],
-        )
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    assert_eq!(
-        err,
-        ContractError::OwnerMissmatch {
-            actual: Some(BOB.to_string()),
-            expected: Some(ALICE.to_string())
-        }
-    )
 }
 
 #[test]


### PR DESCRIPTION
This removes the requirement that vesting payments must be created with the same owner as the payroll factory. This allows for creating vesting payments that are cancellable by someone else, or multiple accounts, while still restricting who is allowed to create new vesting payments on that factory.