### PR TITLE
Update CI workspace-optimizer version

### DIFF
--- a/.github/workflows/release-contracts.yml
+++ b/.github/workflows/release-contracts.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    container: cosmwasm/workspace-optimizer:0.12.13
+    container: cosmwasm/workspace-optimizer:0.14.0
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
This updates the CI job that releases contracts to `0.14.0` to match the version in the `justfile`.