### PR TITLE
bump `cosmwasm-std` to `1.5.4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9008b6bb9fc80b5277f2fe481c09e828743d9151203e804583eb4c9e15b31d"
+checksum = "56953345e39537a3e18bdaeba4cb0c58a78c1f61f361dc0fa7c5c7340ae87c5f"
 
 [[package]]
 name = "bootstrap-env"
@@ -510,32 +510,32 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.5.0"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bb3c77c3b7ce472056968c745eb501c440fbc07be5004eba02782c35bfbbe3"
+checksum = "e6b4c3f9c4616d6413d4b5fc4c270a4cc32a374b9be08671e80e1a019f805d8f"
 dependencies = [
  "digest 0.10.7",
  "ecdsa 0.16.9",
  "ed25519-zebra",
- "k256 0.13.2",
+ "k256 0.13.1",
  "rand_core 0.6.4",
  "thiserror",
 ]
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.5.0"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea73e9162e6efde00018d55ed0061e93a108b5d6ec4548b4f8ce3c706249687"
+checksum = "c586ced10c3b00e809ee664a895025a024f60d65d34fe4c09daed4a4db68a3f3"
 dependencies = [
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.5.0"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df41ea55f2946b6b43579659eec048cc2f66e8c8e2e3652fc5e5e476f673856"
+checksum = "8467874827d384c131955ff6f4d47d02e72a956a08eb3c0ff24f8c903a5517b4"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -546,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.5.0"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43609e92ce1b9368aa951b334dd354a2d0dd4d484931a5f83ae10e12a26c8ba9"
+checksum = "f6db85d98ac80922aef465e564d5b21fa9cfac5058cb62df7f116c3682337393"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.5.0"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d6864742e3a7662d024b51a94ea81c9af21db6faea2f9a6d2232bb97c6e53e"
+checksum = "712fe58f39d55c812f7b2c84e097cdede3a39d520f89b6dc3153837e31741927"
 dependencies = [
  "base64 0.21.5",
  "bech32",
@@ -2929,9 +2929,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
+checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
  "ecdsa 0.16.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ assert_matches = "1.5"
 cosm-orc = { version = "4.0" }
 cosm-tome = "0.2"
 cosmos-sdk-proto = "0.19"
-cosmwasm-schema = { version = "1.2" }
-cosmwasm-std = { version = "1.5.0", features = ["ibc3"] }
+cosmwasm-schema = { version = "1.5.4" }
+cosmwasm-std = { version = "1.5.4", features = ["ibc3"] }
 cw-controllers = "1.1"
 cw-multi-test = "0.18"
 cw-storage-plus = { version = "1.1" }


### PR DESCRIPTION
following the latest [cw security advisory](https://github.com/CosmWasm/advisories/blob/main/CWAs/CWA-2024-002.md), we bump the version of `cosmwasm-std` from `1.5.0` to `1.5.4`.

given that `overflow-checks = true` flag is enabled, we are only affected by:
> - `Uint{64,128}::pow` / `Int{64,128}::pow`
> - `Int{64,128}::neg` (the unary negation operator -). The only value that can overflow is `Int{64,128}::MIN`.

affected contracts (_potentially_):
- `cw20-stake-external-rewards`
- `dao-voting-cw20-staked`
- `dao-voting-cw721-staked`
- `dao-voting-token-staked`
- `dao-voting`


