### PR TITLE
Fix cw-abc hatcher instantiation

### DIFF
--- a/contracts/external/cw-abc/src/commands.rs
+++ b/contracts/external/cw-abc/src/commands.rs
@@ -417,7 +417,7 @@ pub fn toggle_pause(deps: DepsMut, info: MessageInfo) -> Result<Response, Contra
         .add_attribute("is_paused", is_paused.to_string()))
 }
 
-/// Add and remove addresses from the hatcher allowlist (only callable by owner)
+/// Add and remove addresses from the hatcher allowlist (only callable by owner and self)
 pub fn update_hatch_allowlist(
     deps: DepsMut,
     env: Env,
@@ -425,7 +425,9 @@ pub fn update_hatch_allowlist(
     to_add: Vec<HatcherAllowlistEntryMsg>,
     to_remove: Vec<String>,
 ) -> Result<Response, ContractError> {
-    cw_ownable::assert_owner(deps.storage, &info.sender)?;
+    if env.contract.address != info.sender {
+        cw_ownable::assert_owner(deps.storage, &info.sender)?;
+    }
 
     let list = hatcher_allowlist();
 

--- a/contracts/external/cw-abc/src/test_tube/integration_tests.rs
+++ b/contracts/external/cw-abc/src/test_tube/integration_tests.rs
@@ -357,7 +357,13 @@ fn test_allowlist() {
             },
             closed: ClosedConfig {},
         },
-        hatcher_allowlist: None,
+        hatcher_allowlist: Some(vec![HatcherAllowlistEntryMsg {
+            addr: "replaced to accounts[9]".to_string(),
+            config: HatcherAllowlistConfigMsg {
+                config_type: HatcherAllowlistConfigType::Address {},
+                contribution_limits_override: None,
+            },
+        }]),
         curve_type: CurveType::Constant {
             value: Uint128::one(),
             scale: 1,
@@ -403,8 +409,7 @@ fn test_allowlist() {
         ))
     );
 
-    // Enable the allow list, normally this would be passed in through
-    // instantiation.
+    // Update the allowlist
     abc.execute(
         &ExecuteMsg::UpdateHatchAllowlist {
             to_add: vec![

--- a/contracts/external/cw-abc/src/test_tube/test_env.rs
+++ b/contracts/external/cw-abc/src/test_tube/test_env.rs
@@ -234,7 +234,17 @@ impl TestEnvBuilder {
                 funding_pool_forwarding: Some(accounts[0].address()),
                 supply: SupplyToken {
                     subdenom: DENOM.to_string(),
-                    metadata: None,
+                    metadata: Some(NewDenomMetadata {
+                        description: "Awesome token, get it meow!".to_string(),
+                        additional_denom_units: Some(vec![DenomUnit {
+                            denom: "cat".to_string(),
+                            exponent: 6,
+                            aliases: vec![],
+                        }]),
+                        display: "cat".to_string(),
+                        name: "Cat Token".to_string(),
+                        symbol: "CAT".to_string(),
+                    }),
                     decimals: 6,
                     max_supply: Some(Uint128::from(1_000_000_000u128)),
                 },
@@ -296,6 +306,12 @@ impl TestEnvBuilder {
         msg.token_issuer_code_id = issuer_id;
 
         msg.funding_pool_forwarding = Some(accounts[0].address());
+
+        if let Some(allowlist) = msg.hatcher_allowlist.as_mut() {
+            for member in allowlist {
+                member.addr = accounts[9].address();
+            }
+        }
 
         let abc = CwAbc::deploy(app, &msg, &accounts[0])?;
 


### PR DESCRIPTION
Missed the case where instantiating the hatchers would error out, because the contract was not its own cw_owner.
#697 