### PR TITLE
Add query to approver to get proposal ID from pre-propose ID

### DIFF
--- a/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
+++ b/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
@@ -566,6 +566,29 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "required": [
+              "approver_proposal_id_for_pre_propose_approval_id"
+            ],
+            "properties": {
+              "approver_proposal_id_for_pre_propose_approval_id": {
+                "type": "object",
+                "required": [
+                  "id"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
           }
         ]
       }

--- a/contracts/pre-propose/dao-pre-propose-approver/src/contract.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/contract.rs
@@ -16,7 +16,9 @@ use dao_voting::status::Status;
 use crate::msg::{
     BaseInstantiateMsg, ExecuteMsg, InstantiateMsg, ProposeMessageInternal, QueryExt, QueryMsg,
 };
-use crate::state::{PRE_PROPOSE_APPROVAL_CONTRACT, PROPOSAL_ID_TO_PRE_PROPOSE_ID};
+use crate::state::{
+    PRE_PROPOSE_APPROVAL_CONTRACT, PRE_PROPOSE_ID_TO_PROPOSAL_ID, PROPOSAL_ID_TO_PRE_PROPOSE_ID,
+};
 
 pub(crate) const CONTRACT_NAME: &str = "crates.io:dao-pre-propose-approver";
 pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -125,6 +127,7 @@ pub fn execute_propose(
         &dao_interface::proposal::Query::NextProposalId {},
     )?;
     PROPOSAL_ID_TO_PRE_PROPOSE_ID.save(deps.storage, proposal_id, &pre_propose_id)?;
+    PRE_PROPOSE_ID_TO_PROPOSAL_ID.save(deps.storage, pre_propose_id, &proposal_id)?;
 
     let propose_messsage = WasmMsg::Execute {
         contract_addr: proposal_module.into_string(),
@@ -190,6 +193,9 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             }
             QueryExt::PreProposeApprovalIdForApproverProposalId { id } => {
                 to_binary(&PROPOSAL_ID_TO_PRE_PROPOSE_ID.may_load(deps.storage, id)?)
+            }
+            QueryExt::ApproverProposalIdForPreProposeApprovalId { id } => {
+                to_binary(&PRE_PROPOSE_ID_TO_PROPOSAL_ID.may_load(deps.storage, id)?)
             }
         },
         _ => PrePropose::default().query(deps, env, msg),

--- a/contracts/pre-propose/dao-pre-propose-approver/src/msg.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/msg.rs
@@ -17,6 +17,8 @@ pub enum QueryExt {
     PreProposeApprovalContract {},
     #[returns(::std::option::Option<u64>)]
     PreProposeApprovalIdForApproverProposalId { id: u64 },
+    #[returns(::std::option::Option<u64>)]
+    ApproverProposalIdForPreProposeApprovalId { id: u64 },
 }
 
 pub type BaseInstantiateMsg = InstantiateBase<Empty>;

--- a/contracts/pre-propose/dao-pre-propose-approver/src/state.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/state.rs
@@ -4,4 +4,6 @@ use cw_storage_plus::{Item, Map};
 // Stores the address of the pre-propose approval contract
 pub const PRE_PROPOSE_APPROVAL_CONTRACT: Item<Addr> = Item::new("pre_propose_approval_contract");
 // Maps proposal ids to pre-propose ids
-pub const PROPOSAL_ID_TO_PRE_PROPOSE_ID: Map<u64, u64> = Map::new("proposal_ids");
+pub const PROPOSAL_ID_TO_PRE_PROPOSE_ID: Map<u64, u64> = Map::new("proposal_to_pre_propose");
+// Maps pre-propose ids to proposal ids
+pub const PRE_PROPOSE_ID_TO_PROPOSAL_ID: Map<u64, u64> = Map::new("pre_propose_to_proposal");

--- a/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
@@ -1264,7 +1264,20 @@ fn test_propose_open_proposal_submission() {
             },
         )
         .unwrap();
-    assert_eq!(pre_propose_id, pre_propose_id_from_proposal);
+    assert_eq!(pre_propose_id_from_proposal, pre_propose_id);
+
+    let proposal_id_from_pre_propose: u64 = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose_approver.clone(),
+            &ApproverQueryMsg::QueryExtension {
+                msg: ApproverQueryExt::ApproverProposalIdForPreProposeApprovalId {
+                    id: pre_propose_id,
+                },
+            },
+        )
+        .unwrap();
+    assert_eq!(proposal_id_from_pre_propose, approver_prop_id);
 
     // Approver DAO votes to approves
     approve_proposal(&mut app, proposal_single_approver, "ekez", approver_prop_id);


### PR DESCRIPTION
This adds another missing query to the `dao-pre-propose-approver` contract to allow retrieving the approver's proposal ID attached to a given pre-propose-approval pending or completed proposal. This addition means the contract now bidirectional querying to get the attached approval proposal from either side. This is necessary in order to locate and link to the corresponding proposal.