### PR TITLE
Update contracts to v2.4.0 with audit veto fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,12 +271,12 @@ dependencies = [
  "cw-admin-factory",
  "cw-utils 1.0.3",
  "cw20 1.1.2",
- "cw20-stake 2.3.0",
+ "cw20-stake 2.4.0",
  "dao-dao-core",
  "dao-interface",
  "dao-pre-propose-single",
  "dao-proposal-single",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "dao-voting-cw20-staked",
  "env_logger",
  "serde",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "cw-admin-factory"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "cw-denom"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -807,13 +807,13 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-paginate-storage 2.3.0",
+ "cw-paginate-storage 2.4.0",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.3.0",
+ "cw20-stake 2.4.0",
  "dao-dao-core",
  "dao-interface",
  "dao-voting-cw20-staked",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "cw-hooks"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "cw-paginate-storage"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "cw-payroll-factory"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "cw-stake-tracker"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "cw-token-swap"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "cw-tokenfactory-issuer"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1087,7 +1087,7 @@ dependencies = [
 
 [[package]]
 name = "cw-vesting"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1095,7 +1095,7 @@ dependencies = [
  "cw-denom",
  "cw-multi-test",
  "cw-ownable",
- "cw-paginate-storage 2.3.0",
+ "cw-paginate-storage 2.4.0",
  "cw-stake-tracker",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -1111,7 +1111,7 @@ dependencies = [
 
 [[package]]
 name = "cw-wormhole"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1278,7 +1278,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-stake"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1288,7 +1288,7 @@ dependencies = [
  "cw-hooks",
  "cw-multi-test",
  "cw-ownable",
- "cw-paginate-storage 2.3.0",
+ "cw-paginate-storage 2.4.0",
  "cw-storage-plus 1.2.0",
  "cw-utils 0.13.4",
  "cw-utils 1.0.3",
@@ -1297,13 +1297,13 @@ dependencies = [
  "cw20-base 1.1.2",
  "cw20-stake 0.2.6",
  "dao-hooks",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cw20-stake-external-rewards"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1318,7 +1318,7 @@ dependencies = [
  "cw20 0.13.4",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.3.0",
+ "cw20-stake 2.4.0",
  "dao-hooks",
  "stake-cw20-external-rewards",
  "thiserror",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-stake-reward-distributor"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1337,7 +1337,7 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.3.0",
+ "cw20-stake 2.4.0",
  "stake-cw20-reward-distributor",
  "thiserror",
 ]
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-controllers"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-roles"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "dao-cw721-extensions"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1588,13 +1588,13 @@ dependencies = [
 
 [[package]]
 name = "dao-dao-core"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-core",
  "cw-multi-test",
- "cw-paginate-storage 2.3.0",
+ "cw-paginate-storage 2.4.0",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1611,13 +1611,13 @@ dependencies = [
 
 [[package]]
 name = "dao-dao-macros"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-hooks",
  "dao-interface",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1625,19 +1625,19 @@ dependencies = [
 
 [[package]]
 name = "dao-hooks"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-hooks",
  "cw4 1.1.2",
  "dao-pre-propose-base",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
 ]
 
 [[package]]
 name = "dao-interface"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1651,7 +1651,7 @@ dependencies = [
 
 [[package]]
 name = "dao-migrator"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1668,7 +1668,7 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw20-stake 0.2.6",
- "cw20-stake 2.3.0",
+ "cw20-stake 2.4.0",
  "cw20-staked-balance-voting",
  "cw4 0.13.4",
  "cw4-voting",
@@ -1677,7 +1677,7 @@ dependencies = [
  "dao-proposal-single",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
  "thiserror",
@@ -1685,13 +1685,13 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-approval-single"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-denom",
  "cw-multi-test",
- "cw-paginate-storage 2.3.0",
+ "cw-paginate-storage 2.4.0",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1704,7 +1704,7 @@ dependencies = [
  "dao-pre-propose-base",
  "dao-proposal-single",
  "dao-testing",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
  "thiserror",
@@ -1712,7 +1712,7 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-approver"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1731,14 +1731,14 @@ dependencies = [
  "dao-pre-propose-base",
  "dao-proposal-single",
  "dao-testing",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
 ]
 
 [[package]]
 name = "dao-pre-propose-base"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1749,14 +1749,14 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "dao-interface",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-pre-propose-multiple"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1773,14 +1773,14 @@ dependencies = [
  "dao-pre-propose-base",
  "dao-proposal-multiple",
  "dao-testing",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
 ]
 
 [[package]]
 name = "dao-pre-propose-single"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1798,14 +1798,14 @@ dependencies = [
  "dao-pre-propose-base",
  "dao-proposal-single",
  "dao-testing",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
 ]
 
 [[package]]
 name = "dao-proposal-condorcet"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1820,14 +1820,14 @@ dependencies = [
  "dao-dao-macros",
  "dao-interface",
  "dao-testing",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "dao-voting-cw4",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-proposal-hook-counter"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1842,14 +1842,14 @@ dependencies = [
  "dao-hooks",
  "dao-interface",
  "dao-proposal-single",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "dao-voting-cw20-balance",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-proposal-multiple"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1863,7 +1863,7 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.3.0",
+ "cw20-stake 2.4.0",
  "cw3 1.1.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
@@ -1875,7 +1875,7 @@ dependencies = [
  "dao-pre-propose-multiple",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-single"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1904,7 +1904,7 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.3.0",
+ "cw20-stake 2.4.0",
  "cw3 1.1.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
@@ -1917,7 +1917,7 @@ dependencies = [
  "dao-pre-propose-single",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-sudo"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "dao-test-custom-factory"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1958,13 +1958,13 @@ dependencies = [
  "cw721-base 0.18.0",
  "dao-dao-macros",
  "dao-interface",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-testing"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1978,7 +1978,7 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.3.0",
+ "cw20-stake 2.4.0",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
@@ -1991,7 +1991,7 @@ dependencies = [
  "dao-proposal-single",
  "dao-test-custom-factory",
  "dao-voting 0.1.0",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "dao-voting"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-cw20-balance"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-cw20-staked"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2064,16 +2064,16 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.3.0",
+ "cw20-stake 2.4.0",
  "dao-dao-macros",
  "dao-interface",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw4"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2091,14 +2091,14 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-cw721-roles"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
  "cw-ownable",
- "cw-paginate-storage 2.3.0",
+ "cw-paginate-storage 2.4.0",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-cw721-staked"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2124,7 +2124,7 @@ dependencies = [
  "cw-controllers 1.1.2",
  "cw-hooks",
  "cw-multi-test",
- "cw-paginate-storage 2.3.0",
+ "cw-paginate-storage 2.4.0",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -2138,7 +2138,7 @@ dependencies = [
  "dao-proposal-single",
  "dao-test-custom-factory",
  "dao-testing",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "osmosis-std",
  "osmosis-test-tube",
  "serde",
@@ -2147,7 +2147,7 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-token-staked"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2157,7 +2157,7 @@ dependencies = [
  "cw-hooks",
  "cw-multi-test",
  "cw-ownable",
- "cw-paginate-storage 2.3.0",
+ "cw-paginate-storage 2.4.0",
  "cw-storage-plus 1.2.0",
  "cw-tokenfactory-issuer",
  "cw-utils 1.0.3",
@@ -2169,7 +2169,7 @@ dependencies = [
  "dao-proposal-single",
  "dao-test-custom-factory",
  "dao-testing",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "osmosis-std",
  "osmosis-test-tube",
  "serde",
@@ -2857,7 +2857,7 @@ dependencies = [
  "cw-vesting",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.3.0",
+ "cw20-stake 2.4.0",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
  "cw721-roles",
@@ -2866,7 +2866,7 @@ dependencies = [
  "dao-pre-propose-single",
  "dao-proposal-single",
  "dao-test-custom-factory",
- "dao-voting 2.3.0",
+ "dao-voting 2.4.0",
  "dao-voting-cw20-staked",
  "dao-voting-cw721-staked",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/DA0-DA0/dao-contracts"
-version = "2.3.0"
+version = "2.4.0"
 
 [profile.release]
 codegen-units = 1
@@ -32,17 +32,17 @@ rpath = false
 overflow-checks = true
 
 [workspace.dependencies]
-anyhow = {version = "1.0"}
+anyhow = { version = "1.0" }
 assert_matches = "1.5"
-cosm-orc = {version = "4.0"}
+cosm-orc = { version = "4.0" }
 cosm-tome = "0.2"
 cosmos-sdk-proto = "0.19"
-cosmwasm-schema = {version = "1.2"}
-cosmwasm-std = {version = "1.5.0", features = ["ibc3"]}
-cosmwasm-storage = {version = "1.2"}
+cosmwasm-schema = { version = "1.2" }
+cosmwasm-std = { version = "1.5.0", features = ["ibc3"] }
+cosmwasm-storage = { version = "1.2" }
 cw-controllers = "1.1"
 cw-multi-test = "0.18"
-cw-storage-plus = {version = "1.1"}
+cw-storage-plus = { version = "1.1" }
 cw-utils = "1.0"
 cw2 = "1.1"
 cw20 = "1.1"
@@ -61,16 +61,16 @@ prost = "0.11"
 quote = "1.0"
 rand = "0.8"
 schemars = "0.8"
-serde = {version = "1.0", default-features = false, features = ["derive"]}
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 sg-multi-test = "3.1.0"
 sg-std = "3.1.0"
 sg721 = "3.1.0"
 sg721-base = "3.1.0"
-syn = {version = "1.0", features = ["derive"]}
+syn = { version = "1.0", features = ["derive"] }
 test-context = "0.1"
-thiserror = {version = "1.0"}
+thiserror = { version = "1.0" }
 token-bindings = "0.11.0"
 wynd-utils = "0.4"
 
@@ -78,42 +78,42 @@ wynd-utils = "0.4"
 # optional owner.
 cw-ownable = "0.5"
 
-cw-admin-factory = {path = "./contracts/external/cw-admin-factory", version = "2.3.0"}
-cw-denom = {path = "./packages/cw-denom", version = "2.3.0"}
-cw-hooks = {path = "./packages/cw-hooks", version = "2.3.0"}
-cw-paginate-storage = {path = "./packages/cw-paginate-storage", version = "2.3.0"}
-cw-payroll-factory = {path = "./contracts/external/cw-payroll-factory", version = "2.3.0"}
-cw-stake-tracker = {path = "./packages/cw-stake-tracker", version = "2.3.0"}
-cw-tokenfactory-issuer = {path = "./contracts/external/cw-tokenfactory-issuer", version = "2.3.0"}
-cw-vesting = {path = "./contracts/external/cw-vesting", version = "2.3.0"}
-cw-wormhole = {path = "./packages/cw-wormhole", version = "2.3.0"}
-cw20-stake = {path = "./contracts/staking/cw20-stake", version = "2.3.0"}
-cw721-controllers = {path = "./packages/cw721-controllers", version = "2.3.0"}
-cw721-roles = {path = "./contracts/external/cw721-roles", version = "2.3.0"}
-dao-cw721-extensions = {path = "./packages/dao-cw721-extensions", version = "2.3.0"}
-dao-dao-core = {path = "./contracts/dao-dao-core", version = "2.3.0"}
-dao-dao-macros = {path = "./packages/dao-dao-macros", version = "2.3.0"}
-dao-hooks = {path = "./packages/dao-hooks", version = "2.3.0"}
-dao-interface = {path = "./packages/dao-interface", version = "2.3.0"}
-dao-pre-propose-approval-single = {path = "./contracts/pre-propose/dao-pre-propose-approval-single", version = "2.3.0"}
-dao-pre-propose-approver = {path = "./contracts/pre-propose/dao-pre-propose-approver", version = "2.3.0"}
-dao-pre-propose-base = {path = "./packages/dao-pre-propose-base", version = "2.3.0"}
-dao-pre-propose-multiple = {path = "./contracts/pre-propose/dao-pre-propose-multiple", version = "2.3.0"}
-dao-pre-propose-single = {path = "./contracts/pre-propose/dao-pre-propose-single", version = "2.3.0"}
-dao-proposal-condorcet = {path = "./contracts/proposal/dao-proposal-condorcet", version = "2.3.0"}
-dao-proposal-hook-counter = {path = "./contracts/test/dao-proposal-hook-counter", version = "2.3.0"}
-dao-proposal-multiple = {path = "./contracts/proposal/dao-proposal-multiple", version = "2.3.0"}
-dao-proposal-single = {path = "./contracts/proposal/dao-proposal-single", version = "2.3.0"}
-dao-proposal-sudo = {path = "./contracts/test/dao-proposal-sudo", version = "2.3.0"}
-dao-test-custom-factory = {path = "./contracts/test/dao-test-custom-factory", version = "2.3.0"}
-dao-testing = {path = "./packages/dao-testing", version = "2.3.0"}
-dao-voting = {path = "./packages/dao-voting", version = "2.3.0"}
-dao-voting-cw20-balance = {path = "./contracts/test/dao-voting-cw20-balance", version = "2.3.0"}
-dao-voting-cw20-staked = {path = "./contracts/voting/dao-voting-cw20-staked", version = "2.3.0"}
-dao-voting-cw4 = {path = "./contracts/voting/dao-voting-cw4", version = "2.3.0"}
-dao-voting-cw721-roles = {path = "./contracts/voting/dao-voting-cw721-roles", version = "2.3.0"}
-dao-voting-cw721-staked = {path = "./contracts/voting/dao-voting-cw721-staked", version = "2.3.0"}
-dao-voting-token-staked = {path = "./contracts/voting/dao-voting-token-staked", version = "2.3.0"}
+cw-admin-factory = { path = "./contracts/external/cw-admin-factory", version = "2.4.0" }
+cw-denom = { path = "./packages/cw-denom", version = "2.4.0" }
+cw-hooks = { path = "./packages/cw-hooks", version = "2.4.0" }
+cw-paginate-storage = { path = "./packages/cw-paginate-storage", version = "2.4.0" }
+cw-payroll-factory = { path = "./contracts/external/cw-payroll-factory", version = "2.4.0" }
+cw-stake-tracker = { path = "./packages/cw-stake-tracker", version = "2.4.0" }
+cw-tokenfactory-issuer = { path = "./contracts/external/cw-tokenfactory-issuer", version = "2.4.0" }
+cw-vesting = { path = "./contracts/external/cw-vesting", version = "2.4.0" }
+cw-wormhole = { path = "./packages/cw-wormhole", version = "2.4.0" }
+cw20-stake = { path = "./contracts/staking/cw20-stake", version = "2.4.0" }
+cw721-controllers = { path = "./packages/cw721-controllers", version = "2.4.0" }
+cw721-roles = { path = "./contracts/external/cw721-roles", version = "2.4.0" }
+dao-cw721-extensions = { path = "./packages/dao-cw721-extensions", version = "2.4.0" }
+dao-dao-core = { path = "./contracts/dao-dao-core", version = "2.4.0" }
+dao-dao-macros = { path = "./packages/dao-dao-macros", version = "2.4.0" }
+dao-hooks = { path = "./packages/dao-hooks", version = "2.4.0" }
+dao-interface = { path = "./packages/dao-interface", version = "2.4.0" }
+dao-pre-propose-approval-single = { path = "./contracts/pre-propose/dao-pre-propose-approval-single", version = "2.4.0" }
+dao-pre-propose-approver = { path = "./contracts/pre-propose/dao-pre-propose-approver", version = "2.4.0" }
+dao-pre-propose-base = { path = "./packages/dao-pre-propose-base", version = "2.4.0" }
+dao-pre-propose-multiple = { path = "./contracts/pre-propose/dao-pre-propose-multiple", version = "2.4.0" }
+dao-pre-propose-single = { path = "./contracts/pre-propose/dao-pre-propose-single", version = "2.4.0" }
+dao-proposal-condorcet = { path = "./contracts/proposal/dao-proposal-condorcet", version = "2.4.0" }
+dao-proposal-hook-counter = { path = "./contracts/test/dao-proposal-hook-counter", version = "2.4.0" }
+dao-proposal-multiple = { path = "./contracts/proposal/dao-proposal-multiple", version = "2.4.0" }
+dao-proposal-single = { path = "./contracts/proposal/dao-proposal-single", version = "2.4.0" }
+dao-proposal-sudo = { path = "./contracts/test/dao-proposal-sudo", version = "2.4.0" }
+dao-test-custom-factory = { path = "./contracts/test/dao-test-custom-factory", version = "2.4.0" }
+dao-testing = { path = "./packages/dao-testing", version = "2.4.0" }
+dao-voting = { path = "./packages/dao-voting", version = "2.4.0" }
+dao-voting-cw20-balance = { path = "./contracts/test/dao-voting-cw20-balance", version = "2.4.0" }
+dao-voting-cw20-staked = { path = "./contracts/voting/dao-voting-cw20-staked", version = "2.4.0" }
+dao-voting-cw4 = { path = "./contracts/voting/dao-voting-cw4", version = "2.4.0" }
+dao-voting-cw721-roles = { path = "./contracts/voting/dao-voting-cw721-roles", version = "2.4.0" }
+dao-voting-cw721-staked = { path = "./contracts/voting/dao-voting-cw721-staked", version = "2.4.0" }
+dao-voting-token-staked = { path = "./contracts/voting/dao-voting-token-staked", version = "2.4.0" }
 
 # v1 dependencies. used for state migrations.
 cw-core-v1 = { package = "cw-core", version = "0.1.0" }

--- a/contracts/dao-dao-core/schema/dao-dao-core.json
+++ b/contracts/dao-dao-core/schema/dao-dao-core.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-dao-core",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
+++ b/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-admin-factory",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
+++ b/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-payroll-factory",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-token-swap/schema/cw-token-swap.json
+++ b/contracts/external/cw-token-swap/schema/cw-token-swap.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-token-swap",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-tokenfactory-issuer/schema/cw-tokenfactory-issuer.json
+++ b/contracts/external/cw-tokenfactory-issuer/schema/cw-tokenfactory-issuer.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-tokenfactory-issuer",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-vesting/schema/cw-vesting.json
+++ b/contracts/external/cw-vesting/schema/cw-vesting.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-vesting",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw721-roles/schema/cw721-roles.json
+++ b/contracts/external/cw721-roles/schema/cw721-roles.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw721-roles",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/dao-migrator/schema/dao-migrator.json
+++ b/contracts/external/dao-migrator/schema/dao-migrator.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-migrator",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-approval-single",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
+++ b/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-approver",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-multiple",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
+++ b/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-single",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
+++ b/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-condorcet",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
+++ b/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-multiple",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/dao-proposal-multiple/src/contract.rs
+++ b/contracts/proposal/dao-proposal-multiple/src/contract.rs
@@ -453,6 +453,9 @@ pub fn execute_execute(
         .ok_or(ContractError::NoSuchProposal { id: proposal_id })?;
 
     let config = CONFIG.load(deps.storage)?;
+
+    // determine if this sender can execute
+    let mut sender_can_execute = true;
     if config.only_members_execute {
         let power = get_voting_power(
             deps.as_ref(),
@@ -461,16 +464,7 @@ pub fn execute_execute(
             Some(prop.start_height),
         )?;
 
-        // if there is no veto config, then caller is not the vetoer
-        // if there is, we validate the caller addr
-        let vetoer_call = prop
-            .veto
-            .as_ref()
-            .map_or(false, |veto_config| veto_config.vetoer == info.sender);
-
-        if power.is_zero() && !vetoer_call {
-            return Err(ContractError::Unauthorized {});
-        }
+        sender_can_execute = !power.is_zero();
     }
 
     // Check here that the proposal is passed or timelocked.
@@ -481,27 +475,31 @@ pub fn execute_execute(
     prop.update_status(&env.block)?;
     let old_status = prop.status;
     match &prop.status {
-        Status::Passed => (),
-        Status::VetoTimelock { expiration } => {
+        Status::Passed => {
+            // if passed, verify sender can execute
+            if !sender_can_execute {
+                return Err(ContractError::Unauthorized {});
+            }
+        }
+        Status::VetoTimelock { .. } => {
             let veto_config = prop
                 .veto
                 .as_ref()
                 .ok_or(VetoError::NoVetoConfiguration {})?;
 
-            // Check if the sender is the vetoer
-            match veto_config.vetoer == info.sender {
-                // if sender is the vetoer we validate the early exec flag
-                true => veto_config.check_early_execute_enabled()?,
-                // otherwise timelock must be expired in order to execute
-                false => {
-                    // it should never be expired here since the status updates
-                    // to passed after the timelock expires, but let's check
-                    // anyway. i.e. this error should always be returned.
-                    if !expiration.is_expired(&env.block) {
-                        return Err(ContractError::VetoError(VetoError::Timelocked {}));
-                    }
+            // check that the sender is the vetoer
+            if veto_config.vetoer != info.sender {
+                // if the sender can normally execute, but is not the vetoer,
+                // return timelocked error. otherwise return unauthorized.
+                if sender_can_execute {
+                    return Err(ContractError::VetoError(VetoError::Timelocked {}));
+                } else {
+                    return Err(ContractError::Unauthorized {});
                 }
             }
+
+            // if veto timelocked, only allow execution if early_execute enabled
+            veto_config.check_early_execute_enabled()?;
         }
         _ => {
             return Err(ContractError::NotPassed {});

--- a/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
+++ b/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-single",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/staking/cw20-stake-external-rewards/schema/cw20-stake-external-rewards.json
+++ b/contracts/staking/cw20-stake-external-rewards/schema/cw20-stake-external-rewards.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw20-stake-external-rewards",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/staking/cw20-stake-reward-distributor/schema/cw20-stake-reward-distributor.json
+++ b/contracts/staking/cw20-stake-reward-distributor/schema/cw20-stake-reward-distributor.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw20-stake-reward-distributor",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/staking/cw20-stake/schema/cw20-stake.json
+++ b/contracts/staking/cw20-stake/schema/cw20-stake.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw20-stake",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw20-staked/schema/dao-voting-cw20-staked.json
+++ b/contracts/voting/dao-voting-cw20-staked/schema/dao-voting-cw20-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw20-staked",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw4/schema/dao-voting-cw4.json
+++ b/contracts/voting/dao-voting-cw4/schema/dao-voting-cw4.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw4",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw721-roles/schema/dao-voting-cw721-roles.json
+++ b/contracts/voting/dao-voting-cw721-roles/schema/dao-voting-cw721-roles.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw721-roles",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw721-staked/schema/dao-voting-cw721-staked.json
+++ b/contracts/voting/dao-voting-cw721-staked/schema/dao-voting-cw721-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw721-staked",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-token-staked/schema/dao-voting-token-staked.json
+++ b/contracts/voting/dao-voting-token-staked/schema/dao-voting-token-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-token-staked",
-  "contract_version": "2.3.0",
+  "contract_version": "2.4.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
This updates all the contract versions to v2.4.0. It also includes a fix from the veto audit.