### PR TITLE
Update serde-json-wasm to fix low security vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3773,9 +3773,9 @@ dependencies = [
 
 [[package]]
 name = "serde-json-wasm"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
+checksum = "9e9213a07d53faa0b8dd81e767a54a8188a242fdb9be99ab75ec576a774bfdd7"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
https://github.com/CosmWasm/serde-json-wasm/releases/tag/v0.5.2

serde-json-wasm patched a bug recently that causes deeply nested JSON to overflow the stack, which would cause a runtime error and prevent a contract from executing. this would only cause problems if someone submits an extremely nested JSON message in a proposal, which is unlikely and the user can avoid it, but it's still good to fix. no contracts are at risk of being bricked.
