### PR TITLE
Fix clippy errors from latest rust stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,6 @@ version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -892,7 +891,6 @@ name = "cw-paginate-storage"
 version = "2.4.0"
 dependencies = [
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "serde",
@@ -932,7 +930,7 @@ dependencies = [
  "cw-utils 0.13.4",
  "cw2 0.13.4",
  "cw20 0.13.4",
- "cw3 0.13.4",
+ "cw3",
  "dao-voting 0.1.0",
  "indexable-hooks",
  "proposal-hooks",
@@ -1016,7 +1014,6 @@ version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-multi-test",
  "cw-ownable",
  "cw-storage-plus 1.2.0",
@@ -1112,7 +1109,6 @@ dependencies = [
  "cw-denom",
  "cw-multi-test",
  "cw-ownable",
- "cw-paginate-storage 2.4.0",
  "cw-stake-tracker",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -1300,7 +1296,6 @@ dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-controllers 1.1.2",
  "cw-hooks",
  "cw-multi-test",
@@ -1325,7 +1320,6 @@ dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-controllers 1.1.2",
  "cw-multi-test",
  "cw-ownable",
@@ -1390,21 +1384,6 @@ dependencies = [
  "cw-utils 0.13.4",
  "schemars",
  "serde",
-]
-
-[[package]]
-name = "cw3"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2967fbd073d4b626dd9e7148e05a84a3bebd9794e71342e12351110ffbb12395"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-utils 1.0.3",
- "cw20 1.1.2",
- "schemars",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -1658,7 +1637,6 @@ version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-hooks",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
@@ -1871,7 +1849,6 @@ dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-denom",
  "cw-hooks",
  "cw-multi-test",
@@ -1881,7 +1858,6 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw20-stake 2.4.0",
- "cw3 1.1.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
@@ -1909,7 +1885,6 @@ dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-core",
  "cw-denom",
  "cw-hooks",
@@ -1922,7 +1897,6 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw20-stake 2.4.0",
- "cw3 1.1.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
@@ -1949,7 +1923,6 @@ version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
@@ -1964,7 +1937,6 @@ version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-multi-test",
  "cw-ownable",
  "cw-storage-plus 1.2.0",
@@ -2073,7 +2045,6 @@ version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -2093,7 +2064,6 @@ version = "2.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -2114,7 +2084,6 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
  "cw-ownable",
- "cw-paginate-storage 2.4.0",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -2140,7 +2109,6 @@ dependencies = [
  "cw-controllers 1.1.2",
  "cw-hooks",
  "cw-multi-test",
- "cw-paginate-storage 2.4.0",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -2168,12 +2136,10 @@ dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-controllers 1.1.2",
  "cw-hooks",
  "cw-multi-test",
  "cw-ownable",
- "cw-paginate-storage 2.4.0",
  "cw-storage-plus 1.2.0",
  "cw-tokenfactory-issuer",
  "cw-utils 1.0.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ cosm-tome = "0.2"
 cosmos-sdk-proto = "0.19"
 cosmwasm-schema = { version = "1.2" }
 cosmwasm-std = { version = "1.5.0", features = ["ibc3"] }
-cosmwasm-storage = { version = "1.2" }
 cw-controllers = "1.1"
 cw-multi-test = "0.18"
 cw-storage-plus = { version = "1.1" }

--- a/contracts/external/cw-admin-factory/Cargo.toml
+++ b/contracts/external/cw-admin-factory/Cargo.toml
@@ -18,7 +18,6 @@ library = []
 
 [dependencies]
 cosmwasm-std = { workspace = true }
-cosmwasm-storage = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }

--- a/contracts/external/cw-fund-distributor/src/testing/tests.rs
+++ b/contracts/external/cw-fund-distributor/src/testing/tests.rs
@@ -1398,7 +1398,7 @@ fn test_query_cw20_entitlements() {
         .unwrap();
 
     assert_eq!(res.len(), 1);
-    let entitlement = res.get(0).unwrap();
+    let entitlement = res.first().unwrap();
     assert_eq!(entitlement.amount.u128(), 500000);
     assert_eq!(entitlement.token_contract, token_address);
 }
@@ -1451,7 +1451,7 @@ fn test_query_native_entitlements() {
         .unwrap();
 
     assert_eq!(res.len(), 1);
-    let entitlement = res.get(0).unwrap();
+    let entitlement = res.first().unwrap();
     assert_eq!(entitlement.amount.u128(), 500000);
     assert_eq!(entitlement.denom, FEE_DENOM);
 }
@@ -1601,7 +1601,7 @@ fn test_query_cw20_tokens() {
         .unwrap();
 
     assert_eq!(res.len(), 1);
-    let cw20 = res.get(0).unwrap();
+    let cw20 = res.first().unwrap();
     assert_eq!(cw20.token, "contract1");
     assert_eq!(cw20.contract_balance.u128(), 500000);
 }
@@ -1642,7 +1642,7 @@ fn test_query_native_denoms() {
 
     // assert distributor now contains one expected native token
     assert_eq!(res.len(), 1);
-    let denom = res.get(0).unwrap();
+    let denom = res.first().unwrap();
     assert_eq!(denom.denom, FEE_DENOM.to_string());
     assert_eq!(denom.contract_balance.u128(), 500000);
 }

--- a/contracts/external/cw-tokenfactory-issuer/Cargo.toml
+++ b/contracts/external/cw-tokenfactory-issuer/Cargo.toml
@@ -43,7 +43,6 @@ cosmwasm_tokenfactory = ["cw-tokenfactory-types/cosmwasm_tokenfactory"]
 [dependencies]
 cosmwasm-schema = { workspace = true }
 cosmwasm-std = { workspace = true }
-cosmwasm-storage = { workspace = true }
 cw2 = { workspace = true }
 cw-ownable = { workspace = true }
 cw-storage-plus = { workspace = true }

--- a/contracts/external/cw-vesting/Cargo.toml
+++ b/contracts/external/cw-vesting/Cargo.toml
@@ -21,7 +21,6 @@ cosmwasm-schema = { workspace = true }
 cosmwasm-std = { workspace = true, features = ["staking"] }
 cw-denom = { workspace = true }
 cw-ownable = { workspace = true }
-cw-paginate-storage = { workspace = true }
 cw-stake-tracker = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }

--- a/contracts/proposal/dao-proposal-multiple/Cargo.toml
+++ b/contracts/proposal/dao-proposal-multiple/Cargo.toml
@@ -25,13 +25,11 @@ library = []
 
 [dependencies]
 cosmwasm-std = { workspace = true, features = ["ibc3"] }
-cosmwasm-storage = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
-cw3 = { workspace = true }
 thiserror = { workspace = true }
 dao-dao-macros = { workspace = true }
 dao-pre-propose-base = { workspace = true }

--- a/contracts/proposal/dao-proposal-single/Cargo.toml
+++ b/contracts/proposal/dao-proposal-single/Cargo.toml
@@ -18,21 +18,18 @@ library = []
 
 [dependencies]
 cosmwasm-std = { workspace = true, features = ["ibc3"] }
-cosmwasm-storage = { workspace = true }
 cosmwasm-schema = { workspace = true }
+cw-hooks = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
-cw3 = { workspace = true }
-thiserror = { workspace = true }
-
 dao-dao-macros = { workspace = true }
-dao-pre-propose-base = { workspace = true }
-dao-interface = { workspace = true }
-dao-voting = { workspace = true }
-cw-hooks = { workspace = true }
 dao-hooks = { workspace = true }
+dao-interface = { workspace = true }
+dao-pre-propose-base = { workspace = true }
+dao-voting = { workspace = true }
+thiserror = { workspace = true }
 
 cw-utils-v1 = { workspace = true}
 voting-v1 = { workspace = true }

--- a/contracts/staking/cw20-stake-external-rewards/Cargo.toml
+++ b/contracts/staking/cw20-stake-external-rewards/Cargo.toml
@@ -18,7 +18,6 @@ library = []
 [dependencies]
 cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
-cosmwasm-storage = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-controllers = { workspace = true }
 cw20 = { workspace = true }

--- a/contracts/staking/cw20-stake/Cargo.toml
+++ b/contracts/staking/cw20-stake/Cargo.toml
@@ -17,7 +17,6 @@ library = []
 
 [dependencies]
 cosmwasm-std = { workspace = true }
-cosmwasm-storage = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-controllers = { workspace = true }

--- a/contracts/test/dao-proposal-sudo/Cargo.toml
+++ b/contracts/test/dao-proposal-sudo/Cargo.toml
@@ -19,7 +19,6 @@ library = []
 [dependencies]
 cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
-cosmwasm-storage = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
 thiserror = { workspace = true }

--- a/contracts/test/dao-test-custom-factory/Cargo.toml
+++ b/contracts/test/dao-test-custom-factory/Cargo.toml
@@ -19,7 +19,6 @@ library = []
 [dependencies]
 cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
-cosmwasm-storage = { workspace = true }
 cw2 = { workspace = true }
 cw721 = { workspace = true }
 cw721-base = { workspace = true, features = ["library"] }

--- a/contracts/voting/dao-voting-cw20-staked/Cargo.toml
+++ b/contracts/voting/dao-voting-cw20-staked/Cargo.toml
@@ -19,7 +19,6 @@ library = []
 [dependencies]
 cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
-cosmwasm-storage = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw2 = { workspace = true }

--- a/contracts/voting/dao-voting-cw4/Cargo.toml
+++ b/contracts/voting/dao-voting-cw4/Cargo.toml
@@ -18,7 +18,6 @@ library = []
 
 [dependencies]
 cosmwasm-std = { workspace = true }
-cosmwasm-storage = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
 cw-utils = { workspace = true }

--- a/contracts/voting/dao-voting-cw721-roles/Cargo.toml
+++ b/contracts/voting/dao-voting-cw721-roles/Cargo.toml
@@ -24,7 +24,6 @@ dao-interface = { workspace = true }
 cw721-base = { workspace = true, features = ["library"] }
 cw721-controllers = { workspace = true }
 cw-ownable = { workspace = true }
-cw-paginate-storage = { workspace = true }
 cw721 = { workspace = true }
 cw-utils = { workspace = true }
 cw2 = { workspace = true }

--- a/contracts/voting/dao-voting-cw721-staked/Cargo.toml
+++ b/contracts/voting/dao-voting-cw721-staked/Cargo.toml
@@ -31,7 +31,6 @@ cw-hooks = { workspace = true }
 cw721 = { workspace = true }
 cw721-base = { workspace = true, features = ["library"] }
 cw721-controllers = { workspace = true }
-cw-paginate-storage = { workspace = true }
 cw-utils = { workspace = true }
 cw2 = { workspace = true }
 dao-dao-macros = { workspace = true }

--- a/contracts/voting/dao-voting-token-staked/Cargo.toml
+++ b/contracts/voting/dao-voting-token-staked/Cargo.toml
@@ -24,7 +24,6 @@ test-tube = []
 [dependencies]
 cosmwasm-std    = { workspace = true, features = ["cosmwasm_1_1"] }
 cosmwasm-schema = { workspace = true }
-cosmwasm-storage = { workspace = true }
 cw-ownable = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
@@ -36,7 +35,6 @@ dao-dao-macros = { workspace = true }
 dao-hooks = { workspace = true }
 dao-interface = { workspace = true }
 dao-voting = { workspace = true }
-cw-paginate-storage = { workspace = true }
 cw-tokenfactory-issuer = { workspace = true, features = ["library"] }
 
 [dev-dependencies]

--- a/packages/cw-paginate-storage/Cargo.toml
+++ b/packages/cw-paginate-storage/Cargo.toml
@@ -9,7 +9,6 @@ version = { workspace = true }
 
 [dependencies]
 cosmwasm-std = { workspace = true }
-cosmwasm-storage = { workspace = true }
 cw-storage-plus = { workspace = true }
 serde = { workspace = true }
 

--- a/packages/cw-paginate-storage/src/lib.rs
+++ b/packages/cw-paginate-storage/src/lib.rs
@@ -379,7 +379,7 @@ mod tests {
             map.save(
                 &mut deps.storage,
                 ctr,
-                &Uint128::new(ctr.try_into().unwrap()),
+                &Uint128::new(<u32 as std::convert::Into<u128>>::into(ctr)),
                 env.block.height,
             )
             .unwrap();

--- a/packages/dao-interface/Cargo.toml
+++ b/packages/dao-interface/Cargo.toml
@@ -13,7 +13,6 @@ cosmwasm-schema = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
 cw721 = { workspace = true }
-cw-hooks = { workspace = true }
 cw-utils = { workspace = true }
 osmosis-std = { workspace = true }
 


### PR DESCRIPTION
Fixes clippy errors that have come up with the latest rust stable release. No functionality changes.