### PR TITLE
Put cw-vesting staking features behind a feature flag

### DIFF
--- a/contracts/external/cw-vesting/Cargo.toml
+++ b/contracts/external/cw-vesting/Cargo.toml
@@ -11,14 +11,18 @@ version = { workspace = true }
 crate-type = ["cdylib", "rlib"]
 
 [features]
+default = ["staking"]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
+# enable staking features on chains that support staking. most do, so this is a
+# default. Neutron does not, for example.
+staking = ["cosmwasm-std/staking"]
 
 [dependencies]
 cosmwasm-schema = { workspace = true }
-cosmwasm-std = { workspace = true, features = ["staking"] }
+cosmwasm-std = { workspace = true }
 cw-denom = { workspace = true }
 cw-ownable = { workspace = true }
 cw-stake-tracker = { workspace = true }

--- a/contracts/external/cw-vesting/src/contract.rs
+++ b/contracts/external/cw-vesting/src/contract.rs
@@ -1,9 +1,12 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    from_json, to_json_binary, Binary, Coin, CosmosMsg, DelegationResponse, Deps, DepsMut,
-    DistributionMsg, Env, MessageInfo, Response, StakingMsg, StakingQuery, StdResult, Timestamp,
-    Uint128,
+    from_json, to_json_binary, Binary, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response,
+    StdResult, Uint128,
+};
+#[cfg(feature = "staking")]
+use cosmwasm_std::{
+    Coin, DelegationResponse, DistributionMsg, StakingMsg, StakingQuery, Timestamp,
 };
 use cw2::set_contract_version;
 use cw20::Cw20ReceiveMsg;
@@ -52,7 +55,7 @@ pub fn instantiate(
     )?;
     UNBONDING_DURATION_SECONDS.save(deps.storage, &msg.unbonding_duration_seconds)?;
 
-    let resp = match vest.denom {
+    let resp: Option<CosmosMsg> = match vest.denom {
         CheckedDenom::Native(ref denom) => {
             let sent = must_pay(&info, denom)?;
             if vest.total() != sent {
@@ -67,6 +70,7 @@ pub fn instantiate(
             // denomination, set the staking rewards receiver to the
             // payment receiver so that when they stake vested tokens
             // they receive the rewards.
+            #[cfg(feature = "staking")]
             if denom.as_str() == deps.querier.query_bonded_denom()? {
                 Some(CosmosMsg::Distribution(
                     DistributionMsg::SetWithdrawAddress {
@@ -76,6 +80,9 @@ pub fn instantiate(
             } else {
                 None
             }
+
+            #[cfg(not(feature = "staking"))]
+            None
         }
         CheckedDenom::Cw20(_) => {
             nonpayable(&info)?; // Funding happens in ExecuteMsg::Receive.
@@ -98,27 +105,33 @@ pub fn execute(
 ) -> Result<Response, ContractError> {
     match msg {
         ExecuteMsg::Receive(msg) => execute_receive_cw20(env, deps, info, msg),
-        ExecuteMsg::Distribute { amount } => execute_distribute(env, deps, amount),
         ExecuteMsg::Cancel {} => execute_cancel_vesting_payment(env, deps, info),
+        ExecuteMsg::Distribute { amount } => execute_distribute(env, deps, amount),
+        ExecuteMsg::WithdrawCanceledPayment { amount } => {
+            execute_withdraw_canceled_payment(deps, env, amount)
+        }
         ExecuteMsg::UpdateOwnership(action) => execute_update_owner(deps, info, env, action),
+        #[cfg(feature = "staking")]
         ExecuteMsg::Delegate { validator, amount } => {
             execute_delegate(env, deps, info, validator, amount)
         }
+        #[cfg(feature = "staking")]
         ExecuteMsg::Redelegate {
             src_validator,
             dst_validator,
             amount,
         } => execute_redelegate(env, deps, info, src_validator, dst_validator, amount),
+        #[cfg(feature = "staking")]
         ExecuteMsg::Undelegate { validator, amount } => {
             execute_undelegate(env, deps, info, validator, amount)
         }
+        #[cfg(feature = "staking")]
         ExecuteMsg::SetWithdrawAddress { address } => {
             execute_set_withdraw_address(deps, env, info, address)
         }
+        #[cfg(feature = "staking")]
         ExecuteMsg::WithdrawDelegatorReward { validator } => execute_withdraw_rewards(validator),
-        ExecuteMsg::WithdrawCanceledPayment { amount } => {
-            execute_withdraw_canceled_payment(deps, env, amount)
-        }
+        #[cfg(feature = "staking")]
         ExecuteMsg::RegisterSlash {
             validator,
             time,
@@ -227,6 +240,7 @@ pub fn execute_update_owner(
     Ok(Response::default().add_attributes(ownership.into_attributes()))
 }
 
+#[cfg(feature = "staking")]
 pub fn execute_delegate(
     env: Env,
     deps: DepsMut,
@@ -267,6 +281,7 @@ pub fn execute_delegate(
         .add_message(msg))
 }
 
+#[cfg(feature = "staking")]
 pub fn execute_redelegate(
     env: Env,
     deps: DepsMut,
@@ -333,6 +348,7 @@ pub fn execute_redelegate(
         .add_message(msg))
 }
 
+#[cfg(feature = "staking")]
 pub fn execute_undelegate(
     env: Env,
     deps: DepsMut,
@@ -375,6 +391,7 @@ pub fn execute_undelegate(
         .add_attribute("amount", amount))
 }
 
+#[cfg(feature = "staking")]
 pub fn execute_set_withdraw_address(
     deps: DepsMut,
     env: Env,
@@ -407,6 +424,7 @@ pub fn execute_set_withdraw_address(
         .add_message(msg))
 }
 
+#[cfg(feature = "staking")]
 pub fn execute_withdraw_rewards(validator: String) -> Result<Response, ContractError> {
     let withdraw_msg = DistributionMsg::WithdrawDelegatorReward { validator };
     Ok(Response::default()
@@ -414,6 +432,7 @@ pub fn execute_withdraw_rewards(validator: String) -> Result<Response, ContractE
         .add_message(withdraw_msg))
 }
 
+#[cfg(feature = "staking")]
 pub fn execute_register_slash(
     deps: DepsMut,
     env: Env,

--- a/contracts/external/cw-vesting/src/msg.rs
+++ b/contracts/external/cw-vesting/src/msg.rs
@@ -100,6 +100,7 @@ pub enum ExecuteMsg {
     /// contract's address.  Note: this only works with the native
     /// staking denom of a Cosmos chain.  Only callable by Vesting
     /// Payment Recipient.
+    #[cfg(feature = "staking")]
     Delegate {
         /// The validator to delegate to.
         validator: String,
@@ -111,6 +112,7 @@ pub enum ExecuteMsg {
     /// `delegator_address` is automatically filled with the current
     /// contract's address.  Only callable by Vesting Payment
     /// Recipient.
+    #[cfg(feature = "staking")]
     Redelegate {
         src_validator: String,
         dst_validator: String,
@@ -121,6 +123,7 @@ pub enum ExecuteMsg {
     /// `delegator_address` is automatically filled with the current
     /// contract's address.  Only callable by Vesting Payment
     /// Recipient.
+    #[cfg(feature = "staking")]
     Undelegate {
         /// The validator to undelegate from
         validator: String,
@@ -132,11 +135,13 @@ pub enum ExecuteMsg {
     /// `delegator_address` is automatically filled with the current
     /// contract's address.  Only callable by Vesting Payment
     /// Recipient.
+    #[cfg(feature = "staking")]
     SetWithdrawAddress { address: String },
     /// This is translated to a
     /// [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50).
     /// `delegator_address` is automatically filled with the current
     /// contract's address.
+    #[cfg(feature = "staking")]
     WithdrawDelegatorReward {
         /// The validator to claim rewards for.
         validator: String,
@@ -157,6 +162,7 @@ pub enum ExecuteMsg {
     /// A future version of this contract may be able to
     /// permissionlessly take slashing evidence:
     /// <https://github.com/CosmWasm/mesh-security/issues/35>
+    #[cfg(feature = "staking")]
     RegisterSlash {
         /// The validator the slash occured for.
         validator: String,

--- a/contracts/external/cw-vesting/src/vesting.rs
+++ b/contracts/external/cw-vesting/src/vesting.rs
@@ -1,9 +1,9 @@
 use std::cmp::min;
 
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{
-    Addr, Binary, CosmosMsg, DistributionMsg, StdResult, Storage, Timestamp, Uint128, Uint64,
-};
+#[cfg(feature = "staking")]
+use cosmwasm_std::DistributionMsg;
+use cosmwasm_std::{Addr, Binary, CosmosMsg, StdResult, Storage, Timestamp, Uint128, Uint64};
 use cw_denom::CheckedDenom;
 use cw_storage_plus::Item;
 use wynd_utils::{Curve, PiecewiseLinear, SaturatingLinear};
@@ -245,10 +245,13 @@ impl<'a> Payment<'a> {
             // entitled to staking rewards that may accure before the
             // owner has a chance to undelegate from validators. Set
             // the owner to the reward receiver.
-            let mut msgs = vec![DistributionMsg::SetWithdrawAddress {
-                address: owner.to_string(),
-            }
-            .into()];
+            let mut msgs = vec![
+                #[cfg(feature = "staking")]
+                DistributionMsg::SetWithdrawAddress {
+                    address: owner.to_string(),
+                }
+                .into(),
+            ];
 
             if !to_owner.is_zero() {
                 msgs.push(vesting.denom.get_transfer_to_message(owner, to_owner)?);


### PR DESCRIPTION
Neutron does not support the staking module, and the `cw-vesting` contract attempts to execute a staking-related message on instantiate for the native token. This means that the vesting contract does not currently work for NTRN on Neutron.

This PR adds a `staking` feature flag to `cw-vesting` that explicitly enables the execution variants that have to do with staking, in addition to the withdraw address message on instantiate.
