### PR TITLE
Support Kujira's tokenfactory fork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ cw-hooks = { path = "./packages/cw-hooks", version = "2.4.1" }
 cw-paginate-storage = { path = "./packages/cw-paginate-storage", version = "2.4.1" }
 cw-payroll-factory = { path = "./contracts/external/cw-payroll-factory", version = "2.4.1" }
 cw-stake-tracker = { path = "./packages/cw-stake-tracker", version = "2.4.1" }
-cw-tokenfactory-issuer = { path = "./contracts/external/cw-tokenfactory-issuer", version = "2.4.1" }
+cw-tokenfactory-issuer = { path = "./contracts/external/cw-tokenfactory-issuer", version = "2.4.1", default-features = false }
 cw-tokenfactory-types = { path = "./packages/cw-tokenfactory-types", version = "2.4.1", default-features = false }
 cw-vesting = { path = "./contracts/external/cw-vesting", version = "2.4.1" }
 cw-wormhole = { path = "./packages/cw-wormhole", version = "2.4.1" }

--- a/contracts/external/cw-tokenfactory-issuer/Cargo.toml
+++ b/contracts/external/cw-tokenfactory-issuer/Cargo.toml
@@ -39,6 +39,7 @@ test-tube = ["osmosis_tokenfactory"]
 # standard in types library
 osmosis_tokenfactory = ["cw-tokenfactory-types/osmosis_tokenfactory"]
 cosmwasm_tokenfactory = ["cw-tokenfactory-types/cosmwasm_tokenfactory"]
+kujira_tokenfactory = ["cw-tokenfactory-types/kujira_tokenfactory"]
 
 [dependencies]
 cosmwasm-schema = { workspace = true }

--- a/contracts/external/cw-tokenfactory-issuer/src/contract.rs
+++ b/contracts/external/cw-tokenfactory-issuer/src/contract.rs
@@ -112,6 +112,7 @@ pub fn execute(
         ExecuteMsg::SetBeforeSendHook { cosmwasm_address } => {
             execute::set_before_send_hook(deps, env, info, cosmwasm_address)
         }
+        #[cfg(any(feature = "osmosis_tokenfactory", feature = "cosmwasm_tokenfactory"))]
         ExecuteMsg::SetDenomMetadata { metadata } => {
             execute::set_denom_metadata(deps, env, info, metadata)
         }

--- a/contracts/external/cw-tokenfactory-issuer/src/execute.rs
+++ b/contracts/external/cw-tokenfactory-issuer/src/execute.rs
@@ -1,10 +1,10 @@
 use cosmwasm_std::{coins, BankMsg, CosmosMsg, DepsMut, Env, MessageInfo, Response, Uint128};
 
-use cw_tokenfactory_types::msg::{msg_burn, msg_change_admin, msg_mint, msg_set_denom_metadata};
+use cw_tokenfactory_types::msg::{msg_burn, msg_change_admin, msg_mint};
 #[cfg(feature = "osmosis_tokenfactory")]
 use cw_tokenfactory_types::msg::{msg_force_transfer, msg_set_before_send_hook};
-
-use dao_interface::token::Metadata;
+#[cfg(any(feature = "osmosis_tokenfactory", feature = "cosmwasm_tokenfactory"))]
+use {cw_tokenfactory_types::msg::msg_set_denom_metadata, dao_interface::token::Metadata};
 
 use crate::error::ContractError;
 use crate::helpers::{check_before_send_hook_features_enabled, check_is_not_frozen};
@@ -177,6 +177,7 @@ pub fn update_tokenfactory_admin(
 /// Sets metadata related to the Token Factory denom.
 ///
 /// Must be the contract owner to call this method.
+#[cfg(any(feature = "osmosis_tokenfactory", feature = "cosmwasm_tokenfactory"))]
 pub fn set_denom_metadata(
     deps: DepsMut,
     env: Env,

--- a/contracts/external/cw-tokenfactory-issuer/src/msg.rs
+++ b/contracts/external/cw-tokenfactory-issuer/src/msg.rs
@@ -2,6 +2,7 @@ use crate::state::BeforeSendHookInfo;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Coin, Uint128};
 
+#[cfg(any(feature = "osmosis_tokenfactory", feature = "cosmwasm_tokenfactory"))]
 pub use dao_interface::token::{DenomUnit, Metadata};
 
 /// The message used to create a new instance of this smart contract.
@@ -78,6 +79,7 @@ pub enum ExecuteMsg {
     SetBurnerAllowance { address: String, allowance: Uint128 },
 
     /// Set denom metadata. see: https://docs.cosmos.network/main/modules/bank#denom-metadata.
+    #[cfg(any(feature = "osmosis_tokenfactory", feature = "cosmwasm_tokenfactory"))]
     SetDenomMetadata { metadata: Metadata },
 
     /// Grant/revoke mint allowance.

--- a/contracts/external/cw-tokenfactory-issuer/tests/cases/denom_metadata.rs
+++ b/contracts/external/cw-tokenfactory-issuer/tests/cases/denom_metadata.rs
@@ -2,6 +2,7 @@ use cw_tokenfactory_issuer::{msg::InstantiateMsg, ContractError};
 
 use crate::test_env::{TestEnv, TokenfactoryIssuer};
 
+#[cfg(any(feature = "osmosis_tokenfactory", feature = "cosmwasm_tokenfactory"))]
 #[test]
 fn set_denom_metadata_by_contract_owner_should_work() {
     let subdenom = "usthb".to_string();
@@ -35,6 +36,7 @@ fn set_denom_metadata_by_contract_owner_should_work() {
         .unwrap();
 }
 
+#[cfg(any(feature = "osmosis_tokenfactory", feature = "cosmwasm_tokenfactory"))]
 #[test]
 fn set_denom_metadata_by_contract_non_owner_should_fail() {
     let subdenom = "usthb".to_string();
@@ -78,6 +80,7 @@ fn set_denom_metadata_by_contract_non_owner_should_fail() {
     )
 }
 
+#[cfg(any(feature = "osmosis_tokenfactory", feature = "cosmwasm_tokenfactory"))]
 #[test]
 fn set_denom_metadata_with_base_denom_unit_should_overides_default_base_denom_unit() {
     let subdenom = "usthb".to_string();

--- a/contracts/external/cw-tokenfactory-issuer/tests/test_env.rs
+++ b/contracts/external/cw-tokenfactory-issuer/tests/test_env.rs
@@ -6,7 +6,10 @@
 use cosmwasm_std::Uint128;
 use cosmwasm_std::{Addr, Coin};
 
-use cw_tokenfactory_issuer::msg::{AllowlistResponse, DenylistResponse, Metadata, MigrateMsg};
+#[cfg(any(feature = "osmosis_tokenfactory", feature = "cosmwasm_tokenfactory"))]
+use cw_tokenfactory_issuer::msg::Metadata;
+
+use cw_tokenfactory_issuer::msg::{AllowlistResponse, DenylistResponse, MigrateMsg};
 use cw_tokenfactory_issuer::{
     msg::{
         AllowanceResponse, AllowancesResponse, DenomResponse, ExecuteMsg, InstantiateMsg,
@@ -204,6 +207,7 @@ impl TokenfactoryIssuer {
         )
     }
 
+    #[cfg(any(feature = "osmosis_tokenfactory", feature = "cosmwasm_tokenfactory"))]
     pub fn set_denom_metadata(
         &self,
         metadata: Metadata,

--- a/contracts/test/dao-test-custom-factory/Cargo.toml
+++ b/contracts/test/dao-test-custom-factory/Cargo.toml
@@ -29,7 +29,10 @@ thiserror = { workspace = true }
 dao-dao-macros = { workspace = true }
 dao-interface = { workspace = true }
 dao-voting = { workspace = true }
-cw-tokenfactory-issuer = { workspace = true, features = ["library"] }
+cw-tokenfactory-issuer = { workspace = true, features = [
+  "library",
+  "osmosis_tokenfactory",
+] }
 
 [dev-dependencies]
 cw-multi-test = { workspace = true }

--- a/contracts/voting/dao-voting-token-staked/Cargo.toml
+++ b/contracts/voting/dao-voting-token-staked/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "dao-voting-token-staked"
-authors = ["Callum Anderson <callumanderson745@gmail.com>", "Noah Saso <no-reply@no-reply.com>", "Jake Hartnell <no-reply@no-reply.com>"]
+authors = [
+  "Callum Anderson <callumanderson745@gmail.com>",
+  "Noah Saso <no-reply@no-reply.com>",
+  "Jake Hartnell <no-reply@no-reply.com>",
+]
 description = "A DAO DAO voting module based on staked token factory or native tokens. Only works with chains that support Token Factory."
 edition = { workspace = true }
 license = { workspace = true }
@@ -11,6 +15,7 @@ version = { workspace = true }
 crate-type = ["cdylib", "rlib"]
 
 [features]
+default = ["osmosis_tokenfactory"]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
@@ -20,9 +25,14 @@ library = []
 test-tube = []
 # when writing tests you may wish to enable test-tube as a default feature
 # default = ["test-tube"]
+# different tokenfactory cosmos sdk module standards. enable corresponding
+# standard in types library
+osmosis_tokenfactory = ["cw-tokenfactory-issuer/osmosis_tokenfactory"]
+cosmwasm_tokenfactory = ["cw-tokenfactory-issuer/cosmwasm_tokenfactory"]
+kujira_tokenfactory = ["cw-tokenfactory-issuer/kujira_tokenfactory"]
 
 [dependencies]
-cosmwasm-std    = { workspace = true, features = ["cosmwasm_1_1"] }
+cosmwasm-std = { workspace = true, features = ["cosmwasm_1_1"] }
 cosmwasm-schema = { workspace = true }
 cw-ownable = { workspace = true }
 cw-storage-plus = { workspace = true }
@@ -35,12 +45,13 @@ dao-dao-macros = { workspace = true }
 dao-hooks = { workspace = true }
 dao-interface = { workspace = true }
 dao-voting = { workspace = true }
-cw-tokenfactory-issuer = { workspace = true, features = ["library"] }
+cw-tokenfactory-issuer = { workspace = true, default-features = false, features = [
+  "library",
+] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
 cw-multi-test = { workspace = true }
-cw-tokenfactory-issuer = { workspace = true }
 dao-proposal-single = { workspace = true }
 dao-proposal-hook-counter = { workspace = true }
 dao-test-custom-factory = { workspace = true }

--- a/contracts/voting/dao-voting-token-staked/src/contract.rs
+++ b/contracts/voting/dao-voting-token-staked/src/contract.rs
@@ -9,8 +9,12 @@ use cw2::{get_contract_version, set_contract_version, ContractVersion};
 use cw_controllers::ClaimsResponse;
 use cw_storage_plus::Bound;
 use cw_tokenfactory_issuer::msg::{
-    DenomUnit, ExecuteMsg as IssuerExecuteMsg, InstantiateMsg as IssuerInstantiateMsg, Metadata,
+    ExecuteMsg as IssuerExecuteMsg, InstantiateMsg as IssuerInstantiateMsg,
 };
+
+#[cfg(any(feature = "osmosis_tokenfactory", feature = "cosmwasm_tokenfactory"))]
+use cw_tokenfactory_issuer::msg::{DenomUnit, Metadata};
+
 use cw_utils::{
     maybe_addr, must_pay, parse_reply_execute_data, parse_reply_instantiate_data, Duration,
 };
@@ -627,6 +631,10 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                     });
 
                     // If metadata, set it by calling the contract
+                    #[cfg(any(
+                        feature = "osmosis_tokenfactory",
+                        feature = "cosmwasm_tokenfactory"
+                    ))]
                     if let Some(metadata) = token.metadata {
                         // The first denom_unit must be the same as the tf and base denom.
                         // It must have an exponent of 0. This the smallest unit of the token.

--- a/packages/cw-tokenfactory-types/Cargo.toml
+++ b/packages/cw-tokenfactory-types/Cargo.toml
@@ -9,10 +9,12 @@ version = { workspace = true }
 
 [features]
 default = ["osmosis_tokenfactory"]
-# use the /cosmwasm.tokenfactory... msg types
-cosmwasm_tokenfactory = []
 # use the /osmosis.tokenfactory... msg types
 osmosis_tokenfactory = []
+# use the /cosmwasm.tokenfactory... msg types
+cosmwasm_tokenfactory = []
+# use the /kujira.denom... msg types
+kujira_tokenfactory = []
 
 [dependencies]
 cosmwasm-std = { workspace = true }

--- a/packages/cw-tokenfactory-types/README.md
+++ b/packages/cw-tokenfactory-types/README.md
@@ -3,10 +3,12 @@
 This package supports contracts that depend on varying tokenfactory standards,
 which use very similar or identical Cosmos SDK msgs with different type URLs:
 
-- `/cosmwasm.tokenfactory...`
 - `/osmosis.tokenfactory...`
+- `/cosmwasm.tokenfactory...`
+- `/kujira.denom...`
 
-Enabling the `cosmwasm_tokenfactory` build feature will use the
-`/cosmwasm.tokenfactory...` msg type URLs, whereas enabling the
-`osmosis_tokenfactory` build feature will use the `/osmosis.tokenfactory...` msg
-type URLs. `osmosis_tokenfactory` is enabled by default.
+Build features:
+
+- `osmosis_tokenfactory` (default)
+- `cosmwasm_tokenfactory`
+- `kujira_tokenfactory`

--- a/packages/cw-tokenfactory-types/src/cosmos.rs
+++ b/packages/cw-tokenfactory-types/src/cosmos.rs
@@ -1,0 +1,97 @@
+use std::convert::TryFrom;
+use std::convert::TryInto;
+
+use osmosis_std_derive::CosmwasmExt;
+
+/// Coin defines a token with a denomination and an amount.
+///
+/// NOTE: The amount field is an Int which implements the custom method
+/// signatures required by gogoproto.
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.base.v1beta1.Coin")]
+pub struct Coin {
+    #[prost(string, tag = "1")]
+    pub denom: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub amount: ::prost::alloc::string::String,
+}
+
+/// DenomUnit represents a struct that describes a given
+/// denomination unit of the basic token.
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.bank.v1beta1.DenomUnit")]
+pub struct DenomUnit {
+    /// denom represents the string name of the given denom unit (e.g uatom).
+    #[prost(string, tag = "1")]
+    pub denom: ::prost::alloc::string::String,
+    /// exponent represents power of 10 exponent that one must
+    /// raise the base_denom to in order to equal the given DenomUnit's denom
+    /// 1 denom = 1^exponent base_denom
+    /// (e.g. with a base_denom of uatom, one can create a DenomUnit of 'atom' with
+    /// exponent = 6, thus: 1 atom = 10^6 uatom).
+    #[prost(uint32, tag = "2")]
+    #[serde(
+        serialize_with = "crate::shim::as_str::serialize",
+        deserialize_with = "crate::shim::as_str::deserialize"
+    )]
+    pub exponent: u32,
+    /// aliases is a list of string aliases for the given denom
+    #[prost(string, repeated, tag = "3")]
+    pub aliases: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Metadata represents a struct that describes
+/// a basic token.
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    ::prost::Message,
+    ::serde::Serialize,
+    ::serde::Deserialize,
+    ::schemars::JsonSchema,
+    CosmwasmExt,
+)]
+#[proto_message(type_url = "/cosmos.bank.v1beta1.Metadata")]
+pub struct Metadata {
+    #[prost(string, tag = "1")]
+    pub description: ::prost::alloc::string::String,
+    /// denom_units represents the list of DenomUnit's for a given coin
+    #[prost(message, repeated, tag = "2")]
+    pub denom_units: ::prost::alloc::vec::Vec<DenomUnit>,
+    /// base represents the base denom (should be the DenomUnit with exponent = 0).
+    #[prost(string, tag = "3")]
+    pub base: ::prost::alloc::string::String,
+    /// display indicates the suggested denom that should be
+    /// displayed in clients.
+    #[prost(string, tag = "4")]
+    pub display: ::prost::alloc::string::String,
+    /// name defines the name of the token (eg: Cosmos Atom)
+    ///
+    /// Since: cosmos-sdk 0.43
+    #[prost(string, tag = "5")]
+    pub name: ::prost::alloc::string::String,
+    /// symbol is the token symbol usually shown on exchanges (eg: ATOM). This can
+    /// be the same as the display.
+    ///
+    /// Since: cosmos-sdk 0.43
+    #[prost(string, tag = "6")]
+    pub symbol: ::prost::alloc::string::String,
+}

--- a/packages/cw-tokenfactory-types/src/kujira.rs
+++ b/packages/cw-tokenfactory-types/src/kujira.rs
@@ -3,19 +3,13 @@ use std::convert::TryInto;
 
 use osmosis_std_derive::CosmwasmExt;
 
-use crate::cosmos::{Coin, Metadata};
+use crate::cosmos::Coin;
 
-// see https://github.com/notional-labs/wasmd/blob/v0.30.0-sdk469.4/proto/cosmwasm/tokenfactory/v1beta1/tx.proto
+// see https://github.com/Team-Kujira/core/blob/f1c18afd68578be9e9fd33de9adb9a32acc0df99/proto/kujira/denom/tx.proto
 
-/// MsgCreateDenom defines the message structure for the CreateDenom gRPC service
-/// method. It allows an account to create a new denom. It requires a sender
-/// address and a sub denomination. The (sender_address, sub_denomination) tuple
-/// must be unique and cannot be re-used.
-///
-/// The resulting denom created is defined as
-/// <factory/{creatorAddress}/{subdenom}>. The resulting denom's admin is
-/// originally set to be the creator, but this can be changed later. The token
-/// denom does not indicate the current admin.
+/// MsgCreateDenom is the sdk.Msg type for allowing an account to create
+/// a new denom.  It requires a sender address and a unique nonce
+/// (to allow accounts to create multiple denoms)
 #[derive(
     Clone,
     PartialEq,
@@ -26,13 +20,12 @@ use crate::cosmos::{Coin, Metadata};
     schemars::JsonSchema,
     CosmwasmExt,
 )]
-#[proto_message(type_url = "/cosmwasm.tokenfactory.v1beta1.MsgCreateDenom")]
+#[proto_message(type_url = "/kujira.denom.MsgCreateDenom")]
 pub struct MsgCreateDenom {
     #[prost(string, tag = "1")]
     pub sender: ::prost::alloc::string::String,
-    /// subdenom can be up to 44 "alphanumeric" characters long.
     #[prost(string, tag = "2")]
-    pub subdenom: ::prost::alloc::string::String,
+    pub nonce: ::prost::alloc::string::String,
 }
 
 /// MsgCreateDenomResponse is the return value of MsgCreateDenom
@@ -47,14 +40,14 @@ pub struct MsgCreateDenom {
     schemars::JsonSchema,
     CosmwasmExt,
 )]
-#[proto_message(type_url = "/cosmwasm.tokenfactory.v1beta1.MsgCreateDenomResponse")]
+#[proto_message(type_url = "/kujira.denom.MsgCreateDenomResponse")]
 pub struct MsgCreateDenomResponse {
     #[prost(string, tag = "1")]
     pub new_token_denom: ::prost::alloc::string::String,
 }
 
 /// MsgMint is the sdk.Msg type for allowing an admin account to mint
-/// more of a token.  For now, we only support minting to the sender account
+/// more of a token.
 #[derive(
     Clone,
     PartialEq,
@@ -65,12 +58,14 @@ pub struct MsgCreateDenomResponse {
     schemars::JsonSchema,
     CosmwasmExt,
 )]
-#[proto_message(type_url = "/cosmwasm.tokenfactory.v1beta1.MsgMint")]
+#[proto_message(type_url = "/kujira.denom.MsgMint")]
 pub struct MsgMint {
     #[prost(string, tag = "1")]
     pub sender: ::prost::alloc::string::String,
-    #[prost(message, optional, tag = "2")]
+    #[prost(message, tag = "2")]
     pub amount: ::core::option::Option<Coin>,
+    #[prost(string, tag = "3")]
+    pub recipient: ::prost::alloc::string::String,
 }
 
 #[derive(
@@ -83,7 +78,7 @@ pub struct MsgMint {
     schemars::JsonSchema,
     CosmwasmExt,
 )]
-#[proto_message(type_url = "/cosmwasm.tokenfactory.v1beta1.MsgMintResponse")]
+#[proto_message(type_url = "/kujira.denom.MsgMintResponse")]
 pub struct MsgMintResponse {}
 
 /// MsgBurn is the sdk.Msg type for allowing an admin account to burn
@@ -98,11 +93,11 @@ pub struct MsgMintResponse {}
     schemars::JsonSchema,
     CosmwasmExt,
 )]
-#[proto_message(type_url = "/cosmwasm.tokenfactory.v1beta1.MsgBurn")]
+#[proto_message(type_url = "/kujira.denom.MsgBurn")]
 pub struct MsgBurn {
     #[prost(string, tag = "1")]
     pub sender: ::prost::alloc::string::String,
-    #[prost(message, optional, tag = "2")]
+    #[prost(message, tag = "2")]
     pub amount: ::core::option::Option<Coin>,
 }
 
@@ -116,11 +111,11 @@ pub struct MsgBurn {
     schemars::JsonSchema,
     CosmwasmExt,
 )]
-#[proto_message(type_url = "/cosmwasm.tokenfactory.v1beta1.MsgBurnResponse")]
+#[proto_message(type_url = "/kujira.denom.MsgBurnResponse")]
 pub struct MsgBurnResponse {}
 
-/// MsgSetDenomMetadata is the sdk.Msg type for allowing an admin account to set
-/// the denom's bank metadata
+/// MsgChangeAdmin is the sdk.Msg type for allowing an admin account to reassign
+/// adminship of a denom to a new account
 #[derive(
     Clone,
     PartialEq,
@@ -131,41 +126,7 @@ pub struct MsgBurnResponse {}
     ::schemars::JsonSchema,
     CosmwasmExt,
 )]
-#[proto_message(type_url = "/cosmwasm.tokenfactory.v1beta1.MsgSetDenomMetadata")]
-pub struct MsgSetDenomMetadata {
-    #[prost(string, tag = "1")]
-    pub sender: ::prost::alloc::string::String,
-    #[prost(message, optional, tag = "2")]
-    pub metadata: ::core::option::Option<Metadata>,
-}
-/// MsgSetDenomMetadataResponse defines the response structure for an executed
-/// MsgSetDenomMetadata message.
-#[derive(
-    Clone,
-    PartialEq,
-    Eq,
-    ::prost::Message,
-    ::serde::Serialize,
-    ::serde::Deserialize,
-    ::schemars::JsonSchema,
-    CosmwasmExt,
-)]
-#[proto_message(type_url = "/cosmwasm.tokenfactory.v1beta1.MsgSetDenomMetadataResponse")]
-pub struct MsgSetDenomMetadataResponse {}
-
-// MsgChangeAdmin is the sdk.Msg type for allowing an admin account to reassign
-// adminship of a denom to a new account
-#[derive(
-    Clone,
-    PartialEq,
-    Eq,
-    ::prost::Message,
-    ::serde::Serialize,
-    ::serde::Deserialize,
-    ::schemars::JsonSchema,
-    CosmwasmExt,
-)]
-#[proto_message(type_url = "/cosmwasm.tokenfactory.v1beta1.MsgChangeAdmin")]
+#[proto_message(type_url = "/kujira.denom.MsgChangeAdmin")]
 pub struct MsgChangeAdmin {
     #[prost(string, tag = "1")]
     pub sender: ::prost::alloc::string::String,
@@ -186,5 +147,5 @@ pub struct MsgChangeAdmin {
     ::schemars::JsonSchema,
     CosmwasmExt,
 )]
-#[proto_message(type_url = "/cosmwasm.tokenfactory.v1beta1.MsgChangeAdminResponse")]
+#[proto_message(type_url = "/kujira.denom.MsgChangeAdminResponse")]
 pub struct MsgChangeAdminResponse {}

--- a/packages/cw-tokenfactory-types/src/lib.rs
+++ b/packages/cw-tokenfactory-types/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod msg;
 
+pub mod cosmos;
 pub mod cosmwasm;
 pub use osmosis_std::types::osmosis::tokenfactory::v1beta1 as osmosis;
+pub mod kujira;
 
 // helpers for both osmosis types (osmosis_std crate) and cosmwasm types. it
 // needs to be named `shim` because osmosis_std assumes it exists.

--- a/packages/cw-tokenfactory-types/src/msg.rs
+++ b/packages/cw-tokenfactory-types/src/msg.rs
@@ -1,73 +1,3 @@
-#[cfg(feature = "cosmwasm_tokenfactory")]
-mod tokenfactory_msg {
-    use crate::cosmwasm::{
-        Coin, DenomUnit as CosmwasmDenomUnit, Metadata as CosmwasmMetadata, MsgBurn,
-        MsgChangeAdmin, MsgCreateDenom, MsgMint, MsgSetDenomMetadata,
-    };
-    use dao_interface::token::Metadata;
-
-    pub use crate::cosmwasm::MsgCreateDenomResponse;
-
-    pub fn msg_create_denom(sender: String, subdenom: String) -> MsgCreateDenom {
-        MsgCreateDenom { sender, subdenom }
-    }
-
-    pub fn msg_mint(sender: String, amount: u128, denom: String) -> MsgMint {
-        MsgMint {
-            sender,
-            amount: Some(Coin {
-                amount: amount.to_string(),
-                denom,
-            }),
-        }
-    }
-
-    pub fn msg_burn(
-        sender: String,
-        amount: u128,
-        denom: String,
-        _burn_from_address: String,
-    ) -> MsgBurn {
-        MsgBurn {
-            sender,
-            amount: Some(Coin {
-                amount: amount.to_string(),
-                denom,
-            }),
-        }
-    }
-
-    pub fn msg_set_denom_metadata(sender: String, metadata: Metadata) -> MsgSetDenomMetadata {
-        MsgSetDenomMetadata {
-            sender,
-            metadata: Some(CosmwasmMetadata {
-                description: metadata.description,
-                denom_units: metadata
-                    .denom_units
-                    .into_iter()
-                    .map(|denom_unit| CosmwasmDenomUnit {
-                        denom: denom_unit.denom,
-                        exponent: denom_unit.exponent,
-                        aliases: denom_unit.aliases,
-                    })
-                    .collect(),
-                base: metadata.base,
-                display: metadata.display,
-                name: metadata.name,
-                symbol: metadata.symbol,
-            }),
-        }
-    }
-
-    pub fn msg_change_admin(sender: String, denom: String, new_admin: String) -> MsgChangeAdmin {
-        MsgChangeAdmin {
-            sender,
-            denom,
-            new_admin,
-        }
-    }
-}
-
 #[cfg(feature = "osmosis_tokenfactory")]
 mod tokenfactory_msg {
     use crate::osmosis::{
@@ -174,16 +104,152 @@ mod tokenfactory_msg {
     }
 }
 
+#[cfg(feature = "cosmwasm_tokenfactory")]
+mod tokenfactory_msg {
+    use crate::cosmos::{Coin, DenomUnit as CosmwasmDenomUnit, Metadata as CosmwasmMetadata};
+    use crate::cosmwasm::{MsgBurn, MsgChangeAdmin, MsgCreateDenom, MsgMint, MsgSetDenomMetadata};
+    use dao_interface::token::Metadata;
+
+    pub use crate::cosmwasm::MsgCreateDenomResponse;
+
+    pub fn msg_create_denom(sender: String, subdenom: String) -> MsgCreateDenom {
+        MsgCreateDenom { sender, subdenom }
+    }
+
+    pub fn msg_mint(sender: String, amount: u128, denom: String) -> MsgMint {
+        MsgMint {
+            sender,
+            amount: Some(Coin {
+                amount: amount.to_string(),
+                denom,
+            }),
+        }
+    }
+
+    pub fn msg_burn(
+        sender: String,
+        amount: u128,
+        denom: String,
+        _burn_from_address: String,
+    ) -> MsgBurn {
+        MsgBurn {
+            sender,
+            amount: Some(Coin {
+                amount: amount.to_string(),
+                denom,
+            }),
+        }
+    }
+
+    pub fn msg_set_denom_metadata(sender: String, metadata: Metadata) -> MsgSetDenomMetadata {
+        MsgSetDenomMetadata {
+            sender,
+            metadata: Some(CosmwasmMetadata {
+                description: metadata.description,
+                denom_units: metadata
+                    .denom_units
+                    .into_iter()
+                    .map(|denom_unit| CosmwasmDenomUnit {
+                        denom: denom_unit.denom,
+                        exponent: denom_unit.exponent,
+                        aliases: denom_unit.aliases,
+                    })
+                    .collect(),
+                base: metadata.base,
+                display: metadata.display,
+                name: metadata.name,
+                symbol: metadata.symbol,
+            }),
+        }
+    }
+
+    pub fn msg_change_admin(sender: String, denom: String, new_admin: String) -> MsgChangeAdmin {
+        MsgChangeAdmin {
+            sender,
+            denom,
+            new_admin,
+        }
+    }
+}
+
+#[cfg(feature = "kujira_tokenfactory")]
+mod tokenfactory_msg {
+    use crate::{
+        cosmos::Coin,
+        kujira::{MsgBurn, MsgChangeAdmin, MsgCreateDenom, MsgMint},
+    };
+
+    pub use crate::cosmwasm::MsgCreateDenomResponse;
+
+    pub fn msg_create_denom(sender: String, subdenom: String) -> MsgCreateDenom {
+        MsgCreateDenom {
+            sender,
+            nonce: subdenom,
+        }
+    }
+
+    pub fn msg_mint(sender: String, amount: u128, denom: String) -> MsgMint {
+        MsgMint {
+            sender: sender.clone(),
+            amount: Some(Coin {
+                amount: amount.to_string(),
+                denom,
+            }),
+            // other tokenfactories only support minting to the sender, so force
+            // this behavior to be the same
+            recipient: sender,
+        }
+    }
+
+    pub fn msg_burn(
+        sender: String,
+        amount: u128,
+        denom: String,
+        _burn_from_address: String,
+    ) -> MsgBurn {
+        MsgBurn {
+            sender,
+            amount: Some(Coin {
+                amount: amount.to_string(),
+                denom,
+            }),
+        }
+    }
+
+    pub fn msg_change_admin(sender: String, denom: String, new_admin: String) -> MsgChangeAdmin {
+        MsgChangeAdmin {
+            sender,
+            denom,
+            new_admin,
+        }
+    }
+}
+
 // re-export chosen tokenfactory standard
-#[cfg(any(feature = "cosmwasm_tokenfactory", feature = "osmosis_tokenfactory"))]
+#[cfg(any(
+    feature = "osmosis_tokenfactory",
+    feature = "cosmwasm_tokenfactory",
+    feature = "kujira_tokenfactory"
+))]
 pub use tokenfactory_msg::*;
 
 // require one tokenfactory standard to be chosen
-#[cfg(not(any(feature = "cosmwasm_tokenfactory", feature = "osmosis_tokenfactory")))]
+#[cfg(not(any(
+    feature = "osmosis_tokenfactory",
+    feature = "cosmwasm_tokenfactory",
+    feature = "kujira_tokenfactory"
+)))]
 compile_error!(
-    "feature \"cosmwasm_tokenfactory\" or feature \"osmosis_tokenfactory\" must be enabled"
+    "feature \"osmosis_tokenfactory\", \"cosmwasm_tokenfactory\", or \"kujira_tokenfactory\" must be enabled"
 );
 
 // prevent more than one tokenfactory standard from being chosen
-#[cfg(all(feature = "cosmwasm_tokenfactory", feature = "osmosis_tokenfactory"))]
-compile_error!("feature \"cosmwasm_tokenfactory\" and feature \"osmosis_tokenfactory\" cannot be enabled at the same time");
+
+#[cfg(all(feature = "osmosis_tokenfactory", feature = "cosmwasm_tokenfactory"))]
+compile_error!("feature \"osmosis_tokenfactory\" and feature \"cosmwasm_tokenfactory\" cannot be enabled at the same time");
+
+#[cfg(all(feature = "osmosis_tokenfactory", feature = "kujira_tokenfactory"))]
+compile_error!("feature \"osmosis_tokenfactory\" and feature \"kujira_tokenfactory\" cannot be enabled at the same time");
+
+#[cfg(all(feature = "cosmwasm_tokenfactory", feature = "kujira_tokenfactory"))]
+compile_error!("feature \"cosmwasm_tokenfactory\" and feature \"kujira_tokenfactory\" cannot be enabled at the same time");


### PR DESCRIPTION
This adds support for Kujira's tokenfactory fork for the `dao-voting-token-staked` and `cw-tokenfactory-issuer` contracts. Eek! Too many forks D: