### PR TITLE
[feature] Updated SubDao functionality to have members count and an active threshold

### DIFF
--- a/contracts/dao-dao-core/schema/dao-dao-core.json
+++ b/contracts/dao-dao-core/schema/dao-dao-core.json
@@ -1317,19 +1317,33 @@
       "SubDao": {
         "type": "object",
         "required": [
-          "addr"
+          "active_threshold",
+          "addr",
+          "member_count"
         ],
         "properties": {
+          "active_threshold": {
+            "description": "The minimum number of members required for the SubDAO to be considered active.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
           "addr": {
             "description": "The contract address of the SubDAO",
             "type": "string"
           },
           "charter": {
-            "description": "The purpose/constitution for the SubDAO",
+            "description": "The purpose/constitution for the SubDAO. This field is optional.",
             "type": [
               "string",
               "null"
             ]
+          },
+          "member_count": {
+            "description": "The current number of members in the SubDAO.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
           }
         },
         "additionalProperties": false
@@ -2250,19 +2264,33 @@
       "SubDao": {
         "type": "object",
         "required": [
-          "addr"
+          "active_threshold",
+          "addr",
+          "member_count"
         ],
         "properties": {
+          "active_threshold": {
+            "description": "The minimum number of members required for the SubDAO to be considered active.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
           "addr": {
             "description": "The contract address of the SubDAO",
             "type": "string"
           },
           "charter": {
-            "description": "The purpose/constitution for the SubDAO",
+            "description": "The purpose/constitution for the SubDAO. This field is optional.",
             "type": [
               "string",
               "null"
             ]
+          },
+          "member_count": {
+            "description": "The current number of members in the SubDAO.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
           }
         },
         "additionalProperties": false
@@ -2898,19 +2926,33 @@
         "SubDao": {
           "type": "object",
           "required": [
-            "addr"
+            "active_threshold",
+            "addr",
+            "member_count"
           ],
           "properties": {
+            "active_threshold": {
+              "description": "The minimum number of members required for the SubDAO to be considered active.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
             "addr": {
               "description": "The contract address of the SubDAO",
               "type": "string"
             },
             "charter": {
-              "description": "The purpose/constitution for the SubDAO",
+              "description": "The purpose/constitution for the SubDAO. This field is optional.",
               "type": [
                 "string",
                 "null"
               ]
+            },
+            "member_count": {
+              "description": "The current number of members in the SubDAO.",
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
             }
           },
           "additionalProperties": false

--- a/contracts/dao-dao-core/src/contract.rs
+++ b/contracts/dao-dao-core/src/contract.rs
@@ -508,7 +508,7 @@ pub fn execute_update_sub_daos_list(
 
     for subdao in to_add {
         let addr = deps.api.addr_validate(&subdao.addr)?;
-        SUBDAO_LIST.save(deps.storage, &addr, &subdao.charter)?;
+        SUBDAO_LIST.save(deps.storage, &addr, &subdao)?; // Save the entire SubDao object.
     }
 
     Ok(Response::default()
@@ -814,19 +814,21 @@ pub fn query_list_sub_daos(
         .map(|addr| deps.api.addr_validate(&addr))
         .transpose()?;
 
-    let subdaos = cw_paginate_storage::paginate_map(
+    let subdaos = paginate_map(
         deps,
         &SUBDAO_LIST,
         start_at.as_ref(),
         limit,
-        cosmwasm_std::Order::Ascending,
+        Order::Ascending,
     )?;
 
     let subdaos: Vec<SubDao> = subdaos
         .into_iter()
-        .map(|(address, charter)| SubDao {
+        .map(|(address, subdao)| SubDao {
             addr: address.into_string(),
-            charter,
+            charter: subdao.charter, // mapping correctly to the updated SubDao structure.
+            member_count: subdao.member_count, // Include member count.
+            active_threshold: subdao.active_threshold, // Include active threshold.
         })
         .collect();
 

--- a/contracts/dao-dao-core/src/state.rs
+++ b/contracts/dao-dao-core/src/state.rs
@@ -1,6 +1,7 @@
 use cosmwasm_std::{Addr, Empty};
 use cw_storage_plus::{Item, Map};
 use cw_utils::Expiration;
+use dao_interface::query::SubDao;
 use dao_interface::state::{Config, ProposalModule};
 
 /// The admin of the contract. Typically a DAO. The contract admin may
@@ -52,4 +53,4 @@ pub const CW20_LIST: Map<Addr, Empty> = Map::new("cw20s");
 pub const CW721_LIST: Map<Addr, Empty> = Map::new("cw721s");
 
 /// List of SubDAOs associated to this DAO. Each SubDAO has an optional charter.
-pub const SUBDAO_LIST: Map<&Addr, Option<String>> = Map::new("sub_daos");
+pub const SUBDAO_LIST: Map<&Addr, SubDao> = Map::new("sub_daos");

--- a/contracts/dao-dao-core/src/tests.rs
+++ b/contracts/dao-dao-core/src/tests.rs
@@ -3003,18 +3003,26 @@ fn test_add_remove_subdaos() {
         SubDao {
             addr: "subdao001".to_string(),
             charter: None,
+            member_count: 10,
+            active_threshold: 5,
         },
         SubDao {
             addr: "subdao002".to_string(),
             charter: Some("cool charter bro".to_string()),
+            member_count: 20,
+            active_threshold: 10,
         },
         SubDao {
             addr: "subdao005".to_string(),
             charter: None,
+            member_count: 15,
+            active_threshold: 7,
         },
         SubDao {
             addr: "subdao007".to_string(),
             charter: None,
+            member_count: 25,
+            active_threshold: 12,
         },
     ];
     let to_remove: Vec<String> = vec![];
@@ -3025,7 +3033,7 @@ fn test_add_remove_subdaos() {
         &ExecuteMsg::UpdateSubDaos { to_add, to_remove },
         &[],
     )
-    .unwrap();
+        .unwrap();
 
     let res: Vec<SubDao> = app
         .wrap()
@@ -3051,7 +3059,7 @@ fn test_add_remove_subdaos() {
         },
         &[],
     )
-    .unwrap();
+        .unwrap();
 
     let res: Vec<SubDao> = app
         .wrap()
@@ -3069,6 +3077,8 @@ fn test_add_remove_subdaos() {
     let test_res: SubDao = SubDao {
         addr: "subdao002".to_string(),
         charter: Some("cool charter bro".to_string()),
+        member_count: 20,
+        active_threshold: 10,
     };
 
     assert_eq!(res[1], test_res);
@@ -3077,14 +3087,20 @@ fn test_add_remove_subdaos() {
         SubDao {
             addr: "subdao001".to_string(),
             charter: None,
+            member_count: 10,
+            active_threshold: 5,
         },
         SubDao {
             addr: "subdao002".to_string(),
             charter: Some("cool charter bro".to_string()),
+            member_count: 20,
+            active_threshold: 10,
         },
         SubDao {
             addr: "subdao007".to_string(),
             charter: None,
+            member_count: 25,
+            active_threshold: 12,
         },
     ];
 

--- a/contracts/external/dao-migrator/schema/dao-migrator.json
+++ b/contracts/external/dao-migrator/schema/dao-migrator.json
@@ -277,19 +277,33 @@
       "SubDao": {
         "type": "object",
         "required": [
-          "addr"
+          "active_threshold",
+          "addr",
+          "member_count"
         ],
         "properties": {
+          "active_threshold": {
+            "description": "The minimum number of members required for the SubDAO to be considered active.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
           "addr": {
             "description": "The contract address of the SubDAO",
             "type": "string"
           },
           "charter": {
-            "description": "The purpose/constitution for the SubDAO",
+            "description": "The purpose/constitution for the SubDAO. This field is optional.",
             "type": [
               "string",
               "null"
             ]
+          },
+          "member_count": {
+            "description": "The current number of members in the SubDAO.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
           }
         },
         "additionalProperties": false
@@ -671,19 +685,33 @@
       "SubDao": {
         "type": "object",
         "required": [
-          "addr"
+          "active_threshold",
+          "addr",
+          "member_count"
         ],
         "properties": {
+          "active_threshold": {
+            "description": "The minimum number of members required for the SubDAO to be considered active.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          },
           "addr": {
             "description": "The contract address of the SubDAO",
             "type": "string"
           },
           "charter": {
-            "description": "The purpose/constitution for the SubDAO",
+            "description": "The purpose/constitution for the SubDAO. This field is optional.",
             "type": [
               "string",
               "null"
             ]
+          },
+          "member_count": {
+            "description": "The current number of members in the SubDAO.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
           }
         },
         "additionalProperties": false

--- a/contracts/external/dao-migrator/src/testing/test_migration.rs
+++ b/contracts/external/dao-migrator/src/testing/test_migration.rs
@@ -336,6 +336,8 @@ fn test_sub_daos() {
     let sub_dao = SubDao {
         addr: "sub_dao_1".to_string(),
         charter: None,
+        member_count: 0,
+        active_threshold: 1,
     };
 
     execute_migration(

--- a/packages/dao-interface/src/query.rs
+++ b/packages/dao-interface/src/query.rs
@@ -64,8 +64,12 @@ pub struct AdminNominationResponse {
 pub struct SubDao {
     /// The contract address of the SubDAO
     pub addr: String,
-    /// The purpose/constitution for the SubDAO
+    /// The purpose/constitution for the SubDAO. This field is optional.
     pub charter: Option<String>,
+    /// The current number of members in the SubDAO.
+    pub member_count: u32,
+    /// The minimum number of members required for the SubDAO to be considered active.
+    pub active_threshold: u32,
 }
 
 #[cw_serde]


### PR DESCRIPTION
This pull request addresses the issue #781 "Support active_threshold in dao-voting-cw4" by updating the SubDao functionality to include a member count and an active threshold. 

This ensures that SubDAOs can only be considered active if they meet the minimum required member count specified by the active threshold.