### PR TITLE
Switch order of approval-single list queries

### DIFF
--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/contract.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/contract.rs
@@ -358,7 +358,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
                 &PENDING_PROPOSALS,
                 start_after,
                 limit,
-                Order::Descending,
+                Order::Ascending,
             )?),
             QueryExt::ReversePendingProposals {
                 start_before,
@@ -368,7 +368,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
                 &PENDING_PROPOSALS,
                 start_before,
                 limit,
-                Order::Ascending,
+                Order::Descending,
             )?),
             QueryExt::CompletedProposal { id } => {
                 to_binary(&COMPLETED_PROPOSALS.load(deps.storage, id)?)
@@ -378,7 +378,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
                 &COMPLETED_PROPOSALS,
                 start_after,
                 limit,
-                Order::Descending,
+                Order::Ascending,
             )?),
             QueryExt::ReverseCompletedProposals {
                 start_before,
@@ -388,7 +388,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
                 &COMPLETED_PROPOSALS,
                 start_before,
                 limit,
-                Order::Ascending,
+                Order::Descending,
             )?),
             QueryExt::CompletedProposalIdForCreatedProposalId { id } => {
                 to_binary(&CREATED_PROPOSAL_TO_COMPLETED_PROPOSAL.may_load(deps.storage, id)?)

--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
@@ -190,8 +190,8 @@ fn make_pre_proposal(app: &mut App, pre_propose: Addr, proposer: &str, funds: &[
     )
     .unwrap();
 
-    // Query for pending proposal and return latest id. Returns descending.
-    let pending: Vec<Proposal> = app
+    // Query for pending proposal and return latest id.
+    let mut pending: Vec<Proposal> = app
         .wrap()
         .query_wasm_smart(
             pre_propose,
@@ -204,8 +204,8 @@ fn make_pre_proposal(app: &mut App, pre_propose: Addr, proposer: &str, funds: &[
         )
         .unwrap();
 
-    // Return first item in descending list, id is first element of tuple
-    pending[0].approval_id
+    // Return last item in ascending list, id is first element of tuple
+    pending.pop().unwrap().approval_id
 }
 
 fn mint_natives(app: &mut App, receiver: &str, coins: Vec<Coin>) {
@@ -911,7 +911,7 @@ fn test_pending_proposal_queries() {
         )
         .unwrap();
     assert_eq!(pre_propose_props.len(), 2);
-    assert_eq!(pre_propose_props[0].approval_id, 2);
+    assert_eq!(pre_propose_props[0].approval_id, 1);
 
     // Query props in reverse
     let reverse_pre_propose_props: Vec<Proposal> = app
@@ -928,7 +928,7 @@ fn test_pending_proposal_queries() {
         .unwrap();
 
     assert_eq!(reverse_pre_propose_props.len(), 2);
-    assert_eq!(reverse_pre_propose_props[0].approval_id, 1);
+    assert_eq!(reverse_pre_propose_props[0].approval_id, 2);
 }
 
 #[test]
@@ -1051,8 +1051,8 @@ fn test_completed_proposal_queries() {
         )
         .unwrap();
     assert_eq!(pre_propose_props.len(), 2);
-    assert_eq!(pre_propose_props[0].approval_id, reject_id);
-    assert_eq!(pre_propose_props[1].approval_id, approve_id);
+    assert_eq!(pre_propose_props[0].approval_id, approve_id);
+    assert_eq!(pre_propose_props[1].approval_id, reject_id);
 
     // Query props in reverse
     let reverse_pre_propose_props: Vec<Proposal> = app
@@ -1069,8 +1069,8 @@ fn test_completed_proposal_queries() {
         .unwrap();
 
     assert_eq!(reverse_pre_propose_props.len(), 2);
-    assert_eq!(reverse_pre_propose_props[0].approval_id, approve_id);
-    assert_eq!(reverse_pre_propose_props[1].approval_id, reject_id);
+    assert_eq!(reverse_pre_propose_props[0].approval_id, reject_id);
+    assert_eq!(reverse_pre_propose_props[1].approval_id, approve_id);
 }
 
 #[test]


### PR DESCRIPTION
The ordering of approval-single List and ReverseList queries is incorrect and does not match the normal proposal modules. The forward list query has a `start_after` parameter but was sorted in descending order, which does not make sense. The opposite was true for the reverse list query.

This PR makes the forward list query sort ascending, which makes sense for `start_after`, and the reverse list query sort descending, which makes sense for `start_before`.

It also now matches the rest of the codebase.