### PR TITLE
Improve pre-propose proposal creation permission granularity (and bump versions to v2.5.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,12 +271,12 @@ dependencies = [
  "cw-admin-factory",
  "cw-utils 1.0.3",
  "cw20 1.1.2",
- "cw20-stake 2.4.2",
+ "cw20-stake 2.5.0",
  "dao-dao-core",
  "dao-interface",
  "dao-pre-propose-single",
  "dao-proposal-single",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "dao-voting-cw20-staked",
  "env_logger",
  "serde",
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "cw-admin-factory"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "cw-denom"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -801,18 +801,18 @@ dependencies = [
 
 [[package]]
 name = "cw-fund-distributor"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-paginate-storage 2.4.2",
+ "cw-paginate-storage 2.5.0",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.4.2",
+ "cw20-stake 2.5.0",
  "dao-dao-core",
  "dao-interface",
  "dao-voting-cw20-staked",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "cw-hooks"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "cw-paginate-storage"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
@@ -898,7 +898,7 @@ dependencies = [
 
 [[package]]
 name = "cw-payroll-factory"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "cw-stake-tracker"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "cw-token-swap"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "cw-tokenfactory-issuer"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "cw-tokenfactory-types"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1101,7 +1101,7 @@ dependencies = [
 
 [[package]]
 name = "cw-vesting"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "cw-wormhole"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-stake"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1300,7 +1300,7 @@ dependencies = [
  "cw-hooks",
  "cw-multi-test",
  "cw-ownable",
- "cw-paginate-storage 2.4.2",
+ "cw-paginate-storage 2.5.0",
  "cw-storage-plus 1.2.0",
  "cw-utils 0.13.4",
  "cw-utils 1.0.3",
@@ -1309,13 +1309,13 @@ dependencies = [
  "cw20-base 1.1.2",
  "cw20-stake 0.2.6",
  "dao-hooks",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "thiserror",
 ]
 
 [[package]]
 name = "cw20-stake-external-rewards"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1329,7 +1329,7 @@ dependencies = [
  "cw20 0.13.4",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.4.2",
+ "cw20-stake 2.5.0",
  "dao-hooks",
  "stake-cw20-external-rewards",
  "thiserror",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-stake-reward-distributor"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1348,7 +1348,7 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.4.2",
+ "cw20-stake 2.5.0",
  "stake-cw20-reward-distributor",
  "thiserror",
 ]
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-controllers"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1552,7 +1552,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-roles"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1574,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "dao-cw721-extensions"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1584,13 +1584,13 @@ dependencies = [
 
 [[package]]
 name = "dao-dao-core"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-core",
  "cw-multi-test",
- "cw-paginate-storage 2.4.2",
+ "cw-paginate-storage 2.5.0",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1607,13 +1607,13 @@ dependencies = [
 
 [[package]]
 name = "dao-dao-macros"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-hooks",
  "dao-interface",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1621,19 +1621,19 @@ dependencies = [
 
 [[package]]
 name = "dao-hooks"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-hooks",
  "cw4 1.1.2",
  "dao-pre-propose-base",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
 ]
 
 [[package]]
 name = "dao-interface"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "dao-migrator"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1663,7 +1663,7 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw20-stake 0.2.6",
- "cw20-stake 2.4.2",
+ "cw20-stake 2.5.0",
  "cw20-staked-balance-voting",
  "cw4 0.13.4",
  "cw4-voting",
@@ -1672,7 +1672,7 @@ dependencies = [
  "dao-proposal-single",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
  "thiserror",
@@ -1680,13 +1680,13 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-approval-single"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-denom",
  "cw-multi-test",
- "cw-paginate-storage 2.4.2",
+ "cw-paginate-storage 2.5.0",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1699,7 +1699,7 @@ dependencies = [
  "dao-pre-propose-base",
  "dao-proposal-single",
  "dao-testing",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
  "thiserror",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-approver"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1726,14 +1726,14 @@ dependencies = [
  "dao-pre-propose-base",
  "dao-proposal-single",
  "dao-testing",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
 ]
 
 [[package]]
 name = "dao-pre-propose-base"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1744,14 +1744,14 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "dao-interface",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-pre-propose-multiple"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1768,14 +1768,14 @@ dependencies = [
  "dao-pre-propose-base",
  "dao-proposal-multiple",
  "dao-testing",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
 ]
 
 [[package]]
 name = "dao-pre-propose-single"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1793,14 +1793,14 @@ dependencies = [
  "dao-pre-propose-base",
  "dao-proposal-single",
  "dao-testing",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
 ]
 
 [[package]]
 name = "dao-proposal-condorcet"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1815,14 +1815,14 @@ dependencies = [
  "dao-dao-macros",
  "dao-interface",
  "dao-testing",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "dao-voting-cw4",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-proposal-hook-counter"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1837,14 +1837,14 @@ dependencies = [
  "dao-hooks",
  "dao-interface",
  "dao-proposal-single",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "dao-voting-cw20-balance",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-proposal-multiple"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1857,7 +1857,7 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.4.2",
+ "cw20-stake 2.5.0",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
@@ -1868,7 +1868,7 @@ dependencies = [
  "dao-pre-propose-multiple",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
@@ -1880,7 +1880,7 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-single"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1896,7 +1896,7 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.4.2",
+ "cw20-stake 2.5.0",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
@@ -1908,7 +1908,7 @@ dependencies = [
  "dao-pre-propose-single",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
@@ -1919,7 +1919,7 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-sudo"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1933,7 +1933,7 @@ dependencies = [
 
 [[package]]
 name = "dao-rewards-distributor"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1946,14 +1946,14 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.4.2",
+ "cw20-stake 2.5.0",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
  "dao-hooks",
  "dao-interface",
  "dao-testing",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
  "dao-voting-cw721-staked",
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "dao-test-custom-factory"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1977,13 +1977,13 @@ dependencies = [
  "cw721-base 0.18.0",
  "dao-dao-macros",
  "dao-interface",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-testing"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1997,7 +1997,7 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.4.2",
+ "cw20-stake 2.5.0",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
@@ -2010,7 +2010,7 @@ dependencies = [
  "dao-proposal-single",
  "dao-test-custom-factory",
  "dao-voting 0.1.0",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
  "dao-voting-cw4",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "dao-voting"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-cw20-balance"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-cw20-staked"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2081,16 +2081,16 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.4.2",
+ "cw20-stake 2.5.0",
  "dao-dao-macros",
  "dao-interface",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw4"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-cw721-roles"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-cw721-staked"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2152,7 +2152,7 @@ dependencies = [
  "dao-proposal-single",
  "dao-test-custom-factory",
  "dao-testing",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "osmosis-std",
  "osmosis-test-tube",
  "serde",
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-token-staked"
-version = "2.4.2"
+version = "2.5.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2181,7 +2181,7 @@ dependencies = [
  "dao-proposal-single",
  "dao-test-custom-factory",
  "dao-testing",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "osmosis-std",
  "osmosis-test-tube",
  "serde",
@@ -2869,7 +2869,7 @@ dependencies = [
  "cw-vesting",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.4.2",
+ "cw20-stake 2.5.0",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
  "cw721-roles",
@@ -2878,7 +2878,7 @@ dependencies = [
  "dao-pre-propose-single",
  "dao-proposal-single",
  "dao-test-custom-factory",
- "dao-voting 2.4.2",
+ "dao-voting 2.5.0",
  "dao-voting-cw20-staked",
  "dao-voting-cw721-staked",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "2"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/DA0-DA0/dao-contracts"
-version = "2.4.2"
+version = "2.5.0"
 
 [profile.release]
 codegen-units = 1
@@ -81,45 +81,45 @@ wynd-utils = "0.4"
 # optional owner.
 cw-ownable = "0.5"
 
-cw-admin-factory = { path = "./contracts/external/cw-admin-factory", version = "2.4.2" }
-cw-denom = { path = "./packages/cw-denom", version = "2.4.2" }
-cw-fund-distributor = { path = "./contracts/distribution/cw-fund-distributor", version = "2.4.2" }
-cw-hooks = { path = "./packages/cw-hooks", version = "2.4.2" }
-cw-paginate-storage = { path = "./packages/cw-paginate-storage", version = "2.4.2" }
-cw-payroll-factory = { path = "./contracts/external/cw-payroll-factory", version = "2.4.2" }
-cw-stake-tracker = { path = "./packages/cw-stake-tracker", version = "2.4.2" }
-cw-tokenfactory-issuer = { path = "./contracts/external/cw-tokenfactory-issuer", version = "2.4.2", default-features = false }
-cw-tokenfactory-types = { path = "./packages/cw-tokenfactory-types", version = "2.4.2", default-features = false }
-cw-vesting = { path = "./contracts/external/cw-vesting", version = "2.4.2" }
-cw-wormhole = { path = "./packages/cw-wormhole", version = "2.4.2" }
-cw20-stake = { path = "./contracts/staking/cw20-stake", version = "2.4.2" }
-cw721-controllers = { path = "./packages/cw721-controllers", version = "2.4.2" }
-cw721-roles = { path = "./contracts/external/cw721-roles", version = "2.4.2" }
-dao-cw721-extensions = { path = "./packages/dao-cw721-extensions", version = "2.4.2" }
-dao-dao-core = { path = "./contracts/dao-dao-core", version = "2.4.2" }
-dao-dao-macros = { path = "./packages/dao-dao-macros", version = "2.4.2" }
-dao-hooks = { path = "./packages/dao-hooks", version = "2.4.2" }
-dao-interface = { path = "./packages/dao-interface", version = "2.4.2" }
-dao-pre-propose-approval-single = { path = "./contracts/pre-propose/dao-pre-propose-approval-single", version = "2.4.2" }
-dao-pre-propose-approver = { path = "./contracts/pre-propose/dao-pre-propose-approver", version = "2.4.2" }
-dao-pre-propose-base = { path = "./packages/dao-pre-propose-base", version = "2.4.2" }
-dao-pre-propose-multiple = { path = "./contracts/pre-propose/dao-pre-propose-multiple", version = "2.4.2" }
-dao-pre-propose-single = { path = "./contracts/pre-propose/dao-pre-propose-single", version = "2.4.2" }
-dao-proposal-condorcet = { path = "./contracts/proposal/dao-proposal-condorcet", version = "2.4.2" }
-dao-proposal-hook-counter = { path = "./contracts/test/dao-proposal-hook-counter", version = "2.4.2" }
-dao-proposal-multiple = { path = "./contracts/proposal/dao-proposal-multiple", version = "2.4.2" }
-dao-proposal-single = { path = "./contracts/proposal/dao-proposal-single", version = "2.4.2" }
-dao-proposal-sudo = { path = "./contracts/test/dao-proposal-sudo", version = "2.4.2" }
-dao-rewards-distributor = { path = "./contracts/distribution/dao-rewards-distributor", version = "2.4.2" }
-dao-test-custom-factory = { path = "./contracts/test/dao-test-custom-factory", version = "2.4.2" }
-dao-testing = { path = "./packages/dao-testing", version = "2.4.2" }
-dao-voting = { path = "./packages/dao-voting", version = "2.4.2" }
-dao-voting-cw20-balance = { path = "./contracts/test/dao-voting-cw20-balance", version = "2.4.2" }
-dao-voting-cw20-staked = { path = "./contracts/voting/dao-voting-cw20-staked", version = "2.4.2" }
-dao-voting-cw4 = { path = "./contracts/voting/dao-voting-cw4", version = "2.4.2" }
-dao-voting-cw721-roles = { path = "./contracts/voting/dao-voting-cw721-roles", version = "2.4.2" }
-dao-voting-cw721-staked = { path = "./contracts/voting/dao-voting-cw721-staked", version = "2.4.2" }
-dao-voting-token-staked = { path = "./contracts/voting/dao-voting-token-staked", version = "2.4.2" }
+cw-admin-factory = { path = "./contracts/external/cw-admin-factory", version = "2.5.0" }
+cw-denom = { path = "./packages/cw-denom", version = "2.5.0" }
+cw-fund-distributor = { path = "./contracts/distribution/cw-fund-distributor", version = "2.5.0" }
+cw-hooks = { path = "./packages/cw-hooks", version = "2.5.0" }
+cw-paginate-storage = { path = "./packages/cw-paginate-storage", version = "2.5.0" }
+cw-payroll-factory = { path = "./contracts/external/cw-payroll-factory", version = "2.5.0" }
+cw-stake-tracker = { path = "./packages/cw-stake-tracker", version = "2.5.0" }
+cw-tokenfactory-issuer = { path = "./contracts/external/cw-tokenfactory-issuer", version = "2.5.0", default-features = false }
+cw-tokenfactory-types = { path = "./packages/cw-tokenfactory-types", version = "2.5.0", default-features = false }
+cw-vesting = { path = "./contracts/external/cw-vesting", version = "2.5.0" }
+cw-wormhole = { path = "./packages/cw-wormhole", version = "2.5.0" }
+cw20-stake = { path = "./contracts/staking/cw20-stake", version = "2.5.0" }
+cw721-controllers = { path = "./packages/cw721-controllers", version = "2.5.0" }
+cw721-roles = { path = "./contracts/external/cw721-roles", version = "2.5.0" }
+dao-cw721-extensions = { path = "./packages/dao-cw721-extensions", version = "2.5.0" }
+dao-dao-core = { path = "./contracts/dao-dao-core", version = "2.5.0" }
+dao-dao-macros = { path = "./packages/dao-dao-macros", version = "2.5.0" }
+dao-hooks = { path = "./packages/dao-hooks", version = "2.5.0" }
+dao-interface = { path = "./packages/dao-interface", version = "2.5.0" }
+dao-pre-propose-approval-single = { path = "./contracts/pre-propose/dao-pre-propose-approval-single", version = "2.5.0" }
+dao-pre-propose-approver = { path = "./contracts/pre-propose/dao-pre-propose-approver", version = "2.5.0" }
+dao-pre-propose-base = { path = "./packages/dao-pre-propose-base", version = "2.5.0" }
+dao-pre-propose-multiple = { path = "./contracts/pre-propose/dao-pre-propose-multiple", version = "2.5.0" }
+dao-pre-propose-single = { path = "./contracts/pre-propose/dao-pre-propose-single", version = "2.5.0" }
+dao-proposal-condorcet = { path = "./contracts/proposal/dao-proposal-condorcet", version = "2.5.0" }
+dao-proposal-hook-counter = { path = "./contracts/test/dao-proposal-hook-counter", version = "2.5.0" }
+dao-proposal-multiple = { path = "./contracts/proposal/dao-proposal-multiple", version = "2.5.0" }
+dao-proposal-single = { path = "./contracts/proposal/dao-proposal-single", version = "2.5.0" }
+dao-proposal-sudo = { path = "./contracts/test/dao-proposal-sudo", version = "2.5.0" }
+dao-rewards-distributor = { path = "./contracts/distribution/dao-rewards-distributor", version = "2.5.0" }
+dao-test-custom-factory = { path = "./contracts/test/dao-test-custom-factory", version = "2.5.0" }
+dao-testing = { path = "./packages/dao-testing", version = "2.5.0" }
+dao-voting = { path = "./packages/dao-voting", version = "2.5.0" }
+dao-voting-cw20-balance = { path = "./contracts/test/dao-voting-cw20-balance", version = "2.5.0" }
+dao-voting-cw20-staked = { path = "./contracts/voting/dao-voting-cw20-staked", version = "2.5.0" }
+dao-voting-cw4 = { path = "./contracts/voting/dao-voting-cw4", version = "2.5.0" }
+dao-voting-cw721-roles = { path = "./contracts/voting/dao-voting-cw721-roles", version = "2.5.0" }
+dao-voting-cw721-staked = { path = "./contracts/voting/dao-voting-cw721-staked", version = "2.5.0" }
+dao-voting-token-staked = { path = "./contracts/voting/dao-voting-token-staked", version = "2.5.0" }
 
 # v1 dependencies. used for state migrations.
 cw-core-v1 = { package = "cw-core", version = "0.1.0" }

--- a/ci/bootstrap-env/src/main.rs
+++ b/ci/bootstrap-env/src/main.rs
@@ -100,7 +100,11 @@ fn main() -> Result<()> {
                                 amount: Uint128::new(1000000000),
                                 refund_policy: DepositRefundPolicy::OnlyPassed,
                             }),
-                            submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
+                            submission_policy: PreProposeSubmissionPolicy::Specific {
+                                dao_members: true,
+                                allowlist: None,
+                                denylist: None,
+                            },
                             extension: Empty::default(),
                         })
                         .unwrap(),

--- a/ci/bootstrap-env/src/main.rs
+++ b/ci/bootstrap-env/src/main.rs
@@ -4,6 +4,7 @@ use cosm_orc::{config::cfg::Config, orchestrator::cosm_orc::CosmOrc};
 use cosmwasm_std::{to_json_binary, Decimal, Empty, Uint128};
 use cw20::Cw20Coin;
 use dao_interface::state::{Admin, ModuleInstantiateInfo};
+use dao_voting::pre_propose::PreProposeSubmissionPolicy;
 use dao_voting::{
     deposit::{DepositRefundPolicy, DepositToken, UncheckedDepositInfo, VotingModuleTokenType},
     pre_propose::PreProposeInfo,
@@ -99,7 +100,7 @@ fn main() -> Result<()> {
                                 amount: Uint128::new(1000000000),
                                 refund_policy: DepositRefundPolicy::OnlyPassed,
                             }),
-                            open_proposal_submission: false,
+                            submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
                             extension: Empty::default(),
                         })
                         .unwrap(),

--- a/ci/integration-tests/src/helpers/helper.rs
+++ b/ci/integration-tests/src/helpers/helper.rs
@@ -8,7 +8,7 @@ use dao_interface::query::DumpStateResponse;
 use dao_interface::state::{Admin, ModuleInstantiateInfo};
 use dao_voting::{
     deposit::{DepositRefundPolicy, DepositToken, UncheckedDepositInfo, VotingModuleTokenType},
-    pre_propose::{PreProposeInfo, ProposalCreationPolicy},
+    pre_propose::{PreProposeInfo, PreProposeSubmissionPolicy, ProposalCreationPolicy},
     threshold::PercentageThreshold,
     threshold::Threshold,
     voting::Vote,
@@ -84,7 +84,7 @@ pub fn create_dao(
                                 amount: DEPOSIT_AMOUNT,
                                 refund_policy: DepositRefundPolicy::OnlyPassed,
                             }),
-                            open_proposal_submission: false,
+                            submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
                             extension: Empty::default(),
                         })
                         .unwrap(),

--- a/ci/integration-tests/src/helpers/helper.rs
+++ b/ci/integration-tests/src/helpers/helper.rs
@@ -84,7 +84,11 @@ pub fn create_dao(
                                 amount: DEPOSIT_AMOUNT,
                                 refund_policy: DepositRefundPolicy::OnlyPassed,
                             }),
-                            submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
+                            submission_policy: PreProposeSubmissionPolicy::Specific {
+                                dao_members: true,
+                                allowlist: None,
+                                denylist: None,
+                            },
                             extension: Empty::default(),
                         })
                         .unwrap(),

--- a/contracts/dao-dao-core/schema/dao-dao-core.json
+++ b/contracts/dao-dao-core/schema/dao-dao-core.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-dao-core",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -17,10 +17,7 @@
     "properties": {
       "admin": {
         "description": "Optional Admin with the ability to execute DAO messages directly. Useful for building SubDAOs controlled by a parent DAO. If no admin is specified the contract is set as its own admin so that the admin may be updated later by governance.",
-        "type": [
-          "string",
-          "null"
-        ]
+        "type": ["string", "null"]
       },
       "automatically_add_cw20s": {
         "description": "If true the contract will automatically add received cw20 tokens to its treasury.",
@@ -32,10 +29,7 @@
       },
       "dao_uri": {
         "description": "Implements the DAO Star standard: <https://daostar.one/EIP>",
-        "type": [
-          "string",
-          "null"
-        ]
+        "type": ["string", "null"]
       },
       "description": {
         "description": "A description of the core contract.",
@@ -43,17 +37,11 @@
       },
       "image_url": {
         "description": "An image URL to describe the core module contract.",
-        "type": [
-          "string",
-          "null"
-        ]
+        "type": ["string", "null"]
       },
       "initial_items": {
         "description": "The items to instantiate this DAO with. Items are arbitrary key-value pairs whose contents are controlled by governance.\n\nIt is an error to provide two items with the same key.",
-        "type": [
-          "array",
-          "null"
-        ],
+        "type": ["array", "null"],
         "items": {
           "$ref": "#/definitions/InitialItem"
         }
@@ -86,15 +74,11 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "object",
-                "required": [
-                  "addr"
-                ],
+                "required": ["addr"],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -108,9 +92,7 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": [
-              "core_module"
-            ],
+            "required": ["core_module"],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -127,10 +109,7 @@
       },
       "Coin": {
         "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
+        "required": ["amount", "denom"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -143,10 +122,7 @@
       "InitialItem": {
         "description": "Information about an item to be stored in the items list.",
         "type": "object",
-        "required": [
-          "key",
-          "value"
-        ],
+        "required": ["key", "value"],
         "properties": {
           "key": {
             "description": "The name of the item.",
@@ -162,12 +138,7 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": [
-          "code_id",
-          "funds",
-          "label",
-          "msg"
-        ],
+        "required": ["code_id", "funds", "label", "msg"],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -221,15 +192,11 @@
       {
         "description": "Callable by the Admin, if one is configured. Executes messages in order.",
         "type": "object",
-        "required": [
-          "execute_admin_msgs"
-        ],
+        "required": ["execute_admin_msgs"],
         "properties": {
           "execute_admin_msgs": {
             "type": "object",
-            "required": [
-              "msgs"
-            ],
+            "required": ["msgs"],
             "properties": {
               "msgs": {
                 "type": "array",
@@ -246,15 +213,11 @@
       {
         "description": "Callable by proposal modules. The DAO will execute the messages in the hook in order.",
         "type": "object",
-        "required": [
-          "execute_proposal_hook"
-        ],
+        "required": ["execute_proposal_hook"],
         "properties": {
           "execute_proposal_hook": {
             "type": "object",
-            "required": [
-              "msgs"
-            ],
+            "required": ["msgs"],
             "properties": {
               "msgs": {
                 "type": "array",
@@ -271,15 +234,11 @@
       {
         "description": "Pauses the DAO for a set duration. When paused the DAO is unable to execute proposals",
         "type": "object",
-        "required": [
-          "pause"
-        ],
+        "required": ["pause"],
         "properties": {
           "pause": {
             "type": "object",
-            "required": [
-              "duration"
-            ],
+            "required": ["duration"],
             "properties": {
               "duration": {
                 "$ref": "#/definitions/Duration"
@@ -293,9 +252,7 @@
       {
         "description": "Unpauses the DAO",
         "type": "object",
-        "required": [
-          "unpause"
-        ],
+        "required": ["unpause"],
         "properties": {
           "unpause": {
             "type": "object",
@@ -307,9 +264,7 @@
       {
         "description": "Executed when the contract receives a cw20 token. Depending on the contract's configuration the contract will automatically add the token to its treasury.",
         "type": "object",
-        "required": [
-          "receive"
-        ],
+        "required": ["receive"],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -320,9 +275,7 @@
       {
         "description": "Executed when the contract receives a cw721 token. Depending on the contract's configuration the contract will automatically add the token to its treasury.",
         "type": "object",
-        "required": [
-          "receive_nft"
-        ],
+        "required": ["receive_nft"],
         "properties": {
           "receive_nft": {
             "$ref": "#/definitions/Cw721ReceiveMsg"
@@ -333,15 +286,11 @@
       {
         "description": "Removes an item from the governance contract's item map.",
         "type": "object",
-        "required": [
-          "remove_item"
-        ],
+        "required": ["remove_item"],
         "properties": {
           "remove_item": {
             "type": "object",
-            "required": [
-              "key"
-            ],
+            "required": ["key"],
             "properties": {
               "key": {
                 "type": "string"
@@ -355,16 +304,11 @@
       {
         "description": "Adds an item to the governance contract's item map. If the item already exists the existing value is overridden. If the item does not exist a new item is added.",
         "type": "object",
-        "required": [
-          "set_item"
-        ],
+        "required": ["set_item"],
         "properties": {
           "set_item": {
             "type": "object",
-            "required": [
-              "key",
-              "value"
-            ],
+            "required": ["key", "value"],
             "properties": {
               "key": {
                 "type": "string"
@@ -381,18 +325,13 @@
       {
         "description": "Callable by the admin of the contract. If ADMIN is None the admin is set as the contract itself so that it may be updated later by vote. If ADMIN is Some a new admin is proposed and that new admin may become the admin by executing the `AcceptAdminNomination` message.\n\nIf there is already a pending admin nomination the `WithdrawAdminNomination` message must be executed before a new admin may be nominated.",
         "type": "object",
-        "required": [
-          "nominate_admin"
-        ],
+        "required": ["nominate_admin"],
         "properties": {
           "nominate_admin": {
             "type": "object",
             "properties": {
               "admin": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -403,9 +342,7 @@
       {
         "description": "Callable by a nominated admin. Admins are nominated via the `NominateAdmin` message. Accepting a nomination will make the nominated address the new admin.\n\nRequiring that the new admin accepts the nomination before becoming the admin protects against a typo causing the admin to change to an invalid address.",
         "type": "object",
-        "required": [
-          "accept_admin_nomination"
-        ],
+        "required": ["accept_admin_nomination"],
         "properties": {
           "accept_admin_nomination": {
             "type": "object",
@@ -417,9 +354,7 @@
       {
         "description": "Callable by the current admin. Withdraws the current admin nomination.",
         "type": "object",
-        "required": [
-          "withdraw_admin_nomination"
-        ],
+        "required": ["withdraw_admin_nomination"],
         "properties": {
           "withdraw_admin_nomination": {
             "type": "object",
@@ -431,15 +366,11 @@
       {
         "description": "Callable by the core contract. Replaces the current governance contract config with the provided config.",
         "type": "object",
-        "required": [
-          "update_config"
-        ],
+        "required": ["update_config"],
         "properties": {
           "update_config": {
             "type": "object",
-            "required": [
-              "config"
-            ],
+            "required": ["config"],
             "properties": {
               "config": {
                 "$ref": "#/definitions/Config"
@@ -453,16 +384,11 @@
       {
         "description": "Updates the list of cw20 tokens this contract has registered.",
         "type": "object",
-        "required": [
-          "update_cw20_list"
-        ],
+        "required": ["update_cw20_list"],
         "properties": {
           "update_cw20_list": {
             "type": "object",
-            "required": [
-              "to_add",
-              "to_remove"
-            ],
+            "required": ["to_add", "to_remove"],
             "properties": {
               "to_add": {
                 "type": "array",
@@ -485,16 +411,11 @@
       {
         "description": "Updates the list of cw721 tokens this contract has registered.",
         "type": "object",
-        "required": [
-          "update_cw721_list"
-        ],
+        "required": ["update_cw721_list"],
         "properties": {
           "update_cw721_list": {
             "type": "object",
-            "required": [
-              "to_add",
-              "to_remove"
-            ],
+            "required": ["to_add", "to_remove"],
             "properties": {
               "to_add": {
                 "type": "array",
@@ -517,16 +438,11 @@
       {
         "description": "Updates the governance contract's governance modules. Module instantiate info in `to_add` is used to create new modules and install them.",
         "type": "object",
-        "required": [
-          "update_proposal_modules"
-        ],
+        "required": ["update_proposal_modules"],
         "properties": {
           "update_proposal_modules": {
             "type": "object",
-            "required": [
-              "to_add",
-              "to_disable"
-            ],
+            "required": ["to_add", "to_disable"],
             "properties": {
               "to_add": {
                 "description": "NOTE: the pre-propose-base package depends on it being the case that the core module instantiates its proposal module.",
@@ -550,15 +466,11 @@
       {
         "description": "Callable by the core contract. Replaces the current voting module with a new one instantiated by the governance contract.",
         "type": "object",
-        "required": [
-          "update_voting_module"
-        ],
+        "required": ["update_voting_module"],
         "properties": {
           "update_voting_module": {
             "type": "object",
-            "required": [
-              "module"
-            ],
+            "required": ["module"],
             "properties": {
               "module": {
                 "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -572,16 +484,11 @@
       {
         "description": "Update the core module to add/remove SubDAOs and their charters",
         "type": "object",
-        "required": [
-          "update_sub_daos"
-        ],
+        "required": ["update_sub_daos"],
         "properties": {
           "update_sub_daos": {
             "type": "object",
-            "required": [
-              "to_add",
-              "to_remove"
-            ],
+            "required": ["to_add", "to_remove"],
             "properties": {
               "to_add": {
                 "type": "array",
@@ -609,15 +516,11 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "object",
-                "required": [
-                  "addr"
-                ],
+                "required": ["addr"],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -631,9 +534,7 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": [
-              "core_module"
-            ],
+            "required": ["core_module"],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -650,16 +551,11 @@
           {
             "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "send"
-            ],
+            "required": ["send"],
             "properties": {
               "send": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "to_address"
-                ],
+                "required": ["amount", "to_address"],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -678,15 +574,11 @@
           {
             "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
             "type": "object",
-            "required": [
-              "burn"
-            ],
+            "required": ["burn"],
             "properties": {
               "burn": {
                 "type": "object",
-                "required": [
-                  "amount"
-                ],
+                "required": ["amount"],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -707,10 +599,7 @@
       },
       "Coin": {
         "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
+        "required": ["amount", "denom"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -740,10 +629,7 @@
           },
           "dao_uri": {
             "description": "The URI for the DAO as defined by the DAOstar standard <https://daostar.one/EIP>",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "description": {
             "description": "A description of the contract.",
@@ -751,10 +637,7 @@
           },
           "image_url": {
             "description": "An optional image URL for displaying alongside the contract.",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "name": {
             "description": "The name of the contract.",
@@ -767,9 +650,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "bank"
-            ],
+            "required": ["bank"],
             "properties": {
               "bank": {
                 "$ref": "#/definitions/BankMsg"
@@ -779,9 +660,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "custom"
-            ],
+            "required": ["custom"],
             "properties": {
               "custom": {
                 "$ref": "#/definitions/Empty"
@@ -791,9 +670,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "staking"
-            ],
+            "required": ["staking"],
             "properties": {
               "staking": {
                 "$ref": "#/definitions/StakingMsg"
@@ -803,9 +680,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "distribution"
-            ],
+            "required": ["distribution"],
             "properties": {
               "distribution": {
                 "$ref": "#/definitions/DistributionMsg"
@@ -816,16 +691,11 @@
           {
             "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
             "type": "object",
-            "required": [
-              "stargate"
-            ],
+            "required": ["stargate"],
             "properties": {
               "stargate": {
                 "type": "object",
-                "required": [
-                  "type_url",
-                  "value"
-                ],
+                "required": ["type_url", "value"],
                 "properties": {
                   "type_url": {
                     "type": "string"
@@ -840,9 +710,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "ibc"
-            ],
+            "required": ["ibc"],
             "properties": {
               "ibc": {
                 "$ref": "#/definitions/IbcMsg"
@@ -852,9 +720,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "wasm"
-            ],
+            "required": ["wasm"],
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmMsg"
@@ -864,9 +730,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "gov"
-            ],
+            "required": ["gov"],
             "properties": {
               "gov": {
                 "$ref": "#/definitions/GovMsg"
@@ -879,11 +743,7 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": [
-          "amount",
-          "msg",
-          "sender"
-        ],
+        "required": ["amount", "msg", "sender"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -900,11 +760,7 @@
       "Cw721ReceiveMsg": {
         "description": "Cw721ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": [
-          "msg",
-          "sender",
-          "token_id"
-        ],
+        "required": ["msg", "sender", "token_id"],
         "properties": {
           "msg": {
             "$ref": "#/definitions/Binary"
@@ -924,15 +780,11 @@
           {
             "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "set_withdraw_address"
-            ],
+            "required": ["set_withdraw_address"],
             "properties": {
               "set_withdraw_address": {
                 "type": "object",
-                "required": [
-                  "address"
-                ],
+                "required": ["address"],
                 "properties": {
                   "address": {
                     "description": "The `withdraw_address`",
@@ -946,15 +798,11 @@
           {
             "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "withdraw_delegator_reward"
-            ],
+            "required": ["withdraw_delegator_reward"],
             "properties": {
               "withdraw_delegator_reward": {
                 "type": "object",
-                "required": [
-                  "validator"
-                ],
+                "required": ["validator"],
                 "properties": {
                   "validator": {
                     "description": "The `validator_address`",
@@ -972,9 +820,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -987,9 +833,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -1011,16 +855,11 @@
           {
             "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
             "type": "object",
-            "required": [
-              "vote"
-            ],
+            "required": ["vote"],
             "properties": {
               "vote": {
                 "type": "object",
-                "required": [
-                  "proposal_id",
-                  "vote"
-                ],
+                "required": ["proposal_id", "vote"],
                 "properties": {
                   "proposal_id": {
                     "type": "integer",
@@ -1048,18 +887,11 @@
           {
             "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
             "type": "object",
-            "required": [
-              "transfer"
-            ],
+            "required": ["transfer"],
             "properties": {
               "transfer": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "channel_id",
-                  "timeout",
-                  "to_address"
-                ],
+                "required": ["amount", "channel_id", "timeout", "to_address"],
                 "properties": {
                   "amount": {
                     "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -1093,17 +925,11 @@
           {
             "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
             "type": "object",
-            "required": [
-              "send_packet"
-            ],
+            "required": ["send_packet"],
             "properties": {
               "send_packet": {
                 "type": "object",
-                "required": [
-                  "channel_id",
-                  "data",
-                  "timeout"
-                ],
+                "required": ["channel_id", "data", "timeout"],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -1127,15 +953,11 @@
           {
             "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
             "type": "object",
-            "required": [
-              "close_channel"
-            ],
+            "required": ["close_channel"],
             "properties": {
               "close_channel": {
                 "type": "object",
-                "required": [
-                  "channel_id"
-                ],
+                "required": ["channel_id"],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -1176,10 +998,7 @@
       "IbcTimeoutBlock": {
         "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
         "type": "object",
-        "required": [
-          "height",
-          "revision"
-        ],
+        "required": ["height", "revision"],
         "properties": {
           "height": {
             "description": "block height after which the packet times out. the height within the given revision",
@@ -1198,12 +1017,7 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": [
-          "code_id",
-          "funds",
-          "label",
-          "msg"
-        ],
+        "required": ["code_id", "funds", "label", "msg"],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -1250,16 +1064,11 @@
           {
             "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "delegate"
-            ],
+            "required": ["delegate"],
             "properties": {
               "delegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "validator"
-                ],
+                "required": ["amount", "validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1275,16 +1084,11 @@
           {
             "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "undelegate"
-            ],
+            "required": ["undelegate"],
             "properties": {
               "undelegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "validator"
-                ],
+                "required": ["amount", "validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1300,17 +1104,11 @@
           {
             "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "redelegate"
-            ],
+            "required": ["redelegate"],
             "properties": {
               "redelegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "dst_validator",
-                  "src_validator"
-                ],
+                "required": ["amount", "dst_validator", "src_validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1330,9 +1128,7 @@
       },
       "SubDao": {
         "type": "object",
-        "required": [
-          "addr"
-        ],
+        "required": ["addr"],
         "properties": {
           "addr": {
             "description": "The contract address of the SubDAO",
@@ -1340,10 +1136,7 @@
           },
           "charter": {
             "description": "The purpose/constitution for the SubDAO",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           }
         },
         "additionalProperties": false
@@ -1366,12 +1159,7 @@
       },
       "VoteOption": {
         "type": "string",
-        "enum": [
-          "yes",
-          "no",
-          "abstain",
-          "no_with_veto"
-        ]
+        "enum": ["yes", "no", "abstain", "no_with_veto"]
       },
       "WasmMsg": {
         "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
@@ -1379,17 +1167,11 @@
           {
             "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "execute"
-            ],
+            "required": ["execute"],
             "properties": {
               "execute": {
                 "type": "object",
-                "required": [
-                  "contract_addr",
-                  "funds",
-                  "msg"
-                ],
+                "required": ["contract_addr", "funds", "msg"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1416,24 +1198,14 @@
           {
             "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "instantiate"
-            ],
+            "required": ["instantiate"],
             "properties": {
               "instantiate": {
                 "type": "object",
-                "required": [
-                  "code_id",
-                  "funds",
-                  "label",
-                  "msg"
-                ],
+                "required": ["code_id", "funds", "label", "msg"],
                 "properties": {
                   "admin": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": ["string", "null"]
                   },
                   "code_id": {
                     "type": "integer",
@@ -1466,17 +1238,11 @@
           {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "migrate"
-            ],
+            "required": ["migrate"],
             "properties": {
               "migrate": {
                 "type": "object",
-                "required": [
-                  "contract_addr",
-                  "msg",
-                  "new_code_id"
-                ],
+                "required": ["contract_addr", "msg", "new_code_id"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1503,16 +1269,11 @@
           {
             "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": [
-              "update_admin"
-            ],
+            "required": ["update_admin"],
             "properties": {
               "update_admin": {
                 "type": "object",
-                "required": [
-                  "admin",
-                  "contract_addr"
-                ],
+                "required": ["admin", "contract_addr"],
                 "properties": {
                   "admin": {
                     "type": "string"
@@ -1528,15 +1289,11 @@
           {
             "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": [
-              "clear_admin"
-            ],
+            "required": ["clear_admin"],
             "properties": {
               "clear_admin": {
                 "type": "object",
-                "required": [
-                  "contract_addr"
-                ],
+                "required": ["contract_addr"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1557,9 +1314,7 @@
       {
         "description": "Get's the DAO's admin. Returns `Addr`.",
         "type": "object",
-        "required": [
-          "admin"
-        ],
+        "required": ["admin"],
         "properties": {
           "admin": {
             "type": "object",
@@ -1571,9 +1326,7 @@
       {
         "description": "Get's the currently nominated admin (if any).",
         "type": "object",
-        "required": [
-          "admin_nomination"
-        ],
+        "required": ["admin_nomination"],
         "properties": {
           "admin_nomination": {
             "type": "object",
@@ -1585,9 +1338,7 @@
       {
         "description": "Gets the contract's config.",
         "type": "object",
-        "required": [
-          "config"
-        ],
+        "required": ["config"],
         "properties": {
           "config": {
             "type": "object",
@@ -1599,26 +1350,18 @@
       {
         "description": "Gets the token balance for each cw20 registered with the contract.",
         "type": "object",
-        "required": [
-          "cw20_balances"
-        ],
+        "required": ["cw20_balances"],
         "properties": {
           "cw20_balances": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -1629,26 +1372,18 @@
       {
         "description": "Lists the addresses of the cw20 tokens in this contract's treasury.",
         "type": "object",
-        "required": [
-          "cw20_token_list"
-        ],
+        "required": ["cw20_token_list"],
         "properties": {
           "cw20_token_list": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -1659,26 +1394,18 @@
       {
         "description": "Lists the addresses of the cw721 tokens in this contract's treasury.",
         "type": "object",
-        "required": [
-          "cw721_token_list"
-        ],
+        "required": ["cw721_token_list"],
         "properties": {
           "cw721_token_list": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -1689,9 +1416,7 @@
       {
         "description": "Dumps all of the core contract's state in a single query. Useful for frontends as performance for queries is more limited by network times than compute times.",
         "type": "object",
-        "required": [
-          "dump_state"
-        ],
+        "required": ["dump_state"],
         "properties": {
           "dump_state": {
             "type": "object",
@@ -1703,15 +1428,11 @@
       {
         "description": "Gets the address associated with an item key.",
         "type": "object",
-        "required": [
-          "get_item"
-        ],
+        "required": ["get_item"],
         "properties": {
           "get_item": {
             "type": "object",
-            "required": [
-              "key"
-            ],
+            "required": ["key"],
             "properties": {
               "key": {
                 "type": "string"
@@ -1725,26 +1446,18 @@
       {
         "description": "Lists all of the items associted with the contract. For example, given the items `{ \"group\": \"foo\", \"subdao\": \"bar\"}` this query would return `[(\"group\", \"foo\"), (\"subdao\", \"bar\")]`.",
         "type": "object",
-        "required": [
-          "list_items"
-        ],
+        "required": ["list_items"],
         "properties": {
           "list_items": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -1755,9 +1468,7 @@
       {
         "description": "Returns contract version info",
         "type": "object",
-        "required": [
-          "info"
-        ],
+        "required": ["info"],
         "properties": {
           "info": {
             "type": "object",
@@ -1769,26 +1480,18 @@
       {
         "description": "Gets all proposal modules associated with the contract.",
         "type": "object",
-        "required": [
-          "proposal_modules"
-        ],
+        "required": ["proposal_modules"],
         "properties": {
           "proposal_modules": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -1799,26 +1502,18 @@
       {
         "description": "Gets the active proposal modules associated with the contract.",
         "type": "object",
-        "required": [
-          "active_proposal_modules"
-        ],
+        "required": ["active_proposal_modules"],
         "properties": {
           "active_proposal_modules": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -1829,9 +1524,7 @@
       {
         "description": "Gets the number of active and total proposal modules registered with this module.",
         "type": "object",
-        "required": [
-          "proposal_module_count"
-        ],
+        "required": ["proposal_module_count"],
         "properties": {
           "proposal_module_count": {
             "type": "object",
@@ -1843,9 +1536,7 @@
       {
         "description": "Returns information about if the contract is currently paused.",
         "type": "object",
-        "required": [
-          "pause_info"
-        ],
+        "required": ["pause_info"],
         "properties": {
           "pause_info": {
             "type": "object",
@@ -1857,9 +1548,7 @@
       {
         "description": "Gets the contract's voting module.",
         "type": "object",
-        "required": [
-          "voting_module"
-        ],
+        "required": ["voting_module"],
         "properties": {
           "voting_module": {
             "type": "object",
@@ -1871,26 +1560,18 @@
       {
         "description": "Returns all SubDAOs with their charters in a vec. start_after is bound exclusive and asks for a string address.",
         "type": "object",
-        "required": [
-          "list_sub_daos"
-        ],
+        "required": ["list_sub_daos"],
         "properties": {
           "list_sub_daos": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -1901,9 +1582,7 @@
       {
         "description": "Implements the DAO Star standard: <https://daostar.one/EIP>",
         "type": "object",
-        "required": [
-          "dao_u_r_i"
-        ],
+        "required": ["dao_u_r_i"],
         "properties": {
           "dao_u_r_i": {
             "type": "object",
@@ -1915,24 +1594,17 @@
       {
         "description": "Returns the voting power for an address at a given height.",
         "type": "object",
-        "required": [
-          "voting_power_at_height"
-        ],
+        "required": ["voting_power_at_height"],
         "properties": {
           "voting_power_at_height": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
               },
               "height": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -1945,18 +1617,13 @@
       {
         "description": "Returns the total voting power at a given block height.",
         "type": "object",
-        "required": [
-          "total_power_at_height"
-        ],
+        "required": ["total_power_at_height"],
         "properties": {
           "total_power_at_height": {
             "type": "object",
             "properties": {
               "height": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -1974,18 +1641,13 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "from_v1"
-        ],
+        "required": ["from_v1"],
         "properties": {
           "from_v1": {
             "type": "object",
             "properties": {
               "dao_uri": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               },
               "params": {
                 "anyOf": [
@@ -2005,9 +1667,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "from_compatible"
-        ],
+        "required": ["from_compatible"],
         "properties": {
           "from_compatible": {
             "type": "object",
@@ -2024,15 +1684,11 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "object",
-                "required": [
-                  "addr"
-                ],
+                "required": ["addr"],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -2046,9 +1702,7 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": [
-              "core_module"
-            ],
+            "required": ["core_module"],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -2065,10 +1719,7 @@
       },
       "Coin": {
         "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
+        "required": ["amount", "denom"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -2080,10 +1731,7 @@
       },
       "MigrateParams": {
         "type": "object",
-        "required": [
-          "migrator_code_id",
-          "params"
-        ],
+        "required": ["migrator_code_id", "params"],
         "properties": {
           "migrator_code_id": {
             "type": "integer",
@@ -2125,16 +1773,11 @@
       },
       "MigrationModuleParams": {
         "type": "object",
-        "required": [
-          "proposal_params"
-        ],
+        "required": ["proposal_params"],
         "properties": {
           "migrate_stake_cw20_manager": {
             "description": "Rather or not to migrate the stake_cw20 contract and its manager. If this is not set to true and a stake_cw20 contract is detected in the DAO's configuration the migration will be aborted.",
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": ["boolean", "null"]
           },
           "proposal_params": {
             "type": "array",
@@ -2158,12 +1801,7 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": [
-          "code_id",
-          "funds",
-          "label",
-          "msg"
-        ],
+        "required": ["code_id", "funds", "label", "msg"],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -2209,9 +1847,7 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": [
-              "anyone_may_propose"
-            ],
+            "required": ["anyone_may_propose"],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -2223,15 +1859,11 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": [
-              "module_may_propose"
-            ],
+            "required": ["module_may_propose"],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": [
-                  "info"
-                ],
+                "required": ["info"],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -2247,10 +1879,7 @@
       "ProposalParams": {
         "description": "The params we need to provide for migration msgs",
         "type": "object",
-        "required": [
-          "close_proposal_on_execution_failure",
-          "pre_propose_info"
-        ],
+        "required": ["close_proposal_on_execution_failure", "pre_propose_info"],
         "properties": {
           "close_proposal_on_execution_failure": {
             "type": "boolean"
@@ -2263,9 +1892,7 @@
       },
       "SubDao": {
         "type": "object",
-        "required": [
-          "addr"
-        ],
+        "required": ["addr"],
         "properties": {
           "addr": {
             "description": "The contract address of the SubDAO",
@@ -2273,10 +1900,7 @@
           },
           "charter": {
             "description": "The purpose/constitution for the SubDAO",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           }
         },
         "additionalProperties": false
@@ -2368,11 +1992,7 @@
         "ProposalModule": {
           "description": "Top level type describing a proposal module.",
           "type": "object",
-          "required": [
-            "address",
-            "prefix",
-            "status"
-          ],
+          "required": ["address", "prefix", "status"],
           "properties": {
             "address": {
               "description": "The address of the proposal module.",
@@ -2400,10 +2020,7 @@
         "ProposalModuleStatus": {
           "description": "The status of a proposal module.",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ]
+          "enum": ["enabled", "disabled"]
         }
       }
     },
@@ -2461,10 +2078,7 @@
         },
         "dao_uri": {
           "description": "The URI for the DAO as defined by the DAOstar standard <https://daostar.one/EIP>",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "description": {
           "description": "A description of the contract.",
@@ -2472,10 +2086,7 @@
         },
         "image_url": {
           "description": "An optional image URL for displaying alongside the contract.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "name": {
           "description": "The name of the contract.",
@@ -2489,10 +2100,7 @@
       "title": "Cw20BalanceResponse",
       "description": "Returned by the `Cw20Balances` query.",
       "type": "object",
-      "required": [
-        "addr",
-        "balance"
-      ],
+      "required": ["addr", "balance"],
       "properties": {
         "addr": {
           "description": "The address of the token.",
@@ -2557,10 +2165,7 @@
       "type": "object",
       "properties": {
         "dao_uri": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       },
       "additionalProperties": false
@@ -2662,10 +2267,7 @@
             },
             "dao_uri": {
               "description": "The URI for the DAO as defined by the DAOstar standard <https://daostar.one/EIP>",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "description": {
               "description": "A description of the contract.",
@@ -2673,10 +2275,7 @@
             },
             "image_url": {
               "description": "An optional image URL for displaying alongside the contract.",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "name": {
               "description": "The name of the contract.",
@@ -2687,10 +2286,7 @@
         },
         "ContractVersion": {
           "type": "object",
-          "required": [
-            "contract",
-            "version"
-          ],
+          "required": ["contract", "version"],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -2709,9 +2305,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -2724,9 +2318,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -2737,9 +2329,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -2755,15 +2345,11 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "paused"
-              ],
+              "required": ["paused"],
               "properties": {
                 "paused": {
                   "type": "object",
-                  "required": [
-                    "expiration"
-                  ],
+                  "required": ["expiration"],
                   "properties": {
                     "expiration": {
                       "$ref": "#/definitions/Expiration"
@@ -2776,9 +2362,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "unpaused"
-              ],
+              "required": ["unpaused"],
               "properties": {
                 "unpaused": {
                   "type": "object",
@@ -2792,11 +2376,7 @@
         "ProposalModule": {
           "description": "Top level type describing a proposal module.",
           "type": "object",
-          "required": [
-            "address",
-            "prefix",
-            "status"
-          ],
+          "required": ["address", "prefix", "status"],
           "properties": {
             "address": {
               "description": "The address of the proposal module.",
@@ -2824,10 +2404,7 @@
         "ProposalModuleStatus": {
           "description": "The status of a proposal module.",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ]
+          "enum": ["enabled", "disabled"]
         },
         "Timestamp": {
           "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
@@ -2851,10 +2428,7 @@
       "properties": {
         "item": {
           "description": "`None` if no item with the provided key was found, `Some` otherwise.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       },
       "additionalProperties": false
@@ -2863,9 +2437,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": [
-        "info"
-      ],
+      "required": ["info"],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -2875,10 +2447,7 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": [
-            "contract",
-            "version"
-          ],
+          "required": ["contract", "version"],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -2911,9 +2480,7 @@
       "definitions": {
         "SubDao": {
           "type": "object",
-          "required": [
-            "addr"
-          ],
+          "required": ["addr"],
           "properties": {
             "addr": {
               "description": "The contract address of the SubDAO",
@@ -2921,10 +2488,7 @@
             },
             "charter": {
               "description": "The purpose/constitution for the SubDAO",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             }
           },
           "additionalProperties": false
@@ -2938,15 +2502,11 @@
       "oneOf": [
         {
           "type": "object",
-          "required": [
-            "paused"
-          ],
+          "required": ["paused"],
           "properties": {
             "paused": {
               "type": "object",
-              "required": [
-                "expiration"
-              ],
+              "required": ["expiration"],
               "properties": {
                 "expiration": {
                   "$ref": "#/definitions/Expiration"
@@ -2959,9 +2519,7 @@
         },
         {
           "type": "object",
-          "required": [
-            "unpaused"
-          ],
+          "required": ["unpaused"],
           "properties": {
             "unpaused": {
               "type": "object",
@@ -2978,9 +2536,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -2993,9 +2549,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -3006,9 +2560,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -3072,11 +2624,7 @@
         "ProposalModule": {
           "description": "Top level type describing a proposal module.",
           "type": "object",
-          "required": [
-            "address",
-            "prefix",
-            "status"
-          ],
+          "required": ["address", "prefix", "status"],
           "properties": {
             "address": {
               "description": "The address of the proposal module.",
@@ -3104,10 +2652,7 @@
         "ProposalModuleStatus": {
           "description": "The status of a proposal module.",
           "type": "string",
-          "enum": [
-            "enabled",
-            "disabled"
-          ]
+          "enum": ["enabled", "disabled"]
         }
       }
     },
@@ -3115,10 +2660,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalPowerAtHeightResponse",
       "type": "object",
-      "required": [
-        "height",
-        "power"
-      ],
+      "required": ["height", "power"],
       "properties": {
         "height": {
           "type": "integer",
@@ -3147,10 +2689,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VotingPowerAtHeightResponse",
       "type": "object",
-      "required": [
-        "height",
-        "power"
-      ],
+      "required": ["height", "power"],
       "properties": {
         "height": {
           "type": "integer",

--- a/contracts/dao-dao-core/schema/dao-dao-core.json
+++ b/contracts/dao-dao-core/schema/dao-dao-core.json
@@ -17,7 +17,10 @@
     "properties": {
       "admin": {
         "description": "Optional Admin with the ability to execute DAO messages directly. Useful for building SubDAOs controlled by a parent DAO. If no admin is specified the contract is set as its own admin so that the admin may be updated later by governance.",
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "automatically_add_cw20s": {
         "description": "If true the contract will automatically add received cw20 tokens to its treasury.",
@@ -29,7 +32,10 @@
       },
       "dao_uri": {
         "description": "Implements the DAO Star standard: <https://daostar.one/EIP>",
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "description": {
         "description": "A description of the core contract.",
@@ -37,11 +43,17 @@
       },
       "image_url": {
         "description": "An image URL to describe the core module contract.",
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "initial_items": {
         "description": "The items to instantiate this DAO with. Items are arbitrary key-value pairs whose contents are controlled by governance.\n\nIt is an error to provide two items with the same key.",
-        "type": ["array", "null"],
+        "type": [
+          "array",
+          "null"
+        ],
         "items": {
           "$ref": "#/definitions/InitialItem"
         }
@@ -74,11 +86,15 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "object",
-                "required": ["addr"],
+                "required": [
+                  "addr"
+                ],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -92,7 +108,9 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": ["core_module"],
+            "required": [
+              "core_module"
+            ],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -109,7 +127,10 @@
       },
       "Coin": {
         "type": "object",
-        "required": ["amount", "denom"],
+        "required": [
+          "amount",
+          "denom"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -122,7 +143,10 @@
       "InitialItem": {
         "description": "Information about an item to be stored in the items list.",
         "type": "object",
-        "required": ["key", "value"],
+        "required": [
+          "key",
+          "value"
+        ],
         "properties": {
           "key": {
             "description": "The name of the item.",
@@ -138,7 +162,12 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": ["code_id", "funds", "label", "msg"],
+        "required": [
+          "code_id",
+          "funds",
+          "label",
+          "msg"
+        ],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -192,11 +221,15 @@
       {
         "description": "Callable by the Admin, if one is configured. Executes messages in order.",
         "type": "object",
-        "required": ["execute_admin_msgs"],
+        "required": [
+          "execute_admin_msgs"
+        ],
         "properties": {
           "execute_admin_msgs": {
             "type": "object",
-            "required": ["msgs"],
+            "required": [
+              "msgs"
+            ],
             "properties": {
               "msgs": {
                 "type": "array",
@@ -213,11 +246,15 @@
       {
         "description": "Callable by proposal modules. The DAO will execute the messages in the hook in order.",
         "type": "object",
-        "required": ["execute_proposal_hook"],
+        "required": [
+          "execute_proposal_hook"
+        ],
         "properties": {
           "execute_proposal_hook": {
             "type": "object",
-            "required": ["msgs"],
+            "required": [
+              "msgs"
+            ],
             "properties": {
               "msgs": {
                 "type": "array",
@@ -234,11 +271,15 @@
       {
         "description": "Pauses the DAO for a set duration. When paused the DAO is unable to execute proposals",
         "type": "object",
-        "required": ["pause"],
+        "required": [
+          "pause"
+        ],
         "properties": {
           "pause": {
             "type": "object",
-            "required": ["duration"],
+            "required": [
+              "duration"
+            ],
             "properties": {
               "duration": {
                 "$ref": "#/definitions/Duration"
@@ -252,7 +293,9 @@
       {
         "description": "Unpauses the DAO",
         "type": "object",
-        "required": ["unpause"],
+        "required": [
+          "unpause"
+        ],
         "properties": {
           "unpause": {
             "type": "object",
@@ -264,7 +307,9 @@
       {
         "description": "Executed when the contract receives a cw20 token. Depending on the contract's configuration the contract will automatically add the token to its treasury.",
         "type": "object",
-        "required": ["receive"],
+        "required": [
+          "receive"
+        ],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -275,7 +320,9 @@
       {
         "description": "Executed when the contract receives a cw721 token. Depending on the contract's configuration the contract will automatically add the token to its treasury.",
         "type": "object",
-        "required": ["receive_nft"],
+        "required": [
+          "receive_nft"
+        ],
         "properties": {
           "receive_nft": {
             "$ref": "#/definitions/Cw721ReceiveMsg"
@@ -286,11 +333,15 @@
       {
         "description": "Removes an item from the governance contract's item map.",
         "type": "object",
-        "required": ["remove_item"],
+        "required": [
+          "remove_item"
+        ],
         "properties": {
           "remove_item": {
             "type": "object",
-            "required": ["key"],
+            "required": [
+              "key"
+            ],
             "properties": {
               "key": {
                 "type": "string"
@@ -304,11 +355,16 @@
       {
         "description": "Adds an item to the governance contract's item map. If the item already exists the existing value is overridden. If the item does not exist a new item is added.",
         "type": "object",
-        "required": ["set_item"],
+        "required": [
+          "set_item"
+        ],
         "properties": {
           "set_item": {
             "type": "object",
-            "required": ["key", "value"],
+            "required": [
+              "key",
+              "value"
+            ],
             "properties": {
               "key": {
                 "type": "string"
@@ -325,13 +381,18 @@
       {
         "description": "Callable by the admin of the contract. If ADMIN is None the admin is set as the contract itself so that it may be updated later by vote. If ADMIN is Some a new admin is proposed and that new admin may become the admin by executing the `AcceptAdminNomination` message.\n\nIf there is already a pending admin nomination the `WithdrawAdminNomination` message must be executed before a new admin may be nominated.",
         "type": "object",
-        "required": ["nominate_admin"],
+        "required": [
+          "nominate_admin"
+        ],
         "properties": {
           "nominate_admin": {
             "type": "object",
             "properties": {
               "admin": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -342,7 +403,9 @@
       {
         "description": "Callable by a nominated admin. Admins are nominated via the `NominateAdmin` message. Accepting a nomination will make the nominated address the new admin.\n\nRequiring that the new admin accepts the nomination before becoming the admin protects against a typo causing the admin to change to an invalid address.",
         "type": "object",
-        "required": ["accept_admin_nomination"],
+        "required": [
+          "accept_admin_nomination"
+        ],
         "properties": {
           "accept_admin_nomination": {
             "type": "object",
@@ -354,7 +417,9 @@
       {
         "description": "Callable by the current admin. Withdraws the current admin nomination.",
         "type": "object",
-        "required": ["withdraw_admin_nomination"],
+        "required": [
+          "withdraw_admin_nomination"
+        ],
         "properties": {
           "withdraw_admin_nomination": {
             "type": "object",
@@ -366,11 +431,15 @@
       {
         "description": "Callable by the core contract. Replaces the current governance contract config with the provided config.",
         "type": "object",
-        "required": ["update_config"],
+        "required": [
+          "update_config"
+        ],
         "properties": {
           "update_config": {
             "type": "object",
-            "required": ["config"],
+            "required": [
+              "config"
+            ],
             "properties": {
               "config": {
                 "$ref": "#/definitions/Config"
@@ -384,11 +453,16 @@
       {
         "description": "Updates the list of cw20 tokens this contract has registered.",
         "type": "object",
-        "required": ["update_cw20_list"],
+        "required": [
+          "update_cw20_list"
+        ],
         "properties": {
           "update_cw20_list": {
             "type": "object",
-            "required": ["to_add", "to_remove"],
+            "required": [
+              "to_add",
+              "to_remove"
+            ],
             "properties": {
               "to_add": {
                 "type": "array",
@@ -411,11 +485,16 @@
       {
         "description": "Updates the list of cw721 tokens this contract has registered.",
         "type": "object",
-        "required": ["update_cw721_list"],
+        "required": [
+          "update_cw721_list"
+        ],
         "properties": {
           "update_cw721_list": {
             "type": "object",
-            "required": ["to_add", "to_remove"],
+            "required": [
+              "to_add",
+              "to_remove"
+            ],
             "properties": {
               "to_add": {
                 "type": "array",
@@ -438,11 +517,16 @@
       {
         "description": "Updates the governance contract's governance modules. Module instantiate info in `to_add` is used to create new modules and install them.",
         "type": "object",
-        "required": ["update_proposal_modules"],
+        "required": [
+          "update_proposal_modules"
+        ],
         "properties": {
           "update_proposal_modules": {
             "type": "object",
-            "required": ["to_add", "to_disable"],
+            "required": [
+              "to_add",
+              "to_disable"
+            ],
             "properties": {
               "to_add": {
                 "description": "NOTE: the pre-propose-base package depends on it being the case that the core module instantiates its proposal module.",
@@ -466,11 +550,15 @@
       {
         "description": "Callable by the core contract. Replaces the current voting module with a new one instantiated by the governance contract.",
         "type": "object",
-        "required": ["update_voting_module"],
+        "required": [
+          "update_voting_module"
+        ],
         "properties": {
           "update_voting_module": {
             "type": "object",
-            "required": ["module"],
+            "required": [
+              "module"
+            ],
             "properties": {
               "module": {
                 "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -484,11 +572,16 @@
       {
         "description": "Update the core module to add/remove SubDAOs and their charters",
         "type": "object",
-        "required": ["update_sub_daos"],
+        "required": [
+          "update_sub_daos"
+        ],
         "properties": {
           "update_sub_daos": {
             "type": "object",
-            "required": ["to_add", "to_remove"],
+            "required": [
+              "to_add",
+              "to_remove"
+            ],
             "properties": {
               "to_add": {
                 "type": "array",
@@ -516,11 +609,15 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "object",
-                "required": ["addr"],
+                "required": [
+                  "addr"
+                ],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -534,7 +631,9 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": ["core_module"],
+            "required": [
+              "core_module"
+            ],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -551,11 +650,16 @@
           {
             "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["send"],
+            "required": [
+              "send"
+            ],
             "properties": {
               "send": {
                 "type": "object",
-                "required": ["amount", "to_address"],
+                "required": [
+                  "amount",
+                  "to_address"
+                ],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -574,11 +678,15 @@
           {
             "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
             "type": "object",
-            "required": ["burn"],
+            "required": [
+              "burn"
+            ],
             "properties": {
               "burn": {
                 "type": "object",
-                "required": ["amount"],
+                "required": [
+                  "amount"
+                ],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -599,7 +707,10 @@
       },
       "Coin": {
         "type": "object",
-        "required": ["amount", "denom"],
+        "required": [
+          "amount",
+          "denom"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -629,7 +740,10 @@
           },
           "dao_uri": {
             "description": "The URI for the DAO as defined by the DAOstar standard <https://daostar.one/EIP>",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "description": {
             "description": "A description of the contract.",
@@ -637,7 +751,10 @@
           },
           "image_url": {
             "description": "An optional image URL for displaying alongside the contract.",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "name": {
             "description": "The name of the contract.",
@@ -650,7 +767,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["bank"],
+            "required": [
+              "bank"
+            ],
             "properties": {
               "bank": {
                 "$ref": "#/definitions/BankMsg"
@@ -660,7 +779,9 @@
           },
           {
             "type": "object",
-            "required": ["custom"],
+            "required": [
+              "custom"
+            ],
             "properties": {
               "custom": {
                 "$ref": "#/definitions/Empty"
@@ -670,7 +791,9 @@
           },
           {
             "type": "object",
-            "required": ["staking"],
+            "required": [
+              "staking"
+            ],
             "properties": {
               "staking": {
                 "$ref": "#/definitions/StakingMsg"
@@ -680,7 +803,9 @@
           },
           {
             "type": "object",
-            "required": ["distribution"],
+            "required": [
+              "distribution"
+            ],
             "properties": {
               "distribution": {
                 "$ref": "#/definitions/DistributionMsg"
@@ -691,11 +816,16 @@
           {
             "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
             "type": "object",
-            "required": ["stargate"],
+            "required": [
+              "stargate"
+            ],
             "properties": {
               "stargate": {
                 "type": "object",
-                "required": ["type_url", "value"],
+                "required": [
+                  "type_url",
+                  "value"
+                ],
                 "properties": {
                   "type_url": {
                     "type": "string"
@@ -710,7 +840,9 @@
           },
           {
             "type": "object",
-            "required": ["ibc"],
+            "required": [
+              "ibc"
+            ],
             "properties": {
               "ibc": {
                 "$ref": "#/definitions/IbcMsg"
@@ -720,7 +852,9 @@
           },
           {
             "type": "object",
-            "required": ["wasm"],
+            "required": [
+              "wasm"
+            ],
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmMsg"
@@ -730,7 +864,9 @@
           },
           {
             "type": "object",
-            "required": ["gov"],
+            "required": [
+              "gov"
+            ],
             "properties": {
               "gov": {
                 "$ref": "#/definitions/GovMsg"
@@ -743,7 +879,11 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": ["amount", "msg", "sender"],
+        "required": [
+          "amount",
+          "msg",
+          "sender"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -760,7 +900,11 @@
       "Cw721ReceiveMsg": {
         "description": "Cw721ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": ["msg", "sender", "token_id"],
+        "required": [
+          "msg",
+          "sender",
+          "token_id"
+        ],
         "properties": {
           "msg": {
             "$ref": "#/definitions/Binary"
@@ -780,11 +924,15 @@
           {
             "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["set_withdraw_address"],
+            "required": [
+              "set_withdraw_address"
+            ],
             "properties": {
               "set_withdraw_address": {
                 "type": "object",
-                "required": ["address"],
+                "required": [
+                  "address"
+                ],
                 "properties": {
                   "address": {
                     "description": "The `withdraw_address`",
@@ -798,11 +946,15 @@
           {
             "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["withdraw_delegator_reward"],
+            "required": [
+              "withdraw_delegator_reward"
+            ],
             "properties": {
               "withdraw_delegator_reward": {
                 "type": "object",
-                "required": ["validator"],
+                "required": [
+                  "validator"
+                ],
                 "properties": {
                   "validator": {
                     "description": "The `validator_address`",
@@ -820,7 +972,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -833,7 +987,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -855,11 +1011,16 @@
           {
             "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
             "type": "object",
-            "required": ["vote"],
+            "required": [
+              "vote"
+            ],
             "properties": {
               "vote": {
                 "type": "object",
-                "required": ["proposal_id", "vote"],
+                "required": [
+                  "proposal_id",
+                  "vote"
+                ],
                 "properties": {
                   "proposal_id": {
                     "type": "integer",
@@ -887,11 +1048,18 @@
           {
             "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
             "type": "object",
-            "required": ["transfer"],
+            "required": [
+              "transfer"
+            ],
             "properties": {
               "transfer": {
                 "type": "object",
-                "required": ["amount", "channel_id", "timeout", "to_address"],
+                "required": [
+                  "amount",
+                  "channel_id",
+                  "timeout",
+                  "to_address"
+                ],
                 "properties": {
                   "amount": {
                     "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -925,11 +1093,17 @@
           {
             "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
             "type": "object",
-            "required": ["send_packet"],
+            "required": [
+              "send_packet"
+            ],
             "properties": {
               "send_packet": {
                 "type": "object",
-                "required": ["channel_id", "data", "timeout"],
+                "required": [
+                  "channel_id",
+                  "data",
+                  "timeout"
+                ],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -953,11 +1127,15 @@
           {
             "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
             "type": "object",
-            "required": ["close_channel"],
+            "required": [
+              "close_channel"
+            ],
             "properties": {
               "close_channel": {
                 "type": "object",
-                "required": ["channel_id"],
+                "required": [
+                  "channel_id"
+                ],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -998,7 +1176,10 @@
       "IbcTimeoutBlock": {
         "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
         "type": "object",
-        "required": ["height", "revision"],
+        "required": [
+          "height",
+          "revision"
+        ],
         "properties": {
           "height": {
             "description": "block height after which the packet times out. the height within the given revision",
@@ -1017,7 +1198,12 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": ["code_id", "funds", "label", "msg"],
+        "required": [
+          "code_id",
+          "funds",
+          "label",
+          "msg"
+        ],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -1064,11 +1250,16 @@
           {
             "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["delegate"],
+            "required": [
+              "delegate"
+            ],
             "properties": {
               "delegate": {
                 "type": "object",
-                "required": ["amount", "validator"],
+                "required": [
+                  "amount",
+                  "validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1084,11 +1275,16 @@
           {
             "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["undelegate"],
+            "required": [
+              "undelegate"
+            ],
             "properties": {
               "undelegate": {
                 "type": "object",
-                "required": ["amount", "validator"],
+                "required": [
+                  "amount",
+                  "validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1104,11 +1300,17 @@
           {
             "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["redelegate"],
+            "required": [
+              "redelegate"
+            ],
             "properties": {
               "redelegate": {
                 "type": "object",
-                "required": ["amount", "dst_validator", "src_validator"],
+                "required": [
+                  "amount",
+                  "dst_validator",
+                  "src_validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1128,7 +1330,9 @@
       },
       "SubDao": {
         "type": "object",
-        "required": ["addr"],
+        "required": [
+          "addr"
+        ],
         "properties": {
           "addr": {
             "description": "The contract address of the SubDAO",
@@ -1136,7 +1340,10 @@
           },
           "charter": {
             "description": "The purpose/constitution for the SubDAO",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "additionalProperties": false
@@ -1159,7 +1366,12 @@
       },
       "VoteOption": {
         "type": "string",
-        "enum": ["yes", "no", "abstain", "no_with_veto"]
+        "enum": [
+          "yes",
+          "no",
+          "abstain",
+          "no_with_veto"
+        ]
       },
       "WasmMsg": {
         "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
@@ -1167,11 +1379,17 @@
           {
             "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["execute"],
+            "required": [
+              "execute"
+            ],
             "properties": {
               "execute": {
                 "type": "object",
-                "required": ["contract_addr", "funds", "msg"],
+                "required": [
+                  "contract_addr",
+                  "funds",
+                  "msg"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1198,14 +1416,24 @@
           {
             "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["instantiate"],
+            "required": [
+              "instantiate"
+            ],
             "properties": {
               "instantiate": {
                 "type": "object",
-                "required": ["code_id", "funds", "label", "msg"],
+                "required": [
+                  "code_id",
+                  "funds",
+                  "label",
+                  "msg"
+                ],
                 "properties": {
                   "admin": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "code_id": {
                     "type": "integer",
@@ -1238,11 +1466,17 @@
           {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["migrate"],
+            "required": [
+              "migrate"
+            ],
             "properties": {
               "migrate": {
                 "type": "object",
-                "required": ["contract_addr", "msg", "new_code_id"],
+                "required": [
+                  "contract_addr",
+                  "msg",
+                  "new_code_id"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1269,11 +1503,16 @@
           {
             "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": ["update_admin"],
+            "required": [
+              "update_admin"
+            ],
             "properties": {
               "update_admin": {
                 "type": "object",
-                "required": ["admin", "contract_addr"],
+                "required": [
+                  "admin",
+                  "contract_addr"
+                ],
                 "properties": {
                   "admin": {
                     "type": "string"
@@ -1289,11 +1528,15 @@
           {
             "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": ["clear_admin"],
+            "required": [
+              "clear_admin"
+            ],
             "properties": {
               "clear_admin": {
                 "type": "object",
-                "required": ["contract_addr"],
+                "required": [
+                  "contract_addr"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1314,7 +1557,9 @@
       {
         "description": "Get's the DAO's admin. Returns `Addr`.",
         "type": "object",
-        "required": ["admin"],
+        "required": [
+          "admin"
+        ],
         "properties": {
           "admin": {
             "type": "object",
@@ -1326,7 +1571,9 @@
       {
         "description": "Get's the currently nominated admin (if any).",
         "type": "object",
-        "required": ["admin_nomination"],
+        "required": [
+          "admin_nomination"
+        ],
         "properties": {
           "admin_nomination": {
             "type": "object",
@@ -1338,7 +1585,9 @@
       {
         "description": "Gets the contract's config.",
         "type": "object",
-        "required": ["config"],
+        "required": [
+          "config"
+        ],
         "properties": {
           "config": {
             "type": "object",
@@ -1350,18 +1599,26 @@
       {
         "description": "Gets the token balance for each cw20 registered with the contract.",
         "type": "object",
-        "required": ["cw20_balances"],
+        "required": [
+          "cw20_balances"
+        ],
         "properties": {
           "cw20_balances": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -1372,18 +1629,26 @@
       {
         "description": "Lists the addresses of the cw20 tokens in this contract's treasury.",
         "type": "object",
-        "required": ["cw20_token_list"],
+        "required": [
+          "cw20_token_list"
+        ],
         "properties": {
           "cw20_token_list": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -1394,18 +1659,26 @@
       {
         "description": "Lists the addresses of the cw721 tokens in this contract's treasury.",
         "type": "object",
-        "required": ["cw721_token_list"],
+        "required": [
+          "cw721_token_list"
+        ],
         "properties": {
           "cw721_token_list": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -1416,7 +1689,9 @@
       {
         "description": "Dumps all of the core contract's state in a single query. Useful for frontends as performance for queries is more limited by network times than compute times.",
         "type": "object",
-        "required": ["dump_state"],
+        "required": [
+          "dump_state"
+        ],
         "properties": {
           "dump_state": {
             "type": "object",
@@ -1428,11 +1703,15 @@
       {
         "description": "Gets the address associated with an item key.",
         "type": "object",
-        "required": ["get_item"],
+        "required": [
+          "get_item"
+        ],
         "properties": {
           "get_item": {
             "type": "object",
-            "required": ["key"],
+            "required": [
+              "key"
+            ],
             "properties": {
               "key": {
                 "type": "string"
@@ -1446,18 +1725,26 @@
       {
         "description": "Lists all of the items associted with the contract. For example, given the items `{ \"group\": \"foo\", \"subdao\": \"bar\"}` this query would return `[(\"group\", \"foo\"), (\"subdao\", \"bar\")]`.",
         "type": "object",
-        "required": ["list_items"],
+        "required": [
+          "list_items"
+        ],
         "properties": {
           "list_items": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -1468,7 +1755,9 @@
       {
         "description": "Returns contract version info",
         "type": "object",
-        "required": ["info"],
+        "required": [
+          "info"
+        ],
         "properties": {
           "info": {
             "type": "object",
@@ -1480,18 +1769,26 @@
       {
         "description": "Gets all proposal modules associated with the contract.",
         "type": "object",
-        "required": ["proposal_modules"],
+        "required": [
+          "proposal_modules"
+        ],
         "properties": {
           "proposal_modules": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -1502,18 +1799,26 @@
       {
         "description": "Gets the active proposal modules associated with the contract.",
         "type": "object",
-        "required": ["active_proposal_modules"],
+        "required": [
+          "active_proposal_modules"
+        ],
         "properties": {
           "active_proposal_modules": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -1524,7 +1829,9 @@
       {
         "description": "Gets the number of active and total proposal modules registered with this module.",
         "type": "object",
-        "required": ["proposal_module_count"],
+        "required": [
+          "proposal_module_count"
+        ],
         "properties": {
           "proposal_module_count": {
             "type": "object",
@@ -1536,7 +1843,9 @@
       {
         "description": "Returns information about if the contract is currently paused.",
         "type": "object",
-        "required": ["pause_info"],
+        "required": [
+          "pause_info"
+        ],
         "properties": {
           "pause_info": {
             "type": "object",
@@ -1548,7 +1857,9 @@
       {
         "description": "Gets the contract's voting module.",
         "type": "object",
-        "required": ["voting_module"],
+        "required": [
+          "voting_module"
+        ],
         "properties": {
           "voting_module": {
             "type": "object",
@@ -1560,18 +1871,26 @@
       {
         "description": "Returns all SubDAOs with their charters in a vec. start_after is bound exclusive and asks for a string address.",
         "type": "object",
-        "required": ["list_sub_daos"],
+        "required": [
+          "list_sub_daos"
+        ],
         "properties": {
           "list_sub_daos": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -1582,7 +1901,9 @@
       {
         "description": "Implements the DAO Star standard: <https://daostar.one/EIP>",
         "type": "object",
-        "required": ["dao_u_r_i"],
+        "required": [
+          "dao_u_r_i"
+        ],
         "properties": {
           "dao_u_r_i": {
             "type": "object",
@@ -1594,17 +1915,24 @@
       {
         "description": "Returns the voting power for an address at a given height.",
         "type": "object",
-        "required": ["voting_power_at_height"],
+        "required": [
+          "voting_power_at_height"
+        ],
         "properties": {
           "voting_power_at_height": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
               },
               "height": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -1617,13 +1945,18 @@
       {
         "description": "Returns the total voting power at a given block height.",
         "type": "object",
-        "required": ["total_power_at_height"],
+        "required": [
+          "total_power_at_height"
+        ],
         "properties": {
           "total_power_at_height": {
             "type": "object",
             "properties": {
               "height": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -1641,13 +1974,18 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["from_v1"],
+        "required": [
+          "from_v1"
+        ],
         "properties": {
           "from_v1": {
             "type": "object",
             "properties": {
               "dao_uri": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "params": {
                 "anyOf": [
@@ -1667,7 +2005,9 @@
       },
       {
         "type": "object",
-        "required": ["from_compatible"],
+        "required": [
+          "from_compatible"
+        ],
         "properties": {
           "from_compatible": {
             "type": "object",
@@ -1684,11 +2024,15 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "object",
-                "required": ["addr"],
+                "required": [
+                  "addr"
+                ],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -1702,7 +2046,9 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": ["core_module"],
+            "required": [
+              "core_module"
+            ],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -1719,7 +2065,10 @@
       },
       "Coin": {
         "type": "object",
-        "required": ["amount", "denom"],
+        "required": [
+          "amount",
+          "denom"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -1731,7 +2080,10 @@
       },
       "MigrateParams": {
         "type": "object",
-        "required": ["migrator_code_id", "params"],
+        "required": [
+          "migrator_code_id",
+          "params"
+        ],
         "properties": {
           "migrator_code_id": {
             "type": "integer",
@@ -1773,11 +2125,16 @@
       },
       "MigrationModuleParams": {
         "type": "object",
-        "required": ["proposal_params"],
+        "required": [
+          "proposal_params"
+        ],
         "properties": {
           "migrate_stake_cw20_manager": {
             "description": "Rather or not to migrate the stake_cw20 contract and its manager. If this is not set to true and a stake_cw20 contract is detected in the DAO's configuration the migration will be aborted.",
-            "type": ["boolean", "null"]
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "proposal_params": {
             "type": "array",
@@ -1801,7 +2158,12 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": ["code_id", "funds", "label", "msg"],
+        "required": [
+          "code_id",
+          "funds",
+          "label",
+          "msg"
+        ],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -1847,7 +2209,9 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": ["anyone_may_propose"],
+            "required": [
+              "anyone_may_propose"
+            ],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -1859,11 +2223,15 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": ["module_may_propose"],
+            "required": [
+              "module_may_propose"
+            ],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": ["info"],
+                "required": [
+                  "info"
+                ],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -1879,7 +2247,10 @@
       "ProposalParams": {
         "description": "The params we need to provide for migration msgs",
         "type": "object",
-        "required": ["close_proposal_on_execution_failure", "pre_propose_info"],
+        "required": [
+          "close_proposal_on_execution_failure",
+          "pre_propose_info"
+        ],
         "properties": {
           "close_proposal_on_execution_failure": {
             "type": "boolean"
@@ -1892,7 +2263,9 @@
       },
       "SubDao": {
         "type": "object",
-        "required": ["addr"],
+        "required": [
+          "addr"
+        ],
         "properties": {
           "addr": {
             "description": "The contract address of the SubDAO",
@@ -1900,7 +2273,10 @@
           },
           "charter": {
             "description": "The purpose/constitution for the SubDAO",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "additionalProperties": false
@@ -1992,7 +2368,11 @@
         "ProposalModule": {
           "description": "Top level type describing a proposal module.",
           "type": "object",
-          "required": ["address", "prefix", "status"],
+          "required": [
+            "address",
+            "prefix",
+            "status"
+          ],
           "properties": {
             "address": {
               "description": "The address of the proposal module.",
@@ -2020,7 +2400,10 @@
         "ProposalModuleStatus": {
           "description": "The status of a proposal module.",
           "type": "string",
-          "enum": ["enabled", "disabled"]
+          "enum": [
+            "enabled",
+            "disabled"
+          ]
         }
       }
     },
@@ -2078,7 +2461,10 @@
         },
         "dao_uri": {
           "description": "The URI for the DAO as defined by the DAOstar standard <https://daostar.one/EIP>",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "description": {
           "description": "A description of the contract.",
@@ -2086,7 +2472,10 @@
         },
         "image_url": {
           "description": "An optional image URL for displaying alongside the contract.",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "name": {
           "description": "The name of the contract.",
@@ -2100,7 +2489,10 @@
       "title": "Cw20BalanceResponse",
       "description": "Returned by the `Cw20Balances` query.",
       "type": "object",
-      "required": ["addr", "balance"],
+      "required": [
+        "addr",
+        "balance"
+      ],
       "properties": {
         "addr": {
           "description": "The address of the token.",
@@ -2165,7 +2557,10 @@
       "type": "object",
       "properties": {
         "dao_uri": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false
@@ -2267,7 +2662,10 @@
             },
             "dao_uri": {
               "description": "The URI for the DAO as defined by the DAOstar standard <https://daostar.one/EIP>",
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "description": {
               "description": "A description of the contract.",
@@ -2275,7 +2673,10 @@
             },
             "image_url": {
               "description": "An optional image URL for displaying alongside the contract.",
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "name": {
               "description": "The name of the contract.",
@@ -2286,7 +2687,10 @@
         },
         "ContractVersion": {
           "type": "object",
-          "required": ["contract", "version"],
+          "required": [
+            "contract",
+            "version"
+          ],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -2305,7 +2709,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -2318,7 +2724,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -2329,7 +2737,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -2345,11 +2755,15 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["paused"],
+              "required": [
+                "paused"
+              ],
               "properties": {
                 "paused": {
                   "type": "object",
-                  "required": ["expiration"],
+                  "required": [
+                    "expiration"
+                  ],
                   "properties": {
                     "expiration": {
                       "$ref": "#/definitions/Expiration"
@@ -2362,7 +2776,9 @@
             },
             {
               "type": "object",
-              "required": ["unpaused"],
+              "required": [
+                "unpaused"
+              ],
               "properties": {
                 "unpaused": {
                   "type": "object",
@@ -2376,7 +2792,11 @@
         "ProposalModule": {
           "description": "Top level type describing a proposal module.",
           "type": "object",
-          "required": ["address", "prefix", "status"],
+          "required": [
+            "address",
+            "prefix",
+            "status"
+          ],
           "properties": {
             "address": {
               "description": "The address of the proposal module.",
@@ -2404,7 +2824,10 @@
         "ProposalModuleStatus": {
           "description": "The status of a proposal module.",
           "type": "string",
-          "enum": ["enabled", "disabled"]
+          "enum": [
+            "enabled",
+            "disabled"
+          ]
         },
         "Timestamp": {
           "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
@@ -2428,7 +2851,10 @@
       "properties": {
         "item": {
           "description": "`None` if no item with the provided key was found, `Some` otherwise.",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false
@@ -2437,7 +2863,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": ["info"],
+      "required": [
+        "info"
+      ],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -2447,7 +2875,10 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": ["contract", "version"],
+          "required": [
+            "contract",
+            "version"
+          ],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -2480,7 +2911,9 @@
       "definitions": {
         "SubDao": {
           "type": "object",
-          "required": ["addr"],
+          "required": [
+            "addr"
+          ],
           "properties": {
             "addr": {
               "description": "The contract address of the SubDAO",
@@ -2488,7 +2921,10 @@
             },
             "charter": {
               "description": "The purpose/constitution for the SubDAO",
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "additionalProperties": false
@@ -2502,11 +2938,15 @@
       "oneOf": [
         {
           "type": "object",
-          "required": ["paused"],
+          "required": [
+            "paused"
+          ],
           "properties": {
             "paused": {
               "type": "object",
-              "required": ["expiration"],
+              "required": [
+                "expiration"
+              ],
               "properties": {
                 "expiration": {
                   "$ref": "#/definitions/Expiration"
@@ -2519,7 +2959,9 @@
         },
         {
           "type": "object",
-          "required": ["unpaused"],
+          "required": [
+            "unpaused"
+          ],
           "properties": {
             "unpaused": {
               "type": "object",
@@ -2536,7 +2978,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -2549,7 +2993,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -2560,7 +3006,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -2624,7 +3072,11 @@
         "ProposalModule": {
           "description": "Top level type describing a proposal module.",
           "type": "object",
-          "required": ["address", "prefix", "status"],
+          "required": [
+            "address",
+            "prefix",
+            "status"
+          ],
           "properties": {
             "address": {
               "description": "The address of the proposal module.",
@@ -2652,7 +3104,10 @@
         "ProposalModuleStatus": {
           "description": "The status of a proposal module.",
           "type": "string",
-          "enum": ["enabled", "disabled"]
+          "enum": [
+            "enabled",
+            "disabled"
+          ]
         }
       }
     },
@@ -2660,7 +3115,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalPowerAtHeightResponse",
       "type": "object",
-      "required": ["height", "power"],
+      "required": [
+        "height",
+        "power"
+      ],
       "properties": {
         "height": {
           "type": "integer",
@@ -2689,7 +3147,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VotingPowerAtHeightResponse",
       "type": "object",
-      "required": ["height", "power"],
+      "required": [
+        "height",
+        "power"
+      ],
       "properties": {
         "height": {
           "type": "integer",

--- a/contracts/distribution/cw-fund-distributor/schema/cw-fund-distributor.json
+++ b/contracts/distribution/cw-fund-distributor/schema/cw-fund-distributor.json
@@ -1,14 +1,12 @@
 {
   "contract_name": "cw-fund-distributor",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "token_info"
-    ],
+    "required": ["token_info"],
     "properties": {
       "active_threshold": {
         "description": "The number or percentage of tokens that must be staked for the DAO to be active",
@@ -33,15 +31,11 @@
           {
             "description": "The absolute number of tokens that must be staked for the module to be active.",
             "type": "object",
-            "required": [
-              "absolute_count"
-            ],
+            "required": ["absolute_count"],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": [
-                  "count"
-                ],
+                "required": ["count"],
                 "properties": {
                   "count": {
                     "$ref": "#/definitions/Uint128"
@@ -55,15 +49,11 @@
           {
             "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
             "type": "object",
-            "required": [
-              "percentage"
-            ],
+            "required": ["percentage"],
             "properties": {
               "percentage": {
                 "type": "object",
-                "required": [
-                  "percent"
-                ],
+                "required": ["percent"],
                 "properties": {
                   "percent": {
                     "$ref": "#/definitions/Decimal"
@@ -82,10 +72,7 @@
       },
       "Cw20Coin": {
         "type": "object",
-        "required": [
-          "address",
-          "amount"
-        ],
+        "required": ["address", "amount"],
         "properties": {
           "address": {
             "type": "string"
@@ -105,9 +92,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -120,9 +105,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -140,9 +123,7 @@
           {
             "description": "Store the Logo as an SVG file. The content must conform to the spec at https://en.wikipedia.org/wiki/Scalable_Vector_Graphics (The contract should do some light-weight sanity-check validation)",
             "type": "object",
-            "required": [
-              "svg"
-            ],
+            "required": ["svg"],
             "properties": {
               "svg": {
                 "$ref": "#/definitions/Binary"
@@ -153,9 +134,7 @@
           {
             "description": "Store the Logo as a PNG file. This will likely only support up to 64x64 or so within the 5KB limit.",
             "type": "object",
-            "required": [
-              "png"
-            ],
+            "required": ["png"],
             "properties": {
               "png": {
                 "$ref": "#/definitions/Binary"
@@ -169,10 +148,7 @@
         "type": "object",
         "properties": {
           "description": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "logo": {
             "anyOf": [
@@ -185,16 +161,10 @@
             ]
           },
           "marketing": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "project": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           }
         },
         "additionalProperties": false
@@ -205,9 +175,7 @@
           {
             "description": "A reference to an externally hosted logo. Must be a valid HTTP or HTTPS URL.",
             "type": "object",
-            "required": [
-              "url"
-            ],
+            "required": ["url"],
             "properties": {
               "url": {
                 "type": "string"
@@ -218,9 +186,7 @@
           {
             "description": "Logo content stored on the blockchain. Enforce maximum size of 5KB on all variants",
             "type": "object",
-            "required": [
-              "embedded"
-            ],
+            "required": ["embedded"],
             "properties": {
               "embedded": {
                 "$ref": "#/definitions/EmbeddedLogo"
@@ -235,15 +201,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "existing"
-            ],
+            "required": ["existing"],
             "properties": {
               "existing": {
                 "type": "object",
-                "required": [
-                  "staking_contract_address"
-                ],
+                "required": ["staking_contract_address"],
                 "properties": {
                   "staking_contract_address": {
                     "description": "Address of an already instantiated staking contract.",
@@ -257,15 +219,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "new"
-            ],
+            "required": ["new"],
             "properties": {
               "new": {
                 "type": "object",
-                "required": [
-                  "staking_code_id"
-                ],
+                "required": ["staking_code_id"],
                 "properties": {
                   "staking_code_id": {
                     "description": "Code ID for staking contract to instantiate.",
@@ -296,16 +254,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "existing"
-            ],
+            "required": ["existing"],
             "properties": {
               "existing": {
                 "type": "object",
-                "required": [
-                  "address",
-                  "staking_contract"
-                ],
+                "required": ["address", "staking_contract"],
                 "properties": {
                   "address": {
                     "description": "Address of an already instantiated cw20 token contract.",
@@ -327,9 +280,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "new"
-            ],
+            "required": ["new"],
             "properties": {
               "new": {
                 "type": "object",
@@ -426,9 +377,7 @@
       {
         "description": "Sets the active threshold to a new value. Only the instantiator this contract (a DAO most likely) may call this method.",
         "type": "object",
-        "required": [
-          "update_active_threshold"
-        ],
+        "required": ["update_active_threshold"],
         "properties": {
           "update_active_threshold": {
             "type": "object",
@@ -457,15 +406,11 @@
           {
             "description": "The absolute number of tokens that must be staked for the module to be active.",
             "type": "object",
-            "required": [
-              "absolute_count"
-            ],
+            "required": ["absolute_count"],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": [
-                  "count"
-                ],
+                "required": ["count"],
                 "properties": {
                   "count": {
                     "$ref": "#/definitions/Uint128"
@@ -479,15 +424,11 @@
           {
             "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
             "type": "object",
-            "required": [
-              "percentage"
-            ],
+            "required": ["percentage"],
             "properties": {
               "percentage": {
                 "type": "object",
-                "required": [
-                  "percent"
-                ],
+                "required": ["percent"],
                 "properties": {
                   "percent": {
                     "$ref": "#/definitions/Decimal"
@@ -517,9 +458,7 @@
       {
         "description": "Gets the address of the cw20-stake contract this voting module is wrapping.",
         "type": "object",
-        "required": [
-          "staking_contract"
-        ],
+        "required": ["staking_contract"],
         "properties": {
           "staking_contract": {
             "type": "object",
@@ -530,9 +469,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "active_threshold"
-        ],
+        "required": ["active_threshold"],
         "properties": {
           "active_threshold": {
             "type": "object",
@@ -544,24 +481,17 @@
       {
         "description": "Returns the voting power for an address at a given height.",
         "type": "object",
-        "required": [
-          "voting_power_at_height"
-        ],
+        "required": ["voting_power_at_height"],
         "properties": {
           "voting_power_at_height": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
               },
               "height": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -574,18 +504,13 @@
       {
         "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
-        "required": [
-          "total_power_at_height"
-        ],
+        "required": ["total_power_at_height"],
         "properties": {
           "total_power_at_height": {
             "type": "object",
             "properties": {
               "height": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -598,9 +523,7 @@
       {
         "description": "Returns the address of the DAO this module belongs to.",
         "type": "object",
-        "required": [
-          "dao"
-        ],
+        "required": ["dao"],
         "properties": {
           "dao": {
             "type": "object",
@@ -612,9 +535,7 @@
       {
         "description": "Returns contract version info.",
         "type": "object",
-        "required": [
-          "info"
-        ],
+        "required": ["info"],
         "properties": {
           "info": {
             "type": "object",
@@ -625,9 +546,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "token_contract"
-        ],
+        "required": ["token_contract"],
         "properties": {
           "token_contract": {
             "type": "object",
@@ -638,9 +557,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "is_active"
-        ],
+        "required": ["is_active"],
         "properties": {
           "is_active": {
             "type": "object",
@@ -683,15 +600,11 @@
             {
               "description": "The absolute number of tokens that must be staked for the module to be active.",
               "type": "object",
-              "required": [
-                "absolute_count"
-              ],
+              "required": ["absolute_count"],
               "properties": {
                 "absolute_count": {
                   "type": "object",
-                  "required": [
-                    "count"
-                  ],
+                  "required": ["count"],
                   "properties": {
                     "count": {
                       "$ref": "#/definitions/Uint128"
@@ -705,15 +618,11 @@
             {
               "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
               "type": "object",
-              "required": [
-                "percentage"
-              ],
+              "required": ["percentage"],
               "properties": {
                 "percentage": {
                   "type": "object",
-                  "required": [
-                    "percent"
-                  ],
+                  "required": ["percent"],
                   "properties": {
                     "percent": {
                       "$ref": "#/definitions/Decimal"
@@ -746,9 +655,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": [
-        "info"
-      ],
+      "required": ["info"],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -758,10 +665,7 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": [
-            "contract",
-            "version"
-          ],
+          "required": ["contract", "version"],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -797,10 +701,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalPowerAtHeightResponse",
       "type": "object",
-      "required": [
-        "height",
-        "power"
-      ],
+      "required": ["height", "power"],
       "properties": {
         "height": {
           "type": "integer",
@@ -823,10 +724,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VotingPowerAtHeightResponse",
       "type": "object",
-      "required": [
-        "height",
-        "power"
-      ],
+      "required": ["height", "power"],
       "properties": {
         "height": {
           "type": "integer",

--- a/contracts/distribution/cw-fund-distributor/schema/cw-fund-distributor.json
+++ b/contracts/distribution/cw-fund-distributor/schema/cw-fund-distributor.json
@@ -6,7 +6,9 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["token_info"],
+    "required": [
+      "token_info"
+    ],
     "properties": {
       "active_threshold": {
         "description": "The number or percentage of tokens that must be staked for the DAO to be active",
@@ -31,11 +33,15 @@
           {
             "description": "The absolute number of tokens that must be staked for the module to be active.",
             "type": "object",
-            "required": ["absolute_count"],
+            "required": [
+              "absolute_count"
+            ],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": ["count"],
+                "required": [
+                  "count"
+                ],
                 "properties": {
                   "count": {
                     "$ref": "#/definitions/Uint128"
@@ -49,11 +55,15 @@
           {
             "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
             "type": "object",
-            "required": ["percentage"],
+            "required": [
+              "percentage"
+            ],
             "properties": {
               "percentage": {
                 "type": "object",
-                "required": ["percent"],
+                "required": [
+                  "percent"
+                ],
                 "properties": {
                   "percent": {
                     "$ref": "#/definitions/Decimal"
@@ -72,7 +82,10 @@
       },
       "Cw20Coin": {
         "type": "object",
-        "required": ["address", "amount"],
+        "required": [
+          "address",
+          "amount"
+        ],
         "properties": {
           "address": {
             "type": "string"
@@ -92,7 +105,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -105,7 +120,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -123,7 +140,9 @@
           {
             "description": "Store the Logo as an SVG file. The content must conform to the spec at https://en.wikipedia.org/wiki/Scalable_Vector_Graphics (The contract should do some light-weight sanity-check validation)",
             "type": "object",
-            "required": ["svg"],
+            "required": [
+              "svg"
+            ],
             "properties": {
               "svg": {
                 "$ref": "#/definitions/Binary"
@@ -134,7 +153,9 @@
           {
             "description": "Store the Logo as a PNG file. This will likely only support up to 64x64 or so within the 5KB limit.",
             "type": "object",
-            "required": ["png"],
+            "required": [
+              "png"
+            ],
             "properties": {
               "png": {
                 "$ref": "#/definitions/Binary"
@@ -148,7 +169,10 @@
         "type": "object",
         "properties": {
           "description": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "logo": {
             "anyOf": [
@@ -161,10 +185,16 @@
             ]
           },
           "marketing": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "project": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "additionalProperties": false
@@ -175,7 +205,9 @@
           {
             "description": "A reference to an externally hosted logo. Must be a valid HTTP or HTTPS URL.",
             "type": "object",
-            "required": ["url"],
+            "required": [
+              "url"
+            ],
             "properties": {
               "url": {
                 "type": "string"
@@ -186,7 +218,9 @@
           {
             "description": "Logo content stored on the blockchain. Enforce maximum size of 5KB on all variants",
             "type": "object",
-            "required": ["embedded"],
+            "required": [
+              "embedded"
+            ],
             "properties": {
               "embedded": {
                 "$ref": "#/definitions/EmbeddedLogo"
@@ -201,11 +235,15 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["existing"],
+            "required": [
+              "existing"
+            ],
             "properties": {
               "existing": {
                 "type": "object",
-                "required": ["staking_contract_address"],
+                "required": [
+                  "staking_contract_address"
+                ],
                 "properties": {
                   "staking_contract_address": {
                     "description": "Address of an already instantiated staking contract.",
@@ -219,11 +257,15 @@
           },
           {
             "type": "object",
-            "required": ["new"],
+            "required": [
+              "new"
+            ],
             "properties": {
               "new": {
                 "type": "object",
-                "required": ["staking_code_id"],
+                "required": [
+                  "staking_code_id"
+                ],
                 "properties": {
                   "staking_code_id": {
                     "description": "Code ID for staking contract to instantiate.",
@@ -254,11 +296,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["existing"],
+            "required": [
+              "existing"
+            ],
             "properties": {
               "existing": {
                 "type": "object",
-                "required": ["address", "staking_contract"],
+                "required": [
+                  "address",
+                  "staking_contract"
+                ],
                 "properties": {
                   "address": {
                     "description": "Address of an already instantiated cw20 token contract.",
@@ -280,7 +327,9 @@
           },
           {
             "type": "object",
-            "required": ["new"],
+            "required": [
+              "new"
+            ],
             "properties": {
               "new": {
                 "type": "object",
@@ -377,7 +426,9 @@
       {
         "description": "Sets the active threshold to a new value. Only the instantiator this contract (a DAO most likely) may call this method.",
         "type": "object",
-        "required": ["update_active_threshold"],
+        "required": [
+          "update_active_threshold"
+        ],
         "properties": {
           "update_active_threshold": {
             "type": "object",
@@ -406,11 +457,15 @@
           {
             "description": "The absolute number of tokens that must be staked for the module to be active.",
             "type": "object",
-            "required": ["absolute_count"],
+            "required": [
+              "absolute_count"
+            ],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": ["count"],
+                "required": [
+                  "count"
+                ],
                 "properties": {
                   "count": {
                     "$ref": "#/definitions/Uint128"
@@ -424,11 +479,15 @@
           {
             "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
             "type": "object",
-            "required": ["percentage"],
+            "required": [
+              "percentage"
+            ],
             "properties": {
               "percentage": {
                 "type": "object",
-                "required": ["percent"],
+                "required": [
+                  "percent"
+                ],
                 "properties": {
                   "percent": {
                     "$ref": "#/definitions/Decimal"
@@ -458,7 +517,9 @@
       {
         "description": "Gets the address of the cw20-stake contract this voting module is wrapping.",
         "type": "object",
-        "required": ["staking_contract"],
+        "required": [
+          "staking_contract"
+        ],
         "properties": {
           "staking_contract": {
             "type": "object",
@@ -469,7 +530,9 @@
       },
       {
         "type": "object",
-        "required": ["active_threshold"],
+        "required": [
+          "active_threshold"
+        ],
         "properties": {
           "active_threshold": {
             "type": "object",
@@ -481,17 +544,24 @@
       {
         "description": "Returns the voting power for an address at a given height.",
         "type": "object",
-        "required": ["voting_power_at_height"],
+        "required": [
+          "voting_power_at_height"
+        ],
         "properties": {
           "voting_power_at_height": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
               },
               "height": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -504,13 +574,18 @@
       {
         "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
-        "required": ["total_power_at_height"],
+        "required": [
+          "total_power_at_height"
+        ],
         "properties": {
           "total_power_at_height": {
             "type": "object",
             "properties": {
               "height": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -523,7 +598,9 @@
       {
         "description": "Returns the address of the DAO this module belongs to.",
         "type": "object",
-        "required": ["dao"],
+        "required": [
+          "dao"
+        ],
         "properties": {
           "dao": {
             "type": "object",
@@ -535,7 +612,9 @@
       {
         "description": "Returns contract version info.",
         "type": "object",
-        "required": ["info"],
+        "required": [
+          "info"
+        ],
         "properties": {
           "info": {
             "type": "object",
@@ -546,7 +625,9 @@
       },
       {
         "type": "object",
-        "required": ["token_contract"],
+        "required": [
+          "token_contract"
+        ],
         "properties": {
           "token_contract": {
             "type": "object",
@@ -557,7 +638,9 @@
       },
       {
         "type": "object",
-        "required": ["is_active"],
+        "required": [
+          "is_active"
+        ],
         "properties": {
           "is_active": {
             "type": "object",
@@ -600,11 +683,15 @@
             {
               "description": "The absolute number of tokens that must be staked for the module to be active.",
               "type": "object",
-              "required": ["absolute_count"],
+              "required": [
+                "absolute_count"
+              ],
               "properties": {
                 "absolute_count": {
                   "type": "object",
-                  "required": ["count"],
+                  "required": [
+                    "count"
+                  ],
                   "properties": {
                     "count": {
                       "$ref": "#/definitions/Uint128"
@@ -618,11 +705,15 @@
             {
               "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
               "type": "object",
-              "required": ["percentage"],
+              "required": [
+                "percentage"
+              ],
               "properties": {
                 "percentage": {
                   "type": "object",
-                  "required": ["percent"],
+                  "required": [
+                    "percent"
+                  ],
                   "properties": {
                     "percent": {
                       "$ref": "#/definitions/Decimal"
@@ -655,7 +746,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": ["info"],
+      "required": [
+        "info"
+      ],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -665,7 +758,10 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": ["contract", "version"],
+          "required": [
+            "contract",
+            "version"
+          ],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -701,7 +797,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalPowerAtHeightResponse",
       "type": "object",
-      "required": ["height", "power"],
+      "required": [
+        "height",
+        "power"
+      ],
       "properties": {
         "height": {
           "type": "integer",
@@ -724,7 +823,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VotingPowerAtHeightResponse",
       "type": "object",
-      "required": ["height", "power"],
+      "required": [
+        "height",
+        "power"
+      ],
       "properties": {
         "height": {
           "type": "integer",

--- a/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
+++ b/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
@@ -9,7 +9,10 @@
     "properties": {
       "owner": {
         "description": "The owner of the contract. Is able to fund the contract and update the reward duration.",
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       }
     },
     "additionalProperties": false
@@ -21,7 +24,9 @@
       {
         "description": "Called when a member is added or removed to a cw4-groups or cw721-roles contract.",
         "type": "object",
-        "required": ["member_changed_hook"],
+        "required": [
+          "member_changed_hook"
+        ],
         "properties": {
           "member_changed_hook": {
             "$ref": "#/definitions/MemberChangedHookMsg"
@@ -32,7 +37,9 @@
       {
         "description": "Called when NFTs are staked or unstaked.",
         "type": "object",
-        "required": ["nft_stake_change_hook"],
+        "required": [
+          "nft_stake_change_hook"
+        ],
         "properties": {
           "nft_stake_change_hook": {
             "$ref": "#/definitions/NftStakeChangedHookMsg"
@@ -43,7 +50,9 @@
       {
         "description": "Called when tokens are staked or unstaked.",
         "type": "object",
-        "required": ["stake_change_hook"],
+        "required": [
+          "stake_change_hook"
+        ],
         "properties": {
           "stake_change_hook": {
             "$ref": "#/definitions/StakeChangedHookMsg"
@@ -54,11 +63,15 @@
       {
         "description": "Claims rewards for the sender.",
         "type": "object",
-        "required": ["claim"],
+        "required": [
+          "claim"
+        ],
         "properties": {
           "claim": {
             "type": "object",
-            "required": ["denom"],
+            "required": [
+              "denom"
+            ],
             "properties": {
               "denom": {
                 "type": "string"
@@ -72,7 +85,9 @@
       {
         "description": "Used to fund this contract with cw20 tokens.",
         "type": "object",
-        "required": ["receive"],
+        "required": [
+          "receive"
+        ],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -83,7 +98,9 @@
       {
         "description": "Used to fund this contract with native tokens.",
         "type": "object",
-        "required": ["fund"],
+        "required": [
+          "fund"
+        ],
         "properties": {
           "fund": {
             "type": "object",
@@ -95,11 +112,15 @@
       {
         "description": "shuts down the rewards distributor. withdraws all future staking rewards back to the treasury. members can claim whatever they earned until this point.",
         "type": "object",
-        "required": ["shutdown"],
+        "required": [
+          "shutdown"
+        ],
         "properties": {
           "shutdown": {
             "type": "object",
-            "required": ["denom"],
+            "required": [
+              "denom"
+            ],
             "properties": {
               "denom": {
                 "type": "string"
@@ -113,7 +134,9 @@
       {
         "description": "registers a new reward denom",
         "type": "object",
-        "required": ["register_reward_denom"],
+        "required": [
+          "register_reward_denom"
+        ],
         "properties": {
           "register_reward_denom": {
             "type": "object",
@@ -137,7 +160,10 @@
                 "type": "string"
               },
               "withdraw_destination": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -148,7 +174,9 @@
       {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": ["update_ownership"],
+        "required": [
+          "update_ownership"
+        ],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -164,11 +192,15 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": ["transfer_ownership"],
+            "required": [
+              "transfer_ownership"
+            ],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": ["new_owner"],
+                "required": [
+                  "new_owner"
+                ],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -192,12 +224,16 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": ["accept_ownership"]
+            "enum": [
+              "accept_ownership"
+            ]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": ["renounce_ownership"]
+            "enum": [
+              "renounce_ownership"
+            ]
           }
         ]
       },
@@ -212,7 +248,11 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": ["amount", "msg", "sender"],
+        "required": [
+          "amount",
+          "msg",
+          "sender"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -231,7 +271,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -244,7 +286,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -262,7 +306,9 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": ["at_height"],
+            "required": [
+              "at_height"
+            ],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -275,7 +321,9 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": ["at_time"],
+            "required": [
+              "at_time"
+            ],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -286,7 +334,9 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": ["never"],
+            "required": [
+              "never"
+            ],
             "properties": {
               "never": {
                 "type": "object",
@@ -300,7 +350,9 @@
       "MemberChangedHookMsg": {
         "description": "MemberChangedHookMsg should be de/serialized under `MemberChangedHook()` variant in a ExecuteMsg. This contains a list of all diffs on the given transaction.",
         "type": "object",
-        "required": ["diffs"],
+        "required": [
+          "diffs"
+        ],
         "properties": {
           "diffs": {
             "type": "array",
@@ -314,18 +366,26 @@
       "MemberDiff": {
         "description": "MemberDiff shows the old and new states for a given cw4 member They cannot both be None. old = None, new = Some -> Insert old = Some, new = Some -> Update old = Some, new = None -> Delete",
         "type": "object",
-        "required": ["key"],
+        "required": [
+          "key"
+        ],
         "properties": {
           "key": {
             "type": "string"
           },
           "new": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "uint64",
             "minimum": 0.0
           },
           "old": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "uint64",
             "minimum": 0.0
           }
@@ -337,11 +397,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["stake"],
+            "required": [
+              "stake"
+            ],
             "properties": {
               "stake": {
                 "type": "object",
-                "required": ["addr", "token_id"],
+                "required": [
+                  "addr",
+                  "token_id"
+                ],
                 "properties": {
                   "addr": {
                     "$ref": "#/definitions/Addr"
@@ -357,11 +422,16 @@
           },
           {
             "type": "object",
-            "required": ["unstake"],
+            "required": [
+              "unstake"
+            ],
             "properties": {
               "unstake": {
                 "type": "object",
-                "required": ["addr", "token_ids"],
+                "required": [
+                  "addr",
+                  "token_ids"
+                ],
                 "properties": {
                   "addr": {
                     "$ref": "#/definitions/Addr"
@@ -383,7 +453,10 @@
       "RewardEmissionRate": {
         "description": "defines how many tokens (amount) should be distributed per amount of time (duration). e.g. 5udenom per hour.",
         "type": "object",
-        "required": ["amount", "duration"],
+        "required": [
+          "amount",
+          "duration"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -399,11 +472,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["stake"],
+            "required": [
+              "stake"
+            ],
             "properties": {
               "stake": {
                 "type": "object",
-                "required": ["addr", "amount"],
+                "required": [
+                  "addr",
+                  "amount"
+                ],
                 "properties": {
                   "addr": {
                     "$ref": "#/definitions/Addr"
@@ -419,11 +497,16 @@
           },
           {
             "type": "object",
-            "required": ["unstake"],
+            "required": [
+              "unstake"
+            ],
             "properties": {
               "unstake": {
                 "type": "object",
-                "required": ["addr", "amount"],
+                "required": [
+                  "addr",
+                  "amount"
+                ],
                 "properties": {
                   "addr": {
                     "$ref": "#/definitions/Addr"
@@ -459,7 +542,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["native"],
+            "required": [
+              "native"
+            ],
             "properties": {
               "native": {
                 "type": "string"
@@ -469,7 +554,9 @@
           },
           {
             "type": "object",
-            "required": ["cw20"],
+            "required": [
+              "cw20"
+            ],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -488,7 +575,9 @@
       {
         "description": "Returns contract version info",
         "type": "object",
-        "required": ["info"],
+        "required": [
+          "info"
+        ],
         "properties": {
           "info": {
             "type": "object",
@@ -500,7 +589,9 @@
       {
         "description": "Returns the state of the registered reward distributions.",
         "type": "object",
-        "required": ["rewards_state"],
+        "required": [
+          "rewards_state"
+        ],
         "properties": {
           "rewards_state": {
             "type": "object",
@@ -512,11 +603,15 @@
       {
         "description": "Returns the pending rewards for the given address.",
         "type": "object",
-        "required": ["get_pending_rewards"],
+        "required": [
+          "get_pending_rewards"
+        ],
         "properties": {
           "get_pending_rewards": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -530,7 +625,9 @@
       {
         "description": "Returns information about the ownership of this contract.",
         "type": "object",
-        "required": ["ownership"],
+        "required": [
+          "ownership"
+        ],
         "properties": {
           "ownership": {
             "type": "object",
@@ -541,11 +638,15 @@
       },
       {
         "type": "object",
-        "required": ["denom_reward_state"],
+        "required": [
+          "denom_reward_state"
+        ],
         "properties": {
           "denom_reward_state": {
             "type": "object",
-            "required": ["denom"],
+            "required": [
+              "denom"
+            ],
             "properties": {
               "denom": {
                 "type": "string"
@@ -675,7 +776,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["native"],
+              "required": [
+                "native"
+              ],
               "properties": {
                 "native": {
                   "type": "string"
@@ -685,7 +788,9 @@
             },
             {
               "type": "object",
-              "required": ["cw20"],
+              "required": [
+                "cw20"
+              ],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -700,7 +805,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["height"],
+              "required": [
+                "height"
+              ],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -713,7 +820,9 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": ["time"],
+              "required": [
+                "time"
+              ],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -731,7 +840,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -744,7 +855,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -755,7 +868,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -769,7 +884,10 @@
         "RewardEmissionRate": {
           "description": "defines how many tokens (amount) should be distributed per amount of time (duration). e.g. 5udenom per hour.",
           "type": "object",
-          "required": ["amount", "duration"],
+          "required": [
+            "amount",
+            "duration"
+          ],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -806,7 +924,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "PendingRewardsResponse",
       "type": "object",
-      "required": ["address", "pending_rewards"],
+      "required": [
+        "address",
+        "pending_rewards"
+      ],
       "properties": {
         "address": {
           "type": "string"
@@ -830,7 +951,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": ["info"],
+      "required": [
+        "info"
+      ],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -840,7 +963,10 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": ["contract", "version"],
+          "required": [
+            "contract",
+            "version"
+          ],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -907,7 +1033,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -920,7 +1048,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -931,7 +1061,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -960,7 +1092,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "RewardsStateResponse",
       "type": "object",
-      "required": ["rewards"],
+      "required": [
+        "rewards"
+      ],
       "properties": {
         "rewards": {
           "type": "array",
@@ -979,7 +1113,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["native"],
+              "required": [
+                "native"
+              ],
               "properties": {
                 "native": {
                   "type": "string"
@@ -989,7 +1125,9 @@
             },
             {
               "type": "object",
-              "required": ["cw20"],
+              "required": [
+                "cw20"
+              ],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -1103,7 +1241,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["height"],
+              "required": [
+                "height"
+              ],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -1116,7 +1256,9 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": ["time"],
+              "required": [
+                "time"
+              ],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -1134,7 +1276,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1147,7 +1291,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1158,7 +1304,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -1172,7 +1320,10 @@
         "RewardEmissionRate": {
           "description": "defines how many tokens (amount) should be distributed per amount of time (duration). e.g. 5udenom per hour.",
           "type": "object",
-          "required": ["amount", "duration"],
+          "required": [
+            "amount",
+            "duration"
+          ],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"

--- a/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
+++ b/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-rewards-distributor",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -9,10 +9,7 @@
     "properties": {
       "owner": {
         "description": "The owner of the contract. Is able to fund the contract and update the reward duration.",
-        "type": [
-          "string",
-          "null"
-        ]
+        "type": ["string", "null"]
       }
     },
     "additionalProperties": false
@@ -24,9 +21,7 @@
       {
         "description": "Called when a member is added or removed to a cw4-groups or cw721-roles contract.",
         "type": "object",
-        "required": [
-          "member_changed_hook"
-        ],
+        "required": ["member_changed_hook"],
         "properties": {
           "member_changed_hook": {
             "$ref": "#/definitions/MemberChangedHookMsg"
@@ -37,9 +32,7 @@
       {
         "description": "Called when NFTs are staked or unstaked.",
         "type": "object",
-        "required": [
-          "nft_stake_change_hook"
-        ],
+        "required": ["nft_stake_change_hook"],
         "properties": {
           "nft_stake_change_hook": {
             "$ref": "#/definitions/NftStakeChangedHookMsg"
@@ -50,9 +43,7 @@
       {
         "description": "Called when tokens are staked or unstaked.",
         "type": "object",
-        "required": [
-          "stake_change_hook"
-        ],
+        "required": ["stake_change_hook"],
         "properties": {
           "stake_change_hook": {
             "$ref": "#/definitions/StakeChangedHookMsg"
@@ -63,15 +54,11 @@
       {
         "description": "Claims rewards for the sender.",
         "type": "object",
-        "required": [
-          "claim"
-        ],
+        "required": ["claim"],
         "properties": {
           "claim": {
             "type": "object",
-            "required": [
-              "denom"
-            ],
+            "required": ["denom"],
             "properties": {
               "denom": {
                 "type": "string"
@@ -85,9 +72,7 @@
       {
         "description": "Used to fund this contract with cw20 tokens.",
         "type": "object",
-        "required": [
-          "receive"
-        ],
+        "required": ["receive"],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -98,9 +83,7 @@
       {
         "description": "Used to fund this contract with native tokens.",
         "type": "object",
-        "required": [
-          "fund"
-        ],
+        "required": ["fund"],
         "properties": {
           "fund": {
             "type": "object",
@@ -112,15 +95,11 @@
       {
         "description": "shuts down the rewards distributor. withdraws all future staking rewards back to the treasury. members can claim whatever they earned until this point.",
         "type": "object",
-        "required": [
-          "shutdown"
-        ],
+        "required": ["shutdown"],
         "properties": {
           "shutdown": {
             "type": "object",
-            "required": [
-              "denom"
-            ],
+            "required": ["denom"],
             "properties": {
               "denom": {
                 "type": "string"
@@ -134,9 +113,7 @@
       {
         "description": "registers a new reward denom",
         "type": "object",
-        "required": [
-          "register_reward_denom"
-        ],
+        "required": ["register_reward_denom"],
         "properties": {
           "register_reward_denom": {
             "type": "object",
@@ -160,10 +137,7 @@
                 "type": "string"
               },
               "withdraw_destination": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -174,9 +148,7 @@
       {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": [
-          "update_ownership"
-        ],
+        "required": ["update_ownership"],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -192,15 +164,11 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": [
-              "transfer_ownership"
-            ],
+            "required": ["transfer_ownership"],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": [
-                  "new_owner"
-                ],
+                "required": ["new_owner"],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -224,16 +192,12 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": [
-              "accept_ownership"
-            ]
+            "enum": ["accept_ownership"]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": [
-              "renounce_ownership"
-            ]
+            "enum": ["renounce_ownership"]
           }
         ]
       },
@@ -248,11 +212,7 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": [
-          "amount",
-          "msg",
-          "sender"
-        ],
+        "required": ["amount", "msg", "sender"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -271,9 +231,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -286,9 +244,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -306,9 +262,7 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": [
-              "at_height"
-            ],
+            "required": ["at_height"],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -321,9 +275,7 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": [
-              "at_time"
-            ],
+            "required": ["at_time"],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -334,9 +286,7 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": [
-              "never"
-            ],
+            "required": ["never"],
             "properties": {
               "never": {
                 "type": "object",
@@ -350,9 +300,7 @@
       "MemberChangedHookMsg": {
         "description": "MemberChangedHookMsg should be de/serialized under `MemberChangedHook()` variant in a ExecuteMsg. This contains a list of all diffs on the given transaction.",
         "type": "object",
-        "required": [
-          "diffs"
-        ],
+        "required": ["diffs"],
         "properties": {
           "diffs": {
             "type": "array",
@@ -366,26 +314,18 @@
       "MemberDiff": {
         "description": "MemberDiff shows the old and new states for a given cw4 member They cannot both be None. old = None, new = Some -> Insert old = Some, new = Some -> Update old = Some, new = None -> Delete",
         "type": "object",
-        "required": [
-          "key"
-        ],
+        "required": ["key"],
         "properties": {
           "key": {
             "type": "string"
           },
           "new": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "format": "uint64",
             "minimum": 0.0
           },
           "old": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "format": "uint64",
             "minimum": 0.0
           }
@@ -397,16 +337,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "stake"
-            ],
+            "required": ["stake"],
             "properties": {
               "stake": {
                 "type": "object",
-                "required": [
-                  "addr",
-                  "token_id"
-                ],
+                "required": ["addr", "token_id"],
                 "properties": {
                   "addr": {
                     "$ref": "#/definitions/Addr"
@@ -422,16 +357,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "unstake"
-            ],
+            "required": ["unstake"],
             "properties": {
               "unstake": {
                 "type": "object",
-                "required": [
-                  "addr",
-                  "token_ids"
-                ],
+                "required": ["addr", "token_ids"],
                 "properties": {
                   "addr": {
                     "$ref": "#/definitions/Addr"
@@ -453,10 +383,7 @@
       "RewardEmissionRate": {
         "description": "defines how many tokens (amount) should be distributed per amount of time (duration). e.g. 5udenom per hour.",
         "type": "object",
-        "required": [
-          "amount",
-          "duration"
-        ],
+        "required": ["amount", "duration"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -472,16 +399,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "stake"
-            ],
+            "required": ["stake"],
             "properties": {
               "stake": {
                 "type": "object",
-                "required": [
-                  "addr",
-                  "amount"
-                ],
+                "required": ["addr", "amount"],
                 "properties": {
                   "addr": {
                     "$ref": "#/definitions/Addr"
@@ -497,16 +419,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "unstake"
-            ],
+            "required": ["unstake"],
             "properties": {
               "unstake": {
                 "type": "object",
-                "required": [
-                  "addr",
-                  "amount"
-                ],
+                "required": ["addr", "amount"],
                 "properties": {
                   "addr": {
                     "$ref": "#/definitions/Addr"
@@ -542,9 +459,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "native"
-            ],
+            "required": ["native"],
             "properties": {
               "native": {
                 "type": "string"
@@ -554,9 +469,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "cw20"
-            ],
+            "required": ["cw20"],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -575,9 +488,7 @@
       {
         "description": "Returns contract version info",
         "type": "object",
-        "required": [
-          "info"
-        ],
+        "required": ["info"],
         "properties": {
           "info": {
             "type": "object",
@@ -589,9 +500,7 @@
       {
         "description": "Returns the state of the registered reward distributions.",
         "type": "object",
-        "required": [
-          "rewards_state"
-        ],
+        "required": ["rewards_state"],
         "properties": {
           "rewards_state": {
             "type": "object",
@@ -603,15 +512,11 @@
       {
         "description": "Returns the pending rewards for the given address.",
         "type": "object",
-        "required": [
-          "get_pending_rewards"
-        ],
+        "required": ["get_pending_rewards"],
         "properties": {
           "get_pending_rewards": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -625,9 +530,7 @@
       {
         "description": "Returns information about the ownership of this contract.",
         "type": "object",
-        "required": [
-          "ownership"
-        ],
+        "required": ["ownership"],
         "properties": {
           "ownership": {
             "type": "object",
@@ -638,15 +541,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "denom_reward_state"
-        ],
+        "required": ["denom_reward_state"],
         "properties": {
           "denom_reward_state": {
             "type": "object",
-            "required": [
-              "denom"
-            ],
+            "required": ["denom"],
             "properties": {
               "denom": {
                 "type": "string"
@@ -776,9 +675,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "native"
-              ],
+              "required": ["native"],
               "properties": {
                 "native": {
                   "type": "string"
@@ -788,9 +685,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "cw20"
-              ],
+              "required": ["cw20"],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -805,9 +700,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "height"
-              ],
+              "required": ["height"],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -820,9 +713,7 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": [
-                "time"
-              ],
+              "required": ["time"],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -840,9 +731,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -855,9 +744,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -868,9 +755,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -884,10 +769,7 @@
         "RewardEmissionRate": {
           "description": "defines how many tokens (amount) should be distributed per amount of time (duration). e.g. 5udenom per hour.",
           "type": "object",
-          "required": [
-            "amount",
-            "duration"
-          ],
+          "required": ["amount", "duration"],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -924,10 +806,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "PendingRewardsResponse",
       "type": "object",
-      "required": [
-        "address",
-        "pending_rewards"
-      ],
+      "required": ["address", "pending_rewards"],
       "properties": {
         "address": {
           "type": "string"
@@ -951,9 +830,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": [
-        "info"
-      ],
+      "required": ["info"],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -963,10 +840,7 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": [
-            "contract",
-            "version"
-          ],
+          "required": ["contract", "version"],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -1033,9 +907,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1048,9 +920,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1061,9 +931,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -1092,9 +960,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "RewardsStateResponse",
       "type": "object",
-      "required": [
-        "rewards"
-      ],
+      "required": ["rewards"],
       "properties": {
         "rewards": {
           "type": "array",
@@ -1113,9 +979,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "native"
-              ],
+              "required": ["native"],
               "properties": {
                 "native": {
                   "type": "string"
@@ -1125,9 +989,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "cw20"
-              ],
+              "required": ["cw20"],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -1241,9 +1103,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "height"
-              ],
+              "required": ["height"],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -1256,9 +1116,7 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": [
-                "time"
-              ],
+              "required": ["time"],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -1276,9 +1134,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1291,9 +1147,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1304,9 +1158,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -1320,10 +1172,7 @@
         "RewardEmissionRate": {
           "description": "defines how many tokens (amount) should be distributed per amount of time (duration). e.g. 5udenom per hour.",
           "type": "object",
-          "required": [
-            "amount",
-            "duration"
-          ],
+          "required": ["amount", "duration"],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"

--- a/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
+++ b/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-admin-factory",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -9,10 +9,7 @@
     "properties": {
       "admin": {
         "description": "The account allowed to execute this contract. If no admin, anyone can execute it.",
-        "type": [
-          "string",
-          "null"
-        ]
+        "type": ["string", "null"]
       }
     },
     "additionalProperties": false
@@ -24,17 +21,11 @@
       {
         "description": "Instantiates the target contract with the provided instantiate message and code id and updates the contract's admin to be itself.",
         "type": "object",
-        "required": [
-          "instantiate_contract_with_self_admin"
-        ],
+        "required": ["instantiate_contract_with_self_admin"],
         "properties": {
           "instantiate_contract_with_self_admin": {
             "type": "object",
-            "required": [
-              "code_id",
-              "instantiate_msg",
-              "label"
-            ],
+            "required": ["code_id", "instantiate_msg", "label"],
             "properties": {
               "code_id": {
                 "type": "integer",
@@ -67,9 +58,7 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "admin"
-        ],
+        "required": ["admin"],
         "properties": {
           "admin": {
             "type": "object",

--- a/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
+++ b/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
@@ -9,7 +9,10 @@
     "properties": {
       "admin": {
         "description": "The account allowed to execute this contract. If no admin, anyone can execute it.",
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       }
     },
     "additionalProperties": false
@@ -21,11 +24,17 @@
       {
         "description": "Instantiates the target contract with the provided instantiate message and code id and updates the contract's admin to be itself.",
         "type": "object",
-        "required": ["instantiate_contract_with_self_admin"],
+        "required": [
+          "instantiate_contract_with_self_admin"
+        ],
         "properties": {
           "instantiate_contract_with_self_admin": {
             "type": "object",
-            "required": ["code_id", "instantiate_msg", "label"],
+            "required": [
+              "code_id",
+              "instantiate_msg",
+              "label"
+            ],
             "properties": {
               "code_id": {
                 "type": "integer",
@@ -58,7 +67,9 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["admin"],
+        "required": [
+          "admin"
+        ],
         "properties": {
           "admin": {
             "type": "object",

--- a/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
+++ b/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
@@ -6,10 +6,15 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["vesting_code_id"],
+    "required": [
+      "vesting_code_id"
+    ],
     "properties": {
       "owner": {
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "vesting_code_id": {
         "type": "integer",
@@ -26,7 +31,9 @@
       {
         "description": "Instantiates a new vesting contract that is funded by a cw20 token.",
         "type": "object",
-        "required": ["receive"],
+        "required": [
+          "receive"
+        ],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -37,11 +44,16 @@
       {
         "description": "Instantiates a new vesting contract that is funded by a native token.",
         "type": "object",
-        "required": ["instantiate_native_payroll_contract"],
+        "required": [
+          "instantiate_native_payroll_contract"
+        ],
         "properties": {
           "instantiate_native_payroll_contract": {
             "type": "object",
-            "required": ["instantiate_msg", "label"],
+            "required": [
+              "instantiate_msg",
+              "label"
+            ],
             "properties": {
               "instantiate_msg": {
                 "$ref": "#/definitions/InstantiateMsg"
@@ -58,11 +70,15 @@
       {
         "description": "Callable only by the current owner. Updates the code ID used while instantiating vesting contracts.",
         "type": "object",
-        "required": ["update_code_id"],
+        "required": [
+          "update_code_id"
+        ],
         "properties": {
           "update_code_id": {
             "type": "object",
-            "required": ["vesting_code_id"],
+            "required": [
+              "vesting_code_id"
+            ],
             "properties": {
               "vesting_code_id": {
                 "type": "integer",
@@ -78,7 +94,9 @@
       {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": ["update_ownership"],
+        "required": [
+          "update_ownership"
+        ],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -94,11 +112,15 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": ["transfer_ownership"],
+            "required": [
+              "transfer_ownership"
+            ],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": ["new_owner"],
+                "required": [
+                  "new_owner"
+                ],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -122,12 +144,16 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": ["accept_ownership"]
+            "enum": [
+              "accept_ownership"
+            ]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": ["renounce_ownership"]
+            "enum": [
+              "renounce_ownership"
+            ]
           }
         ]
       },
@@ -138,7 +164,11 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": ["amount", "msg", "sender"],
+        "required": [
+          "amount",
+          "msg",
+          "sender"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -158,7 +188,9 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": ["at_height"],
+            "required": [
+              "at_height"
+            ],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -171,7 +203,9 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": ["at_time"],
+            "required": [
+              "at_time"
+            ],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -182,7 +216,9 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": ["never"],
+            "required": [
+              "never"
+            ],
             "properties": {
               "never": {
                 "type": "object",
@@ -215,11 +251,17 @@
           },
           "description": {
             "description": "A description for the payment to provide more context.",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "owner": {
             "description": "The optional owner address of the contract. If an owner is specified, the owner may cancel the vesting contract at any time and withdraw unvested funds.",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "recipient": {
             "description": "The receiver address of the vesting tokens.",
@@ -276,12 +318,16 @@
           {
             "description": "Vests linearally from `0` to `total`.",
             "type": "string",
-            "enum": ["saturating_linear"]
+            "enum": [
+              "saturating_linear"
+            ]
           },
           {
             "description": "Vests by linearally interpolating between the provided (seconds, amount) points. The first amount must be zero and the last amount the total vesting amount. `seconds` are seconds since the vest start time.\n\nThere is a problem in the underlying Curve library that doesn't allow zero start values, so the first value of `seconds` must be > 1. To start at a particular time (if you need that level of percision), subtract one from the true start time, and make the first `seconds` value `1`.\n\n<https://github.com/cosmorama/wynddao/pull/4>",
             "type": "object",
-            "required": ["piecewise_linear"],
+            "required": [
+              "piecewise_linear"
+            ],
             "properties": {
               "piecewise_linear": {
                 "type": "array",
@@ -328,7 +374,9 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": ["native"],
+            "required": [
+              "native"
+            ],
             "properties": {
               "native": {
                 "type": "string"
@@ -339,7 +387,9 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": ["cw20"],
+            "required": [
+              "cw20"
+            ],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -358,18 +408,26 @@
       {
         "description": "Returns list of all vesting payment contracts",
         "type": "object",
-        "required": ["list_vesting_contracts"],
+        "required": [
+          "list_vesting_contracts"
+        ],
         "properties": {
           "list_vesting_contracts": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -380,18 +438,26 @@
       {
         "description": "Returns list of all vesting payment contracts in reverse",
         "type": "object",
-        "required": ["list_vesting_contracts_reverse"],
+        "required": [
+          "list_vesting_contracts_reverse"
+        ],
         "properties": {
           "list_vesting_contracts_reverse": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_before": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -402,22 +468,32 @@
       {
         "description": "Returns list of all vesting payment contracts by who instantiated them",
         "type": "object",
-        "required": ["list_vesting_contracts_by_instantiator"],
+        "required": [
+          "list_vesting_contracts_by_instantiator"
+        ],
         "properties": {
           "list_vesting_contracts_by_instantiator": {
             "type": "object",
-            "required": ["instantiator"],
+            "required": [
+              "instantiator"
+            ],
             "properties": {
               "instantiator": {
                 "type": "string"
               },
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -428,22 +504,32 @@
       {
         "description": "Returns list of all vesting payment contracts by who instantiated them in reverse",
         "type": "object",
-        "required": ["list_vesting_contracts_by_instantiator_reverse"],
+        "required": [
+          "list_vesting_contracts_by_instantiator_reverse"
+        ],
         "properties": {
           "list_vesting_contracts_by_instantiator_reverse": {
             "type": "object",
-            "required": ["instantiator"],
+            "required": [
+              "instantiator"
+            ],
             "properties": {
               "instantiator": {
                 "type": "string"
               },
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_before": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -454,14 +540,21 @@
       {
         "description": "Returns list of all vesting payment contracts by recipient",
         "type": "object",
-        "required": ["list_vesting_contracts_by_recipient"],
+        "required": [
+          "list_vesting_contracts_by_recipient"
+        ],
         "properties": {
           "list_vesting_contracts_by_recipient": {
             "type": "object",
-            "required": ["recipient"],
+            "required": [
+              "recipient"
+            ],
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
@@ -469,7 +562,10 @@
                 "type": "string"
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -480,14 +576,21 @@
       {
         "description": "Returns list of all vesting payment contracts by recipient in reverse",
         "type": "object",
-        "required": ["list_vesting_contracts_by_recipient_reverse"],
+        "required": [
+          "list_vesting_contracts_by_recipient_reverse"
+        ],
         "properties": {
           "list_vesting_contracts_by_recipient_reverse": {
             "type": "object",
-            "required": ["recipient"],
+            "required": [
+              "recipient"
+            ],
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
@@ -495,7 +598,10 @@
                 "type": "string"
               },
               "start_before": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -506,7 +612,9 @@
       {
         "description": "Returns info about the contract ownership, if set",
         "type": "object",
-        "required": ["ownership"],
+        "required": [
+          "ownership"
+        ],
         "properties": {
           "ownership": {
             "type": "object",
@@ -518,7 +626,9 @@
       {
         "description": "Returns the code ID currently being used to instantiate vesting contracts.",
         "type": "object",
-        "required": ["code_id"],
+        "required": [
+          "code_id"
+        ],
         "properties": {
           "code_id": {
             "type": "object",
@@ -549,7 +659,11 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": ["contract", "instantiator", "recipient"],
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
           "properties": {
             "contract": {
               "type": "string"
@@ -575,7 +689,11 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": ["contract", "instantiator", "recipient"],
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
           "properties": {
             "contract": {
               "type": "string"
@@ -601,7 +719,11 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": ["contract", "instantiator", "recipient"],
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
           "properties": {
             "contract": {
               "type": "string"
@@ -627,7 +749,11 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": ["contract", "instantiator", "recipient"],
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
           "properties": {
             "contract": {
               "type": "string"
@@ -653,7 +779,11 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": ["contract", "instantiator", "recipient"],
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
           "properties": {
             "contract": {
               "type": "string"
@@ -679,7 +809,11 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": ["contract", "instantiator", "recipient"],
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
           "properties": {
             "contract": {
               "type": "string"
@@ -747,7 +881,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -760,7 +896,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -771,7 +909,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",

--- a/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
+++ b/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
@@ -1,20 +1,15 @@
 {
   "contract_name": "cw-payroll-factory",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "vesting_code_id"
-    ],
+    "required": ["vesting_code_id"],
     "properties": {
       "owner": {
-        "type": [
-          "string",
-          "null"
-        ]
+        "type": ["string", "null"]
       },
       "vesting_code_id": {
         "type": "integer",
@@ -31,9 +26,7 @@
       {
         "description": "Instantiates a new vesting contract that is funded by a cw20 token.",
         "type": "object",
-        "required": [
-          "receive"
-        ],
+        "required": ["receive"],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -44,16 +37,11 @@
       {
         "description": "Instantiates a new vesting contract that is funded by a native token.",
         "type": "object",
-        "required": [
-          "instantiate_native_payroll_contract"
-        ],
+        "required": ["instantiate_native_payroll_contract"],
         "properties": {
           "instantiate_native_payroll_contract": {
             "type": "object",
-            "required": [
-              "instantiate_msg",
-              "label"
-            ],
+            "required": ["instantiate_msg", "label"],
             "properties": {
               "instantiate_msg": {
                 "$ref": "#/definitions/InstantiateMsg"
@@ -70,15 +58,11 @@
       {
         "description": "Callable only by the current owner. Updates the code ID used while instantiating vesting contracts.",
         "type": "object",
-        "required": [
-          "update_code_id"
-        ],
+        "required": ["update_code_id"],
         "properties": {
           "update_code_id": {
             "type": "object",
-            "required": [
-              "vesting_code_id"
-            ],
+            "required": ["vesting_code_id"],
             "properties": {
               "vesting_code_id": {
                 "type": "integer",
@@ -94,9 +78,7 @@
       {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": [
-          "update_ownership"
-        ],
+        "required": ["update_ownership"],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -112,15 +94,11 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": [
-              "transfer_ownership"
-            ],
+            "required": ["transfer_ownership"],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": [
-                  "new_owner"
-                ],
+                "required": ["new_owner"],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -144,16 +122,12 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": [
-              "accept_ownership"
-            ]
+            "enum": ["accept_ownership"]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": [
-              "renounce_ownership"
-            ]
+            "enum": ["renounce_ownership"]
           }
         ]
       },
@@ -164,11 +138,7 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": [
-          "amount",
-          "msg",
-          "sender"
-        ],
+        "required": ["amount", "msg", "sender"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -188,9 +158,7 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": [
-              "at_height"
-            ],
+            "required": ["at_height"],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -203,9 +171,7 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": [
-              "at_time"
-            ],
+            "required": ["at_time"],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -216,9 +182,7 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": [
-              "never"
-            ],
+            "required": ["never"],
             "properties": {
               "never": {
                 "type": "object",
@@ -251,17 +215,11 @@
           },
           "description": {
             "description": "A description for the payment to provide more context.",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "owner": {
             "description": "The optional owner address of the contract. If an owner is specified, the owner may cancel the vesting contract at any time and withdraw unvested funds.",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "recipient": {
             "description": "The receiver address of the vesting tokens.",
@@ -318,16 +276,12 @@
           {
             "description": "Vests linearally from `0` to `total`.",
             "type": "string",
-            "enum": [
-              "saturating_linear"
-            ]
+            "enum": ["saturating_linear"]
           },
           {
             "description": "Vests by linearally interpolating between the provided (seconds, amount) points. The first amount must be zero and the last amount the total vesting amount. `seconds` are seconds since the vest start time.\n\nThere is a problem in the underlying Curve library that doesn't allow zero start values, so the first value of `seconds` must be > 1. To start at a particular time (if you need that level of percision), subtract one from the true start time, and make the first `seconds` value `1`.\n\n<https://github.com/cosmorama/wynddao/pull/4>",
             "type": "object",
-            "required": [
-              "piecewise_linear"
-            ],
+            "required": ["piecewise_linear"],
             "properties": {
               "piecewise_linear": {
                 "type": "array",
@@ -374,9 +328,7 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": [
-              "native"
-            ],
+            "required": ["native"],
             "properties": {
               "native": {
                 "type": "string"
@@ -387,9 +339,7 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": [
-              "cw20"
-            ],
+            "required": ["cw20"],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -408,26 +358,18 @@
       {
         "description": "Returns list of all vesting payment contracts",
         "type": "object",
-        "required": [
-          "list_vesting_contracts"
-        ],
+        "required": ["list_vesting_contracts"],
         "properties": {
           "list_vesting_contracts": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -438,26 +380,18 @@
       {
         "description": "Returns list of all vesting payment contracts in reverse",
         "type": "object",
-        "required": [
-          "list_vesting_contracts_reverse"
-        ],
+        "required": ["list_vesting_contracts_reverse"],
         "properties": {
           "list_vesting_contracts_reverse": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_before": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -468,32 +402,22 @@
       {
         "description": "Returns list of all vesting payment contracts by who instantiated them",
         "type": "object",
-        "required": [
-          "list_vesting_contracts_by_instantiator"
-        ],
+        "required": ["list_vesting_contracts_by_instantiator"],
         "properties": {
           "list_vesting_contracts_by_instantiator": {
             "type": "object",
-            "required": [
-              "instantiator"
-            ],
+            "required": ["instantiator"],
             "properties": {
               "instantiator": {
                 "type": "string"
               },
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -504,32 +428,22 @@
       {
         "description": "Returns list of all vesting payment contracts by who instantiated them in reverse",
         "type": "object",
-        "required": [
-          "list_vesting_contracts_by_instantiator_reverse"
-        ],
+        "required": ["list_vesting_contracts_by_instantiator_reverse"],
         "properties": {
           "list_vesting_contracts_by_instantiator_reverse": {
             "type": "object",
-            "required": [
-              "instantiator"
-            ],
+            "required": ["instantiator"],
             "properties": {
               "instantiator": {
                 "type": "string"
               },
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_before": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -540,21 +454,14 @@
       {
         "description": "Returns list of all vesting payment contracts by recipient",
         "type": "object",
-        "required": [
-          "list_vesting_contracts_by_recipient"
-        ],
+        "required": ["list_vesting_contracts_by_recipient"],
         "properties": {
           "list_vesting_contracts_by_recipient": {
             "type": "object",
-            "required": [
-              "recipient"
-            ],
+            "required": ["recipient"],
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
@@ -562,10 +469,7 @@
                 "type": "string"
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -576,21 +480,14 @@
       {
         "description": "Returns list of all vesting payment contracts by recipient in reverse",
         "type": "object",
-        "required": [
-          "list_vesting_contracts_by_recipient_reverse"
-        ],
+        "required": ["list_vesting_contracts_by_recipient_reverse"],
         "properties": {
           "list_vesting_contracts_by_recipient_reverse": {
             "type": "object",
-            "required": [
-              "recipient"
-            ],
+            "required": ["recipient"],
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
@@ -598,10 +495,7 @@
                 "type": "string"
               },
               "start_before": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -612,9 +506,7 @@
       {
         "description": "Returns info about the contract ownership, if set",
         "type": "object",
-        "required": [
-          "ownership"
-        ],
+        "required": ["ownership"],
         "properties": {
           "ownership": {
             "type": "object",
@@ -626,9 +518,7 @@
       {
         "description": "Returns the code ID currently being used to instantiate vesting contracts.",
         "type": "object",
-        "required": [
-          "code_id"
-        ],
+        "required": ["code_id"],
         "properties": {
           "code_id": {
             "type": "object",
@@ -659,11 +549,7 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": [
-            "contract",
-            "instantiator",
-            "recipient"
-          ],
+          "required": ["contract", "instantiator", "recipient"],
           "properties": {
             "contract": {
               "type": "string"
@@ -689,11 +575,7 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": [
-            "contract",
-            "instantiator",
-            "recipient"
-          ],
+          "required": ["contract", "instantiator", "recipient"],
           "properties": {
             "contract": {
               "type": "string"
@@ -719,11 +601,7 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": [
-            "contract",
-            "instantiator",
-            "recipient"
-          ],
+          "required": ["contract", "instantiator", "recipient"],
           "properties": {
             "contract": {
               "type": "string"
@@ -749,11 +627,7 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": [
-            "contract",
-            "instantiator",
-            "recipient"
-          ],
+          "required": ["contract", "instantiator", "recipient"],
           "properties": {
             "contract": {
               "type": "string"
@@ -779,11 +653,7 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": [
-            "contract",
-            "instantiator",
-            "recipient"
-          ],
+          "required": ["contract", "instantiator", "recipient"],
           "properties": {
             "contract": {
               "type": "string"
@@ -809,11 +679,7 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": [
-            "contract",
-            "instantiator",
-            "recipient"
-          ],
+          "required": ["contract", "instantiator", "recipient"],
           "properties": {
             "contract": {
               "type": "string"
@@ -881,9 +747,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -896,9 +760,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -909,9 +771,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",

--- a/contracts/external/cw-token-swap/schema/cw-token-swap.json
+++ b/contracts/external/cw-token-swap/schema/cw-token-swap.json
@@ -6,7 +6,10 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["counterparty_one", "counterparty_two"],
+    "required": [
+      "counterparty_one",
+      "counterparty_two"
+    ],
     "properties": {
       "counterparty_one": {
         "$ref": "#/definitions/Counterparty"
@@ -20,7 +23,10 @@
       "Counterparty": {
         "description": "Information about a counterparty in this escrow transaction and their promised funds.",
         "type": "object",
-        "required": ["address", "promise"],
+        "required": [
+          "address",
+          "promise"
+        ],
         "properties": {
           "address": {
             "description": "The address of the counterparty.",
@@ -43,11 +49,16 @@
           {
             "description": "A native token.",
             "type": "object",
-            "required": ["native"],
+            "required": [
+              "native"
+            ],
             "properties": {
               "native": {
                 "type": "object",
-                "required": ["amount", "denom"],
+                "required": [
+                  "amount",
+                  "denom"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Uint128"
@@ -64,11 +75,16 @@
           {
             "description": "A cw20 token.",
             "type": "object",
-            "required": ["cw20"],
+            "required": [
+              "cw20"
+            ],
             "properties": {
               "cw20": {
                 "type": "object",
-                "required": ["amount", "contract_addr"],
+                "required": [
+                  "amount",
+                  "contract_addr"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Uint128"
@@ -97,7 +113,9 @@
       {
         "description": "Used to provide cw20 tokens to satisfy a funds promise.",
         "type": "object",
-        "required": ["receive"],
+        "required": [
+          "receive"
+        ],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -108,7 +126,9 @@
       {
         "description": "Provides native tokens to satisfy a funds promise.",
         "type": "object",
-        "required": ["fund"],
+        "required": [
+          "fund"
+        ],
         "properties": {
           "fund": {
             "type": "object",
@@ -120,7 +140,9 @@
       {
         "description": "Withdraws provided funds. Only allowed if the other counterparty has yet to provide their promised funds.",
         "type": "object",
-        "required": ["withdraw"],
+        "required": [
+          "withdraw"
+        ],
         "properties": {
           "withdraw": {
             "type": "object",
@@ -138,7 +160,11 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": ["amount", "msg", "sender"],
+        "required": [
+          "amount",
+          "msg",
+          "sender"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -164,7 +190,9 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["status"],
+        "required": [
+          "status"
+        ],
         "properties": {
           "status": {
             "type": "object",
@@ -187,7 +215,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "StatusResponse",
       "type": "object",
-      "required": ["counterparty_one", "counterparty_two"],
+      "required": [
+        "counterparty_one",
+        "counterparty_two"
+      ],
       "properties": {
         "counterparty_one": {
           "$ref": "#/definitions/CheckedCounterparty"
@@ -204,7 +235,11 @@
         },
         "CheckedCounterparty": {
           "type": "object",
-          "required": ["address", "promise", "provided"],
+          "required": [
+            "address",
+            "promise",
+            "provided"
+          ],
           "properties": {
             "address": {
               "$ref": "#/definitions/Addr"
@@ -222,11 +257,16 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["native"],
+              "required": [
+                "native"
+              ],
               "properties": {
                 "native": {
                   "type": "object",
-                  "required": ["amount", "denom"],
+                  "required": [
+                    "amount",
+                    "denom"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Uint128"
@@ -242,11 +282,16 @@
             },
             {
               "type": "object",
-              "required": ["cw20"],
+              "required": [
+                "cw20"
+              ],
               "properties": {
                 "cw20": {
                   "type": "object",
-                  "required": ["amount", "contract_addr"],
+                  "required": [
+                    "amount",
+                    "contract_addr"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Uint128"

--- a/contracts/external/cw-token-swap/schema/cw-token-swap.json
+++ b/contracts/external/cw-token-swap/schema/cw-token-swap.json
@@ -1,15 +1,12 @@
 {
   "contract_name": "cw-token-swap",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "counterparty_one",
-      "counterparty_two"
-    ],
+    "required": ["counterparty_one", "counterparty_two"],
     "properties": {
       "counterparty_one": {
         "$ref": "#/definitions/Counterparty"
@@ -23,10 +20,7 @@
       "Counterparty": {
         "description": "Information about a counterparty in this escrow transaction and their promised funds.",
         "type": "object",
-        "required": [
-          "address",
-          "promise"
-        ],
+        "required": ["address", "promise"],
         "properties": {
           "address": {
             "description": "The address of the counterparty.",
@@ -49,16 +43,11 @@
           {
             "description": "A native token.",
             "type": "object",
-            "required": [
-              "native"
-            ],
+            "required": ["native"],
             "properties": {
               "native": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "denom"
-                ],
+                "required": ["amount", "denom"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Uint128"
@@ -75,16 +64,11 @@
           {
             "description": "A cw20 token.",
             "type": "object",
-            "required": [
-              "cw20"
-            ],
+            "required": ["cw20"],
             "properties": {
               "cw20": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "contract_addr"
-                ],
+                "required": ["amount", "contract_addr"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Uint128"
@@ -113,9 +97,7 @@
       {
         "description": "Used to provide cw20 tokens to satisfy a funds promise.",
         "type": "object",
-        "required": [
-          "receive"
-        ],
+        "required": ["receive"],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -126,9 +108,7 @@
       {
         "description": "Provides native tokens to satisfy a funds promise.",
         "type": "object",
-        "required": [
-          "fund"
-        ],
+        "required": ["fund"],
         "properties": {
           "fund": {
             "type": "object",
@@ -140,9 +120,7 @@
       {
         "description": "Withdraws provided funds. Only allowed if the other counterparty has yet to provide their promised funds.",
         "type": "object",
-        "required": [
-          "withdraw"
-        ],
+        "required": ["withdraw"],
         "properties": {
           "withdraw": {
             "type": "object",
@@ -160,11 +138,7 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": [
-          "amount",
-          "msg",
-          "sender"
-        ],
+        "required": ["amount", "msg", "sender"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -190,9 +164,7 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "status"
-        ],
+        "required": ["status"],
         "properties": {
           "status": {
             "type": "object",
@@ -215,10 +187,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "StatusResponse",
       "type": "object",
-      "required": [
-        "counterparty_one",
-        "counterparty_two"
-      ],
+      "required": ["counterparty_one", "counterparty_two"],
       "properties": {
         "counterparty_one": {
           "$ref": "#/definitions/CheckedCounterparty"
@@ -235,11 +204,7 @@
         },
         "CheckedCounterparty": {
           "type": "object",
-          "required": [
-            "address",
-            "promise",
-            "provided"
-          ],
+          "required": ["address", "promise", "provided"],
           "properties": {
             "address": {
               "$ref": "#/definitions/Addr"
@@ -257,16 +222,11 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "native"
-              ],
+              "required": ["native"],
               "properties": {
                 "native": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "denom"
-                  ],
+                  "required": ["amount", "denom"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Uint128"
@@ -282,16 +242,11 @@
             },
             {
               "type": "object",
-              "required": [
-                "cw20"
-              ],
+              "required": ["cw20"],
               "properties": {
                 "cw20": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "contract_addr"
-                  ],
+                  "required": ["amount", "contract_addr"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Uint128"

--- a/contracts/external/cw-tokenfactory-issuer/schema/cw-tokenfactory-issuer.json
+++ b/contracts/external/cw-tokenfactory-issuer/schema/cw-tokenfactory-issuer.json
@@ -10,11 +10,15 @@
       {
         "description": "`NewToken` will create a new token when instantiate the contract. Newly created token will have full denom as `factory/<contract_address>/<subdenom>`. It will be attached to the contract setup the beforesend listener automatically.",
         "type": "object",
-        "required": ["new_token"],
+        "required": [
+          "new_token"
+        ],
         "properties": {
           "new_token": {
             "type": "object",
-            "required": ["subdenom"],
+            "required": [
+              "subdenom"
+            ],
             "properties": {
               "subdenom": {
                 "description": "component of fulldenom (`factory/<contract_address>/<subdenom>`).",
@@ -29,11 +33,15 @@
       {
         "description": "`ExistingToken` will use already created token. So to set this up, Token Factory admin for the existing token needs trasfer admin over to this contract, and optionally set the `BeforeSendHook` manually.",
         "type": "object",
-        "required": ["existing_token"],
+        "required": [
+          "existing_token"
+        ],
         "properties": {
           "existing_token": {
             "type": "object",
-            "required": ["denom"],
+            "required": [
+              "denom"
+            ],
             "properties": {
               "denom": {
                 "type": "string"
@@ -54,11 +62,16 @@
       {
         "description": "Allow adds the target address to the allowlist to be able to send or recieve tokens even if the token is frozen. Token Factory's BeforeSendHook listener must be set to this contract in order for this feature to work.\n\nThis functionality is intedended for DAOs who do not wish to have a their tokens liquid while bootstrapping their DAO. For example, a DAO may wish to white list a Token Staking contract (to allow users to stake their tokens in the DAO) or a Merkle Drop contract (to allow users to claim their tokens).",
         "type": "object",
-        "required": ["allow"],
+        "required": [
+          "allow"
+        ],
         "properties": {
           "allow": {
             "type": "object",
-            "required": ["address", "status"],
+            "required": [
+              "address",
+              "status"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -75,11 +88,16 @@
       {
         "description": "Burn token to address. Burn allowance is required and wiil be deducted after successful burn.",
         "type": "object",
-        "required": ["burn"],
+        "required": [
+          "burn"
+        ],
         "properties": {
           "burn": {
             "type": "object",
-            "required": ["amount", "from_address"],
+            "required": [
+              "amount",
+              "from_address"
+            ],
             "properties": {
               "amount": {
                 "$ref": "#/definitions/Uint128"
@@ -96,11 +114,16 @@
       {
         "description": "Mint token to address. Mint allowance is required and wiil be deducted after successful mint.",
         "type": "object",
-        "required": ["mint"],
+        "required": [
+          "mint"
+        ],
         "properties": {
           "mint": {
             "type": "object",
-            "required": ["amount", "to_address"],
+            "required": [
+              "amount",
+              "to_address"
+            ],
             "properties": {
               "amount": {
                 "$ref": "#/definitions/Uint128"
@@ -117,11 +140,16 @@
       {
         "description": "Deny adds the target address to the denylist, whis prevents them from sending/receiving the token attached to this contract tokenfactory's BeforeSendHook listener must be set to this contract in order for this feature to work as intended.",
         "type": "object",
-        "required": ["deny"],
+        "required": [
+          "deny"
+        ],
         "properties": {
           "deny": {
             "type": "object",
-            "required": ["address", "status"],
+            "required": [
+              "address",
+              "status"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -138,11 +166,15 @@
       {
         "description": "Block every token transfers of the token attached to this contract. Token Factory's BeforeSendHook listener must be set to this contract in order for this feature to work as intended.",
         "type": "object",
-        "required": ["freeze"],
+        "required": [
+          "freeze"
+        ],
         "properties": {
           "freeze": {
             "type": "object",
-            "required": ["status"],
+            "required": [
+              "status"
+            ],
             "properties": {
               "status": {
                 "type": "boolean"
@@ -156,11 +188,17 @@
       {
         "description": "Force transfer token from one address to another.",
         "type": "object",
-        "required": ["force_transfer"],
+        "required": [
+          "force_transfer"
+        ],
         "properties": {
           "force_transfer": {
             "type": "object",
-            "required": ["amount", "from_address", "to_address"],
+            "required": [
+              "amount",
+              "from_address",
+              "to_address"
+            ],
             "properties": {
               "amount": {
                 "$ref": "#/definitions/Uint128"
@@ -180,11 +218,15 @@
       {
         "description": "Attempt to SetBeforeSendHook on the token attached to this contract. This will fail if the chain does not support bank module hooks (many Token Factory implementations do not yet support).\n\nThis takes a cosmwasm_address as an argument, which is the address of the contract that will be called before every token transfer. Normally, this will be the issuer contract itself, though it can be a custom contract for greater flexibility.\n\nSetting the address to an empty string will remove the SetBeforeSendHook.\n\nThis method can only be called by the contract owner.",
         "type": "object",
-        "required": ["set_before_send_hook"],
+        "required": [
+          "set_before_send_hook"
+        ],
         "properties": {
           "set_before_send_hook": {
             "type": "object",
-            "required": ["cosmwasm_address"],
+            "required": [
+              "cosmwasm_address"
+            ],
             "properties": {
               "cosmwasm_address": {
                 "type": "string"
@@ -198,11 +240,16 @@
       {
         "description": "Grant/revoke burn allowance.",
         "type": "object",
-        "required": ["set_burner_allowance"],
+        "required": [
+          "set_burner_allowance"
+        ],
         "properties": {
           "set_burner_allowance": {
             "type": "object",
-            "required": ["address", "allowance"],
+            "required": [
+              "address",
+              "allowance"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -219,11 +266,15 @@
       {
         "description": "Set denom metadata. see: https://docs.cosmos.network/main/modules/bank#denom-metadata.",
         "type": "object",
-        "required": ["set_denom_metadata"],
+        "required": [
+          "set_denom_metadata"
+        ],
         "properties": {
           "set_denom_metadata": {
             "type": "object",
-            "required": ["metadata"],
+            "required": [
+              "metadata"
+            ],
             "properties": {
               "metadata": {
                 "$ref": "#/definitions/Metadata"
@@ -237,11 +288,16 @@
       {
         "description": "Grant/revoke mint allowance.",
         "type": "object",
-        "required": ["set_minter_allowance"],
+        "required": [
+          "set_minter_allowance"
+        ],
         "properties": {
           "set_minter_allowance": {
             "type": "object",
-            "required": ["address", "allowance"],
+            "required": [
+              "address",
+              "allowance"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -258,11 +314,15 @@
       {
         "description": "Updates the admin of the Token Factory token. Normally this is the cw-tokenfactory-issuer contract itself. This is intended to be used only if you seek to transfer ownership of the Token somewhere else (i.e. to another management contract).",
         "type": "object",
-        "required": ["update_token_factory_admin"],
+        "required": [
+          "update_token_factory_admin"
+        ],
         "properties": {
           "update_token_factory_admin": {
             "type": "object",
-            "required": ["new_admin"],
+            "required": [
+              "new_admin"
+            ],
             "properties": {
               "new_admin": {
                 "type": "string"
@@ -276,7 +336,9 @@
       {
         "description": "Updates the owner of this contract who is allowed to call privileged methods. NOTE: this is separate from the Token Factory token admin, for this contract to work at all, it needs to the be the Token Factory token admin.\n\nNormally, the contract owner will be a DAO.\n\nThe `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": ["update_ownership"],
+        "required": [
+          "update_ownership"
+        ],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -292,11 +354,15 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": ["transfer_ownership"],
+            "required": [
+              "transfer_ownership"
+            ],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": ["new_owner"],
+                "required": [
+                  "new_owner"
+                ],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -320,19 +386,27 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": ["accept_ownership"]
+            "enum": [
+              "accept_ownership"
+            ]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": ["renounce_ownership"]
+            "enum": [
+              "renounce_ownership"
+            ]
           }
         ]
       },
       "DenomUnit": {
         "description": "DenomUnit represents a struct that describes a given denomination unit of the basic token.",
         "type": "object",
-        "required": ["aliases", "denom", "exponent"],
+        "required": [
+          "aliases",
+          "denom",
+          "exponent"
+        ],
         "properties": {
           "aliases": {
             "description": "aliases is a list of string aliases for the given denom",
@@ -359,7 +433,9 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": ["at_height"],
+            "required": [
+              "at_height"
+            ],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -372,7 +448,9 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": ["at_time"],
+            "required": [
+              "at_time"
+            ],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -383,7 +461,9 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": ["never"],
+            "required": [
+              "never"
+            ],
             "properties": {
               "never": {
                 "type": "object",
@@ -460,7 +540,9 @@
       {
         "description": "Returns if token transfer is disabled. Response: IsFrozenResponse",
         "type": "object",
-        "required": ["is_frozen"],
+        "required": [
+          "is_frozen"
+        ],
         "properties": {
           "is_frozen": {
             "type": "object",
@@ -472,7 +554,9 @@
       {
         "description": "Returns the token denom that this contract is the admin for. Response: DenomResponse",
         "type": "object",
-        "required": ["denom"],
+        "required": [
+          "denom"
+        ],
         "properties": {
           "denom": {
             "type": "object",
@@ -483,7 +567,9 @@
       },
       {
         "type": "object",
-        "required": ["ownership"],
+        "required": [
+          "ownership"
+        ],
         "properties": {
           "ownership": {
             "type": "object",
@@ -495,11 +581,15 @@
       {
         "description": "Returns the burn allowance of the specified address. Response: AllowanceResponse",
         "type": "object",
-        "required": ["burn_allowance"],
+        "required": [
+          "burn_allowance"
+        ],
         "properties": {
           "burn_allowance": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -513,18 +603,26 @@
       {
         "description": "Enumerates over all burn allownances. Response: AllowancesResponse",
         "type": "object",
-        "required": ["burn_allowances"],
+        "required": [
+          "burn_allowances"
+        ],
         "properties": {
           "burn_allowances": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -535,11 +633,15 @@
       {
         "description": "Returns the mint allowance of the specified user. Response: AllowanceResponse",
         "type": "object",
-        "required": ["mint_allowance"],
+        "required": [
+          "mint_allowance"
+        ],
         "properties": {
           "mint_allowance": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -553,18 +655,26 @@
       {
         "description": "Enumerates over all mint allownances. Response: AllowancesResponse",
         "type": "object",
-        "required": ["mint_allowances"],
+        "required": [
+          "mint_allowances"
+        ],
         "properties": {
           "mint_allowances": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -575,11 +685,15 @@
       {
         "description": "Returns wether the user is on denylist or not. Response: StatusResponse",
         "type": "object",
-        "required": ["is_denied"],
+        "required": [
+          "is_denied"
+        ],
         "properties": {
           "is_denied": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -593,18 +707,26 @@
       {
         "description": "Enumerates over all addresses on the denylist. Response: DenylistResponse",
         "type": "object",
-        "required": ["denylist"],
+        "required": [
+          "denylist"
+        ],
         "properties": {
           "denylist": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -615,11 +737,15 @@
       {
         "description": "Returns wether the user is on the allowlist or not. Response: StatusResponse",
         "type": "object",
-        "required": ["is_allowed"],
+        "required": [
+          "is_allowed"
+        ],
         "properties": {
           "is_allowed": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -633,18 +759,26 @@
       {
         "description": "Enumerates over all addresses on the allowlist. Response: AllowlistResponse",
         "type": "object",
-        "required": ["allowlist"],
+        "required": [
+          "allowlist"
+        ],
         "properties": {
           "allowlist": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -655,7 +789,9 @@
       {
         "description": "Returns information about the BeforeSendHook for the token. Note: many Token Factory chains do not yet support this feature.\n\nThe information returned is: - Whether features in this contract that require MsgBeforeSendHook are enabled. - The address of the BeforeSendHook contract if configured.\n\nResponse: BeforeSendHookInfo",
         "type": "object",
-        "required": ["before_send_hook_info"],
+        "required": [
+          "before_send_hook_info"
+        ],
         "properties": {
           "before_send_hook_info": {
             "type": "object",
@@ -674,11 +810,17 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["block_before_send"],
+        "required": [
+          "block_before_send"
+        ],
         "properties": {
           "block_before_send": {
             "type": "object",
-            "required": ["amount", "from", "to"],
+            "required": [
+              "amount",
+              "from",
+              "to"
+            ],
             "properties": {
               "amount": {
                 "$ref": "#/definitions/Coin"
@@ -699,7 +841,10 @@
     "definitions": {
       "Coin": {
         "type": "object",
-        "required": ["amount", "denom"],
+        "required": [
+          "amount",
+          "denom"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -721,7 +866,9 @@
       "title": "AllowlistResponse",
       "description": "Returns a list of addresses currently on the allowlist",
       "type": "object",
-      "required": ["allowlist"],
+      "required": [
+        "allowlist"
+      ],
       "properties": {
         "allowlist": {
           "type": "array",
@@ -735,7 +882,10 @@
         "StatusInfo": {
           "description": "Account info for list queries related to allowlist and denylist",
           "type": "object",
-          "required": ["address", "status"],
+          "required": [
+            "address",
+            "status"
+          ],
           "properties": {
             "address": {
               "type": "string"
@@ -753,7 +903,9 @@
       "title": "BeforeSendHookInfo",
       "description": "Whether or not features that require MsgBeforeSendHook are enabled Many Token Factory chains do not yet support MsgBeforeSendHook",
       "type": "object",
-      "required": ["advanced_features_enabled"],
+      "required": [
+        "advanced_features_enabled"
+      ],
       "properties": {
         "advanced_features_enabled": {
           "description": "Whether or not features in this contract that require MsgBeforeSendHook are enabled.",
@@ -761,7 +913,10 @@
         },
         "hook_contract_address": {
           "description": "The address of the contract that implements the BeforeSendHook interface. Most often this will be the cw_tokenfactory_issuer contract itself.",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false
@@ -771,7 +926,9 @@
       "title": "AllowanceResponse",
       "description": "Returns a mint or burn allowance for a particular address, representing the amount of tokens the account is allowed to mint or burn",
       "type": "object",
-      "required": ["allowance"],
+      "required": [
+        "allowance"
+      ],
       "properties": {
         "allowance": {
           "$ref": "#/definitions/Uint128"
@@ -790,7 +947,9 @@
       "title": "AllowancesResponse",
       "description": "Returns a list of all mint or burn allowances",
       "type": "object",
-      "required": ["allowances"],
+      "required": [
+        "allowances"
+      ],
       "properties": {
         "allowances": {
           "type": "array",
@@ -804,7 +963,10 @@
         "AllowanceInfo": {
           "description": "Information about a particular account and its mint / burn allowances. Used in list queries.",
           "type": "object",
-          "required": ["address", "allowance"],
+          "required": [
+            "address",
+            "allowance"
+          ],
           "properties": {
             "address": {
               "type": "string"
@@ -826,7 +988,9 @@
       "title": "DenomResponse",
       "description": "Returns the full denomination for the Token Factory token. For example: `factory/{contract address}/{subdenom}`",
       "type": "object",
-      "required": ["denom"],
+      "required": [
+        "denom"
+      ],
       "properties": {
         "denom": {
           "type": "string"
@@ -839,7 +1003,9 @@
       "title": "DenylistResponse",
       "description": "Returns a list of addresses currently on the denylist.",
       "type": "object",
-      "required": ["denylist"],
+      "required": [
+        "denylist"
+      ],
       "properties": {
         "denylist": {
           "type": "array",
@@ -853,7 +1019,10 @@
         "StatusInfo": {
           "description": "Account info for list queries related to allowlist and denylist",
           "type": "object",
-          "required": ["address", "status"],
+          "required": [
+            "address",
+            "status"
+          ],
           "properties": {
             "address": {
               "type": "string"
@@ -871,7 +1040,9 @@
       "title": "StatusResponse",
       "description": "Whether a particular account is allowed or denied",
       "type": "object",
-      "required": ["status"],
+      "required": [
+        "status"
+      ],
       "properties": {
         "status": {
           "type": "boolean"
@@ -884,7 +1055,9 @@
       "title": "StatusResponse",
       "description": "Whether a particular account is allowed or denied",
       "type": "object",
-      "required": ["status"],
+      "required": [
+        "status"
+      ],
       "properties": {
         "status": {
           "type": "boolean"
@@ -897,7 +1070,9 @@
       "title": "IsFrozenResponse",
       "description": "Returns whether or not the Token Factory token is frozen and transfers are disabled.",
       "type": "object",
-      "required": ["is_frozen"],
+      "required": [
+        "is_frozen"
+      ],
       "properties": {
         "is_frozen": {
           "type": "boolean"
@@ -910,7 +1085,9 @@
       "title": "AllowanceResponse",
       "description": "Returns a mint or burn allowance for a particular address, representing the amount of tokens the account is allowed to mint or burn",
       "type": "object",
-      "required": ["allowance"],
+      "required": [
+        "allowance"
+      ],
       "properties": {
         "allowance": {
           "$ref": "#/definitions/Uint128"
@@ -929,7 +1106,9 @@
       "title": "AllowancesResponse",
       "description": "Returns a list of all mint or burn allowances",
       "type": "object",
-      "required": ["allowances"],
+      "required": [
+        "allowances"
+      ],
       "properties": {
         "allowances": {
           "type": "array",
@@ -943,7 +1122,10 @@
         "AllowanceInfo": {
           "description": "Information about a particular account and its mint / burn allowances. Used in list queries.",
           "type": "object",
-          "required": ["address", "allowance"],
+          "required": [
+            "address",
+            "allowance"
+          ],
           "properties": {
             "address": {
               "type": "string"
@@ -1012,7 +1194,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1025,7 +1209,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1036,7 +1222,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",

--- a/contracts/external/cw-tokenfactory-issuer/schema/cw-tokenfactory-issuer.json
+++ b/contracts/external/cw-tokenfactory-issuer/schema/cw-tokenfactory-issuer.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-tokenfactory-issuer",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -10,15 +10,11 @@
       {
         "description": "`NewToken` will create a new token when instantiate the contract. Newly created token will have full denom as `factory/<contract_address>/<subdenom>`. It will be attached to the contract setup the beforesend listener automatically.",
         "type": "object",
-        "required": [
-          "new_token"
-        ],
+        "required": ["new_token"],
         "properties": {
           "new_token": {
             "type": "object",
-            "required": [
-              "subdenom"
-            ],
+            "required": ["subdenom"],
             "properties": {
               "subdenom": {
                 "description": "component of fulldenom (`factory/<contract_address>/<subdenom>`).",
@@ -33,15 +29,11 @@
       {
         "description": "`ExistingToken` will use already created token. So to set this up, Token Factory admin for the existing token needs trasfer admin over to this contract, and optionally set the `BeforeSendHook` manually.",
         "type": "object",
-        "required": [
-          "existing_token"
-        ],
+        "required": ["existing_token"],
         "properties": {
           "existing_token": {
             "type": "object",
-            "required": [
-              "denom"
-            ],
+            "required": ["denom"],
             "properties": {
               "denom": {
                 "type": "string"
@@ -62,16 +54,11 @@
       {
         "description": "Allow adds the target address to the allowlist to be able to send or recieve tokens even if the token is frozen. Token Factory's BeforeSendHook listener must be set to this contract in order for this feature to work.\n\nThis functionality is intedended for DAOs who do not wish to have a their tokens liquid while bootstrapping their DAO. For example, a DAO may wish to white list a Token Staking contract (to allow users to stake their tokens in the DAO) or a Merkle Drop contract (to allow users to claim their tokens).",
         "type": "object",
-        "required": [
-          "allow"
-        ],
+        "required": ["allow"],
         "properties": {
           "allow": {
             "type": "object",
-            "required": [
-              "address",
-              "status"
-            ],
+            "required": ["address", "status"],
             "properties": {
               "address": {
                 "type": "string"
@@ -88,16 +75,11 @@
       {
         "description": "Burn token to address. Burn allowance is required and wiil be deducted after successful burn.",
         "type": "object",
-        "required": [
-          "burn"
-        ],
+        "required": ["burn"],
         "properties": {
           "burn": {
             "type": "object",
-            "required": [
-              "amount",
-              "from_address"
-            ],
+            "required": ["amount", "from_address"],
             "properties": {
               "amount": {
                 "$ref": "#/definitions/Uint128"
@@ -114,16 +96,11 @@
       {
         "description": "Mint token to address. Mint allowance is required and wiil be deducted after successful mint.",
         "type": "object",
-        "required": [
-          "mint"
-        ],
+        "required": ["mint"],
         "properties": {
           "mint": {
             "type": "object",
-            "required": [
-              "amount",
-              "to_address"
-            ],
+            "required": ["amount", "to_address"],
             "properties": {
               "amount": {
                 "$ref": "#/definitions/Uint128"
@@ -140,16 +117,11 @@
       {
         "description": "Deny adds the target address to the denylist, whis prevents them from sending/receiving the token attached to this contract tokenfactory's BeforeSendHook listener must be set to this contract in order for this feature to work as intended.",
         "type": "object",
-        "required": [
-          "deny"
-        ],
+        "required": ["deny"],
         "properties": {
           "deny": {
             "type": "object",
-            "required": [
-              "address",
-              "status"
-            ],
+            "required": ["address", "status"],
             "properties": {
               "address": {
                 "type": "string"
@@ -166,15 +138,11 @@
       {
         "description": "Block every token transfers of the token attached to this contract. Token Factory's BeforeSendHook listener must be set to this contract in order for this feature to work as intended.",
         "type": "object",
-        "required": [
-          "freeze"
-        ],
+        "required": ["freeze"],
         "properties": {
           "freeze": {
             "type": "object",
-            "required": [
-              "status"
-            ],
+            "required": ["status"],
             "properties": {
               "status": {
                 "type": "boolean"
@@ -188,17 +156,11 @@
       {
         "description": "Force transfer token from one address to another.",
         "type": "object",
-        "required": [
-          "force_transfer"
-        ],
+        "required": ["force_transfer"],
         "properties": {
           "force_transfer": {
             "type": "object",
-            "required": [
-              "amount",
-              "from_address",
-              "to_address"
-            ],
+            "required": ["amount", "from_address", "to_address"],
             "properties": {
               "amount": {
                 "$ref": "#/definitions/Uint128"
@@ -218,15 +180,11 @@
       {
         "description": "Attempt to SetBeforeSendHook on the token attached to this contract. This will fail if the chain does not support bank module hooks (many Token Factory implementations do not yet support).\n\nThis takes a cosmwasm_address as an argument, which is the address of the contract that will be called before every token transfer. Normally, this will be the issuer contract itself, though it can be a custom contract for greater flexibility.\n\nSetting the address to an empty string will remove the SetBeforeSendHook.\n\nThis method can only be called by the contract owner.",
         "type": "object",
-        "required": [
-          "set_before_send_hook"
-        ],
+        "required": ["set_before_send_hook"],
         "properties": {
           "set_before_send_hook": {
             "type": "object",
-            "required": [
-              "cosmwasm_address"
-            ],
+            "required": ["cosmwasm_address"],
             "properties": {
               "cosmwasm_address": {
                 "type": "string"
@@ -240,16 +198,11 @@
       {
         "description": "Grant/revoke burn allowance.",
         "type": "object",
-        "required": [
-          "set_burner_allowance"
-        ],
+        "required": ["set_burner_allowance"],
         "properties": {
           "set_burner_allowance": {
             "type": "object",
-            "required": [
-              "address",
-              "allowance"
-            ],
+            "required": ["address", "allowance"],
             "properties": {
               "address": {
                 "type": "string"
@@ -266,15 +219,11 @@
       {
         "description": "Set denom metadata. see: https://docs.cosmos.network/main/modules/bank#denom-metadata.",
         "type": "object",
-        "required": [
-          "set_denom_metadata"
-        ],
+        "required": ["set_denom_metadata"],
         "properties": {
           "set_denom_metadata": {
             "type": "object",
-            "required": [
-              "metadata"
-            ],
+            "required": ["metadata"],
             "properties": {
               "metadata": {
                 "$ref": "#/definitions/Metadata"
@@ -288,16 +237,11 @@
       {
         "description": "Grant/revoke mint allowance.",
         "type": "object",
-        "required": [
-          "set_minter_allowance"
-        ],
+        "required": ["set_minter_allowance"],
         "properties": {
           "set_minter_allowance": {
             "type": "object",
-            "required": [
-              "address",
-              "allowance"
-            ],
+            "required": ["address", "allowance"],
             "properties": {
               "address": {
                 "type": "string"
@@ -314,15 +258,11 @@
       {
         "description": "Updates the admin of the Token Factory token. Normally this is the cw-tokenfactory-issuer contract itself. This is intended to be used only if you seek to transfer ownership of the Token somewhere else (i.e. to another management contract).",
         "type": "object",
-        "required": [
-          "update_token_factory_admin"
-        ],
+        "required": ["update_token_factory_admin"],
         "properties": {
           "update_token_factory_admin": {
             "type": "object",
-            "required": [
-              "new_admin"
-            ],
+            "required": ["new_admin"],
             "properties": {
               "new_admin": {
                 "type": "string"
@@ -336,9 +276,7 @@
       {
         "description": "Updates the owner of this contract who is allowed to call privileged methods. NOTE: this is separate from the Token Factory token admin, for this contract to work at all, it needs to the be the Token Factory token admin.\n\nNormally, the contract owner will be a DAO.\n\nThe `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": [
-          "update_ownership"
-        ],
+        "required": ["update_ownership"],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -354,15 +292,11 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": [
-              "transfer_ownership"
-            ],
+            "required": ["transfer_ownership"],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": [
-                  "new_owner"
-                ],
+                "required": ["new_owner"],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -386,27 +320,19 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": [
-              "accept_ownership"
-            ]
+            "enum": ["accept_ownership"]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": [
-              "renounce_ownership"
-            ]
+            "enum": ["renounce_ownership"]
           }
         ]
       },
       "DenomUnit": {
         "description": "DenomUnit represents a struct that describes a given denomination unit of the basic token.",
         "type": "object",
-        "required": [
-          "aliases",
-          "denom",
-          "exponent"
-        ],
+        "required": ["aliases", "denom", "exponent"],
         "properties": {
           "aliases": {
             "description": "aliases is a list of string aliases for the given denom",
@@ -433,9 +359,7 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": [
-              "at_height"
-            ],
+            "required": ["at_height"],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -448,9 +372,7 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": [
-              "at_time"
-            ],
+            "required": ["at_time"],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -461,9 +383,7 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": [
-              "never"
-            ],
+            "required": ["never"],
             "properties": {
               "never": {
                 "type": "object",
@@ -540,9 +460,7 @@
       {
         "description": "Returns if token transfer is disabled. Response: IsFrozenResponse",
         "type": "object",
-        "required": [
-          "is_frozen"
-        ],
+        "required": ["is_frozen"],
         "properties": {
           "is_frozen": {
             "type": "object",
@@ -554,9 +472,7 @@
       {
         "description": "Returns the token denom that this contract is the admin for. Response: DenomResponse",
         "type": "object",
-        "required": [
-          "denom"
-        ],
+        "required": ["denom"],
         "properties": {
           "denom": {
             "type": "object",
@@ -567,9 +483,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "ownership"
-        ],
+        "required": ["ownership"],
         "properties": {
           "ownership": {
             "type": "object",
@@ -581,15 +495,11 @@
       {
         "description": "Returns the burn allowance of the specified address. Response: AllowanceResponse",
         "type": "object",
-        "required": [
-          "burn_allowance"
-        ],
+        "required": ["burn_allowance"],
         "properties": {
           "burn_allowance": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -603,26 +513,18 @@
       {
         "description": "Enumerates over all burn allownances. Response: AllowancesResponse",
         "type": "object",
-        "required": [
-          "burn_allowances"
-        ],
+        "required": ["burn_allowances"],
         "properties": {
           "burn_allowances": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -633,15 +535,11 @@
       {
         "description": "Returns the mint allowance of the specified user. Response: AllowanceResponse",
         "type": "object",
-        "required": [
-          "mint_allowance"
-        ],
+        "required": ["mint_allowance"],
         "properties": {
           "mint_allowance": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -655,26 +553,18 @@
       {
         "description": "Enumerates over all mint allownances. Response: AllowancesResponse",
         "type": "object",
-        "required": [
-          "mint_allowances"
-        ],
+        "required": ["mint_allowances"],
         "properties": {
           "mint_allowances": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -685,15 +575,11 @@
       {
         "description": "Returns wether the user is on denylist or not. Response: StatusResponse",
         "type": "object",
-        "required": [
-          "is_denied"
-        ],
+        "required": ["is_denied"],
         "properties": {
           "is_denied": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -707,26 +593,18 @@
       {
         "description": "Enumerates over all addresses on the denylist. Response: DenylistResponse",
         "type": "object",
-        "required": [
-          "denylist"
-        ],
+        "required": ["denylist"],
         "properties": {
           "denylist": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -737,15 +615,11 @@
       {
         "description": "Returns wether the user is on the allowlist or not. Response: StatusResponse",
         "type": "object",
-        "required": [
-          "is_allowed"
-        ],
+        "required": ["is_allowed"],
         "properties": {
           "is_allowed": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -759,26 +633,18 @@
       {
         "description": "Enumerates over all addresses on the allowlist. Response: AllowlistResponse",
         "type": "object",
-        "required": [
-          "allowlist"
-        ],
+        "required": ["allowlist"],
         "properties": {
           "allowlist": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -789,9 +655,7 @@
       {
         "description": "Returns information about the BeforeSendHook for the token. Note: many Token Factory chains do not yet support this feature.\n\nThe information returned is: - Whether features in this contract that require MsgBeforeSendHook are enabled. - The address of the BeforeSendHook contract if configured.\n\nResponse: BeforeSendHookInfo",
         "type": "object",
-        "required": [
-          "before_send_hook_info"
-        ],
+        "required": ["before_send_hook_info"],
         "properties": {
           "before_send_hook_info": {
             "type": "object",
@@ -810,17 +674,11 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "block_before_send"
-        ],
+        "required": ["block_before_send"],
         "properties": {
           "block_before_send": {
             "type": "object",
-            "required": [
-              "amount",
-              "from",
-              "to"
-            ],
+            "required": ["amount", "from", "to"],
             "properties": {
               "amount": {
                 "$ref": "#/definitions/Coin"
@@ -841,10 +699,7 @@
     "definitions": {
       "Coin": {
         "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
+        "required": ["amount", "denom"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -866,9 +721,7 @@
       "title": "AllowlistResponse",
       "description": "Returns a list of addresses currently on the allowlist",
       "type": "object",
-      "required": [
-        "allowlist"
-      ],
+      "required": ["allowlist"],
       "properties": {
         "allowlist": {
           "type": "array",
@@ -882,10 +735,7 @@
         "StatusInfo": {
           "description": "Account info for list queries related to allowlist and denylist",
           "type": "object",
-          "required": [
-            "address",
-            "status"
-          ],
+          "required": ["address", "status"],
           "properties": {
             "address": {
               "type": "string"
@@ -903,9 +753,7 @@
       "title": "BeforeSendHookInfo",
       "description": "Whether or not features that require MsgBeforeSendHook are enabled Many Token Factory chains do not yet support MsgBeforeSendHook",
       "type": "object",
-      "required": [
-        "advanced_features_enabled"
-      ],
+      "required": ["advanced_features_enabled"],
       "properties": {
         "advanced_features_enabled": {
           "description": "Whether or not features in this contract that require MsgBeforeSendHook are enabled.",
@@ -913,10 +761,7 @@
         },
         "hook_contract_address": {
           "description": "The address of the contract that implements the BeforeSendHook interface. Most often this will be the cw_tokenfactory_issuer contract itself.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       },
       "additionalProperties": false
@@ -926,9 +771,7 @@
       "title": "AllowanceResponse",
       "description": "Returns a mint or burn allowance for a particular address, representing the amount of tokens the account is allowed to mint or burn",
       "type": "object",
-      "required": [
-        "allowance"
-      ],
+      "required": ["allowance"],
       "properties": {
         "allowance": {
           "$ref": "#/definitions/Uint128"
@@ -947,9 +790,7 @@
       "title": "AllowancesResponse",
       "description": "Returns a list of all mint or burn allowances",
       "type": "object",
-      "required": [
-        "allowances"
-      ],
+      "required": ["allowances"],
       "properties": {
         "allowances": {
           "type": "array",
@@ -963,10 +804,7 @@
         "AllowanceInfo": {
           "description": "Information about a particular account and its mint / burn allowances. Used in list queries.",
           "type": "object",
-          "required": [
-            "address",
-            "allowance"
-          ],
+          "required": ["address", "allowance"],
           "properties": {
             "address": {
               "type": "string"
@@ -988,9 +826,7 @@
       "title": "DenomResponse",
       "description": "Returns the full denomination for the Token Factory token. For example: `factory/{contract address}/{subdenom}`",
       "type": "object",
-      "required": [
-        "denom"
-      ],
+      "required": ["denom"],
       "properties": {
         "denom": {
           "type": "string"
@@ -1003,9 +839,7 @@
       "title": "DenylistResponse",
       "description": "Returns a list of addresses currently on the denylist.",
       "type": "object",
-      "required": [
-        "denylist"
-      ],
+      "required": ["denylist"],
       "properties": {
         "denylist": {
           "type": "array",
@@ -1019,10 +853,7 @@
         "StatusInfo": {
           "description": "Account info for list queries related to allowlist and denylist",
           "type": "object",
-          "required": [
-            "address",
-            "status"
-          ],
+          "required": ["address", "status"],
           "properties": {
             "address": {
               "type": "string"
@@ -1040,9 +871,7 @@
       "title": "StatusResponse",
       "description": "Whether a particular account is allowed or denied",
       "type": "object",
-      "required": [
-        "status"
-      ],
+      "required": ["status"],
       "properties": {
         "status": {
           "type": "boolean"
@@ -1055,9 +884,7 @@
       "title": "StatusResponse",
       "description": "Whether a particular account is allowed or denied",
       "type": "object",
-      "required": [
-        "status"
-      ],
+      "required": ["status"],
       "properties": {
         "status": {
           "type": "boolean"
@@ -1070,9 +897,7 @@
       "title": "IsFrozenResponse",
       "description": "Returns whether or not the Token Factory token is frozen and transfers are disabled.",
       "type": "object",
-      "required": [
-        "is_frozen"
-      ],
+      "required": ["is_frozen"],
       "properties": {
         "is_frozen": {
           "type": "boolean"
@@ -1085,9 +910,7 @@
       "title": "AllowanceResponse",
       "description": "Returns a mint or burn allowance for a particular address, representing the amount of tokens the account is allowed to mint or burn",
       "type": "object",
-      "required": [
-        "allowance"
-      ],
+      "required": ["allowance"],
       "properties": {
         "allowance": {
           "$ref": "#/definitions/Uint128"
@@ -1106,9 +929,7 @@
       "title": "AllowancesResponse",
       "description": "Returns a list of all mint or burn allowances",
       "type": "object",
-      "required": [
-        "allowances"
-      ],
+      "required": ["allowances"],
       "properties": {
         "allowances": {
           "type": "array",
@@ -1122,10 +943,7 @@
         "AllowanceInfo": {
           "description": "Information about a particular account and its mint / burn allowances. Used in list queries.",
           "type": "object",
-          "required": [
-            "address",
-            "allowance"
-          ],
+          "required": ["address", "allowance"],
           "properties": {
             "address": {
               "type": "string"
@@ -1194,9 +1012,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1209,9 +1025,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1222,9 +1036,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",

--- a/contracts/external/cw-vesting/schema/cw-vesting.json
+++ b/contracts/external/cw-vesting/schema/cw-vesting.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-vesting",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -26,17 +26,11 @@
       },
       "description": {
         "description": "A description for the payment to provide more context.",
-        "type": [
-          "string",
-          "null"
-        ]
+        "type": ["string", "null"]
       },
       "owner": {
         "description": "The optional owner address of the contract. If an owner is specified, the owner may cancel the vesting contract at any time and withdraw unvested funds.",
-        "type": [
-          "string",
-          "null"
-        ]
+        "type": ["string", "null"]
       },
       "recipient": {
         "description": "The receiver address of the vesting tokens.",
@@ -93,16 +87,12 @@
           {
             "description": "Vests linearally from `0` to `total`.",
             "type": "string",
-            "enum": [
-              "saturating_linear"
-            ]
+            "enum": ["saturating_linear"]
           },
           {
             "description": "Vests by linearally interpolating between the provided (seconds, amount) points. The first amount must be zero and the last amount the total vesting amount. `seconds` are seconds since the vest start time.\n\nThere is a problem in the underlying Curve library that doesn't allow zero start values, so the first value of `seconds` must be > 1. To start at a particular time (if you need that level of percision), subtract one from the true start time, and make the first `seconds` value `1`.\n\n<https://github.com/cosmorama/wynddao/pull/4>",
             "type": "object",
-            "required": [
-              "piecewise_linear"
-            ],
+            "required": ["piecewise_linear"],
             "properties": {
               "piecewise_linear": {
                 "type": "array",
@@ -149,9 +139,7 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": [
-              "native"
-            ],
+            "required": ["native"],
             "properties": {
               "native": {
                 "type": "string"
@@ -162,9 +150,7 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": [
-              "cw20"
-            ],
+            "required": ["cw20"],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -183,9 +169,7 @@
       {
         "description": "Fund the contract with a cw20 token. The `msg` field must have the shape `{\"fund\":{}}`, and the amount sent must be the same as the amount to be vested (as set during instantiation). Anyone may call this method so long as the contract has not yet been funded.",
         "type": "object",
-        "required": [
-          "receive"
-        ],
+        "required": ["receive"],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -196,9 +180,7 @@
       {
         "description": "Distribute vested tokens to the vest receiver. Anyone may call this method.",
         "type": "object",
-        "required": [
-          "distribute"
-        ],
+        "required": ["distribute"],
         "properties": {
           "distribute": {
             "type": "object",
@@ -223,9 +205,7 @@
       {
         "description": "Cancels the vesting payment. The current amount vested becomes the total amount that will ever vest, and all pending and future staking rewards from tokens staked by this contract will be sent to the owner. Tote that canceling does not impact already vested tokens.\n\nUpon canceling, the contract will use any liquid tokens in the contract to settle pending payments to the vestee, and then returns the rest to the owner. Staked tokens are then split between the owner and the vestee according to the number of tokens that the vestee is entitled to.\n\nThe vestee will no longer receive staking rewards after cancelation, and may unbond and distribute (vested - claimed) tokens at their leisure. the owner will receive staking rewards and may unbond and withdraw (staked - (vested - claimed)) tokens at their leisure.",
         "type": "object",
-        "required": [
-          "cancel"
-        ],
+        "required": ["cancel"],
         "properties": {
           "cancel": {
             "type": "object",
@@ -237,16 +217,11 @@
       {
         "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.  Note: this only works with the native staking denom of a Cosmos chain.  Only callable by Vesting Payment Recipient.",
         "type": "object",
-        "required": [
-          "delegate"
-        ],
+        "required": ["delegate"],
         "properties": {
           "delegate": {
             "type": "object",
-            "required": [
-              "amount",
-              "validator"
-            ],
+            "required": ["amount", "validator"],
             "properties": {
               "amount": {
                 "description": "The amount to delegate.",
@@ -269,17 +244,11 @@
       {
         "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L96). `delegator_address` is automatically filled with the current contract's address.  Only callable by Vesting Payment Recipient.",
         "type": "object",
-        "required": [
-          "redelegate"
-        ],
+        "required": ["redelegate"],
         "properties": {
           "redelegate": {
             "type": "object",
-            "required": [
-              "amount",
-              "dst_validator",
-              "src_validator"
-            ],
+            "required": ["amount", "dst_validator", "src_validator"],
             "properties": {
               "amount": {
                 "$ref": "#/definitions/Uint128"
@@ -299,16 +268,11 @@
       {
         "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.  Only callable by Vesting Payment Recipient.",
         "type": "object",
-        "required": [
-          "undelegate"
-        ],
+        "required": ["undelegate"],
         "properties": {
           "undelegate": {
             "type": "object",
-            "required": [
-              "amount",
-              "validator"
-            ],
+            "required": ["amount", "validator"],
             "properties": {
               "amount": {
                 "description": "The amount to delegate",
@@ -331,15 +295,11 @@
       {
         "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L31-L37). `delegator_address` is automatically filled with the current contract's address.  Only callable by Vesting Payment Recipient.",
         "type": "object",
-        "required": [
-          "set_withdraw_address"
-        ],
+        "required": ["set_withdraw_address"],
         "properties": {
           "set_withdraw_address": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -353,15 +313,11 @@
       {
         "description": "This is translated to a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
         "type": "object",
-        "required": [
-          "withdraw_delegator_reward"
-        ],
+        "required": ["withdraw_delegator_reward"],
         "properties": {
           "withdraw_delegator_reward": {
             "type": "object",
-            "required": [
-              "validator"
-            ],
+            "required": ["validator"],
             "properties": {
               "validator": {
                 "description": "The validator to claim rewards for.",
@@ -376,9 +332,7 @@
       {
         "description": "If the owner cancels a payment and there are not enough liquid tokens to settle the owner may become entitled to some number of staked tokens. They may then unbond those tokens and then call this method to return them.",
         "type": "object",
-        "required": [
-          "withdraw_canceled_payment"
-        ],
+        "required": ["withdraw_canceled_payment"],
         "properties": {
           "withdraw_canceled_payment": {
             "type": "object",
@@ -403,18 +357,11 @@
       {
         "description": "Registers a slash event bonded or unbonding tokens with the contract. Only callable by the owner as the contract is unable to verify that the slash actually occured. The owner is assumed to be honest.\n\nA future version of this contract may be able to permissionlessly take slashing evidence: <https://github.com/CosmWasm/mesh-security/issues/35>",
         "type": "object",
-        "required": [
-          "register_slash"
-        ],
+        "required": ["register_slash"],
         "properties": {
           "register_slash": {
             "type": "object",
-            "required": [
-              "amount",
-              "during_unbonding",
-              "time",
-              "validator"
-            ],
+            "required": ["amount", "during_unbonding", "time", "validator"],
             "properties": {
               "amount": {
                 "description": "The number of tokens that THIS CONTRACT lost as a result of the slash. Note that this differs from the total amount slashed from the validator.",
@@ -449,9 +396,7 @@
       {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": [
-          "update_ownership"
-        ],
+        "required": ["update_ownership"],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -467,15 +412,11 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": [
-              "transfer_ownership"
-            ],
+            "required": ["transfer_ownership"],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": [
-                  "new_owner"
-                ],
+                "required": ["new_owner"],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -499,16 +440,12 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": [
-              "accept_ownership"
-            ]
+            "enum": ["accept_ownership"]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": [
-              "renounce_ownership"
-            ]
+            "enum": ["renounce_ownership"]
           }
         ]
       },
@@ -519,11 +456,7 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": [
-          "amount",
-          "msg",
-          "sender"
-        ],
+        "required": ["amount", "msg", "sender"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -543,9 +476,7 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": [
-              "at_height"
-            ],
+            "required": ["at_height"],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -558,9 +489,7 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": [
-              "at_time"
-            ],
+            "required": ["at_time"],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -571,9 +500,7 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": [
-              "never"
-            ],
+            "required": ["never"],
             "properties": {
               "never": {
                 "type": "object",
@@ -609,9 +536,7 @@
       {
         "description": "Get the current ownership.",
         "type": "object",
-        "required": [
-          "ownership"
-        ],
+        "required": ["ownership"],
         "properties": {
           "ownership": {
             "type": "object",
@@ -623,9 +548,7 @@
       {
         "description": "Returns information about the vesting contract and the status of the payment.",
         "type": "object",
-        "required": [
-          "info"
-        ],
+        "required": ["info"],
         "properties": {
           "info": {
             "type": "object",
@@ -637,9 +560,7 @@
       {
         "description": "Returns the number of tokens currently claimable by the vestee. This is the minimum of the number of unstaked tokens in the contract, and the number of tokens that have been vested at time t.",
         "type": "object",
-        "required": [
-          "distributable"
-        ],
+        "required": ["distributable"],
         "properties": {
           "distributable": {
             "type": "object",
@@ -664,9 +585,7 @@
       {
         "description": "Gets the current value of `vested(t)`. If `t` is `None`, the current time is used.",
         "type": "object",
-        "required": [
-          "vested"
-        ],
+        "required": ["vested"],
         "properties": {
           "vested": {
             "type": "object",
@@ -690,9 +609,7 @@
       {
         "description": "Gets the total amount that will ever vest, `max(vested(t))`.\n\nNote that if the contract is canceled at time c, this value will change to `vested(c)`. Thus, it can not be assumed to be constant over the contract's lifetime.",
         "type": "object",
-        "required": [
-          "total_to_vest"
-        ],
+        "required": ["total_to_vest"],
         "properties": {
           "total_to_vest": {
             "type": "object",
@@ -704,9 +621,7 @@
       {
         "description": "Gets the amount of time between the vest starting, and it completing. Returns `None` if the vest has been cancelled.",
         "type": "object",
-        "required": [
-          "vest_duration"
-        ],
+        "required": ["vest_duration"],
         "properties": {
           "vest_duration": {
             "type": "object",
@@ -718,9 +633,7 @@
       {
         "description": "Queries information about the contract's understanding of it's bonded and unbonding token balances. See the `StakeTrackerQuery` in `packages/cw-stake-tracker/lib.rs` for query methods and their return types.",
         "type": "object",
-        "required": [
-          "stake"
-        ],
+        "required": ["stake"],
         "properties": {
           "stake": {
             "$ref": "#/definitions/StakeTrackerQuery"
@@ -734,15 +647,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "cardinality"
-            ],
+            "required": ["cardinality"],
             "properties": {
               "cardinality": {
                 "type": "object",
-                "required": [
-                  "t"
-                ],
+                "required": ["t"],
                 "properties": {
                   "t": {
                     "$ref": "#/definitions/Timestamp"
@@ -755,15 +664,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "total_staked"
-            ],
+            "required": ["total_staked"],
             "properties": {
               "total_staked": {
                 "type": "object",
-                "required": [
-                  "t"
-                ],
+                "required": ["t"],
                 "properties": {
                   "t": {
                     "$ref": "#/definitions/Timestamp"
@@ -776,16 +681,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "validator_staked"
-            ],
+            "required": ["validator_staked"],
             "properties": {
               "validator_staked": {
                 "type": "object",
-                "required": [
-                  "t",
-                  "validator"
-                ],
+                "required": ["t", "validator"],
                 "properties": {
                   "t": {
                     "$ref": "#/definitions/Timestamp"
@@ -851,10 +751,7 @@
           "$ref": "#/definitions/CheckedDenom"
         },
         "description": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "recipient": {
           "$ref": "#/definitions/Addr"
@@ -897,9 +794,7 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": [
-                "native"
-              ],
+              "required": ["native"],
               "properties": {
                 "native": {
                   "type": "string"
@@ -910,9 +805,7 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": [
-                "cw20"
-              ],
+              "required": ["cw20"],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -926,15 +819,11 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "constant"
-              ],
+              "required": ["constant"],
               "properties": {
                 "constant": {
                   "type": "object",
-                  "required": [
-                    "y"
-                  ],
+                  "required": ["y"],
                   "properties": {
                     "y": {
                       "$ref": "#/definitions/Uint128"
@@ -946,9 +835,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "saturating_linear"
-              ],
+              "required": ["saturating_linear"],
               "properties": {
                 "saturating_linear": {
                   "$ref": "#/definitions/SaturatingLinear"
@@ -958,9 +845,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "piecewise_linear"
-              ],
+              "required": ["piecewise_linear"],
               "properties": {
                 "piecewise_linear": {
                   "$ref": "#/definitions/PiecewiseLinear"
@@ -973,9 +858,7 @@
         "PiecewiseLinear": {
           "description": "This is a generalization of SaturatingLinear, steps must be arranged with increasing time (u64). Any point before first step gets the first value, after last step the last value. Otherwise, it is a linear interpolation between the two closest points. Vec of length 1 -> Constant Vec of length 2 -> SaturatingLinear",
           "type": "object",
-          "required": [
-            "steps"
-          ],
+          "required": ["steps"],
           "properties": {
             "steps": {
               "type": "array",
@@ -1000,12 +883,7 @@
         "SaturatingLinear": {
           "description": "min_y for all x <= min_x, max_y for all x >= max_x, linear in between",
           "type": "object",
-          "required": [
-            "max_x",
-            "max_y",
-            "min_x",
-            "min_y"
-          ],
+          "required": ["max_x", "max_y", "min_x", "min_y"],
           "properties": {
             "max_x": {
               "type": "integer",
@@ -1029,22 +907,15 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": [
-                "unfunded",
-                "funded"
-              ]
+              "enum": ["unfunded", "funded"]
             },
             {
               "type": "object",
-              "required": [
-                "canceled"
-              ],
+              "required": ["canceled"],
               "properties": {
                 "canceled": {
                   "type": "object",
-                  "required": [
-                    "owner_withdrawable"
-                  ],
+                  "required": ["owner_withdrawable"],
                   "properties": {
                     "owner_withdrawable": {
                       "description": "owner_withdrawable(t). This is monotonically decreasing and will be zero once the owner has completed withdrawing their funds.",
@@ -1132,9 +1003,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1147,9 +1016,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1160,9 +1027,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",

--- a/contracts/external/cw-vesting/schema/cw-vesting.json
+++ b/contracts/external/cw-vesting/schema/cw-vesting.json
@@ -26,11 +26,17 @@
       },
       "description": {
         "description": "A description for the payment to provide more context.",
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "owner": {
         "description": "The optional owner address of the contract. If an owner is specified, the owner may cancel the vesting contract at any time and withdraw unvested funds.",
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "recipient": {
         "description": "The receiver address of the vesting tokens.",
@@ -87,12 +93,16 @@
           {
             "description": "Vests linearally from `0` to `total`.",
             "type": "string",
-            "enum": ["saturating_linear"]
+            "enum": [
+              "saturating_linear"
+            ]
           },
           {
             "description": "Vests by linearally interpolating between the provided (seconds, amount) points. The first amount must be zero and the last amount the total vesting amount. `seconds` are seconds since the vest start time.\n\nThere is a problem in the underlying Curve library that doesn't allow zero start values, so the first value of `seconds` must be > 1. To start at a particular time (if you need that level of percision), subtract one from the true start time, and make the first `seconds` value `1`.\n\n<https://github.com/cosmorama/wynddao/pull/4>",
             "type": "object",
-            "required": ["piecewise_linear"],
+            "required": [
+              "piecewise_linear"
+            ],
             "properties": {
               "piecewise_linear": {
                 "type": "array",
@@ -139,7 +149,9 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": ["native"],
+            "required": [
+              "native"
+            ],
             "properties": {
               "native": {
                 "type": "string"
@@ -150,7 +162,9 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": ["cw20"],
+            "required": [
+              "cw20"
+            ],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -169,7 +183,9 @@
       {
         "description": "Fund the contract with a cw20 token. The `msg` field must have the shape `{\"fund\":{}}`, and the amount sent must be the same as the amount to be vested (as set during instantiation). Anyone may call this method so long as the contract has not yet been funded.",
         "type": "object",
-        "required": ["receive"],
+        "required": [
+          "receive"
+        ],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -180,7 +196,9 @@
       {
         "description": "Distribute vested tokens to the vest receiver. Anyone may call this method.",
         "type": "object",
-        "required": ["distribute"],
+        "required": [
+          "distribute"
+        ],
         "properties": {
           "distribute": {
             "type": "object",
@@ -205,7 +223,9 @@
       {
         "description": "Cancels the vesting payment. The current amount vested becomes the total amount that will ever vest, and all pending and future staking rewards from tokens staked by this contract will be sent to the owner. Tote that canceling does not impact already vested tokens.\n\nUpon canceling, the contract will use any liquid tokens in the contract to settle pending payments to the vestee, and then returns the rest to the owner. Staked tokens are then split between the owner and the vestee according to the number of tokens that the vestee is entitled to.\n\nThe vestee will no longer receive staking rewards after cancelation, and may unbond and distribute (vested - claimed) tokens at their leisure. the owner will receive staking rewards and may unbond and withdraw (staked - (vested - claimed)) tokens at their leisure.",
         "type": "object",
-        "required": ["cancel"],
+        "required": [
+          "cancel"
+        ],
         "properties": {
           "cancel": {
             "type": "object",
@@ -217,11 +237,16 @@
       {
         "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.  Note: this only works with the native staking denom of a Cosmos chain.  Only callable by Vesting Payment Recipient.",
         "type": "object",
-        "required": ["delegate"],
+        "required": [
+          "delegate"
+        ],
         "properties": {
           "delegate": {
             "type": "object",
-            "required": ["amount", "validator"],
+            "required": [
+              "amount",
+              "validator"
+            ],
             "properties": {
               "amount": {
                 "description": "The amount to delegate.",
@@ -244,11 +269,17 @@
       {
         "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L96). `delegator_address` is automatically filled with the current contract's address.  Only callable by Vesting Payment Recipient.",
         "type": "object",
-        "required": ["redelegate"],
+        "required": [
+          "redelegate"
+        ],
         "properties": {
           "redelegate": {
             "type": "object",
-            "required": ["amount", "dst_validator", "src_validator"],
+            "required": [
+              "amount",
+              "dst_validator",
+              "src_validator"
+            ],
             "properties": {
               "amount": {
                 "$ref": "#/definitions/Uint128"
@@ -268,11 +299,16 @@
       {
         "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.  Only callable by Vesting Payment Recipient.",
         "type": "object",
-        "required": ["undelegate"],
+        "required": [
+          "undelegate"
+        ],
         "properties": {
           "undelegate": {
             "type": "object",
-            "required": ["amount", "validator"],
+            "required": [
+              "amount",
+              "validator"
+            ],
             "properties": {
               "amount": {
                 "description": "The amount to delegate",
@@ -295,11 +331,15 @@
       {
         "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L31-L37). `delegator_address` is automatically filled with the current contract's address.  Only callable by Vesting Payment Recipient.",
         "type": "object",
-        "required": ["set_withdraw_address"],
+        "required": [
+          "set_withdraw_address"
+        ],
         "properties": {
           "set_withdraw_address": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -313,11 +353,15 @@
       {
         "description": "This is translated to a [MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
         "type": "object",
-        "required": ["withdraw_delegator_reward"],
+        "required": [
+          "withdraw_delegator_reward"
+        ],
         "properties": {
           "withdraw_delegator_reward": {
             "type": "object",
-            "required": ["validator"],
+            "required": [
+              "validator"
+            ],
             "properties": {
               "validator": {
                 "description": "The validator to claim rewards for.",
@@ -332,7 +376,9 @@
       {
         "description": "If the owner cancels a payment and there are not enough liquid tokens to settle the owner may become entitled to some number of staked tokens. They may then unbond those tokens and then call this method to return them.",
         "type": "object",
-        "required": ["withdraw_canceled_payment"],
+        "required": [
+          "withdraw_canceled_payment"
+        ],
         "properties": {
           "withdraw_canceled_payment": {
             "type": "object",
@@ -357,11 +403,18 @@
       {
         "description": "Registers a slash event bonded or unbonding tokens with the contract. Only callable by the owner as the contract is unable to verify that the slash actually occured. The owner is assumed to be honest.\n\nA future version of this contract may be able to permissionlessly take slashing evidence: <https://github.com/CosmWasm/mesh-security/issues/35>",
         "type": "object",
-        "required": ["register_slash"],
+        "required": [
+          "register_slash"
+        ],
         "properties": {
           "register_slash": {
             "type": "object",
-            "required": ["amount", "during_unbonding", "time", "validator"],
+            "required": [
+              "amount",
+              "during_unbonding",
+              "time",
+              "validator"
+            ],
             "properties": {
               "amount": {
                 "description": "The number of tokens that THIS CONTRACT lost as a result of the slash. Note that this differs from the total amount slashed from the validator.",
@@ -396,7 +449,9 @@
       {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": ["update_ownership"],
+        "required": [
+          "update_ownership"
+        ],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -412,11 +467,15 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": ["transfer_ownership"],
+            "required": [
+              "transfer_ownership"
+            ],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": ["new_owner"],
+                "required": [
+                  "new_owner"
+                ],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -440,12 +499,16 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": ["accept_ownership"]
+            "enum": [
+              "accept_ownership"
+            ]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": ["renounce_ownership"]
+            "enum": [
+              "renounce_ownership"
+            ]
           }
         ]
       },
@@ -456,7 +519,11 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": ["amount", "msg", "sender"],
+        "required": [
+          "amount",
+          "msg",
+          "sender"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -476,7 +543,9 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": ["at_height"],
+            "required": [
+              "at_height"
+            ],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -489,7 +558,9 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": ["at_time"],
+            "required": [
+              "at_time"
+            ],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -500,7 +571,9 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": ["never"],
+            "required": [
+              "never"
+            ],
             "properties": {
               "never": {
                 "type": "object",
@@ -536,7 +609,9 @@
       {
         "description": "Get the current ownership.",
         "type": "object",
-        "required": ["ownership"],
+        "required": [
+          "ownership"
+        ],
         "properties": {
           "ownership": {
             "type": "object",
@@ -548,7 +623,9 @@
       {
         "description": "Returns information about the vesting contract and the status of the payment.",
         "type": "object",
-        "required": ["info"],
+        "required": [
+          "info"
+        ],
         "properties": {
           "info": {
             "type": "object",
@@ -560,7 +637,9 @@
       {
         "description": "Returns the number of tokens currently claimable by the vestee. This is the minimum of the number of unstaked tokens in the contract, and the number of tokens that have been vested at time t.",
         "type": "object",
-        "required": ["distributable"],
+        "required": [
+          "distributable"
+        ],
         "properties": {
           "distributable": {
             "type": "object",
@@ -585,7 +664,9 @@
       {
         "description": "Gets the current value of `vested(t)`. If `t` is `None`, the current time is used.",
         "type": "object",
-        "required": ["vested"],
+        "required": [
+          "vested"
+        ],
         "properties": {
           "vested": {
             "type": "object",
@@ -609,7 +690,9 @@
       {
         "description": "Gets the total amount that will ever vest, `max(vested(t))`.\n\nNote that if the contract is canceled at time c, this value will change to `vested(c)`. Thus, it can not be assumed to be constant over the contract's lifetime.",
         "type": "object",
-        "required": ["total_to_vest"],
+        "required": [
+          "total_to_vest"
+        ],
         "properties": {
           "total_to_vest": {
             "type": "object",
@@ -621,7 +704,9 @@
       {
         "description": "Gets the amount of time between the vest starting, and it completing. Returns `None` if the vest has been cancelled.",
         "type": "object",
-        "required": ["vest_duration"],
+        "required": [
+          "vest_duration"
+        ],
         "properties": {
           "vest_duration": {
             "type": "object",
@@ -633,7 +718,9 @@
       {
         "description": "Queries information about the contract's understanding of it's bonded and unbonding token balances. See the `StakeTrackerQuery` in `packages/cw-stake-tracker/lib.rs` for query methods and their return types.",
         "type": "object",
-        "required": ["stake"],
+        "required": [
+          "stake"
+        ],
         "properties": {
           "stake": {
             "$ref": "#/definitions/StakeTrackerQuery"
@@ -647,11 +734,15 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["cardinality"],
+            "required": [
+              "cardinality"
+            ],
             "properties": {
               "cardinality": {
                 "type": "object",
-                "required": ["t"],
+                "required": [
+                  "t"
+                ],
                 "properties": {
                   "t": {
                     "$ref": "#/definitions/Timestamp"
@@ -664,11 +755,15 @@
           },
           {
             "type": "object",
-            "required": ["total_staked"],
+            "required": [
+              "total_staked"
+            ],
             "properties": {
               "total_staked": {
                 "type": "object",
-                "required": ["t"],
+                "required": [
+                  "t"
+                ],
                 "properties": {
                   "t": {
                     "$ref": "#/definitions/Timestamp"
@@ -681,11 +776,16 @@
           },
           {
             "type": "object",
-            "required": ["validator_staked"],
+            "required": [
+              "validator_staked"
+            ],
             "properties": {
               "validator_staked": {
                 "type": "object",
-                "required": ["t", "validator"],
+                "required": [
+                  "t",
+                  "validator"
+                ],
                 "properties": {
                   "t": {
                     "$ref": "#/definitions/Timestamp"
@@ -751,7 +851,10 @@
           "$ref": "#/definitions/CheckedDenom"
         },
         "description": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "recipient": {
           "$ref": "#/definitions/Addr"
@@ -794,7 +897,9 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": ["native"],
+              "required": [
+                "native"
+              ],
               "properties": {
                 "native": {
                   "type": "string"
@@ -805,7 +910,9 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": ["cw20"],
+              "required": [
+                "cw20"
+              ],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -819,11 +926,15 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["constant"],
+              "required": [
+                "constant"
+              ],
               "properties": {
                 "constant": {
                   "type": "object",
-                  "required": ["y"],
+                  "required": [
+                    "y"
+                  ],
                   "properties": {
                     "y": {
                       "$ref": "#/definitions/Uint128"
@@ -835,7 +946,9 @@
             },
             {
               "type": "object",
-              "required": ["saturating_linear"],
+              "required": [
+                "saturating_linear"
+              ],
               "properties": {
                 "saturating_linear": {
                   "$ref": "#/definitions/SaturatingLinear"
@@ -845,7 +958,9 @@
             },
             {
               "type": "object",
-              "required": ["piecewise_linear"],
+              "required": [
+                "piecewise_linear"
+              ],
               "properties": {
                 "piecewise_linear": {
                   "$ref": "#/definitions/PiecewiseLinear"
@@ -858,7 +973,9 @@
         "PiecewiseLinear": {
           "description": "This is a generalization of SaturatingLinear, steps must be arranged with increasing time (u64). Any point before first step gets the first value, after last step the last value. Otherwise, it is a linear interpolation between the two closest points. Vec of length 1 -> Constant Vec of length 2 -> SaturatingLinear",
           "type": "object",
-          "required": ["steps"],
+          "required": [
+            "steps"
+          ],
           "properties": {
             "steps": {
               "type": "array",
@@ -883,7 +1000,12 @@
         "SaturatingLinear": {
           "description": "min_y for all x <= min_x, max_y for all x >= max_x, linear in between",
           "type": "object",
-          "required": ["max_x", "max_y", "min_x", "min_y"],
+          "required": [
+            "max_x",
+            "max_y",
+            "min_x",
+            "min_y"
+          ],
           "properties": {
             "max_x": {
               "type": "integer",
@@ -907,15 +1029,22 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": ["unfunded", "funded"]
+              "enum": [
+                "unfunded",
+                "funded"
+              ]
             },
             {
               "type": "object",
-              "required": ["canceled"],
+              "required": [
+                "canceled"
+              ],
               "properties": {
                 "canceled": {
                   "type": "object",
-                  "required": ["owner_withdrawable"],
+                  "required": [
+                    "owner_withdrawable"
+                  ],
                   "properties": {
                     "owner_withdrawable": {
                       "description": "owner_withdrawable(t). This is monotonically decreasing and will be zero once the owner has completed withdrawing their funds.",
@@ -1003,7 +1132,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1016,7 +1147,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1027,7 +1160,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",

--- a/contracts/external/cw721-roles/schema/cw721-roles.json
+++ b/contracts/external/cw721-roles/schema/cw721-roles.json
@@ -1,16 +1,12 @@
 {
   "contract_name": "cw721-roles",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "minter",
-      "name",
-      "symbol"
-    ],
+    "required": ["minter", "name", "symbol"],
     "properties": {
       "minter": {
         "description": "The minter is the only one who can create new NFTs. This is designed for a base NFT that is controlled by an external program or contract. You will likely replace this with custom logic in custom NFTs",
@@ -35,16 +31,11 @@
       {
         "description": "Transfer is a base message to move a token to another account without triggering actions",
         "type": "object",
-        "required": [
-          "transfer_nft"
-        ],
+        "required": ["transfer_nft"],
         "properties": {
           "transfer_nft": {
             "type": "object",
-            "required": [
-              "recipient",
-              "token_id"
-            ],
+            "required": ["recipient", "token_id"],
             "properties": {
               "recipient": {
                 "type": "string"
@@ -61,17 +52,11 @@
       {
         "description": "Send is a base message to transfer a token to a contract and trigger an action on the receiving contract.",
         "type": "object",
-        "required": [
-          "send_nft"
-        ],
+        "required": ["send_nft"],
         "properties": {
           "send_nft": {
             "type": "object",
-            "required": [
-              "contract",
-              "msg",
-              "token_id"
-            ],
+            "required": ["contract", "msg", "token_id"],
             "properties": {
               "contract": {
                 "type": "string"
@@ -91,16 +76,11 @@
       {
         "description": "Allows operator to transfer / send the token from the owner's account. If expiration is set, then this allowance has a time/height limit",
         "type": "object",
-        "required": [
-          "approve"
-        ],
+        "required": ["approve"],
         "properties": {
           "approve": {
             "type": "object",
-            "required": [
-              "spender",
-              "token_id"
-            ],
+            "required": ["spender", "token_id"],
             "properties": {
               "expires": {
                 "anyOf": [
@@ -127,16 +107,11 @@
       {
         "description": "Remove previously granted Approval",
         "type": "object",
-        "required": [
-          "revoke"
-        ],
+        "required": ["revoke"],
         "properties": {
           "revoke": {
             "type": "object",
-            "required": [
-              "spender",
-              "token_id"
-            ],
+            "required": ["spender", "token_id"],
             "properties": {
               "spender": {
                 "type": "string"
@@ -153,15 +128,11 @@
       {
         "description": "Allows operator to transfer / send any token from the owner's account. If expiration is set, then this allowance has a time/height limit",
         "type": "object",
-        "required": [
-          "approve_all"
-        ],
+        "required": ["approve_all"],
         "properties": {
           "approve_all": {
             "type": "object",
-            "required": [
-              "operator"
-            ],
+            "required": ["operator"],
             "properties": {
               "expires": {
                 "anyOf": [
@@ -185,15 +156,11 @@
       {
         "description": "Remove previously granted ApproveAll permission",
         "type": "object",
-        "required": [
-          "revoke_all"
-        ],
+        "required": ["revoke_all"],
         "properties": {
           "revoke_all": {
             "type": "object",
-            "required": [
-              "operator"
-            ],
+            "required": ["operator"],
             "properties": {
               "operator": {
                 "type": "string"
@@ -207,17 +174,11 @@
       {
         "description": "Mint a new NFT, can only be called by the contract minter",
         "type": "object",
-        "required": [
-          "mint"
-        ],
+        "required": ["mint"],
         "properties": {
           "mint": {
             "type": "object",
-            "required": [
-              "extension",
-              "owner",
-              "token_id"
-            ],
+            "required": ["extension", "owner", "token_id"],
             "properties": {
               "extension": {
                 "description": "Any custom extension used by this contract",
@@ -237,10 +198,7 @@
               },
               "token_uri": {
                 "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -251,15 +209,11 @@
       {
         "description": "Burn an NFT the sender has access to",
         "type": "object",
-        "required": [
-          "burn"
-        ],
+        "required": ["burn"],
         "properties": {
           "burn": {
             "type": "object",
-            "required": [
-              "token_id"
-            ],
+            "required": ["token_id"],
             "properties": {
               "token_id": {
                 "type": "string"
@@ -273,15 +227,11 @@
       {
         "description": "Extension msg",
         "type": "object",
-        "required": [
-          "extension"
-        ],
+        "required": ["extension"],
         "properties": {
           "extension": {
             "type": "object",
-            "required": [
-              "msg"
-            ],
+            "required": ["msg"],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/ExecuteExt"
@@ -295,9 +245,7 @@
       {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": [
-          "update_ownership"
-        ],
+        "required": ["update_ownership"],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -313,15 +261,11 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": [
-              "transfer_ownership"
-            ],
+            "required": ["transfer_ownership"],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": [
-                  "new_owner"
-                ],
+                "required": ["new_owner"],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -345,16 +289,12 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": [
-              "accept_ownership"
-            ]
+            "enum": ["accept_ownership"]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": [
-              "renounce_ownership"
-            ]
+            "enum": ["renounce_ownership"]
           }
         ]
       },
@@ -367,15 +307,11 @@
           {
             "description": "Add a new hook to be informed of all membership changes. Must be called by Admin",
             "type": "object",
-            "required": [
-              "add_hook"
-            ],
+            "required": ["add_hook"],
             "properties": {
               "add_hook": {
                 "type": "object",
-                "required": [
-                  "addr"
-                ],
+                "required": ["addr"],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -389,15 +325,11 @@
           {
             "description": "Remove a hook. Must be called by Admin",
             "type": "object",
-            "required": [
-              "remove_hook"
-            ],
+            "required": ["remove_hook"],
             "properties": {
               "remove_hook": {
                 "type": "object",
-                "required": [
-                  "addr"
-                ],
+                "required": ["addr"],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -411,24 +343,17 @@
           {
             "description": "Update the token_uri for a particular NFT. Must be called by minter / admin",
             "type": "object",
-            "required": [
-              "update_token_uri"
-            ],
+            "required": ["update_token_uri"],
             "properties": {
               "update_token_uri": {
                 "type": "object",
-                "required": [
-                  "token_id"
-                ],
+                "required": ["token_id"],
                 "properties": {
                   "token_id": {
                     "type": "string"
                   },
                   "token_uri": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": ["string", "null"]
                   }
                 },
                 "additionalProperties": false
@@ -439,16 +364,11 @@
           {
             "description": "Updates the voting weight of a token. Must be called by minter / admin",
             "type": "object",
-            "required": [
-              "update_token_weight"
-            ],
+            "required": ["update_token_weight"],
             "properties": {
               "update_token_weight": {
                 "type": "object",
-                "required": [
-                  "token_id",
-                  "weight"
-                ],
+                "required": ["token_id", "weight"],
                 "properties": {
                   "token_id": {
                     "type": "string"
@@ -467,21 +387,14 @@
           {
             "description": "Udates the role of a token. Must be called by minter / admin",
             "type": "object",
-            "required": [
-              "update_token_role"
-            ],
+            "required": ["update_token_role"],
             "properties": {
               "update_token_role": {
                 "type": "object",
-                "required": [
-                  "token_id"
-                ],
+                "required": ["token_id"],
                 "properties": {
                   "role": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": ["string", "null"]
                   },
                   "token_id": {
                     "type": "string"
@@ -500,9 +413,7 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": [
-              "at_height"
-            ],
+            "required": ["at_height"],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -515,9 +426,7 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": [
-              "at_time"
-            ],
+            "required": ["at_time"],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -528,9 +437,7 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": [
-              "never"
-            ],
+            "required": ["never"],
             "properties": {
               "never": {
                 "type": "object",
@@ -543,16 +450,11 @@
       },
       "MetadataExt": {
         "type": "object",
-        "required": [
-          "weight"
-        ],
+        "required": ["weight"],
         "properties": {
           "role": {
             "description": "Optional on-chain role for this member, can be used by other contracts to enforce permissions",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "weight": {
             "description": "The voting weight of this role",
@@ -584,22 +486,15 @@
       {
         "description": "Return the owner of the given token, error if token does not exist",
         "type": "object",
-        "required": [
-          "owner_of"
-        ],
+        "required": ["owner_of"],
         "properties": {
           "owner_of": {
             "type": "object",
-            "required": [
-              "token_id"
-            ],
+            "required": ["token_id"],
             "properties": {
               "include_expired": {
                 "description": "unset or false will filter out expired approvals, you must set to true to see them",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": ["boolean", "null"]
               },
               "token_id": {
                 "type": "string"
@@ -613,22 +508,14 @@
       {
         "description": "Return operator that can access all of the owner's tokens.",
         "type": "object",
-        "required": [
-          "approval"
-        ],
+        "required": ["approval"],
         "properties": {
           "approval": {
             "type": "object",
-            "required": [
-              "spender",
-              "token_id"
-            ],
+            "required": ["spender", "token_id"],
             "properties": {
               "include_expired": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": ["boolean", "null"]
               },
               "spender": {
                 "type": "string"
@@ -645,21 +532,14 @@
       {
         "description": "Return approvals that a token has",
         "type": "object",
-        "required": [
-          "approvals"
-        ],
+        "required": ["approvals"],
         "properties": {
           "approvals": {
             "type": "object",
-            "required": [
-              "token_id"
-            ],
+            "required": ["token_id"],
             "properties": {
               "include_expired": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": ["boolean", "null"]
               },
               "token_id": {
                 "type": "string"
@@ -673,22 +553,14 @@
       {
         "description": "Return approval of a given operator for all tokens of an owner, error if not set",
         "type": "object",
-        "required": [
-          "operator"
-        ],
+        "required": ["operator"],
         "properties": {
           "operator": {
             "type": "object",
-            "required": [
-              "operator",
-              "owner"
-            ],
+            "required": ["operator", "owner"],
             "properties": {
               "include_expired": {
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": ["boolean", "null"]
               },
               "operator": {
                 "type": "string"
@@ -705,28 +577,18 @@
       {
         "description": "List all operators that can access all of the owner's tokens",
         "type": "object",
-        "required": [
-          "all_operators"
-        ],
+        "required": ["all_operators"],
         "properties": {
           "all_operators": {
             "type": "object",
-            "required": [
-              "owner"
-            ],
+            "required": ["owner"],
             "properties": {
               "include_expired": {
                 "description": "unset or false will filter out expired items, you must set to true to see them",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": ["boolean", "null"]
               },
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
@@ -734,10 +596,7 @@
                 "type": "string"
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -748,9 +607,7 @@
       {
         "description": "Total number of tokens issued",
         "type": "object",
-        "required": [
-          "num_tokens"
-        ],
+        "required": ["num_tokens"],
         "properties": {
           "num_tokens": {
             "type": "object",
@@ -762,9 +619,7 @@
       {
         "description": "With MetaData Extension. Returns top-level metadata about the contract",
         "type": "object",
-        "required": [
-          "contract_info"
-        ],
+        "required": ["contract_info"],
         "properties": {
           "contract_info": {
             "type": "object",
@@ -776,15 +631,11 @@
       {
         "description": "With MetaData Extension. Returns metadata about one particular token, based on *ERC721 Metadata JSON Schema* but directly from the contract",
         "type": "object",
-        "required": [
-          "nft_info"
-        ],
+        "required": ["nft_info"],
         "properties": {
           "nft_info": {
             "type": "object",
-            "required": [
-              "token_id"
-            ],
+            "required": ["token_id"],
             "properties": {
               "token_id": {
                 "type": "string"
@@ -798,22 +649,15 @@
       {
         "description": "With MetaData Extension. Returns the result of both `NftInfo` and `OwnerOf` as one query as an optimization for clients",
         "type": "object",
-        "required": [
-          "all_nft_info"
-        ],
+        "required": ["all_nft_info"],
         "properties": {
           "all_nft_info": {
             "type": "object",
-            "required": [
-              "token_id"
-            ],
+            "required": ["token_id"],
             "properties": {
               "include_expired": {
                 "description": "unset or false will filter out expired approvals, you must set to true to see them",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": ["boolean", "null"]
               },
               "token_id": {
                 "type": "string"
@@ -827,21 +671,14 @@
       {
         "description": "With Enumerable extension. Returns all tokens owned by the given address, [] if unset.",
         "type": "object",
-        "required": [
-          "tokens"
-        ],
+        "required": ["tokens"],
         "properties": {
           "tokens": {
             "type": "object",
-            "required": [
-              "owner"
-            ],
+            "required": ["owner"],
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
@@ -849,10 +686,7 @@
                 "type": "string"
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -863,26 +697,18 @@
       {
         "description": "With Enumerable extension. Requires pagination. Lists all token_ids controlled by the contract.",
         "type": "object",
-        "required": [
-          "all_tokens"
-        ],
+        "required": ["all_tokens"],
         "properties": {
           "all_tokens": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -893,9 +719,7 @@
       {
         "description": "Return the minter",
         "type": "object",
-        "required": [
-          "minter"
-        ],
+        "required": ["minter"],
         "properties": {
           "minter": {
             "type": "object",
@@ -907,15 +731,11 @@
       {
         "description": "Extension query",
         "type": "object",
-        "required": [
-          "extension"
-        ],
+        "required": ["extension"],
         "properties": {
           "extension": {
             "type": "object",
-            "required": [
-              "msg"
-            ],
+            "required": ["msg"],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/QueryExt"
@@ -929,9 +749,7 @@
       {
         "description": "Query the contract's ownership information",
         "type": "object",
-        "required": [
-          "ownership"
-        ],
+        "required": ["ownership"],
         "properties": {
           "ownership": {
             "type": "object",
@@ -947,18 +765,13 @@
           {
             "description": "Total weight at a given height",
             "type": "object",
-            "required": [
-              "total_weight"
-            ],
+            "required": ["total_weight"],
             "properties": {
               "total_weight": {
                 "type": "object",
                 "properties": {
                   "at_height": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
+                    "type": ["integer", "null"],
                     "format": "uint64",
                     "minimum": 0.0
                   }
@@ -971,26 +784,18 @@
           {
             "description": "Returns a list of Members",
             "type": "object",
-            "required": [
-              "list_members"
-            ],
+            "required": ["list_members"],
             "properties": {
               "list_members": {
                 "type": "object",
                 "properties": {
                   "limit": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
+                    "type": ["integer", "null"],
                     "format": "uint32",
                     "minimum": 0.0
                   },
                   "start_after": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": ["string", "null"]
                   }
                 },
                 "additionalProperties": false
@@ -1001,24 +806,17 @@
           {
             "description": "Returns the weight of a certain member",
             "type": "object",
-            "required": [
-              "member"
-            ],
+            "required": ["member"],
             "properties": {
               "member": {
                 "type": "object",
-                "required": [
-                  "addr"
-                ],
+                "required": ["addr"],
                 "properties": {
                   "addr": {
                     "type": "string"
                   },
                   "at_height": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
+                    "type": ["integer", "null"],
                     "format": "uint64",
                     "minimum": 0.0
                   }
@@ -1031,9 +829,7 @@
           {
             "description": "Shows all registered hooks.",
             "type": "object",
-            "required": [
-              "hooks"
-            ],
+            "required": ["hooks"],
             "properties": {
               "hooks": {
                 "type": "object",
@@ -1053,10 +849,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "AllNftInfoResponse_for_QueryExt",
       "type": "object",
-      "required": [
-        "access",
-        "info"
-      ],
+      "required": ["access", "info"],
       "properties": {
         "access": {
           "description": "Who can transfer the token",
@@ -1079,10 +872,7 @@
       "definitions": {
         "Approval": {
           "type": "object",
-          "required": [
-            "expires",
-            "spender"
-          ],
+          "required": ["expires", "spender"],
           "properties": {
             "expires": {
               "description": "When the Approval expires (maybe Expiration::never)",
@@ -1105,9 +895,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1120,9 +908,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1133,9 +919,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -1148,9 +932,7 @@
         },
         "NftInfoResponse_for_QueryExt": {
           "type": "object",
-          "required": [
-            "extension"
-          ],
+          "required": ["extension"],
           "properties": {
             "extension": {
               "description": "You can add any custom metadata here when you extend cw721-base",
@@ -1162,20 +944,14 @@
             },
             "token_uri": {
               "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             }
           },
           "additionalProperties": false
         },
         "OwnerOfResponse": {
           "type": "object",
-          "required": [
-            "approvals",
-            "owner"
-          ],
+          "required": ["approvals", "owner"],
           "properties": {
             "approvals": {
               "description": "If set this address is approved to transfer/send the token as well",
@@ -1196,18 +972,13 @@
             {
               "description": "Total weight at a given height",
               "type": "object",
-              "required": [
-                "total_weight"
-              ],
+              "required": ["total_weight"],
               "properties": {
                 "total_weight": {
                   "type": "object",
                   "properties": {
                     "at_height": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ],
+                      "type": ["integer", "null"],
                       "format": "uint64",
                       "minimum": 0.0
                     }
@@ -1220,26 +991,18 @@
             {
               "description": "Returns a list of Members",
               "type": "object",
-              "required": [
-                "list_members"
-              ],
+              "required": ["list_members"],
               "properties": {
                 "list_members": {
                   "type": "object",
                   "properties": {
                     "limit": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ],
+                      "type": ["integer", "null"],
                       "format": "uint32",
                       "minimum": 0.0
                     },
                     "start_after": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": ["string", "null"]
                     }
                   },
                   "additionalProperties": false
@@ -1250,24 +1013,17 @@
             {
               "description": "Returns the weight of a certain member",
               "type": "object",
-              "required": [
-                "member"
-              ],
+              "required": ["member"],
               "properties": {
                 "member": {
                   "type": "object",
-                  "required": [
-                    "addr"
-                  ],
+                  "required": ["addr"],
                   "properties": {
                     "addr": {
                       "type": "string"
                     },
                     "at_height": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ],
+                      "type": ["integer", "null"],
                       "format": "uint64",
                       "minimum": 0.0
                     }
@@ -1280,9 +1036,7 @@
             {
               "description": "Shows all registered hooks.",
               "type": "object",
-              "required": [
-                "hooks"
-              ],
+              "required": ["hooks"],
               "properties": {
                 "hooks": {
                   "type": "object",
@@ -1311,9 +1065,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "OperatorsResponse",
       "type": "object",
-      "required": [
-        "operators"
-      ],
+      "required": ["operators"],
       "properties": {
         "operators": {
           "type": "array",
@@ -1326,10 +1078,7 @@
       "definitions": {
         "Approval": {
           "type": "object",
-          "required": [
-            "expires",
-            "spender"
-          ],
+          "required": ["expires", "spender"],
           "properties": {
             "expires": {
               "description": "When the Approval expires (maybe Expiration::never)",
@@ -1352,9 +1101,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1367,9 +1114,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1380,9 +1125,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -1411,9 +1154,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TokensResponse",
       "type": "object",
-      "required": [
-        "tokens"
-      ],
+      "required": ["tokens"],
       "properties": {
         "tokens": {
           "description": "Contains all token_ids in lexicographical ordering If there are more than `limit`, use `start_after` in future queries to achieve pagination.",
@@ -1429,9 +1170,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ApprovalResponse",
       "type": "object",
-      "required": [
-        "approval"
-      ],
+      "required": ["approval"],
       "properties": {
         "approval": {
           "$ref": "#/definitions/Approval"
@@ -1441,10 +1180,7 @@
       "definitions": {
         "Approval": {
           "type": "object",
-          "required": [
-            "expires",
-            "spender"
-          ],
+          "required": ["expires", "spender"],
           "properties": {
             "expires": {
               "description": "When the Approval expires (maybe Expiration::never)",
@@ -1467,9 +1203,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1482,9 +1216,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1495,9 +1227,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -1526,9 +1256,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ApprovalsResponse",
       "type": "object",
-      "required": [
-        "approvals"
-      ],
+      "required": ["approvals"],
       "properties": {
         "approvals": {
           "type": "array",
@@ -1541,10 +1269,7 @@
       "definitions": {
         "Approval": {
           "type": "object",
-          "required": [
-            "expires",
-            "spender"
-          ],
+          "required": ["expires", "spender"],
           "properties": {
             "expires": {
               "description": "When the Approval expires (maybe Expiration::never)",
@@ -1567,9 +1292,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1582,9 +1305,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1595,9 +1316,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -1626,10 +1345,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ContractInfoResponse",
       "type": "object",
-      "required": [
-        "name",
-        "symbol"
-      ],
+      "required": ["name", "symbol"],
       "properties": {
         "name": {
           "type": "string"
@@ -1652,10 +1368,7 @@
       "type": "object",
       "properties": {
         "minter": {
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       },
       "additionalProperties": false
@@ -1664,9 +1377,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "NftInfoResponse_for_QueryExt",
       "type": "object",
-      "required": [
-        "extension"
-      ],
+      "required": ["extension"],
       "properties": {
         "extension": {
           "description": "You can add any custom metadata here when you extend cw721-base",
@@ -1678,10 +1389,7 @@
         },
         "token_uri": {
           "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       },
       "additionalProperties": false,
@@ -1691,18 +1399,13 @@
             {
               "description": "Total weight at a given height",
               "type": "object",
-              "required": [
-                "total_weight"
-              ],
+              "required": ["total_weight"],
               "properties": {
                 "total_weight": {
                   "type": "object",
                   "properties": {
                     "at_height": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ],
+                      "type": ["integer", "null"],
                       "format": "uint64",
                       "minimum": 0.0
                     }
@@ -1715,26 +1418,18 @@
             {
               "description": "Returns a list of Members",
               "type": "object",
-              "required": [
-                "list_members"
-              ],
+              "required": ["list_members"],
               "properties": {
                 "list_members": {
                   "type": "object",
                   "properties": {
                     "limit": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ],
+                      "type": ["integer", "null"],
                       "format": "uint32",
                       "minimum": 0.0
                     },
                     "start_after": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": ["string", "null"]
                     }
                   },
                   "additionalProperties": false
@@ -1745,24 +1440,17 @@
             {
               "description": "Returns the weight of a certain member",
               "type": "object",
-              "required": [
-                "member"
-              ],
+              "required": ["member"],
               "properties": {
                 "member": {
                   "type": "object",
-                  "required": [
-                    "addr"
-                  ],
+                  "required": ["addr"],
                   "properties": {
                     "addr": {
                       "type": "string"
                     },
                     "at_height": {
-                      "type": [
-                        "integer",
-                        "null"
-                      ],
+                      "type": ["integer", "null"],
                       "format": "uint64",
                       "minimum": 0.0
                     }
@@ -1775,9 +1463,7 @@
             {
               "description": "Shows all registered hooks.",
               "type": "object",
-              "required": [
-                "hooks"
-              ],
+              "required": ["hooks"],
               "properties": {
                 "hooks": {
                   "type": "object",
@@ -1794,9 +1480,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "NumTokensResponse",
       "type": "object",
-      "required": [
-        "count"
-      ],
+      "required": ["count"],
       "properties": {
         "count": {
           "type": "integer",
@@ -1810,9 +1494,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "OperatorResponse",
       "type": "object",
-      "required": [
-        "approval"
-      ],
+      "required": ["approval"],
       "properties": {
         "approval": {
           "$ref": "#/definitions/Approval"
@@ -1822,10 +1504,7 @@
       "definitions": {
         "Approval": {
           "type": "object",
-          "required": [
-            "expires",
-            "spender"
-          ],
+          "required": ["expires", "spender"],
           "properties": {
             "expires": {
               "description": "When the Approval expires (maybe Expiration::never)",
@@ -1848,9 +1527,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1863,9 +1540,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1876,9 +1551,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -1907,10 +1580,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "OwnerOfResponse",
       "type": "object",
-      "required": [
-        "approvals",
-        "owner"
-      ],
+      "required": ["approvals", "owner"],
       "properties": {
         "approvals": {
           "description": "If set this address is approved to transfer/send the token as well",
@@ -1928,10 +1598,7 @@
       "definitions": {
         "Approval": {
           "type": "object",
-          "required": [
-            "expires",
-            "spender"
-          ],
+          "required": ["expires", "spender"],
           "properties": {
             "expires": {
               "description": "When the Approval expires (maybe Expiration::never)",
@@ -1954,9 +1621,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1969,9 +1634,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1982,9 +1645,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -2017,10 +1678,7 @@
       "properties": {
         "owner": {
           "description": "The contract's current owner. `None` if the ownership has been renounced.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         },
         "pending_expiry": {
           "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
@@ -2035,10 +1693,7 @@
         },
         "pending_owner": {
           "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "type": ["string", "null"]
         }
       },
       "additionalProperties": false,
@@ -2049,9 +1704,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -2064,9 +1717,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -2077,9 +1728,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -2108,9 +1757,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TokensResponse",
       "type": "object",
-      "required": [
-        "tokens"
-      ],
+      "required": ["tokens"],
       "properties": {
         "tokens": {
           "description": "Contains all token_ids in lexicographical ordering If there are more than `limit`, use `start_after` in future queries to achieve pagination.",

--- a/contracts/external/cw721-roles/schema/cw721-roles.json
+++ b/contracts/external/cw721-roles/schema/cw721-roles.json
@@ -6,7 +6,11 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["minter", "name", "symbol"],
+    "required": [
+      "minter",
+      "name",
+      "symbol"
+    ],
     "properties": {
       "minter": {
         "description": "The minter is the only one who can create new NFTs. This is designed for a base NFT that is controlled by an external program or contract. You will likely replace this with custom logic in custom NFTs",
@@ -31,11 +35,16 @@
       {
         "description": "Transfer is a base message to move a token to another account without triggering actions",
         "type": "object",
-        "required": ["transfer_nft"],
+        "required": [
+          "transfer_nft"
+        ],
         "properties": {
           "transfer_nft": {
             "type": "object",
-            "required": ["recipient", "token_id"],
+            "required": [
+              "recipient",
+              "token_id"
+            ],
             "properties": {
               "recipient": {
                 "type": "string"
@@ -52,11 +61,17 @@
       {
         "description": "Send is a base message to transfer a token to a contract and trigger an action on the receiving contract.",
         "type": "object",
-        "required": ["send_nft"],
+        "required": [
+          "send_nft"
+        ],
         "properties": {
           "send_nft": {
             "type": "object",
-            "required": ["contract", "msg", "token_id"],
+            "required": [
+              "contract",
+              "msg",
+              "token_id"
+            ],
             "properties": {
               "contract": {
                 "type": "string"
@@ -76,11 +91,16 @@
       {
         "description": "Allows operator to transfer / send the token from the owner's account. If expiration is set, then this allowance has a time/height limit",
         "type": "object",
-        "required": ["approve"],
+        "required": [
+          "approve"
+        ],
         "properties": {
           "approve": {
             "type": "object",
-            "required": ["spender", "token_id"],
+            "required": [
+              "spender",
+              "token_id"
+            ],
             "properties": {
               "expires": {
                 "anyOf": [
@@ -107,11 +127,16 @@
       {
         "description": "Remove previously granted Approval",
         "type": "object",
-        "required": ["revoke"],
+        "required": [
+          "revoke"
+        ],
         "properties": {
           "revoke": {
             "type": "object",
-            "required": ["spender", "token_id"],
+            "required": [
+              "spender",
+              "token_id"
+            ],
             "properties": {
               "spender": {
                 "type": "string"
@@ -128,11 +153,15 @@
       {
         "description": "Allows operator to transfer / send any token from the owner's account. If expiration is set, then this allowance has a time/height limit",
         "type": "object",
-        "required": ["approve_all"],
+        "required": [
+          "approve_all"
+        ],
         "properties": {
           "approve_all": {
             "type": "object",
-            "required": ["operator"],
+            "required": [
+              "operator"
+            ],
             "properties": {
               "expires": {
                 "anyOf": [
@@ -156,11 +185,15 @@
       {
         "description": "Remove previously granted ApproveAll permission",
         "type": "object",
-        "required": ["revoke_all"],
+        "required": [
+          "revoke_all"
+        ],
         "properties": {
           "revoke_all": {
             "type": "object",
-            "required": ["operator"],
+            "required": [
+              "operator"
+            ],
             "properties": {
               "operator": {
                 "type": "string"
@@ -174,11 +207,17 @@
       {
         "description": "Mint a new NFT, can only be called by the contract minter",
         "type": "object",
-        "required": ["mint"],
+        "required": [
+          "mint"
+        ],
         "properties": {
           "mint": {
             "type": "object",
-            "required": ["extension", "owner", "token_id"],
+            "required": [
+              "extension",
+              "owner",
+              "token_id"
+            ],
             "properties": {
               "extension": {
                 "description": "Any custom extension used by this contract",
@@ -198,7 +237,10 @@
               },
               "token_uri": {
                 "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -209,11 +251,15 @@
       {
         "description": "Burn an NFT the sender has access to",
         "type": "object",
-        "required": ["burn"],
+        "required": [
+          "burn"
+        ],
         "properties": {
           "burn": {
             "type": "object",
-            "required": ["token_id"],
+            "required": [
+              "token_id"
+            ],
             "properties": {
               "token_id": {
                 "type": "string"
@@ -227,11 +273,15 @@
       {
         "description": "Extension msg",
         "type": "object",
-        "required": ["extension"],
+        "required": [
+          "extension"
+        ],
         "properties": {
           "extension": {
             "type": "object",
-            "required": ["msg"],
+            "required": [
+              "msg"
+            ],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/ExecuteExt"
@@ -245,7 +295,9 @@
       {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": ["update_ownership"],
+        "required": [
+          "update_ownership"
+        ],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -261,11 +313,15 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": ["transfer_ownership"],
+            "required": [
+              "transfer_ownership"
+            ],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": ["new_owner"],
+                "required": [
+                  "new_owner"
+                ],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -289,12 +345,16 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": ["accept_ownership"]
+            "enum": [
+              "accept_ownership"
+            ]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": ["renounce_ownership"]
+            "enum": [
+              "renounce_ownership"
+            ]
           }
         ]
       },
@@ -307,11 +367,15 @@
           {
             "description": "Add a new hook to be informed of all membership changes. Must be called by Admin",
             "type": "object",
-            "required": ["add_hook"],
+            "required": [
+              "add_hook"
+            ],
             "properties": {
               "add_hook": {
                 "type": "object",
-                "required": ["addr"],
+                "required": [
+                  "addr"
+                ],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -325,11 +389,15 @@
           {
             "description": "Remove a hook. Must be called by Admin",
             "type": "object",
-            "required": ["remove_hook"],
+            "required": [
+              "remove_hook"
+            ],
             "properties": {
               "remove_hook": {
                 "type": "object",
-                "required": ["addr"],
+                "required": [
+                  "addr"
+                ],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -343,17 +411,24 @@
           {
             "description": "Update the token_uri for a particular NFT. Must be called by minter / admin",
             "type": "object",
-            "required": ["update_token_uri"],
+            "required": [
+              "update_token_uri"
+            ],
             "properties": {
               "update_token_uri": {
                 "type": "object",
-                "required": ["token_id"],
+                "required": [
+                  "token_id"
+                ],
                 "properties": {
                   "token_id": {
                     "type": "string"
                   },
                   "token_uri": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -364,11 +439,16 @@
           {
             "description": "Updates the voting weight of a token. Must be called by minter / admin",
             "type": "object",
-            "required": ["update_token_weight"],
+            "required": [
+              "update_token_weight"
+            ],
             "properties": {
               "update_token_weight": {
                 "type": "object",
-                "required": ["token_id", "weight"],
+                "required": [
+                  "token_id",
+                  "weight"
+                ],
                 "properties": {
                   "token_id": {
                     "type": "string"
@@ -387,14 +467,21 @@
           {
             "description": "Udates the role of a token. Must be called by minter / admin",
             "type": "object",
-            "required": ["update_token_role"],
+            "required": [
+              "update_token_role"
+            ],
             "properties": {
               "update_token_role": {
                 "type": "object",
-                "required": ["token_id"],
+                "required": [
+                  "token_id"
+                ],
                 "properties": {
                   "role": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "token_id": {
                     "type": "string"
@@ -413,7 +500,9 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": ["at_height"],
+            "required": [
+              "at_height"
+            ],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -426,7 +515,9 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": ["at_time"],
+            "required": [
+              "at_time"
+            ],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -437,7 +528,9 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": ["never"],
+            "required": [
+              "never"
+            ],
             "properties": {
               "never": {
                 "type": "object",
@@ -450,11 +543,16 @@
       },
       "MetadataExt": {
         "type": "object",
-        "required": ["weight"],
+        "required": [
+          "weight"
+        ],
         "properties": {
           "role": {
             "description": "Optional on-chain role for this member, can be used by other contracts to enforce permissions",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "weight": {
             "description": "The voting weight of this role",
@@ -486,15 +584,22 @@
       {
         "description": "Return the owner of the given token, error if token does not exist",
         "type": "object",
-        "required": ["owner_of"],
+        "required": [
+          "owner_of"
+        ],
         "properties": {
           "owner_of": {
             "type": "object",
-            "required": ["token_id"],
+            "required": [
+              "token_id"
+            ],
             "properties": {
               "include_expired": {
                 "description": "unset or false will filter out expired approvals, you must set to true to see them",
-                "type": ["boolean", "null"]
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               },
               "token_id": {
                 "type": "string"
@@ -508,14 +613,22 @@
       {
         "description": "Return operator that can access all of the owner's tokens.",
         "type": "object",
-        "required": ["approval"],
+        "required": [
+          "approval"
+        ],
         "properties": {
           "approval": {
             "type": "object",
-            "required": ["spender", "token_id"],
+            "required": [
+              "spender",
+              "token_id"
+            ],
             "properties": {
               "include_expired": {
-                "type": ["boolean", "null"]
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               },
               "spender": {
                 "type": "string"
@@ -532,14 +645,21 @@
       {
         "description": "Return approvals that a token has",
         "type": "object",
-        "required": ["approvals"],
+        "required": [
+          "approvals"
+        ],
         "properties": {
           "approvals": {
             "type": "object",
-            "required": ["token_id"],
+            "required": [
+              "token_id"
+            ],
             "properties": {
               "include_expired": {
-                "type": ["boolean", "null"]
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               },
               "token_id": {
                 "type": "string"
@@ -553,14 +673,22 @@
       {
         "description": "Return approval of a given operator for all tokens of an owner, error if not set",
         "type": "object",
-        "required": ["operator"],
+        "required": [
+          "operator"
+        ],
         "properties": {
           "operator": {
             "type": "object",
-            "required": ["operator", "owner"],
+            "required": [
+              "operator",
+              "owner"
+            ],
             "properties": {
               "include_expired": {
-                "type": ["boolean", "null"]
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               },
               "operator": {
                 "type": "string"
@@ -577,18 +705,28 @@
       {
         "description": "List all operators that can access all of the owner's tokens",
         "type": "object",
-        "required": ["all_operators"],
+        "required": [
+          "all_operators"
+        ],
         "properties": {
           "all_operators": {
             "type": "object",
-            "required": ["owner"],
+            "required": [
+              "owner"
+            ],
             "properties": {
               "include_expired": {
                 "description": "unset or false will filter out expired items, you must set to true to see them",
-                "type": ["boolean", "null"]
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               },
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
@@ -596,7 +734,10 @@
                 "type": "string"
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -607,7 +748,9 @@
       {
         "description": "Total number of tokens issued",
         "type": "object",
-        "required": ["num_tokens"],
+        "required": [
+          "num_tokens"
+        ],
         "properties": {
           "num_tokens": {
             "type": "object",
@@ -619,7 +762,9 @@
       {
         "description": "With MetaData Extension. Returns top-level metadata about the contract",
         "type": "object",
-        "required": ["contract_info"],
+        "required": [
+          "contract_info"
+        ],
         "properties": {
           "contract_info": {
             "type": "object",
@@ -631,11 +776,15 @@
       {
         "description": "With MetaData Extension. Returns metadata about one particular token, based on *ERC721 Metadata JSON Schema* but directly from the contract",
         "type": "object",
-        "required": ["nft_info"],
+        "required": [
+          "nft_info"
+        ],
         "properties": {
           "nft_info": {
             "type": "object",
-            "required": ["token_id"],
+            "required": [
+              "token_id"
+            ],
             "properties": {
               "token_id": {
                 "type": "string"
@@ -649,15 +798,22 @@
       {
         "description": "With MetaData Extension. Returns the result of both `NftInfo` and `OwnerOf` as one query as an optimization for clients",
         "type": "object",
-        "required": ["all_nft_info"],
+        "required": [
+          "all_nft_info"
+        ],
         "properties": {
           "all_nft_info": {
             "type": "object",
-            "required": ["token_id"],
+            "required": [
+              "token_id"
+            ],
             "properties": {
               "include_expired": {
                 "description": "unset or false will filter out expired approvals, you must set to true to see them",
-                "type": ["boolean", "null"]
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               },
               "token_id": {
                 "type": "string"
@@ -671,14 +827,21 @@
       {
         "description": "With Enumerable extension. Returns all tokens owned by the given address, [] if unset.",
         "type": "object",
-        "required": ["tokens"],
+        "required": [
+          "tokens"
+        ],
         "properties": {
           "tokens": {
             "type": "object",
-            "required": ["owner"],
+            "required": [
+              "owner"
+            ],
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
@@ -686,7 +849,10 @@
                 "type": "string"
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -697,18 +863,26 @@
       {
         "description": "With Enumerable extension. Requires pagination. Lists all token_ids controlled by the contract.",
         "type": "object",
-        "required": ["all_tokens"],
+        "required": [
+          "all_tokens"
+        ],
         "properties": {
           "all_tokens": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -719,7 +893,9 @@
       {
         "description": "Return the minter",
         "type": "object",
-        "required": ["minter"],
+        "required": [
+          "minter"
+        ],
         "properties": {
           "minter": {
             "type": "object",
@@ -731,11 +907,15 @@
       {
         "description": "Extension query",
         "type": "object",
-        "required": ["extension"],
+        "required": [
+          "extension"
+        ],
         "properties": {
           "extension": {
             "type": "object",
-            "required": ["msg"],
+            "required": [
+              "msg"
+            ],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/QueryExt"
@@ -749,7 +929,9 @@
       {
         "description": "Query the contract's ownership information",
         "type": "object",
-        "required": ["ownership"],
+        "required": [
+          "ownership"
+        ],
         "properties": {
           "ownership": {
             "type": "object",
@@ -765,13 +947,18 @@
           {
             "description": "Total weight at a given height",
             "type": "object",
-            "required": ["total_weight"],
+            "required": [
+              "total_weight"
+            ],
             "properties": {
               "total_weight": {
                 "type": "object",
                 "properties": {
                   "at_height": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "format": "uint64",
                     "minimum": 0.0
                   }
@@ -784,18 +971,26 @@
           {
             "description": "Returns a list of Members",
             "type": "object",
-            "required": ["list_members"],
+            "required": [
+              "list_members"
+            ],
             "properties": {
               "list_members": {
                 "type": "object",
                 "properties": {
                   "limit": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "format": "uint32",
                     "minimum": 0.0
                   },
                   "start_after": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -806,17 +1001,24 @@
           {
             "description": "Returns the weight of a certain member",
             "type": "object",
-            "required": ["member"],
+            "required": [
+              "member"
+            ],
             "properties": {
               "member": {
                 "type": "object",
-                "required": ["addr"],
+                "required": [
+                  "addr"
+                ],
                 "properties": {
                   "addr": {
                     "type": "string"
                   },
                   "at_height": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "format": "uint64",
                     "minimum": 0.0
                   }
@@ -829,7 +1031,9 @@
           {
             "description": "Shows all registered hooks.",
             "type": "object",
-            "required": ["hooks"],
+            "required": [
+              "hooks"
+            ],
             "properties": {
               "hooks": {
                 "type": "object",
@@ -849,7 +1053,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "AllNftInfoResponse_for_QueryExt",
       "type": "object",
-      "required": ["access", "info"],
+      "required": [
+        "access",
+        "info"
+      ],
       "properties": {
         "access": {
           "description": "Who can transfer the token",
@@ -872,7 +1079,10 @@
       "definitions": {
         "Approval": {
           "type": "object",
-          "required": ["expires", "spender"],
+          "required": [
+            "expires",
+            "spender"
+          ],
           "properties": {
             "expires": {
               "description": "When the Approval expires (maybe Expiration::never)",
@@ -895,7 +1105,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -908,7 +1120,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -919,7 +1133,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -932,7 +1148,9 @@
         },
         "NftInfoResponse_for_QueryExt": {
           "type": "object",
-          "required": ["extension"],
+          "required": [
+            "extension"
+          ],
           "properties": {
             "extension": {
               "description": "You can add any custom metadata here when you extend cw721-base",
@@ -944,14 +1162,20 @@
             },
             "token_uri": {
               "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "additionalProperties": false
         },
         "OwnerOfResponse": {
           "type": "object",
-          "required": ["approvals", "owner"],
+          "required": [
+            "approvals",
+            "owner"
+          ],
           "properties": {
             "approvals": {
               "description": "If set this address is approved to transfer/send the token as well",
@@ -972,13 +1196,18 @@
             {
               "description": "Total weight at a given height",
               "type": "object",
-              "required": ["total_weight"],
+              "required": [
+                "total_weight"
+              ],
               "properties": {
                 "total_weight": {
                   "type": "object",
                   "properties": {
                     "at_height": {
-                      "type": ["integer", "null"],
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
                       "format": "uint64",
                       "minimum": 0.0
                     }
@@ -991,18 +1220,26 @@
             {
               "description": "Returns a list of Members",
               "type": "object",
-              "required": ["list_members"],
+              "required": [
+                "list_members"
+              ],
               "properties": {
                 "list_members": {
                   "type": "object",
                   "properties": {
                     "limit": {
-                      "type": ["integer", "null"],
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
                       "format": "uint32",
                       "minimum": 0.0
                     },
                     "start_after": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   },
                   "additionalProperties": false
@@ -1013,17 +1250,24 @@
             {
               "description": "Returns the weight of a certain member",
               "type": "object",
-              "required": ["member"],
+              "required": [
+                "member"
+              ],
               "properties": {
                 "member": {
                   "type": "object",
-                  "required": ["addr"],
+                  "required": [
+                    "addr"
+                  ],
                   "properties": {
                     "addr": {
                       "type": "string"
                     },
                     "at_height": {
-                      "type": ["integer", "null"],
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
                       "format": "uint64",
                       "minimum": 0.0
                     }
@@ -1036,7 +1280,9 @@
             {
               "description": "Shows all registered hooks.",
               "type": "object",
-              "required": ["hooks"],
+              "required": [
+                "hooks"
+              ],
               "properties": {
                 "hooks": {
                   "type": "object",
@@ -1065,7 +1311,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "OperatorsResponse",
       "type": "object",
-      "required": ["operators"],
+      "required": [
+        "operators"
+      ],
       "properties": {
         "operators": {
           "type": "array",
@@ -1078,7 +1326,10 @@
       "definitions": {
         "Approval": {
           "type": "object",
-          "required": ["expires", "spender"],
+          "required": [
+            "expires",
+            "spender"
+          ],
           "properties": {
             "expires": {
               "description": "When the Approval expires (maybe Expiration::never)",
@@ -1101,7 +1352,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1114,7 +1367,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1125,7 +1380,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -1154,7 +1411,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TokensResponse",
       "type": "object",
-      "required": ["tokens"],
+      "required": [
+        "tokens"
+      ],
       "properties": {
         "tokens": {
           "description": "Contains all token_ids in lexicographical ordering If there are more than `limit`, use `start_after` in future queries to achieve pagination.",
@@ -1170,7 +1429,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ApprovalResponse",
       "type": "object",
-      "required": ["approval"],
+      "required": [
+        "approval"
+      ],
       "properties": {
         "approval": {
           "$ref": "#/definitions/Approval"
@@ -1180,7 +1441,10 @@
       "definitions": {
         "Approval": {
           "type": "object",
-          "required": ["expires", "spender"],
+          "required": [
+            "expires",
+            "spender"
+          ],
           "properties": {
             "expires": {
               "description": "When the Approval expires (maybe Expiration::never)",
@@ -1203,7 +1467,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1216,7 +1482,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1227,7 +1495,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -1256,7 +1526,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ApprovalsResponse",
       "type": "object",
-      "required": ["approvals"],
+      "required": [
+        "approvals"
+      ],
       "properties": {
         "approvals": {
           "type": "array",
@@ -1269,7 +1541,10 @@
       "definitions": {
         "Approval": {
           "type": "object",
-          "required": ["expires", "spender"],
+          "required": [
+            "expires",
+            "spender"
+          ],
           "properties": {
             "expires": {
               "description": "When the Approval expires (maybe Expiration::never)",
@@ -1292,7 +1567,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1305,7 +1582,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1316,7 +1595,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -1345,7 +1626,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ContractInfoResponse",
       "type": "object",
-      "required": ["name", "symbol"],
+      "required": [
+        "name",
+        "symbol"
+      ],
       "properties": {
         "name": {
           "type": "string"
@@ -1368,7 +1652,10 @@
       "type": "object",
       "properties": {
         "minter": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false
@@ -1377,7 +1664,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "NftInfoResponse_for_QueryExt",
       "type": "object",
-      "required": ["extension"],
+      "required": [
+        "extension"
+      ],
       "properties": {
         "extension": {
           "description": "You can add any custom metadata here when you extend cw721-base",
@@ -1389,7 +1678,10 @@
         },
         "token_uri": {
           "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false,
@@ -1399,13 +1691,18 @@
             {
               "description": "Total weight at a given height",
               "type": "object",
-              "required": ["total_weight"],
+              "required": [
+                "total_weight"
+              ],
               "properties": {
                 "total_weight": {
                   "type": "object",
                   "properties": {
                     "at_height": {
-                      "type": ["integer", "null"],
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
                       "format": "uint64",
                       "minimum": 0.0
                     }
@@ -1418,18 +1715,26 @@
             {
               "description": "Returns a list of Members",
               "type": "object",
-              "required": ["list_members"],
+              "required": [
+                "list_members"
+              ],
               "properties": {
                 "list_members": {
                   "type": "object",
                   "properties": {
                     "limit": {
-                      "type": ["integer", "null"],
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
                       "format": "uint32",
                       "minimum": 0.0
                     },
                     "start_after": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     }
                   },
                   "additionalProperties": false
@@ -1440,17 +1745,24 @@
             {
               "description": "Returns the weight of a certain member",
               "type": "object",
-              "required": ["member"],
+              "required": [
+                "member"
+              ],
               "properties": {
                 "member": {
                   "type": "object",
-                  "required": ["addr"],
+                  "required": [
+                    "addr"
+                  ],
                   "properties": {
                     "addr": {
                       "type": "string"
                     },
                     "at_height": {
-                      "type": ["integer", "null"],
+                      "type": [
+                        "integer",
+                        "null"
+                      ],
                       "format": "uint64",
                       "minimum": 0.0
                     }
@@ -1463,7 +1775,9 @@
             {
               "description": "Shows all registered hooks.",
               "type": "object",
-              "required": ["hooks"],
+              "required": [
+                "hooks"
+              ],
               "properties": {
                 "hooks": {
                   "type": "object",
@@ -1480,7 +1794,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "NumTokensResponse",
       "type": "object",
-      "required": ["count"],
+      "required": [
+        "count"
+      ],
       "properties": {
         "count": {
           "type": "integer",
@@ -1494,7 +1810,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "OperatorResponse",
       "type": "object",
-      "required": ["approval"],
+      "required": [
+        "approval"
+      ],
       "properties": {
         "approval": {
           "$ref": "#/definitions/Approval"
@@ -1504,7 +1822,10 @@
       "definitions": {
         "Approval": {
           "type": "object",
-          "required": ["expires", "spender"],
+          "required": [
+            "expires",
+            "spender"
+          ],
           "properties": {
             "expires": {
               "description": "When the Approval expires (maybe Expiration::never)",
@@ -1527,7 +1848,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1540,7 +1863,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1551,7 +1876,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -1580,7 +1907,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "OwnerOfResponse",
       "type": "object",
-      "required": ["approvals", "owner"],
+      "required": [
+        "approvals",
+        "owner"
+      ],
       "properties": {
         "approvals": {
           "description": "If set this address is approved to transfer/send the token as well",
@@ -1598,7 +1928,10 @@
       "definitions": {
         "Approval": {
           "type": "object",
-          "required": ["expires", "spender"],
+          "required": [
+            "expires",
+            "spender"
+          ],
           "properties": {
             "expires": {
               "description": "When the Approval expires (maybe Expiration::never)",
@@ -1621,7 +1954,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1634,7 +1969,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1645,7 +1982,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -1678,7 +2017,10 @@
       "properties": {
         "owner": {
           "description": "The contract's current owner. `None` if the ownership has been renounced.",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "pending_expiry": {
           "description": "The deadline for the pending owner to accept the ownership. `None` if there isn't a pending ownership transfer, or if a transfer exists and it doesn't have a deadline.",
@@ -1693,7 +2035,10 @@
         },
         "pending_owner": {
           "description": "The account who has been proposed to take over the ownership. `None` if there isn't a pending ownership transfer.",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false,
@@ -1704,7 +2049,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1717,7 +2064,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1728,7 +2077,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -1757,7 +2108,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TokensResponse",
       "type": "object",
-      "required": ["tokens"],
+      "required": [
+        "tokens"
+      ],
       "properties": {
         "tokens": {
           "description": "Contains all token_ids in lexicographical ordering If there are more than `limit`, use `start_after` in future queries to achieve pagination.",

--- a/contracts/external/dao-migrator/schema/dao-migrator.json
+++ b/contracts/external/dao-migrator/schema/dao-migrator.json
@@ -1,17 +1,12 @@
 {
   "contract_name": "dao-migrator",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "migration_params",
-      "sub_daos",
-      "v1_code_ids",
-      "v2_code_ids"
-    ],
+    "required": ["migration_params", "sub_daos", "v1_code_ids", "v2_code_ids"],
     "properties": {
       "migration_params": {
         "$ref": "#/definitions/MigrationParams"
@@ -37,15 +32,11 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "object",
-                "required": [
-                  "addr"
-                ],
+                "required": ["addr"],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -59,9 +50,7 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": [
-              "core_module"
-            ],
+            "required": ["core_module"],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -78,10 +67,7 @@
       },
       "Coin": {
         "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
+        "required": ["amount", "denom"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -96,9 +82,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -111,9 +95,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -127,16 +109,11 @@
       },
       "MigrationParams": {
         "type": "object",
-        "required": [
-          "proposal_params"
-        ],
+        "required": ["proposal_params"],
         "properties": {
           "migrate_stake_cw20_manager": {
             "description": "Rather or not to migrate the stake_cw20 contract and its manager. If this is not set to true and a stake_cw20 contract is detected in the DAO's configuration the migration will be aborted.",
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": ["boolean", "null"]
           },
           "proposal_params": {
             "description": "List of (address, ProposalParams) where `address` is an address of a proposal module currently part of the DAO.",
@@ -161,12 +138,7 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": [
-          "code_id",
-          "funds",
-          "label",
-          "msg"
-        ],
+        "required": ["code_id", "funds", "label", "msg"],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -212,9 +184,7 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": [
-              "anyone_may_propose"
-            ],
+            "required": ["anyone_may_propose"],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -226,15 +196,11 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": [
-              "module_may_propose"
-            ],
+            "required": ["module_may_propose"],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": [
-                  "info"
-                ],
+                "required": ["info"],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -250,10 +216,7 @@
       "ProposalParams": {
         "description": "The params we need to provide for migration msgs",
         "type": "object",
-        "required": [
-          "close_proposal_on_execution_failure",
-          "pre_propose_info"
-        ],
+        "required": ["close_proposal_on_execution_failure", "pre_propose_info"],
         "properties": {
           "close_proposal_on_execution_failure": {
             "type": "boolean"
@@ -276,9 +239,7 @@
       },
       "SubDao": {
         "type": "object",
-        "required": [
-          "addr"
-        ],
+        "required": ["addr"],
         "properties": {
           "addr": {
             "description": "The contract address of the SubDAO",
@@ -286,10 +247,7 @@
           },
           "charter": {
             "description": "The purpose/constitution for the SubDAO",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           }
         },
         "additionalProperties": false
@@ -400,12 +358,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "ExecuteMsg",
     "type": "object",
-    "required": [
-      "migration_params",
-      "sub_daos",
-      "v1_code_ids",
-      "v2_code_ids"
-    ],
+    "required": ["migration_params", "sub_daos", "v1_code_ids", "v2_code_ids"],
     "properties": {
       "migration_params": {
         "$ref": "#/definitions/MigrationParams"
@@ -431,15 +384,11 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "object",
-                "required": [
-                  "addr"
-                ],
+                "required": ["addr"],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -453,9 +402,7 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": [
-              "core_module"
-            ],
+            "required": ["core_module"],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -472,10 +419,7 @@
       },
       "Coin": {
         "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
+        "required": ["amount", "denom"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -490,9 +434,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -505,9 +447,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -521,16 +461,11 @@
       },
       "MigrationParams": {
         "type": "object",
-        "required": [
-          "proposal_params"
-        ],
+        "required": ["proposal_params"],
         "properties": {
           "migrate_stake_cw20_manager": {
             "description": "Rather or not to migrate the stake_cw20 contract and its manager. If this is not set to true and a stake_cw20 contract is detected in the DAO's configuration the migration will be aborted.",
-            "type": [
-              "boolean",
-              "null"
-            ]
+            "type": ["boolean", "null"]
           },
           "proposal_params": {
             "description": "List of (address, ProposalParams) where `address` is an address of a proposal module currently part of the DAO.",
@@ -555,12 +490,7 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": [
-          "code_id",
-          "funds",
-          "label",
-          "msg"
-        ],
+        "required": ["code_id", "funds", "label", "msg"],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -606,9 +536,7 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": [
-              "anyone_may_propose"
-            ],
+            "required": ["anyone_may_propose"],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -620,15 +548,11 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": [
-              "module_may_propose"
-            ],
+            "required": ["module_may_propose"],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": [
-                  "info"
-                ],
+                "required": ["info"],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -644,10 +568,7 @@
       "ProposalParams": {
         "description": "The params we need to provide for migration msgs",
         "type": "object",
-        "required": [
-          "close_proposal_on_execution_failure",
-          "pre_propose_info"
-        ],
+        "required": ["close_proposal_on_execution_failure", "pre_propose_info"],
         "properties": {
           "close_proposal_on_execution_failure": {
             "type": "boolean"
@@ -670,9 +591,7 @@
       },
       "SubDao": {
         "type": "object",
-        "required": [
-          "addr"
-        ],
+        "required": ["addr"],
         "properties": {
           "addr": {
             "description": "The contract address of the SubDAO",
@@ -680,10 +599,7 @@
           },
           "charter": {
             "description": "The purpose/constitution for the SubDAO",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           }
         },
         "additionalProperties": false

--- a/contracts/external/dao-migrator/schema/dao-migrator.json
+++ b/contracts/external/dao-migrator/schema/dao-migrator.json
@@ -6,7 +6,12 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["migration_params", "sub_daos", "v1_code_ids", "v2_code_ids"],
+    "required": [
+      "migration_params",
+      "sub_daos",
+      "v1_code_ids",
+      "v2_code_ids"
+    ],
     "properties": {
       "migration_params": {
         "$ref": "#/definitions/MigrationParams"
@@ -32,11 +37,15 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "object",
-                "required": ["addr"],
+                "required": [
+                  "addr"
+                ],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -50,7 +59,9 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": ["core_module"],
+            "required": [
+              "core_module"
+            ],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -67,7 +78,10 @@
       },
       "Coin": {
         "type": "object",
-        "required": ["amount", "denom"],
+        "required": [
+          "amount",
+          "denom"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -82,7 +96,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -95,7 +111,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -109,11 +127,16 @@
       },
       "MigrationParams": {
         "type": "object",
-        "required": ["proposal_params"],
+        "required": [
+          "proposal_params"
+        ],
         "properties": {
           "migrate_stake_cw20_manager": {
             "description": "Rather or not to migrate the stake_cw20 contract and its manager. If this is not set to true and a stake_cw20 contract is detected in the DAO's configuration the migration will be aborted.",
-            "type": ["boolean", "null"]
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "proposal_params": {
             "description": "List of (address, ProposalParams) where `address` is an address of a proposal module currently part of the DAO.",
@@ -138,7 +161,12 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": ["code_id", "funds", "label", "msg"],
+        "required": [
+          "code_id",
+          "funds",
+          "label",
+          "msg"
+        ],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -184,7 +212,9 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": ["anyone_may_propose"],
+            "required": [
+              "anyone_may_propose"
+            ],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -196,11 +226,15 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": ["module_may_propose"],
+            "required": [
+              "module_may_propose"
+            ],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": ["info"],
+                "required": [
+                  "info"
+                ],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -216,7 +250,10 @@
       "ProposalParams": {
         "description": "The params we need to provide for migration msgs",
         "type": "object",
-        "required": ["close_proposal_on_execution_failure", "pre_propose_info"],
+        "required": [
+          "close_proposal_on_execution_failure",
+          "pre_propose_info"
+        ],
         "properties": {
           "close_proposal_on_execution_failure": {
             "type": "boolean"
@@ -239,7 +276,9 @@
       },
       "SubDao": {
         "type": "object",
-        "required": ["addr"],
+        "required": [
+          "addr"
+        ],
         "properties": {
           "addr": {
             "description": "The contract address of the SubDAO",
@@ -247,7 +286,10 @@
           },
           "charter": {
             "description": "The purpose/constitution for the SubDAO",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "additionalProperties": false
@@ -358,7 +400,12 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "ExecuteMsg",
     "type": "object",
-    "required": ["migration_params", "sub_daos", "v1_code_ids", "v2_code_ids"],
+    "required": [
+      "migration_params",
+      "sub_daos",
+      "v1_code_ids",
+      "v2_code_ids"
+    ],
     "properties": {
       "migration_params": {
         "$ref": "#/definitions/MigrationParams"
@@ -384,11 +431,15 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "object",
-                "required": ["addr"],
+                "required": [
+                  "addr"
+                ],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -402,7 +453,9 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": ["core_module"],
+            "required": [
+              "core_module"
+            ],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -419,7 +472,10 @@
       },
       "Coin": {
         "type": "object",
-        "required": ["amount", "denom"],
+        "required": [
+          "amount",
+          "denom"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -434,7 +490,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -447,7 +505,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -461,11 +521,16 @@
       },
       "MigrationParams": {
         "type": "object",
-        "required": ["proposal_params"],
+        "required": [
+          "proposal_params"
+        ],
         "properties": {
           "migrate_stake_cw20_manager": {
             "description": "Rather or not to migrate the stake_cw20 contract and its manager. If this is not set to true and a stake_cw20 contract is detected in the DAO's configuration the migration will be aborted.",
-            "type": ["boolean", "null"]
+            "type": [
+              "boolean",
+              "null"
+            ]
           },
           "proposal_params": {
             "description": "List of (address, ProposalParams) where `address` is an address of a proposal module currently part of the DAO.",
@@ -490,7 +555,12 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": ["code_id", "funds", "label", "msg"],
+        "required": [
+          "code_id",
+          "funds",
+          "label",
+          "msg"
+        ],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -536,7 +606,9 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": ["anyone_may_propose"],
+            "required": [
+              "anyone_may_propose"
+            ],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -548,11 +620,15 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": ["module_may_propose"],
+            "required": [
+              "module_may_propose"
+            ],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": ["info"],
+                "required": [
+                  "info"
+                ],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -568,7 +644,10 @@
       "ProposalParams": {
         "description": "The params we need to provide for migration msgs",
         "type": "object",
-        "required": ["close_proposal_on_execution_failure", "pre_propose_info"],
+        "required": [
+          "close_proposal_on_execution_failure",
+          "pre_propose_info"
+        ],
         "properties": {
           "close_proposal_on_execution_failure": {
             "type": "boolean"
@@ -591,7 +670,9 @@
       },
       "SubDao": {
         "type": "object",
-        "required": ["addr"],
+        "required": [
+          "addr"
+        ],
         "properties": {
           "addr": {
             "description": "The contract address of the SubDAO",
@@ -599,7 +680,10 @@
           },
           "charter": {
             "description": "The purpose/constitution for the SubDAO",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "additionalProperties": false

--- a/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
@@ -41,10 +41,6 @@
     },
     "additionalProperties": false,
     "definitions": {
-      "Addr": {
-        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-        "type": "string"
-      },
       "DepositRefundPolicy": {
         "oneOf": [
           {
@@ -151,7 +147,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   }
                 },
@@ -180,7 +176,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   },
                   "dao_members": {
@@ -194,7 +190,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   }
                 },
@@ -320,11 +316,9 @@
         "properties": {
           "update_config": {
             "type": "object",
-            "required": [
-              "submission_policy"
-            ],
             "properties": {
               "deposit_info": {
+                "description": "If None, will remove the deposit. Backwards compatible.",
                 "anyOf": [
                   {
                     "$ref": "#/definitions/UncheckedDepositInfo"
@@ -335,7 +329,78 @@
                 ]
               },
               "submission_policy": {
-                "$ref": "#/definitions/PreProposeSubmissionPolicy"
+                "description": "If None, will leave the submission policy in the config as-is.",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/PreProposeSubmissionPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Perform more granular submission policy updates to allow for atomic operations that don't override others.",
+        "type": "object",
+        "required": [
+          "update_submission_policy"
+        ],
+        "properties": {
+          "update_submission_policy": {
+            "type": "object",
+            "properties": {
+              "allowlist_add": {
+                "description": "If using specific policy, optionally add to the allowlist.",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "allowlist_remove": {
+                "description": "If using specific policy, optionally remove from the allowlist.",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "denylist_add": {
+                "description": "Optionally add to the denylist. Works for any submission policy.",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "denylist_remove": {
+                "description": "Optionally remove from denylist. Works for any submission policy.",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "set_dao_members": {
+                "description": "If using specific policy, optionally update the `dao_members` flag.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -466,10 +531,6 @@
       }
     ],
     "definitions": {
-      "Addr": {
-        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-        "type": "string"
-      },
       "BankMsg": {
         "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
         "oneOf": [
@@ -1117,7 +1178,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   }
                 },
@@ -1146,7 +1207,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   },
                   "dao_members": {
@@ -1160,7 +1221,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   }
                 },
@@ -2224,7 +2285,7 @@
                         "null"
                       ],
                       "items": {
-                        "$ref": "#/definitions/Addr"
+                        "type": "string"
                       }
                     }
                   },
@@ -2253,7 +2314,7 @@
                         "null"
                       ],
                       "items": {
-                        "$ref": "#/definitions/Addr"
+                        "type": "string"
                       }
                     },
                     "dao_members": {
@@ -2267,7 +2328,7 @@
                         "null"
                       ],
                       "items": {
-                        "$ref": "#/definitions/Addr"
+                        "type": "string"
                       }
                     }
                   },

--- a/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
@@ -1,15 +1,12 @@
 {
   "contract_name": "dao-pre-propose-approval-single",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "extension",
-      "submission_policy"
-    ],
+    "required": ["extension", "submission_policy"],
     "properties": {
       "deposit_info": {
         "description": "Information about the deposit requirements for this module. None if no deposit.",
@@ -46,23 +43,17 @@
           {
             "description": "Deposits should always be refunded.",
             "type": "string",
-            "enum": [
-              "always"
-            ]
+            "enum": ["always"]
           },
           {
             "description": "Deposits should only be refunded for passed proposals.",
             "type": "string",
-            "enum": [
-              "only_passed"
-            ]
+            "enum": ["only_passed"]
           },
           {
             "description": "Deposits should never be refunded.",
             "type": "string",
-            "enum": [
-              "never"
-            ]
+            "enum": ["never"]
           }
         ]
       },
@@ -72,15 +63,11 @@
           {
             "description": "Use a specific token address as the deposit token.",
             "type": "object",
-            "required": [
-              "token"
-            ],
+            "required": ["token"],
             "properties": {
               "token": {
                 "type": "object",
-                "required": [
-                  "denom"
-                ],
+                "required": ["denom"],
                 "properties": {
                   "denom": {
                     "$ref": "#/definitions/UncheckedDenom"
@@ -94,15 +81,11 @@
           {
             "description": "Use the token native denom or cw20 contract address of the associated DAO's voting module. NOTE: in order to retrieve the token automatically via this variant, the voting module must either (1) use a native token and implement the `Denom {}` query type defined by `dao_dao_macros::native_token_query` OR (2) use a cw20 token and implement the `TokenContract {}` query type defined by `dao_dao_macros::cw20_token_query`. Failing to implement correctly will cause this option to fail to instantiate.",
             "type": "object",
-            "required": [
-              "voting_module_token"
-            ],
+            "required": ["voting_module_token"],
             "properties": {
               "voting_module_token": {
                 "type": "object",
-                "required": [
-                  "token_type"
-                ],
+                "required": ["token_type"],
                 "properties": {
                   "token_type": {
                     "$ref": "#/definitions/VotingModuleTokenType"
@@ -117,9 +100,7 @@
       },
       "InstantiateExt": {
         "type": "object",
-        "required": [
-          "approver"
-        ],
+        "required": ["approver"],
         "properties": {
           "approver": {
             "type": "string"
@@ -133,19 +114,14 @@
           {
             "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
-            "required": [
-              "anyone"
-            ],
+            "required": ["anyone"],
             "properties": {
               "anyone": {
                 "type": "object",
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -159,22 +135,15 @@
           {
             "description": "Specific people may create proposals.",
             "type": "object",
-            "required": [
-              "specific"
-            ],
+            "required": ["specific"],
             "properties": {
               "specific": {
                 "type": "object",
-                "required": [
-                  "dao_members"
-                ],
+                "required": ["dao_members"],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -185,10 +154,7 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -211,9 +177,7 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": [
-              "native"
-            ],
+            "required": ["native"],
             "properties": {
               "native": {
                 "type": "string"
@@ -224,9 +188,7 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": [
-              "cw20"
-            ],
+            "required": ["cw20"],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -239,11 +201,7 @@
       "UncheckedDepositInfo": {
         "description": "Information about the deposit required to create a proposal.",
         "type": "object",
-        "required": [
-          "amount",
-          "denom",
-          "refund_policy"
-        ],
+        "required": ["amount", "denom", "refund_policy"],
         "properties": {
           "amount": {
             "description": "The number of tokens that must be deposited to create a proposal. Must be a positive, non-zero number.",
@@ -274,10 +232,7 @@
       },
       "VotingModuleTokenType": {
         "type": "string",
-        "enum": [
-          "native",
-          "cw20"
-        ]
+        "enum": ["native", "cw20"]
       }
     }
   },
@@ -288,15 +243,11 @@
       {
         "description": "Creates a new proposal in the pre-propose module. MSG will be serialized and used as the proposal creation message.",
         "type": "object",
-        "required": [
-          "propose"
-        ],
+        "required": ["propose"],
         "properties": {
           "propose": {
             "type": "object",
-            "required": [
-              "msg"
-            ],
+            "required": ["msg"],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/ProposeMessage"
@@ -310,9 +261,7 @@
       {
         "description": "Updates the configuration of this module. This will completely override the existing configuration. This new configuration will only apply to proposals created after the config is updated. Only the DAO may execute this message.",
         "type": "object",
-        "required": [
-          "update_config"
-        ],
+        "required": ["update_config"],
         "properties": {
           "update_config": {
             "type": "object",
@@ -348,59 +297,42 @@
       {
         "description": "Perform more granular submission policy updates to allow for atomic operations that don't override others.",
         "type": "object",
-        "required": [
-          "update_submission_policy"
-        ],
+        "required": ["update_submission_policy"],
         "properties": {
           "update_submission_policy": {
             "type": "object",
             "properties": {
               "allowlist_add": {
                 "description": "If using specific policy, optionally add to the allowlist.",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "allowlist_remove": {
                 "description": "If using specific policy, optionally remove from the allowlist.",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "denylist_add": {
                 "description": "Optionally add to the denylist. Works for any submission policy.",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "denylist_remove": {
                 "description": "Optionally remove from denylist. Works for any submission policy.",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "set_dao_members": {
                 "description": "If using specific policy, optionally update the `dao_members` flag.",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": ["boolean", "null"]
               }
             },
             "additionalProperties": false
@@ -411,9 +343,7 @@
       {
         "description": "Withdraws funds inside of this contract to the message sender. The contracts entire balance for the specifed DENOM is withdrawn to the message sender. Only the DAO may call this method.\n\nThis is intended only as an escape hatch in the event of a critical bug in this contract or it's proposal module. Withdrawing funds will cause future attempts to return proposal deposits to fail their transactions as the contract will have insufficent balance to return them. In the case of `cw-proposal-single` this transaction failure will cause the module to remove the pre-propose module from its proposal hook receivers.\n\nMore likely than not, this should NEVER BE CALLED unless a bug in this contract or the proposal module it is associated with has caused it to stop receiving proposal hook messages, or if a critical security vulnerability has been found that allows an attacker to drain proposal deposits.",
         "type": "object",
-        "required": [
-          "withdraw"
-        ],
+        "required": ["withdraw"],
         "properties": {
           "withdraw": {
             "type": "object",
@@ -438,15 +368,11 @@
       {
         "description": "Extension message. Contracts that extend this one should put their custom execute logic here. The default implementation will do nothing if this variant is executed.",
         "type": "object",
-        "required": [
-          "extension"
-        ],
+        "required": ["extension"],
         "properties": {
           "extension": {
             "type": "object",
-            "required": [
-              "msg"
-            ],
+            "required": ["msg"],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/ExecuteExt"
@@ -460,15 +386,11 @@
       {
         "description": "Adds a proposal submitted hook. Fires when a new proposal is submitted to the pre-propose contract. Only the DAO may call this method.",
         "type": "object",
-        "required": [
-          "add_proposal_submitted_hook"
-        ],
+        "required": ["add_proposal_submitted_hook"],
         "properties": {
           "add_proposal_submitted_hook": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -482,15 +404,11 @@
       {
         "description": "Removes a proposal submitted hook. Only the DAO may call this method.",
         "type": "object",
-        "required": [
-          "remove_proposal_submitted_hook"
-        ],
+        "required": ["remove_proposal_submitted_hook"],
         "properties": {
           "remove_proposal_submitted_hook": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -504,16 +422,11 @@
       {
         "description": "Handles proposal hook fired by the associated proposal module when a proposal is completed (ie executed or rejected). By default, the base contract will return deposits proposals, when they are closed, when proposals are executed, or, if it is refunding failed.",
         "type": "object",
-        "required": [
-          "proposal_completed_hook"
-        ],
+        "required": ["proposal_completed_hook"],
         "properties": {
           "proposal_completed_hook": {
             "type": "object",
-            "required": [
-              "new_status",
-              "proposal_id"
-            ],
+            "required": ["new_status", "proposal_id"],
             "properties": {
               "new_status": {
                 "$ref": "#/definitions/Status"
@@ -537,16 +450,11 @@
           {
             "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "send"
-            ],
+            "required": ["send"],
             "properties": {
               "send": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "to_address"
-                ],
+                "required": ["amount", "to_address"],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -565,15 +473,11 @@
           {
             "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
             "type": "object",
-            "required": [
-              "burn"
-            ],
+            "required": ["burn"],
             "properties": {
               "burn": {
                 "type": "object",
-                "required": [
-                  "amount"
-                ],
+                "required": ["amount"],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -594,10 +498,7 @@
       },
       "Coin": {
         "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
+        "required": ["amount", "denom"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -611,9 +512,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "bank"
-            ],
+            "required": ["bank"],
             "properties": {
               "bank": {
                 "$ref": "#/definitions/BankMsg"
@@ -623,9 +522,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "custom"
-            ],
+            "required": ["custom"],
             "properties": {
               "custom": {
                 "$ref": "#/definitions/Empty"
@@ -635,9 +532,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "staking"
-            ],
+            "required": ["staking"],
             "properties": {
               "staking": {
                 "$ref": "#/definitions/StakingMsg"
@@ -647,9 +542,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "distribution"
-            ],
+            "required": ["distribution"],
             "properties": {
               "distribution": {
                 "$ref": "#/definitions/DistributionMsg"
@@ -660,16 +553,11 @@
           {
             "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
             "type": "object",
-            "required": [
-              "stargate"
-            ],
+            "required": ["stargate"],
             "properties": {
               "stargate": {
                 "type": "object",
-                "required": [
-                  "type_url",
-                  "value"
-                ],
+                "required": ["type_url", "value"],
                 "properties": {
                   "type_url": {
                     "type": "string"
@@ -684,9 +572,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "ibc"
-            ],
+            "required": ["ibc"],
             "properties": {
               "ibc": {
                 "$ref": "#/definitions/IbcMsg"
@@ -696,9 +582,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "wasm"
-            ],
+            "required": ["wasm"],
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmMsg"
@@ -708,9 +592,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "gov"
-            ],
+            "required": ["gov"],
             "properties": {
               "gov": {
                 "$ref": "#/definitions/GovMsg"
@@ -725,23 +607,17 @@
           {
             "description": "Deposits should always be refunded.",
             "type": "string",
-            "enum": [
-              "always"
-            ]
+            "enum": ["always"]
           },
           {
             "description": "Deposits should only be refunded for passed proposals.",
             "type": "string",
-            "enum": [
-              "only_passed"
-            ]
+            "enum": ["only_passed"]
           },
           {
             "description": "Deposits should never be refunded.",
             "type": "string",
-            "enum": [
-              "never"
-            ]
+            "enum": ["never"]
           }
         ]
       },
@@ -751,15 +627,11 @@
           {
             "description": "Use a specific token address as the deposit token.",
             "type": "object",
-            "required": [
-              "token"
-            ],
+            "required": ["token"],
             "properties": {
               "token": {
                 "type": "object",
-                "required": [
-                  "denom"
-                ],
+                "required": ["denom"],
                 "properties": {
                   "denom": {
                     "$ref": "#/definitions/UncheckedDenom"
@@ -773,15 +645,11 @@
           {
             "description": "Use the token native denom or cw20 contract address of the associated DAO's voting module. NOTE: in order to retrieve the token automatically via this variant, the voting module must either (1) use a native token and implement the `Denom {}` query type defined by `dao_dao_macros::native_token_query` OR (2) use a cw20 token and implement the `TokenContract {}` query type defined by `dao_dao_macros::cw20_token_query`. Failing to implement correctly will cause this option to fail to instantiate.",
             "type": "object",
-            "required": [
-              "voting_module_token"
-            ],
+            "required": ["voting_module_token"],
             "properties": {
               "voting_module_token": {
                 "type": "object",
-                "required": [
-                  "token_type"
-                ],
+                "required": ["token_type"],
                 "properties": {
                   "token_type": {
                     "$ref": "#/definitions/VotingModuleTokenType"
@@ -800,15 +668,11 @@
           {
             "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "set_withdraw_address"
-            ],
+            "required": ["set_withdraw_address"],
             "properties": {
               "set_withdraw_address": {
                 "type": "object",
-                "required": [
-                  "address"
-                ],
+                "required": ["address"],
                 "properties": {
                   "address": {
                     "description": "The `withdraw_address`",
@@ -822,15 +686,11 @@
           {
             "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "withdraw_delegator_reward"
-            ],
+            "required": ["withdraw_delegator_reward"],
             "properties": {
               "withdraw_delegator_reward": {
                 "type": "object",
-                "required": [
-                  "validator"
-                ],
+                "required": ["validator"],
                 "properties": {
                   "validator": {
                     "description": "The `validator_address`",
@@ -852,15 +712,11 @@
           {
             "description": "Approve a proposal, only callable by approver",
             "type": "object",
-            "required": [
-              "approve"
-            ],
+            "required": ["approve"],
             "properties": {
               "approve": {
                 "type": "object",
-                "required": [
-                  "id"
-                ],
+                "required": ["id"],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -876,15 +732,11 @@
           {
             "description": "Reject a proposal, only callable by approver",
             "type": "object",
-            "required": [
-              "reject"
-            ],
+            "required": ["reject"],
             "properties": {
               "reject": {
                 "type": "object",
-                "required": [
-                  "id"
-                ],
+                "required": ["id"],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -900,15 +752,11 @@
           {
             "description": "Updates the approver, can only be called the current approver",
             "type": "object",
-            "required": [
-              "update_approver"
-            ],
+            "required": ["update_approver"],
             "properties": {
               "update_approver": {
                 "type": "object",
-                "required": [
-                  "address"
-                ],
+                "required": ["address"],
                 "properties": {
                   "address": {
                     "type": "string"
@@ -927,9 +775,7 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": [
-              "at_height"
-            ],
+            "required": ["at_height"],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -942,9 +788,7 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": [
-              "at_time"
-            ],
+            "required": ["at_time"],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -955,9 +799,7 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": [
-              "never"
-            ],
+            "required": ["never"],
             "properties": {
               "never": {
                 "type": "object",
@@ -974,16 +816,11 @@
           {
             "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
             "type": "object",
-            "required": [
-              "vote"
-            ],
+            "required": ["vote"],
             "properties": {
               "vote": {
                 "type": "object",
-                "required": [
-                  "proposal_id",
-                  "vote"
-                ],
+                "required": ["proposal_id", "vote"],
                 "properties": {
                   "proposal_id": {
                     "type": "integer",
@@ -1011,18 +848,11 @@
           {
             "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
             "type": "object",
-            "required": [
-              "transfer"
-            ],
+            "required": ["transfer"],
             "properties": {
               "transfer": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "channel_id",
-                  "timeout",
-                  "to_address"
-                ],
+                "required": ["amount", "channel_id", "timeout", "to_address"],
                 "properties": {
                   "amount": {
                     "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -1056,17 +886,11 @@
           {
             "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
             "type": "object",
-            "required": [
-              "send_packet"
-            ],
+            "required": ["send_packet"],
             "properties": {
               "send_packet": {
                 "type": "object",
-                "required": [
-                  "channel_id",
-                  "data",
-                  "timeout"
-                ],
+                "required": ["channel_id", "data", "timeout"],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -1090,15 +914,11 @@
           {
             "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
             "type": "object",
-            "required": [
-              "close_channel"
-            ],
+            "required": ["close_channel"],
             "properties": {
               "close_channel": {
                 "type": "object",
-                "required": [
-                  "channel_id"
-                ],
+                "required": ["channel_id"],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -1139,10 +959,7 @@
       "IbcTimeoutBlock": {
         "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
         "type": "object",
-        "required": [
-          "height",
-          "revision"
-        ],
+        "required": ["height", "revision"],
         "properties": {
           "height": {
             "description": "block height after which the packet times out. the height within the given revision",
@@ -1164,19 +981,14 @@
           {
             "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
-            "required": [
-              "anyone"
-            ],
+            "required": ["anyone"],
             "properties": {
               "anyone": {
                 "type": "object",
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -1190,22 +1002,15 @@
           {
             "description": "Specific people may create proposals.",
             "type": "object",
-            "required": [
-              "specific"
-            ],
+            "required": ["specific"],
             "properties": {
               "specific": {
                 "type": "object",
-                "required": [
-                  "dao_members"
-                ],
+                "required": ["dao_members"],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -1216,10 +1021,7 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -1236,17 +1038,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "propose"
-            ],
+            "required": ["propose"],
             "properties": {
               "propose": {
                 "type": "object",
-                "required": [
-                  "description",
-                  "msgs",
-                  "title"
-                ],
+                "required": ["description", "msgs", "title"],
                 "properties": {
                   "description": {
                     "type": "string"
@@ -1280,16 +1076,11 @@
       },
       "SingleChoiceAutoVote": {
         "type": "object",
-        "required": [
-          "vote"
-        ],
+        "required": ["vote"],
         "properties": {
           "rationale": {
             "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "vote": {
             "description": "The proposer's position on the proposal.",
@@ -1308,16 +1099,11 @@
           {
             "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "delegate"
-            ],
+            "required": ["delegate"],
             "properties": {
               "delegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "validator"
-                ],
+                "required": ["amount", "validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1333,16 +1119,11 @@
           {
             "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "undelegate"
-            ],
+            "required": ["undelegate"],
             "properties": {
               "undelegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "validator"
-                ],
+                "required": ["amount", "validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1358,17 +1139,11 @@
           {
             "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "redelegate"
-            ],
+            "required": ["redelegate"],
             "properties": {
               "redelegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "dst_validator",
-                  "src_validator"
-                ],
+                "required": ["amount", "dst_validator", "src_validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1391,57 +1166,41 @@
           {
             "description": "The proposal is open for voting.",
             "type": "string",
-            "enum": [
-              "open"
-            ]
+            "enum": ["open"]
           },
           {
             "description": "The proposal has been rejected.",
             "type": "string",
-            "enum": [
-              "rejected"
-            ]
+            "enum": ["rejected"]
           },
           {
             "description": "The proposal has been passed but has not been executed.",
             "type": "string",
-            "enum": [
-              "passed"
-            ]
+            "enum": ["passed"]
           },
           {
             "description": "The proposal has been passed and executed.",
             "type": "string",
-            "enum": [
-              "executed"
-            ]
+            "enum": ["executed"]
           },
           {
             "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
             "type": "string",
-            "enum": [
-              "closed"
-            ]
+            "enum": ["closed"]
           },
           {
             "description": "The proposal's execution failed.",
             "type": "string",
-            "enum": [
-              "execution_failed"
-            ]
+            "enum": ["execution_failed"]
           },
           {
             "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
             "type": "object",
-            "required": [
-              "veto_timelock"
-            ],
+            "required": ["veto_timelock"],
             "properties": {
               "veto_timelock": {
                 "type": "object",
-                "required": [
-                  "expiration"
-                ],
+                "required": ["expiration"],
                 "properties": {
                   "expiration": {
                     "$ref": "#/definitions/Expiration"
@@ -1455,9 +1214,7 @@
           {
             "description": "The proposal has been vetoed.",
             "type": "string",
-            "enum": [
-              "vetoed"
-            ]
+            "enum": ["vetoed"]
           }
         ]
       },
@@ -1483,9 +1240,7 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": [
-              "native"
-            ],
+            "required": ["native"],
             "properties": {
               "native": {
                 "type": "string"
@@ -1496,9 +1251,7 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": [
-              "cw20"
-            ],
+            "required": ["cw20"],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -1511,11 +1264,7 @@
       "UncheckedDepositInfo": {
         "description": "Information about the deposit required to create a proposal.",
         "type": "object",
-        "required": [
-          "amount",
-          "denom",
-          "refund_policy"
-        ],
+        "required": ["amount", "denom", "refund_policy"],
         "properties": {
           "amount": {
             "description": "The number of tokens that must be deposited to create a proposal. Must be a positive, non-zero number.",
@@ -1549,41 +1298,27 @@
           {
             "description": "Marks support for the proposal.",
             "type": "string",
-            "enum": [
-              "yes"
-            ]
+            "enum": ["yes"]
           },
           {
             "description": "Marks opposition to the proposal.",
             "type": "string",
-            "enum": [
-              "no"
-            ]
+            "enum": ["no"]
           },
           {
             "description": "Marks participation but does not count towards the ratio of support / opposed.",
             "type": "string",
-            "enum": [
-              "abstain"
-            ]
+            "enum": ["abstain"]
           }
         ]
       },
       "VoteOption": {
         "type": "string",
-        "enum": [
-          "yes",
-          "no",
-          "abstain",
-          "no_with_veto"
-        ]
+        "enum": ["yes", "no", "abstain", "no_with_veto"]
       },
       "VotingModuleTokenType": {
         "type": "string",
-        "enum": [
-          "native",
-          "cw20"
-        ]
+        "enum": ["native", "cw20"]
       },
       "WasmMsg": {
         "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
@@ -1591,17 +1326,11 @@
           {
             "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "execute"
-            ],
+            "required": ["execute"],
             "properties": {
               "execute": {
                 "type": "object",
-                "required": [
-                  "contract_addr",
-                  "funds",
-                  "msg"
-                ],
+                "required": ["contract_addr", "funds", "msg"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1628,24 +1357,14 @@
           {
             "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "instantiate"
-            ],
+            "required": ["instantiate"],
             "properties": {
               "instantiate": {
                 "type": "object",
-                "required": [
-                  "code_id",
-                  "funds",
-                  "label",
-                  "msg"
-                ],
+                "required": ["code_id", "funds", "label", "msg"],
                 "properties": {
                   "admin": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": ["string", "null"]
                   },
                   "code_id": {
                     "type": "integer",
@@ -1678,17 +1397,11 @@
           {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "migrate"
-            ],
+            "required": ["migrate"],
             "properties": {
               "migrate": {
                 "type": "object",
-                "required": [
-                  "contract_addr",
-                  "msg",
-                  "new_code_id"
-                ],
+                "required": ["contract_addr", "msg", "new_code_id"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1715,16 +1428,11 @@
           {
             "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": [
-              "update_admin"
-            ],
+            "required": ["update_admin"],
             "properties": {
               "update_admin": {
                 "type": "object",
-                "required": [
-                  "admin",
-                  "contract_addr"
-                ],
+                "required": ["admin", "contract_addr"],
                 "properties": {
                   "admin": {
                     "type": "string"
@@ -1740,15 +1448,11 @@
           {
             "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": [
-              "clear_admin"
-            ],
+            "required": ["clear_admin"],
             "properties": {
               "clear_admin": {
                 "type": "object",
-                "required": [
-                  "contract_addr"
-                ],
+                "required": ["contract_addr"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1769,9 +1473,7 @@
       {
         "description": "Gets the proposal module that this pre propose module is associated with. Returns `Addr`.",
         "type": "object",
-        "required": [
-          "proposal_module"
-        ],
+        "required": ["proposal_module"],
         "properties": {
           "proposal_module": {
             "type": "object",
@@ -1783,9 +1485,7 @@
       {
         "description": "Gets the DAO (dao-dao-core) module this contract is associated with. Returns `Addr`.",
         "type": "object",
-        "required": [
-          "dao"
-        ],
+        "required": ["dao"],
         "properties": {
           "dao": {
             "type": "object",
@@ -1797,9 +1497,7 @@
       {
         "description": "Gets the module's configuration.",
         "type": "object",
-        "required": [
-          "config"
-        ],
+        "required": ["config"],
         "properties": {
           "config": {
             "type": "object",
@@ -1811,15 +1509,11 @@
       {
         "description": "Gets the deposit info for the proposal identified by PROPOSAL_ID.",
         "type": "object",
-        "required": [
-          "deposit_info"
-        ],
+        "required": ["deposit_info"],
         "properties": {
           "deposit_info": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -1835,9 +1529,7 @@
       {
         "description": "Returns list of proposal submitted hooks.",
         "type": "object",
-        "required": [
-          "proposal_submitted_hooks"
-        ],
+        "required": ["proposal_submitted_hooks"],
         "properties": {
           "proposal_submitted_hooks": {
             "type": "object",
@@ -1849,15 +1541,11 @@
       {
         "description": "Extension for queries. The default implementation will do nothing if queried for will return `Binary::default()`.",
         "type": "object",
-        "required": [
-          "query_extension"
-        ],
+        "required": ["query_extension"],
         "properties": {
           "query_extension": {
             "type": "object",
-            "required": [
-              "msg"
-            ],
+            "required": ["msg"],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/QueryExt"
@@ -1875,9 +1563,7 @@
           {
             "description": "List the approver address",
             "type": "object",
-            "required": [
-              "approver"
-            ],
+            "required": ["approver"],
             "properties": {
               "approver": {
                 "type": "object",
@@ -1889,15 +1575,11 @@
           {
             "description": "Return whether or not the proposal is pending",
             "type": "object",
-            "required": [
-              "is_pending"
-            ],
+            "required": ["is_pending"],
             "properties": {
               "is_pending": {
                 "type": "object",
-                "required": [
-                  "id"
-                ],
+                "required": ["id"],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -1913,15 +1595,11 @@
           {
             "description": "A proposal, pending or completed.",
             "type": "object",
-            "required": [
-              "proposal"
-            ],
+            "required": ["proposal"],
             "properties": {
               "proposal": {
                 "type": "object",
-                "required": [
-                  "id"
-                ],
+                "required": ["id"],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -1937,15 +1615,11 @@
           {
             "description": "A pending proposal",
             "type": "object",
-            "required": [
-              "pending_proposal"
-            ],
+            "required": ["pending_proposal"],
             "properties": {
               "pending_proposal": {
                 "type": "object",
-                "required": [
-                  "id"
-                ],
+                "required": ["id"],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -1961,26 +1635,18 @@
           {
             "description": "List of proposals awaiting approval",
             "type": "object",
-            "required": [
-              "pending_proposals"
-            ],
+            "required": ["pending_proposals"],
             "properties": {
               "pending_proposals": {
                 "type": "object",
                 "properties": {
                   "limit": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
+                    "type": ["integer", "null"],
                     "format": "uint32",
                     "minimum": 0.0
                   },
                   "start_after": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
+                    "type": ["integer", "null"],
                     "format": "uint64",
                     "minimum": 0.0
                   }
@@ -1992,26 +1658,18 @@
           },
           {
             "type": "object",
-            "required": [
-              "reverse_pending_proposals"
-            ],
+            "required": ["reverse_pending_proposals"],
             "properties": {
               "reverse_pending_proposals": {
                 "type": "object",
                 "properties": {
                   "limit": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
+                    "type": ["integer", "null"],
                     "format": "uint32",
                     "minimum": 0.0
                   },
                   "start_before": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
+                    "type": ["integer", "null"],
                     "format": "uint64",
                     "minimum": 0.0
                   }
@@ -2024,15 +1682,11 @@
           {
             "description": "A completed proposal",
             "type": "object",
-            "required": [
-              "completed_proposal"
-            ],
+            "required": ["completed_proposal"],
             "properties": {
               "completed_proposal": {
                 "type": "object",
-                "required": [
-                  "id"
-                ],
+                "required": ["id"],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -2048,26 +1702,18 @@
           {
             "description": "List of completed proposals",
             "type": "object",
-            "required": [
-              "completed_proposals"
-            ],
+            "required": ["completed_proposals"],
             "properties": {
               "completed_proposals": {
                 "type": "object",
                 "properties": {
                   "limit": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
+                    "type": ["integer", "null"],
                     "format": "uint32",
                     "minimum": 0.0
                   },
                   "start_after": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
+                    "type": ["integer", "null"],
                     "format": "uint64",
                     "minimum": 0.0
                   }
@@ -2079,26 +1725,18 @@
           },
           {
             "type": "object",
-            "required": [
-              "reverse_completed_proposals"
-            ],
+            "required": ["reverse_completed_proposals"],
             "properties": {
               "reverse_completed_proposals": {
                 "type": "object",
                 "properties": {
                   "limit": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
+                    "type": ["integer", "null"],
                     "format": "uint32",
                     "minimum": 0.0
                   },
                   "start_before": {
-                    "type": [
-                      "integer",
-                      "null"
-                    ],
+                    "type": ["integer", "null"],
                     "format": "uint64",
                     "minimum": 0.0
                   }
@@ -2111,15 +1749,11 @@
           {
             "description": "The completed approval ID for a created proposal ID.",
             "type": "object",
-            "required": [
-              "completed_proposal_id_for_created_proposal_id"
-            ],
+            "required": ["completed_proposal_id_for_created_proposal_id"],
             "properties": {
               "completed_proposal_id_for_created_proposal_id": {
                 "type": "object",
-                "required": [
-                  "id"
-                ],
+                "required": ["id"],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -2143,9 +1777,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Config",
       "type": "object",
-      "required": [
-        "submission_policy"
-      ],
+      "required": ["submission_policy"],
       "properties": {
         "deposit_info": {
           "description": "Information about the deposit required to create a proposal. If `None`, no deposit is required.",
@@ -2179,9 +1811,7 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": [
-                "native"
-              ],
+              "required": ["native"],
               "properties": {
                 "native": {
                   "type": "string"
@@ -2192,9 +1822,7 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": [
-                "cw20"
-              ],
+              "required": ["cw20"],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -2207,11 +1835,7 @@
         "CheckedDepositInfo": {
           "description": "Counterpart to the `DepositInfo` struct which has been processed. This type should never be constructed literally and should always by built by calling `into_checked` on a `DepositInfo` instance.",
           "type": "object",
-          "required": [
-            "amount",
-            "denom",
-            "refund_policy"
-          ],
+          "required": ["amount", "denom", "refund_policy"],
           "properties": {
             "amount": {
               "description": "The number of tokens that must be deposited to create a proposal. This is validated to be non-zero if this struct is constructed by converted via the `into_checked` method on `DepositInfo`.",
@@ -2245,23 +1869,17 @@
             {
               "description": "Deposits should always be refunded.",
               "type": "string",
-              "enum": [
-                "always"
-              ]
+              "enum": ["always"]
             },
             {
               "description": "Deposits should only be refunded for passed proposals.",
               "type": "string",
-              "enum": [
-                "only_passed"
-              ]
+              "enum": ["only_passed"]
             },
             {
               "description": "Deposits should never be refunded.",
               "type": "string",
-              "enum": [
-                "never"
-              ]
+              "enum": ["never"]
             }
           ]
         },
@@ -2271,19 +1889,14 @@
             {
               "description": "Anyone may create proposals, except for those in the denylist.",
               "type": "object",
-              "required": [
-                "anyone"
-              ],
+              "required": ["anyone"],
               "properties": {
                 "anyone": {
                   "type": "object",
                   "properties": {
                     "denylist": {
                       "description": "Addresses that may not create proposals.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": ["array", "null"],
                       "items": {
                         "type": "string"
                       }
@@ -2297,22 +1910,15 @@
             {
               "description": "Specific people may create proposals.",
               "type": "object",
-              "required": [
-                "specific"
-              ],
+              "required": ["specific"],
               "properties": {
                 "specific": {
                   "type": "object",
-                  "required": [
-                    "dao_members"
-                  ],
+                  "required": ["dao_members"],
                   "properties": {
                     "allowlist": {
                       "description": "Addresses that may create proposals.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": ["array", "null"],
                       "items": {
                         "type": "string"
                       }
@@ -2323,10 +1929,7 @@
                     },
                     "denylist": {
                       "description": "Addresses that may not create proposals, overriding other settings.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": ["array", "null"],
                       "items": {
                         "type": "string"
                       }
@@ -2355,9 +1958,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "DepositInfoResponse",
       "type": "object",
-      "required": [
-        "proposer"
-      ],
+      "required": ["proposer"],
       "properties": {
         "deposit_info": {
           "description": "The deposit that has been paid for the specified proposal.",
@@ -2391,9 +1992,7 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": [
-                "native"
-              ],
+              "required": ["native"],
               "properties": {
                 "native": {
                   "type": "string"
@@ -2404,9 +2003,7 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": [
-                "cw20"
-              ],
+              "required": ["cw20"],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -2419,11 +2016,7 @@
         "CheckedDepositInfo": {
           "description": "Counterpart to the `DepositInfo` struct which has been processed. This type should never be constructed literally and should always by built by calling `into_checked` on a `DepositInfo` instance.",
           "type": "object",
-          "required": [
-            "amount",
-            "denom",
-            "refund_policy"
-          ],
+          "required": ["amount", "denom", "refund_policy"],
           "properties": {
             "amount": {
               "description": "The number of tokens that must be deposited to create a proposal. This is validated to be non-zero if this struct is constructed by converted via the `into_checked` method on `DepositInfo`.",
@@ -2457,23 +2050,17 @@
             {
               "description": "Deposits should always be refunded.",
               "type": "string",
-              "enum": [
-                "always"
-              ]
+              "enum": ["always"]
             },
             {
               "description": "Deposits should only be refunded for passed proposals.",
               "type": "string",
-              "enum": [
-                "only_passed"
-              ]
+              "enum": ["only_passed"]
             },
             {
               "description": "Deposits should never be refunded.",
               "type": "string",
-              "enum": [
-                "never"
-              ]
+              "enum": ["never"]
             }
           ]
         },
@@ -2493,9 +2080,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": [
-        "hooks"
-      ],
+      "required": ["hooks"],
       "properties": {
         "hooks": {
           "type": "array",

--- a/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
@@ -8,7 +8,7 @@
     "type": "object",
     "required": [
       "extension",
-      "open_proposal_submission"
+      "submission_policy"
     ],
     "properties": {
       "deposit_info": {
@@ -30,13 +30,21 @@
           }
         ]
       },
-      "open_proposal_submission": {
-        "description": "If false, only members (addresses with voting power) may create proposals in the DAO. Otherwise, any address may create a proposal so long as they pay the deposit.",
-        "type": "boolean"
+      "submission_policy": {
+        "description": "The policy dictating who is allowed to submit proposals.",
+        "allOf": [
+          {
+            "$ref": "#/definitions/PreProposeSubmissionPolicy"
+          }
+        ]
       }
     },
     "additionalProperties": false,
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "DepositRefundPolicy": {
         "oneOf": [
           {
@@ -122,6 +130,64 @@
           }
         },
         "additionalProperties": false
+      },
+      "PreProposeSubmissionPolicy": {
+        "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
+        "oneOf": [
+          {
+            "description": "Anyone may create a proposal.",
+            "type": "object",
+            "required": [
+              "anyone"
+            ],
+            "properties": {
+              "anyone": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Only members of the DAO may create a proposal.",
+            "type": "object",
+            "required": [
+              "dao_members"
+            ],
+            "properties": {
+              "dao_members": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Only the specified addresses may create a proposal.",
+            "type": "object",
+            "required": [
+              "allowlist"
+            ],
+            "properties": {
+              "allowlist": {
+                "type": "object",
+                "required": [
+                  "addresses"
+                ],
+                "properties": {
+                  "addresses": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "Uint128": {
         "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
@@ -239,7 +305,7 @@
           "update_config": {
             "type": "object",
             "required": [
-              "open_proposal_submission"
+              "submission_policy"
             ],
             "properties": {
               "deposit_info": {
@@ -252,8 +318,8 @@
                   }
                 ]
               },
-              "open_proposal_submission": {
-                "type": "boolean"
+              "submission_policy": {
+                "$ref": "#/definitions/PreProposeSubmissionPolicy"
               }
             },
             "additionalProperties": false
@@ -384,6 +450,10 @@
       }
     ],
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "BankMsg": {
         "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
         "oneOf": [
@@ -1010,6 +1080,64 @@
             "minimum": 0.0
           }
         }
+      },
+      "PreProposeSubmissionPolicy": {
+        "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
+        "oneOf": [
+          {
+            "description": "Anyone may create a proposal.",
+            "type": "object",
+            "required": [
+              "anyone"
+            ],
+            "properties": {
+              "anyone": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Only members of the DAO may create a proposal.",
+            "type": "object",
+            "required": [
+              "dao_members"
+            ],
+            "properties": {
+              "dao_members": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Only the specified addresses may create a proposal.",
+            "type": "object",
+            "required": [
+              "allowlist"
+            ],
+            "properties": {
+              "allowlist": {
+                "type": "object",
+                "required": [
+                  "addresses"
+                ],
+                "properties": {
+                  "addresses": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "ProposeMessage": {
         "oneOf": [
@@ -1923,7 +2051,7 @@
       "title": "Config",
       "type": "object",
       "required": [
-        "open_proposal_submission"
+        "submission_policy"
       ],
       "properties": {
         "deposit_info": {
@@ -1937,9 +2065,13 @@
             }
           ]
         },
-        "open_proposal_submission": {
-          "description": "If false, only members (addresses with voting power) may create proposals in the DAO. Otherwise, any address may create a proposal so long as they pay the deposit.",
-          "type": "boolean"
+        "submission_policy": {
+          "description": "The policy dictating who is allowed to submit proposals.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PreProposeSubmissionPolicy"
+            }
+          ]
         }
       },
       "additionalProperties": false,
@@ -2037,6 +2169,64 @@
               "enum": [
                 "never"
               ]
+            }
+          ]
+        },
+        "PreProposeSubmissionPolicy": {
+          "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
+          "oneOf": [
+            {
+              "description": "Anyone may create a proposal.",
+              "type": "object",
+              "required": [
+                "anyone"
+              ],
+              "properties": {
+                "anyone": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Only members of the DAO may create a proposal.",
+              "type": "object",
+              "required": [
+                "dao_members"
+              ],
+              "properties": {
+                "dao_members": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Only the specified addresses may create a proposal.",
+              "type": "object",
+              "required": [
+                "allowlist"
+              ],
+              "properties": {
+                "allowlist": {
+                  "type": "object",
+                  "required": [
+                    "addresses"
+                  ],
+                  "properties": {
+                    "addresses": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Addr"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
             }
           ]
         },

--- a/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
@@ -135,7 +135,7 @@
         "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
         "oneOf": [
           {
-            "description": "Anyone may create a proposal.",
+            "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
             "required": [
               "anyone"
@@ -143,40 +143,56 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "properties": {
+                  "denylist": {
+                    "description": "Addresses that may not create proposals.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  }
+                },
                 "additionalProperties": false
               }
             },
             "additionalProperties": false
           },
           {
-            "description": "Only members of the DAO may create a proposal.",
+            "description": "Specific people may create proposals.",
             "type": "object",
             "required": [
-              "dao_members"
+              "specific"
             ],
             "properties": {
-              "dao_members": {
-                "type": "object",
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Only the specified addresses may create a proposal.",
-            "type": "object",
-            "required": [
-              "allowlist"
-            ],
-            "properties": {
-              "allowlist": {
+              "specific": {
                 "type": "object",
                 "required": [
-                  "addresses"
+                  "dao_members"
                 ],
                 "properties": {
-                  "addresses": {
-                    "type": "array",
+                  "allowlist": {
+                    "description": "Addresses that may create proposals.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  },
+                  "dao_members": {
+                    "description": "Whether or not DAO members may create proposals.",
+                    "type": "boolean"
+                  },
+                  "denylist": {
+                    "description": "Addresses that may not create proposals, overriding other settings.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "$ref": "#/definitions/Addr"
                     }
@@ -1085,7 +1101,7 @@
         "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
         "oneOf": [
           {
-            "description": "Anyone may create a proposal.",
+            "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
             "required": [
               "anyone"
@@ -1093,40 +1109,56 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "properties": {
+                  "denylist": {
+                    "description": "Addresses that may not create proposals.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  }
+                },
                 "additionalProperties": false
               }
             },
             "additionalProperties": false
           },
           {
-            "description": "Only members of the DAO may create a proposal.",
+            "description": "Specific people may create proposals.",
             "type": "object",
             "required": [
-              "dao_members"
+              "specific"
             ],
             "properties": {
-              "dao_members": {
-                "type": "object",
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Only the specified addresses may create a proposal.",
-            "type": "object",
-            "required": [
-              "allowlist"
-            ],
-            "properties": {
-              "allowlist": {
+              "specific": {
                 "type": "object",
                 "required": [
-                  "addresses"
+                  "dao_members"
                 ],
                 "properties": {
-                  "addresses": {
-                    "type": "array",
+                  "allowlist": {
+                    "description": "Addresses that may create proposals.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  },
+                  "dao_members": {
+                    "description": "Whether or not DAO members may create proposals.",
+                    "type": "boolean"
+                  },
+                  "denylist": {
+                    "description": "Addresses that may not create proposals, overriding other settings.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "$ref": "#/definitions/Addr"
                     }
@@ -2176,7 +2208,7 @@
           "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
           "oneOf": [
             {
-              "description": "Anyone may create a proposal.",
+              "description": "Anyone may create proposals, except for those in the denylist.",
               "type": "object",
               "required": [
                 "anyone"
@@ -2184,40 +2216,56 @@
               "properties": {
                 "anyone": {
                   "type": "object",
+                  "properties": {
+                    "denylist": {
+                      "description": "Addresses that may not create proposals.",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "$ref": "#/definitions/Addr"
+                      }
+                    }
+                  },
                   "additionalProperties": false
                 }
               },
               "additionalProperties": false
             },
             {
-              "description": "Only members of the DAO may create a proposal.",
+              "description": "Specific people may create proposals.",
               "type": "object",
               "required": [
-                "dao_members"
+                "specific"
               ],
               "properties": {
-                "dao_members": {
-                  "type": "object",
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "description": "Only the specified addresses may create a proposal.",
-              "type": "object",
-              "required": [
-                "allowlist"
-              ],
-              "properties": {
-                "allowlist": {
+                "specific": {
                   "type": "object",
                   "required": [
-                    "addresses"
+                    "dao_members"
                   ],
                   "properties": {
-                    "addresses": {
-                      "type": "array",
+                    "allowlist": {
+                      "description": "Addresses that may create proposals.",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "$ref": "#/definitions/Addr"
+                      }
+                    },
+                    "dao_members": {
+                      "description": "Whether or not DAO members may create proposals.",
+                      "type": "boolean"
+                    },
+                    "denylist": {
+                      "description": "Addresses that may not create proposals, overriding other settings.",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "items": {
                         "$ref": "#/definitions/Addr"
                       }

--- a/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
@@ -6,7 +6,10 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["extension", "submission_policy"],
+    "required": [
+      "extension",
+      "submission_policy"
+    ],
     "properties": {
       "deposit_info": {
         "description": "Information about the deposit requirements for this module. None if no deposit.",
@@ -43,17 +46,23 @@
           {
             "description": "Deposits should always be refunded.",
             "type": "string",
-            "enum": ["always"]
+            "enum": [
+              "always"
+            ]
           },
           {
             "description": "Deposits should only be refunded for passed proposals.",
             "type": "string",
-            "enum": ["only_passed"]
+            "enum": [
+              "only_passed"
+            ]
           },
           {
             "description": "Deposits should never be refunded.",
             "type": "string",
-            "enum": ["never"]
+            "enum": [
+              "never"
+            ]
           }
         ]
       },
@@ -63,11 +72,15 @@
           {
             "description": "Use a specific token address as the deposit token.",
             "type": "object",
-            "required": ["token"],
+            "required": [
+              "token"
+            ],
             "properties": {
               "token": {
                 "type": "object",
-                "required": ["denom"],
+                "required": [
+                  "denom"
+                ],
                 "properties": {
                   "denom": {
                     "$ref": "#/definitions/UncheckedDenom"
@@ -81,11 +94,15 @@
           {
             "description": "Use the token native denom or cw20 contract address of the associated DAO's voting module. NOTE: in order to retrieve the token automatically via this variant, the voting module must either (1) use a native token and implement the `Denom {}` query type defined by `dao_dao_macros::native_token_query` OR (2) use a cw20 token and implement the `TokenContract {}` query type defined by `dao_dao_macros::cw20_token_query`. Failing to implement correctly will cause this option to fail to instantiate.",
             "type": "object",
-            "required": ["voting_module_token"],
+            "required": [
+              "voting_module_token"
+            ],
             "properties": {
               "voting_module_token": {
                 "type": "object",
-                "required": ["token_type"],
+                "required": [
+                  "token_type"
+                ],
                 "properties": {
                   "token_type": {
                     "$ref": "#/definitions/VotingModuleTokenType"
@@ -100,7 +117,9 @@
       },
       "InstantiateExt": {
         "type": "object",
-        "required": ["approver"],
+        "required": [
+          "approver"
+        ],
         "properties": {
           "approver": {
             "type": "string"
@@ -114,14 +133,19 @@
           {
             "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
-            "required": ["anyone"],
+            "required": [
+              "anyone"
+            ],
             "properties": {
               "anyone": {
                 "type": "object",
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -135,15 +159,22 @@
           {
             "description": "Specific people may create proposals.",
             "type": "object",
-            "required": ["specific"],
+            "required": [
+              "specific"
+            ],
             "properties": {
               "specific": {
                 "type": "object",
-                "required": ["dao_members"],
+                "required": [
+                  "dao_members"
+                ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -154,7 +185,10 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -177,7 +211,9 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": ["native"],
+            "required": [
+              "native"
+            ],
             "properties": {
               "native": {
                 "type": "string"
@@ -188,7 +224,9 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": ["cw20"],
+            "required": [
+              "cw20"
+            ],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -201,7 +239,11 @@
       "UncheckedDepositInfo": {
         "description": "Information about the deposit required to create a proposal.",
         "type": "object",
-        "required": ["amount", "denom", "refund_policy"],
+        "required": [
+          "amount",
+          "denom",
+          "refund_policy"
+        ],
         "properties": {
           "amount": {
             "description": "The number of tokens that must be deposited to create a proposal. Must be a positive, non-zero number.",
@@ -232,7 +274,10 @@
       },
       "VotingModuleTokenType": {
         "type": "string",
-        "enum": ["native", "cw20"]
+        "enum": [
+          "native",
+          "cw20"
+        ]
       }
     }
   },
@@ -243,11 +288,15 @@
       {
         "description": "Creates a new proposal in the pre-propose module. MSG will be serialized and used as the proposal creation message.",
         "type": "object",
-        "required": ["propose"],
+        "required": [
+          "propose"
+        ],
         "properties": {
           "propose": {
             "type": "object",
-            "required": ["msg"],
+            "required": [
+              "msg"
+            ],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/ProposeMessage"
@@ -261,7 +310,9 @@
       {
         "description": "Updates the configuration of this module. This will completely override the existing configuration. This new configuration will only apply to proposals created after the config is updated. Only the DAO may execute this message.",
         "type": "object",
-        "required": ["update_config"],
+        "required": [
+          "update_config"
+        ],
         "properties": {
           "update_config": {
             "type": "object",
@@ -297,42 +348,59 @@
       {
         "description": "Perform more granular submission policy updates to allow for atomic operations that don't override others.",
         "type": "object",
-        "required": ["update_submission_policy"],
+        "required": [
+          "update_submission_policy"
+        ],
         "properties": {
           "update_submission_policy": {
             "type": "object",
             "properties": {
               "allowlist_add": {
                 "description": "If using specific policy, optionally add to the allowlist.",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "string"
                 }
               },
               "allowlist_remove": {
                 "description": "If using specific policy, optionally remove from the allowlist.",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "string"
                 }
               },
               "denylist_add": {
                 "description": "Optionally add to the denylist. Works for any submission policy.",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "string"
                 }
               },
               "denylist_remove": {
                 "description": "Optionally remove from denylist. Works for any submission policy.",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "string"
                 }
               },
               "set_dao_members": {
                 "description": "If using specific policy, optionally update the `dao_members` flag.",
-                "type": ["boolean", "null"]
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -343,7 +411,9 @@
       {
         "description": "Withdraws funds inside of this contract to the message sender. The contracts entire balance for the specifed DENOM is withdrawn to the message sender. Only the DAO may call this method.\n\nThis is intended only as an escape hatch in the event of a critical bug in this contract or it's proposal module. Withdrawing funds will cause future attempts to return proposal deposits to fail their transactions as the contract will have insufficent balance to return them. In the case of `cw-proposal-single` this transaction failure will cause the module to remove the pre-propose module from its proposal hook receivers.\n\nMore likely than not, this should NEVER BE CALLED unless a bug in this contract or the proposal module it is associated with has caused it to stop receiving proposal hook messages, or if a critical security vulnerability has been found that allows an attacker to drain proposal deposits.",
         "type": "object",
-        "required": ["withdraw"],
+        "required": [
+          "withdraw"
+        ],
         "properties": {
           "withdraw": {
             "type": "object",
@@ -368,11 +438,15 @@
       {
         "description": "Extension message. Contracts that extend this one should put their custom execute logic here. The default implementation will do nothing if this variant is executed.",
         "type": "object",
-        "required": ["extension"],
+        "required": [
+          "extension"
+        ],
         "properties": {
           "extension": {
             "type": "object",
-            "required": ["msg"],
+            "required": [
+              "msg"
+            ],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/ExecuteExt"
@@ -386,11 +460,15 @@
       {
         "description": "Adds a proposal submitted hook. Fires when a new proposal is submitted to the pre-propose contract. Only the DAO may call this method.",
         "type": "object",
-        "required": ["add_proposal_submitted_hook"],
+        "required": [
+          "add_proposal_submitted_hook"
+        ],
         "properties": {
           "add_proposal_submitted_hook": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -404,11 +482,15 @@
       {
         "description": "Removes a proposal submitted hook. Only the DAO may call this method.",
         "type": "object",
-        "required": ["remove_proposal_submitted_hook"],
+        "required": [
+          "remove_proposal_submitted_hook"
+        ],
         "properties": {
           "remove_proposal_submitted_hook": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -422,11 +504,16 @@
       {
         "description": "Handles proposal hook fired by the associated proposal module when a proposal is completed (ie executed or rejected). By default, the base contract will return deposits proposals, when they are closed, when proposals are executed, or, if it is refunding failed.",
         "type": "object",
-        "required": ["proposal_completed_hook"],
+        "required": [
+          "proposal_completed_hook"
+        ],
         "properties": {
           "proposal_completed_hook": {
             "type": "object",
-            "required": ["new_status", "proposal_id"],
+            "required": [
+              "new_status",
+              "proposal_id"
+            ],
             "properties": {
               "new_status": {
                 "$ref": "#/definitions/Status"
@@ -450,11 +537,16 @@
           {
             "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["send"],
+            "required": [
+              "send"
+            ],
             "properties": {
               "send": {
                 "type": "object",
-                "required": ["amount", "to_address"],
+                "required": [
+                  "amount",
+                  "to_address"
+                ],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -473,11 +565,15 @@
           {
             "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
             "type": "object",
-            "required": ["burn"],
+            "required": [
+              "burn"
+            ],
             "properties": {
               "burn": {
                 "type": "object",
-                "required": ["amount"],
+                "required": [
+                  "amount"
+                ],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -498,7 +594,10 @@
       },
       "Coin": {
         "type": "object",
-        "required": ["amount", "denom"],
+        "required": [
+          "amount",
+          "denom"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -512,7 +611,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["bank"],
+            "required": [
+              "bank"
+            ],
             "properties": {
               "bank": {
                 "$ref": "#/definitions/BankMsg"
@@ -522,7 +623,9 @@
           },
           {
             "type": "object",
-            "required": ["custom"],
+            "required": [
+              "custom"
+            ],
             "properties": {
               "custom": {
                 "$ref": "#/definitions/Empty"
@@ -532,7 +635,9 @@
           },
           {
             "type": "object",
-            "required": ["staking"],
+            "required": [
+              "staking"
+            ],
             "properties": {
               "staking": {
                 "$ref": "#/definitions/StakingMsg"
@@ -542,7 +647,9 @@
           },
           {
             "type": "object",
-            "required": ["distribution"],
+            "required": [
+              "distribution"
+            ],
             "properties": {
               "distribution": {
                 "$ref": "#/definitions/DistributionMsg"
@@ -553,11 +660,16 @@
           {
             "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
             "type": "object",
-            "required": ["stargate"],
+            "required": [
+              "stargate"
+            ],
             "properties": {
               "stargate": {
                 "type": "object",
-                "required": ["type_url", "value"],
+                "required": [
+                  "type_url",
+                  "value"
+                ],
                 "properties": {
                   "type_url": {
                     "type": "string"
@@ -572,7 +684,9 @@
           },
           {
             "type": "object",
-            "required": ["ibc"],
+            "required": [
+              "ibc"
+            ],
             "properties": {
               "ibc": {
                 "$ref": "#/definitions/IbcMsg"
@@ -582,7 +696,9 @@
           },
           {
             "type": "object",
-            "required": ["wasm"],
+            "required": [
+              "wasm"
+            ],
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmMsg"
@@ -592,7 +708,9 @@
           },
           {
             "type": "object",
-            "required": ["gov"],
+            "required": [
+              "gov"
+            ],
             "properties": {
               "gov": {
                 "$ref": "#/definitions/GovMsg"
@@ -607,17 +725,23 @@
           {
             "description": "Deposits should always be refunded.",
             "type": "string",
-            "enum": ["always"]
+            "enum": [
+              "always"
+            ]
           },
           {
             "description": "Deposits should only be refunded for passed proposals.",
             "type": "string",
-            "enum": ["only_passed"]
+            "enum": [
+              "only_passed"
+            ]
           },
           {
             "description": "Deposits should never be refunded.",
             "type": "string",
-            "enum": ["never"]
+            "enum": [
+              "never"
+            ]
           }
         ]
       },
@@ -627,11 +751,15 @@
           {
             "description": "Use a specific token address as the deposit token.",
             "type": "object",
-            "required": ["token"],
+            "required": [
+              "token"
+            ],
             "properties": {
               "token": {
                 "type": "object",
-                "required": ["denom"],
+                "required": [
+                  "denom"
+                ],
                 "properties": {
                   "denom": {
                     "$ref": "#/definitions/UncheckedDenom"
@@ -645,11 +773,15 @@
           {
             "description": "Use the token native denom or cw20 contract address of the associated DAO's voting module. NOTE: in order to retrieve the token automatically via this variant, the voting module must either (1) use a native token and implement the `Denom {}` query type defined by `dao_dao_macros::native_token_query` OR (2) use a cw20 token and implement the `TokenContract {}` query type defined by `dao_dao_macros::cw20_token_query`. Failing to implement correctly will cause this option to fail to instantiate.",
             "type": "object",
-            "required": ["voting_module_token"],
+            "required": [
+              "voting_module_token"
+            ],
             "properties": {
               "voting_module_token": {
                 "type": "object",
-                "required": ["token_type"],
+                "required": [
+                  "token_type"
+                ],
                 "properties": {
                   "token_type": {
                     "$ref": "#/definitions/VotingModuleTokenType"
@@ -668,11 +800,15 @@
           {
             "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["set_withdraw_address"],
+            "required": [
+              "set_withdraw_address"
+            ],
             "properties": {
               "set_withdraw_address": {
                 "type": "object",
-                "required": ["address"],
+                "required": [
+                  "address"
+                ],
                 "properties": {
                   "address": {
                     "description": "The `withdraw_address`",
@@ -686,11 +822,15 @@
           {
             "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["withdraw_delegator_reward"],
+            "required": [
+              "withdraw_delegator_reward"
+            ],
             "properties": {
               "withdraw_delegator_reward": {
                 "type": "object",
-                "required": ["validator"],
+                "required": [
+                  "validator"
+                ],
                 "properties": {
                   "validator": {
                     "description": "The `validator_address`",
@@ -712,11 +852,15 @@
           {
             "description": "Approve a proposal, only callable by approver",
             "type": "object",
-            "required": ["approve"],
+            "required": [
+              "approve"
+            ],
             "properties": {
               "approve": {
                 "type": "object",
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -732,11 +876,15 @@
           {
             "description": "Reject a proposal, only callable by approver",
             "type": "object",
-            "required": ["reject"],
+            "required": [
+              "reject"
+            ],
             "properties": {
               "reject": {
                 "type": "object",
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -752,11 +900,15 @@
           {
             "description": "Updates the approver, can only be called the current approver",
             "type": "object",
-            "required": ["update_approver"],
+            "required": [
+              "update_approver"
+            ],
             "properties": {
               "update_approver": {
                 "type": "object",
-                "required": ["address"],
+                "required": [
+                  "address"
+                ],
                 "properties": {
                   "address": {
                     "type": "string"
@@ -775,7 +927,9 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": ["at_height"],
+            "required": [
+              "at_height"
+            ],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -788,7 +942,9 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": ["at_time"],
+            "required": [
+              "at_time"
+            ],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -799,7 +955,9 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": ["never"],
+            "required": [
+              "never"
+            ],
             "properties": {
               "never": {
                 "type": "object",
@@ -816,11 +974,16 @@
           {
             "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
             "type": "object",
-            "required": ["vote"],
+            "required": [
+              "vote"
+            ],
             "properties": {
               "vote": {
                 "type": "object",
-                "required": ["proposal_id", "vote"],
+                "required": [
+                  "proposal_id",
+                  "vote"
+                ],
                 "properties": {
                   "proposal_id": {
                     "type": "integer",
@@ -848,11 +1011,18 @@
           {
             "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
             "type": "object",
-            "required": ["transfer"],
+            "required": [
+              "transfer"
+            ],
             "properties": {
               "transfer": {
                 "type": "object",
-                "required": ["amount", "channel_id", "timeout", "to_address"],
+                "required": [
+                  "amount",
+                  "channel_id",
+                  "timeout",
+                  "to_address"
+                ],
                 "properties": {
                   "amount": {
                     "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -886,11 +1056,17 @@
           {
             "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
             "type": "object",
-            "required": ["send_packet"],
+            "required": [
+              "send_packet"
+            ],
             "properties": {
               "send_packet": {
                 "type": "object",
-                "required": ["channel_id", "data", "timeout"],
+                "required": [
+                  "channel_id",
+                  "data",
+                  "timeout"
+                ],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -914,11 +1090,15 @@
           {
             "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
             "type": "object",
-            "required": ["close_channel"],
+            "required": [
+              "close_channel"
+            ],
             "properties": {
               "close_channel": {
                 "type": "object",
-                "required": ["channel_id"],
+                "required": [
+                  "channel_id"
+                ],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -959,7 +1139,10 @@
       "IbcTimeoutBlock": {
         "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
         "type": "object",
-        "required": ["height", "revision"],
+        "required": [
+          "height",
+          "revision"
+        ],
         "properties": {
           "height": {
             "description": "block height after which the packet times out. the height within the given revision",
@@ -981,14 +1164,19 @@
           {
             "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
-            "required": ["anyone"],
+            "required": [
+              "anyone"
+            ],
             "properties": {
               "anyone": {
                 "type": "object",
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -1002,15 +1190,22 @@
           {
             "description": "Specific people may create proposals.",
             "type": "object",
-            "required": ["specific"],
+            "required": [
+              "specific"
+            ],
             "properties": {
               "specific": {
                 "type": "object",
-                "required": ["dao_members"],
+                "required": [
+                  "dao_members"
+                ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -1021,7 +1216,10 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -1038,11 +1236,17 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["propose"],
+            "required": [
+              "propose"
+            ],
             "properties": {
               "propose": {
                 "type": "object",
-                "required": ["description", "msgs", "title"],
+                "required": [
+                  "description",
+                  "msgs",
+                  "title"
+                ],
                 "properties": {
                   "description": {
                     "type": "string"
@@ -1076,11 +1280,16 @@
       },
       "SingleChoiceAutoVote": {
         "type": "object",
-        "required": ["vote"],
+        "required": [
+          "vote"
+        ],
         "properties": {
           "rationale": {
             "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "vote": {
             "description": "The proposer's position on the proposal.",
@@ -1099,11 +1308,16 @@
           {
             "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["delegate"],
+            "required": [
+              "delegate"
+            ],
             "properties": {
               "delegate": {
                 "type": "object",
-                "required": ["amount", "validator"],
+                "required": [
+                  "amount",
+                  "validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1119,11 +1333,16 @@
           {
             "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["undelegate"],
+            "required": [
+              "undelegate"
+            ],
             "properties": {
               "undelegate": {
                 "type": "object",
-                "required": ["amount", "validator"],
+                "required": [
+                  "amount",
+                  "validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1139,11 +1358,17 @@
           {
             "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["redelegate"],
+            "required": [
+              "redelegate"
+            ],
             "properties": {
               "redelegate": {
                 "type": "object",
-                "required": ["amount", "dst_validator", "src_validator"],
+                "required": [
+                  "amount",
+                  "dst_validator",
+                  "src_validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1166,41 +1391,57 @@
           {
             "description": "The proposal is open for voting.",
             "type": "string",
-            "enum": ["open"]
+            "enum": [
+              "open"
+            ]
           },
           {
             "description": "The proposal has been rejected.",
             "type": "string",
-            "enum": ["rejected"]
+            "enum": [
+              "rejected"
+            ]
           },
           {
             "description": "The proposal has been passed but has not been executed.",
             "type": "string",
-            "enum": ["passed"]
+            "enum": [
+              "passed"
+            ]
           },
           {
             "description": "The proposal has been passed and executed.",
             "type": "string",
-            "enum": ["executed"]
+            "enum": [
+              "executed"
+            ]
           },
           {
             "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
             "type": "string",
-            "enum": ["closed"]
+            "enum": [
+              "closed"
+            ]
           },
           {
             "description": "The proposal's execution failed.",
             "type": "string",
-            "enum": ["execution_failed"]
+            "enum": [
+              "execution_failed"
+            ]
           },
           {
             "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
             "type": "object",
-            "required": ["veto_timelock"],
+            "required": [
+              "veto_timelock"
+            ],
             "properties": {
               "veto_timelock": {
                 "type": "object",
-                "required": ["expiration"],
+                "required": [
+                  "expiration"
+                ],
                 "properties": {
                   "expiration": {
                     "$ref": "#/definitions/Expiration"
@@ -1214,7 +1455,9 @@
           {
             "description": "The proposal has been vetoed.",
             "type": "string",
-            "enum": ["vetoed"]
+            "enum": [
+              "vetoed"
+            ]
           }
         ]
       },
@@ -1240,7 +1483,9 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": ["native"],
+            "required": [
+              "native"
+            ],
             "properties": {
               "native": {
                 "type": "string"
@@ -1251,7 +1496,9 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": ["cw20"],
+            "required": [
+              "cw20"
+            ],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -1264,7 +1511,11 @@
       "UncheckedDepositInfo": {
         "description": "Information about the deposit required to create a proposal.",
         "type": "object",
-        "required": ["amount", "denom", "refund_policy"],
+        "required": [
+          "amount",
+          "denom",
+          "refund_policy"
+        ],
         "properties": {
           "amount": {
             "description": "The number of tokens that must be deposited to create a proposal. Must be a positive, non-zero number.",
@@ -1298,27 +1549,41 @@
           {
             "description": "Marks support for the proposal.",
             "type": "string",
-            "enum": ["yes"]
+            "enum": [
+              "yes"
+            ]
           },
           {
             "description": "Marks opposition to the proposal.",
             "type": "string",
-            "enum": ["no"]
+            "enum": [
+              "no"
+            ]
           },
           {
             "description": "Marks participation but does not count towards the ratio of support / opposed.",
             "type": "string",
-            "enum": ["abstain"]
+            "enum": [
+              "abstain"
+            ]
           }
         ]
       },
       "VoteOption": {
         "type": "string",
-        "enum": ["yes", "no", "abstain", "no_with_veto"]
+        "enum": [
+          "yes",
+          "no",
+          "abstain",
+          "no_with_veto"
+        ]
       },
       "VotingModuleTokenType": {
         "type": "string",
-        "enum": ["native", "cw20"]
+        "enum": [
+          "native",
+          "cw20"
+        ]
       },
       "WasmMsg": {
         "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
@@ -1326,11 +1591,17 @@
           {
             "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["execute"],
+            "required": [
+              "execute"
+            ],
             "properties": {
               "execute": {
                 "type": "object",
-                "required": ["contract_addr", "funds", "msg"],
+                "required": [
+                  "contract_addr",
+                  "funds",
+                  "msg"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1357,14 +1628,24 @@
           {
             "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["instantiate"],
+            "required": [
+              "instantiate"
+            ],
             "properties": {
               "instantiate": {
                 "type": "object",
-                "required": ["code_id", "funds", "label", "msg"],
+                "required": [
+                  "code_id",
+                  "funds",
+                  "label",
+                  "msg"
+                ],
                 "properties": {
                   "admin": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "code_id": {
                     "type": "integer",
@@ -1397,11 +1678,17 @@
           {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["migrate"],
+            "required": [
+              "migrate"
+            ],
             "properties": {
               "migrate": {
                 "type": "object",
-                "required": ["contract_addr", "msg", "new_code_id"],
+                "required": [
+                  "contract_addr",
+                  "msg",
+                  "new_code_id"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1428,11 +1715,16 @@
           {
             "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": ["update_admin"],
+            "required": [
+              "update_admin"
+            ],
             "properties": {
               "update_admin": {
                 "type": "object",
-                "required": ["admin", "contract_addr"],
+                "required": [
+                  "admin",
+                  "contract_addr"
+                ],
                 "properties": {
                   "admin": {
                     "type": "string"
@@ -1448,11 +1740,15 @@
           {
             "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": ["clear_admin"],
+            "required": [
+              "clear_admin"
+            ],
             "properties": {
               "clear_admin": {
                 "type": "object",
-                "required": ["contract_addr"],
+                "required": [
+                  "contract_addr"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1473,7 +1769,9 @@
       {
         "description": "Gets the proposal module that this pre propose module is associated with. Returns `Addr`.",
         "type": "object",
-        "required": ["proposal_module"],
+        "required": [
+          "proposal_module"
+        ],
         "properties": {
           "proposal_module": {
             "type": "object",
@@ -1485,7 +1783,9 @@
       {
         "description": "Gets the DAO (dao-dao-core) module this contract is associated with. Returns `Addr`.",
         "type": "object",
-        "required": ["dao"],
+        "required": [
+          "dao"
+        ],
         "properties": {
           "dao": {
             "type": "object",
@@ -1497,7 +1797,9 @@
       {
         "description": "Gets the module's configuration.",
         "type": "object",
-        "required": ["config"],
+        "required": [
+          "config"
+        ],
         "properties": {
           "config": {
             "type": "object",
@@ -1509,11 +1811,15 @@
       {
         "description": "Gets the deposit info for the proposal identified by PROPOSAL_ID.",
         "type": "object",
-        "required": ["deposit_info"],
+        "required": [
+          "deposit_info"
+        ],
         "properties": {
           "deposit_info": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -1527,9 +1833,33 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns whether or not the address can submit proposals.",
+        "type": "object",
+        "required": [
+          "can_propose"
+        ],
+        "properties": {
+          "can_propose": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Returns list of proposal submitted hooks.",
         "type": "object",
-        "required": ["proposal_submitted_hooks"],
+        "required": [
+          "proposal_submitted_hooks"
+        ],
         "properties": {
           "proposal_submitted_hooks": {
             "type": "object",
@@ -1541,11 +1871,15 @@
       {
         "description": "Extension for queries. The default implementation will do nothing if queried for will return `Binary::default()`.",
         "type": "object",
-        "required": ["query_extension"],
+        "required": [
+          "query_extension"
+        ],
         "properties": {
           "query_extension": {
             "type": "object",
-            "required": ["msg"],
+            "required": [
+              "msg"
+            ],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/QueryExt"
@@ -1563,7 +1897,9 @@
           {
             "description": "List the approver address",
             "type": "object",
-            "required": ["approver"],
+            "required": [
+              "approver"
+            ],
             "properties": {
               "approver": {
                 "type": "object",
@@ -1575,11 +1911,15 @@
           {
             "description": "Return whether or not the proposal is pending",
             "type": "object",
-            "required": ["is_pending"],
+            "required": [
+              "is_pending"
+            ],
             "properties": {
               "is_pending": {
                 "type": "object",
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -1595,11 +1935,15 @@
           {
             "description": "A proposal, pending or completed.",
             "type": "object",
-            "required": ["proposal"],
+            "required": [
+              "proposal"
+            ],
             "properties": {
               "proposal": {
                 "type": "object",
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -1615,11 +1959,15 @@
           {
             "description": "A pending proposal",
             "type": "object",
-            "required": ["pending_proposal"],
+            "required": [
+              "pending_proposal"
+            ],
             "properties": {
               "pending_proposal": {
                 "type": "object",
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -1635,18 +1983,26 @@
           {
             "description": "List of proposals awaiting approval",
             "type": "object",
-            "required": ["pending_proposals"],
+            "required": [
+              "pending_proposals"
+            ],
             "properties": {
               "pending_proposals": {
                 "type": "object",
                 "properties": {
                   "limit": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "format": "uint32",
                     "minimum": 0.0
                   },
                   "start_after": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "format": "uint64",
                     "minimum": 0.0
                   }
@@ -1658,18 +2014,26 @@
           },
           {
             "type": "object",
-            "required": ["reverse_pending_proposals"],
+            "required": [
+              "reverse_pending_proposals"
+            ],
             "properties": {
               "reverse_pending_proposals": {
                 "type": "object",
                 "properties": {
                   "limit": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "format": "uint32",
                     "minimum": 0.0
                   },
                   "start_before": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "format": "uint64",
                     "minimum": 0.0
                   }
@@ -1682,11 +2046,15 @@
           {
             "description": "A completed proposal",
             "type": "object",
-            "required": ["completed_proposal"],
+            "required": [
+              "completed_proposal"
+            ],
             "properties": {
               "completed_proposal": {
                 "type": "object",
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -1702,18 +2070,26 @@
           {
             "description": "List of completed proposals",
             "type": "object",
-            "required": ["completed_proposals"],
+            "required": [
+              "completed_proposals"
+            ],
             "properties": {
               "completed_proposals": {
                 "type": "object",
                 "properties": {
                   "limit": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "format": "uint32",
                     "minimum": 0.0
                   },
                   "start_after": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "format": "uint64",
                     "minimum": 0.0
                   }
@@ -1725,18 +2101,26 @@
           },
           {
             "type": "object",
-            "required": ["reverse_completed_proposals"],
+            "required": [
+              "reverse_completed_proposals"
+            ],
             "properties": {
               "reverse_completed_proposals": {
                 "type": "object",
                 "properties": {
                   "limit": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "format": "uint32",
                     "minimum": 0.0
                   },
                   "start_before": {
-                    "type": ["integer", "null"],
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
                     "format": "uint64",
                     "minimum": 0.0
                   }
@@ -1749,11 +2133,15 @@
           {
             "description": "The completed approval ID for a created proposal ID.",
             "type": "object",
-            "required": ["completed_proposal_id_for_created_proposal_id"],
+            "required": [
+              "completed_proposal_id_for_created_proposal_id"
+            ],
             "properties": {
               "completed_proposal_id_for_created_proposal_id": {
                 "type": "object",
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -1773,11 +2161,18 @@
   "migrate": null,
   "sudo": null,
   "responses": {
+    "can_propose": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Boolean",
+      "type": "boolean"
+    },
     "config": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Config",
       "type": "object",
-      "required": ["submission_policy"],
+      "required": [
+        "submission_policy"
+      ],
       "properties": {
         "deposit_info": {
           "description": "Information about the deposit required to create a proposal. If `None`, no deposit is required.",
@@ -1811,7 +2206,9 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": ["native"],
+              "required": [
+                "native"
+              ],
               "properties": {
                 "native": {
                   "type": "string"
@@ -1822,7 +2219,9 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": ["cw20"],
+              "required": [
+                "cw20"
+              ],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -1835,7 +2234,11 @@
         "CheckedDepositInfo": {
           "description": "Counterpart to the `DepositInfo` struct which has been processed. This type should never be constructed literally and should always by built by calling `into_checked` on a `DepositInfo` instance.",
           "type": "object",
-          "required": ["amount", "denom", "refund_policy"],
+          "required": [
+            "amount",
+            "denom",
+            "refund_policy"
+          ],
           "properties": {
             "amount": {
               "description": "The number of tokens that must be deposited to create a proposal. This is validated to be non-zero if this struct is constructed by converted via the `into_checked` method on `DepositInfo`.",
@@ -1869,17 +2272,23 @@
             {
               "description": "Deposits should always be refunded.",
               "type": "string",
-              "enum": ["always"]
+              "enum": [
+                "always"
+              ]
             },
             {
               "description": "Deposits should only be refunded for passed proposals.",
               "type": "string",
-              "enum": ["only_passed"]
+              "enum": [
+                "only_passed"
+              ]
             },
             {
               "description": "Deposits should never be refunded.",
               "type": "string",
-              "enum": ["never"]
+              "enum": [
+                "never"
+              ]
             }
           ]
         },
@@ -1889,14 +2298,19 @@
             {
               "description": "Anyone may create proposals, except for those in the denylist.",
               "type": "object",
-              "required": ["anyone"],
+              "required": [
+                "anyone"
+              ],
               "properties": {
                 "anyone": {
                   "type": "object",
                   "properties": {
                     "denylist": {
                       "description": "Addresses that may not create proposals.",
-                      "type": ["array", "null"],
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "items": {
                         "type": "string"
                       }
@@ -1910,15 +2324,22 @@
             {
               "description": "Specific people may create proposals.",
               "type": "object",
-              "required": ["specific"],
+              "required": [
+                "specific"
+              ],
               "properties": {
                 "specific": {
                   "type": "object",
-                  "required": ["dao_members"],
+                  "required": [
+                    "dao_members"
+                  ],
                   "properties": {
                     "allowlist": {
                       "description": "Addresses that may create proposals.",
-                      "type": ["array", "null"],
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "items": {
                         "type": "string"
                       }
@@ -1929,7 +2350,10 @@
                     },
                     "denylist": {
                       "description": "Addresses that may not create proposals, overriding other settings.",
-                      "type": ["array", "null"],
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "items": {
                         "type": "string"
                       }
@@ -1958,7 +2382,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "DepositInfoResponse",
       "type": "object",
-      "required": ["proposer"],
+      "required": [
+        "proposer"
+      ],
       "properties": {
         "deposit_info": {
           "description": "The deposit that has been paid for the specified proposal.",
@@ -1992,7 +2418,9 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": ["native"],
+              "required": [
+                "native"
+              ],
               "properties": {
                 "native": {
                   "type": "string"
@@ -2003,7 +2431,9 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": ["cw20"],
+              "required": [
+                "cw20"
+              ],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -2016,7 +2446,11 @@
         "CheckedDepositInfo": {
           "description": "Counterpart to the `DepositInfo` struct which has been processed. This type should never be constructed literally and should always by built by calling `into_checked` on a `DepositInfo` instance.",
           "type": "object",
-          "required": ["amount", "denom", "refund_policy"],
+          "required": [
+            "amount",
+            "denom",
+            "refund_policy"
+          ],
           "properties": {
             "amount": {
               "description": "The number of tokens that must be deposited to create a proposal. This is validated to be non-zero if this struct is constructed by converted via the `into_checked` method on `DepositInfo`.",
@@ -2050,17 +2484,23 @@
             {
               "description": "Deposits should always be refunded.",
               "type": "string",
-              "enum": ["always"]
+              "enum": [
+                "always"
+              ]
             },
             {
               "description": "Deposits should only be refunded for passed proposals.",
               "type": "string",
-              "enum": ["only_passed"]
+              "enum": [
+                "only_passed"
+              ]
             },
             {
               "description": "Deposits should never be refunded.",
               "type": "string",
-              "enum": ["never"]
+              "enum": [
+                "never"
+              ]
             }
           ]
         },
@@ -2080,7 +2520,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": ["hooks"],
+      "required": [
+        "hooks"
+      ],
       "properties": {
         "hooks": {
           "type": "array",

--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
@@ -9,7 +9,7 @@ use dao_interface::state::{Admin, ModuleInstantiateInfo};
 use dao_pre_propose_base::{error::PreProposeError, msg::DepositInfoResponse, state::Config};
 use dao_proposal_single::query::ProposalResponse;
 use dao_testing::helpers::instantiate_with_cw4_groups_governance;
-use dao_voting::pre_propose::PreProposeSubmissionPolicy;
+use dao_voting::pre_propose::{PreProposeSubmissionPolicy, PreProposeSubmissionPolicyError};
 use dao_voting::{
     deposit::{CheckedDepositInfo, DepositRefundPolicy, DepositToken, UncheckedDepositInfo},
     pre_propose::{PreProposeInfo, ProposalCreationPolicy},
@@ -1172,7 +1172,12 @@ fn test_permissions() {
         .unwrap_err()
         .downcast()
         .unwrap();
-    assert_eq!(err, PreProposeError::NotMember {});
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::UnauthorizedDaoMembers {}
+        )
+    );
 }
 
 #[test]
@@ -1321,7 +1326,12 @@ fn test_no_deposit_required_members_submission() {
         .unwrap_err()
         .downcast()
         .unwrap();
-    assert_eq!(err, PreProposeError::NotMember {});
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::UnauthorizedDaoMembers {}
+        )
+    );
 
     let pre_propose_id = make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &[]);
 

--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
@@ -321,7 +321,7 @@ fn update_config(
         module.clone(),
         &ExecuteMsg::UpdateConfig {
             deposit_info,
-            submission_policy,
+            submission_policy: Some(submission_policy),
         },
         &[],
     )
@@ -342,7 +342,7 @@ fn update_config_should_fail(
         module,
         &ExecuteMsg::UpdateConfig {
             deposit_info,
-            submission_policy,
+            submission_policy: Some(submission_policy),
         },
         &[],
     )

--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
@@ -54,9 +54,13 @@ fn get_default_proposal_module_instantiate(
     let pre_propose_id = app.store_code(cw_pre_propose_base_proposal_single());
 
     let submission_policy = if open_proposal_submission {
-        PreProposeSubmissionPolicy::Anyone {}
+        PreProposeSubmissionPolicy::Anyone { denylist: None }
     } else {
-        PreProposeSubmissionPolicy::DaoMembers {}
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        }
     };
 
     dao_proposal_single::msg::InstantiateMsg {
@@ -1174,9 +1178,7 @@ fn test_permissions() {
         .unwrap();
     assert_eq!(
         err,
-        PreProposeError::SubmissionPolicy(
-            PreProposeSubmissionPolicyError::UnauthorizedDaoMembers {}
-        )
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
     );
 }
 
@@ -1328,9 +1330,7 @@ fn test_no_deposit_required_members_submission() {
         .unwrap();
     assert_eq!(
         err,
-        PreProposeError::SubmissionPolicy(
-            PreProposeSubmissionPolicyError::UnauthorizedDaoMembers {}
-        )
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
     );
 
     let pre_propose_id = make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &[]);
@@ -1371,7 +1371,11 @@ fn test_instantiate_with_zero_native_deposit() {
                             amount: Uint128::zero(),
                             refund_policy: DepositRefundPolicy::OnlyPassed,
                         }),
-                        submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
+                        submission_policy: PreProposeSubmissionPolicy::Specific {
+                            dao_members: true,
+                            allowlist: None,
+                            denylist: None,
+                        },
                         extension: InstantiateExt {
                             approver: "approver".to_string(),
                         },
@@ -1436,7 +1440,11 @@ fn test_instantiate_with_zero_cw20_deposit() {
                             amount: Uint128::zero(),
                             refund_policy: DepositRefundPolicy::OnlyPassed,
                         }),
-                        submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
+                        submission_policy: PreProposeSubmissionPolicy::Specific {
+                            dao_members: true,
+                            allowlist: None,
+                            denylist: None,
+                        },
                         extension: InstantiateExt {
                             approver: "approver".to_string(),
                         },
@@ -1484,7 +1492,11 @@ fn test_update_config() {
         config,
         Config {
             deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::DaoMembers {}
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None
+            }
         }
     );
 
@@ -1504,7 +1516,7 @@ fn test_update_config() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Never,
         }),
-        PreProposeSubmissionPolicy::Anyone {},
+        PreProposeSubmissionPolicy::Anyone { denylist: None },
     );
 
     let config = get_config(&app, pre_propose.clone());
@@ -1516,7 +1528,7 @@ fn test_update_config() {
                 amount: Uint128::new(10),
                 refund_policy: DepositRefundPolicy::Never
             }),
-            submission_policy: PreProposeSubmissionPolicy::Anyone {},
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
         }
     );
 
@@ -1571,7 +1583,7 @@ fn test_update_config() {
         pre_propose,
         proposal_single.as_str(),
         None,
-        PreProposeSubmissionPolicy::Anyone {},
+        PreProposeSubmissionPolicy::Anyone { denylist: None },
     );
     assert_eq!(err, PreProposeError::NotDao {});
 }
@@ -1617,7 +1629,11 @@ fn test_withdraw() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Always,
         }),
-        PreProposeSubmissionPolicy::DaoMembers {},
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        },
     );
 
     // Withdraw with no specified denom - should fall back to the one
@@ -1664,7 +1680,11 @@ fn test_withdraw() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Always,
         }),
-        PreProposeSubmissionPolicy::DaoMembers {},
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        },
     );
 
     increase_allowance(

--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
@@ -1373,7 +1373,7 @@ fn test_anyone_denylist() {
     let rando = "rando";
 
     // Proposal succeeds when anyone can propose.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), true);
+    assert!(query_can_propose(&app, pre_propose.clone(), rando));
     make_pre_proposal(&mut app, pre_propose.clone(), rando, &[]);
 
     update_config(
@@ -1387,7 +1387,7 @@ fn test_anyone_denylist() {
     );
 
     // Proposing fails if on denylist.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), false);
+    assert!(!query_can_propose(&app, pre_propose.clone(), rando));
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked(rando),
@@ -1411,7 +1411,7 @@ fn test_anyone_denylist() {
     );
 
     // Proposing succeeds if not on denylist.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), true);
+    assert!(query_can_propose(&app, pre_propose.clone(), "ekez"));
     make_pre_proposal(&mut app, pre_propose, "ekez", &[]);
 }
 
@@ -1437,13 +1437,13 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposal succeeds for member.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), true);
+    assert!(query_can_propose(&app, pre_propose.clone(), "ekez"));
     make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &[]);
 
     let rando = "rando";
 
     // Proposing fails for non-member.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), false);
+    assert!(!query_can_propose(&app, pre_propose.clone(), rando));
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked(rando),
@@ -1479,7 +1479,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposal succeeds if on allowlist.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), true);
+    assert!(query_can_propose(&app, pre_propose.clone(), rando));
     make_pre_proposal(&mut app, pre_propose.clone(), rando, &[]);
 
     update_config(
@@ -1495,7 +1495,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposing fails if on denylist.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), false);
+    assert!(!query_can_propose(&app, pre_propose.clone(), "ekez"));
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked("ekez"),
@@ -1531,7 +1531,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposing fails if members not allowed.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), false);
+    assert!(!query_can_propose(&app, pre_propose.clone(), "ekez"));
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked("ekez"),
@@ -1555,7 +1555,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposal succeeds if on allowlist.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), true);
+    assert!(query_can_propose(&app, pre_propose.clone(), rando));
     make_pre_proposal(&mut app, pre_propose.clone(), rando, &[]);
 }
 

--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
@@ -9,6 +9,7 @@ use dao_interface::state::{Admin, ModuleInstantiateInfo};
 use dao_pre_propose_base::{error::PreProposeError, msg::DepositInfoResponse, state::Config};
 use dao_proposal_single::query::ProposalResponse;
 use dao_testing::helpers::instantiate_with_cw4_groups_governance;
+use dao_voting::pre_propose::PreProposeSubmissionPolicy;
 use dao_voting::{
     deposit::{CheckedDepositInfo, DepositRefundPolicy, DepositToken, UncheckedDepositInfo},
     pre_propose::{PreProposeInfo, ProposalCreationPolicy},
@@ -52,6 +53,12 @@ fn get_default_proposal_module_instantiate(
 ) -> dao_proposal_single::msg::InstantiateMsg {
     let pre_propose_id = app.store_code(cw_pre_propose_base_proposal_single());
 
+    let submission_policy = if open_proposal_submission {
+        PreProposeSubmissionPolicy::Anyone {}
+    } else {
+        PreProposeSubmissionPolicy::DaoMembers {}
+    };
+
     dao_proposal_single::msg::InstantiateMsg {
         threshold: Threshold::AbsolutePercentage {
             percentage: PercentageThreshold::Majority {},
@@ -65,7 +72,7 @@ fn get_default_proposal_module_instantiate(
                 code_id: pre_propose_id,
                 msg: to_json_binary(&InstantiateMsg {
                     deposit_info,
-                    open_proposal_submission,
+                    submission_policy,
                     extension: InstantiateExt {
                         approver: "approver".to_string(),
                     },
@@ -303,14 +310,14 @@ fn update_config(
     module: Addr,
     sender: &str,
     deposit_info: Option<UncheckedDepositInfo>,
-    open_proposal_submission: bool,
+    submission_policy: PreProposeSubmissionPolicy,
 ) -> Config {
     app.execute_contract(
         Addr::unchecked(sender),
         module.clone(),
         &ExecuteMsg::UpdateConfig {
             deposit_info,
-            open_proposal_submission,
+            submission_policy,
         },
         &[],
     )
@@ -324,14 +331,14 @@ fn update_config_should_fail(
     module: Addr,
     sender: &str,
     deposit_info: Option<UncheckedDepositInfo>,
-    open_proposal_submission: bool,
+    submission_policy: PreProposeSubmissionPolicy,
 ) -> PreProposeError {
     app.execute_contract(
         Addr::unchecked(sender),
         module,
         &ExecuteMsg::UpdateConfig {
             deposit_info,
-            open_proposal_submission,
+            submission_policy,
         },
         &[],
     )
@@ -1354,7 +1361,7 @@ fn test_instantiate_with_zero_native_deposit() {
                             amount: Uint128::zero(),
                             refund_policy: DepositRefundPolicy::OnlyPassed,
                         }),
-                        open_proposal_submission: false,
+                        submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
                         extension: InstantiateExt {
                             approver: "approver".to_string(),
                         },
@@ -1419,7 +1426,7 @@ fn test_instantiate_with_zero_cw20_deposit() {
                             amount: Uint128::zero(),
                             refund_policy: DepositRefundPolicy::OnlyPassed,
                         }),
-                        open_proposal_submission: false,
+                        submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
                         extension: InstantiateExt {
                             approver: "approver".to_string(),
                         },
@@ -1467,7 +1474,7 @@ fn test_update_config() {
         config,
         Config {
             deposit_info: None,
-            open_proposal_submission: false
+            submission_policy: PreProposeSubmissionPolicy::DaoMembers {}
         }
     );
 
@@ -1487,7 +1494,7 @@ fn test_update_config() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Never,
         }),
-        true,
+        PreProposeSubmissionPolicy::Anyone {},
     );
 
     let config = get_config(&app, pre_propose.clone());
@@ -1499,7 +1506,7 @@ fn test_update_config() {
                 amount: Uint128::new(10),
                 refund_policy: DepositRefundPolicy::Never
             }),
-            open_proposal_submission: true,
+            submission_policy: PreProposeSubmissionPolicy::Anyone {},
         }
     );
 
@@ -1549,8 +1556,13 @@ fn test_update_config() {
     assert_eq!(balance, Uint128::new(0));
 
     // Only the core module can update the config.
-    let err =
-        update_config_should_fail(&mut app, pre_propose, proposal_single.as_str(), None, true);
+    let err = update_config_should_fail(
+        &mut app,
+        pre_propose,
+        proposal_single.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Anyone {},
+    );
     assert_eq!(err, PreProposeError::NotDao {});
 }
 
@@ -1595,7 +1607,7 @@ fn test_withdraw() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Always,
         }),
-        false,
+        PreProposeSubmissionPolicy::DaoMembers {},
     );
 
     // Withdraw with no specified denom - should fall back to the one
@@ -1642,7 +1654,7 @@ fn test_withdraw() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Always,
         }),
-        false,
+        PreProposeSubmissionPolicy::DaoMembers {},
     );
 
     increase_allowance(

--- a/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
+++ b/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
@@ -51,11 +51,9 @@
         "properties": {
           "update_config": {
             "type": "object",
-            "required": [
-              "submission_policy"
-            ],
             "properties": {
               "deposit_info": {
+                "description": "If None, will remove the deposit. Backwards compatible.",
                 "anyOf": [
                   {
                     "$ref": "#/definitions/UncheckedDepositInfo"
@@ -66,7 +64,78 @@
                 ]
               },
               "submission_policy": {
-                "$ref": "#/definitions/PreProposeSubmissionPolicy"
+                "description": "If None, will leave the submission policy in the config as-is.",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/PreProposeSubmissionPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Perform more granular submission policy updates to allow for atomic operations that don't override others.",
+        "type": "object",
+        "required": [
+          "update_submission_policy"
+        ],
+        "properties": {
+          "update_submission_policy": {
+            "type": "object",
+            "properties": {
+              "allowlist_add": {
+                "description": "If using specific policy, optionally add to the allowlist.",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "allowlist_remove": {
+                "description": "If using specific policy, optionally remove from the allowlist.",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "denylist_add": {
+                "description": "Optionally add to the denylist. Works for any submission policy.",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "denylist_remove": {
+                "description": "Optionally remove from denylist. Works for any submission policy.",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "set_dao_members": {
+                "description": "If using specific policy, optionally update the `dao_members` flag.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -197,10 +266,6 @@
       }
     ],
     "definitions": {
-      "Addr": {
-        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-        "type": "string"
-      },
       "ApproverProposeMessage": {
         "oneOf": [
           {
@@ -394,7 +459,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   }
                 },
@@ -423,7 +488,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   },
                   "dao_members": {
@@ -437,7 +502,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   }
                 },
@@ -937,7 +1002,7 @@
                         "null"
                       ],
                       "items": {
-                        "$ref": "#/definitions/Addr"
+                        "type": "string"
                       }
                     }
                   },
@@ -966,7 +1031,7 @@
                         "null"
                       ],
                       "items": {
-                        "$ref": "#/definitions/Addr"
+                        "type": "string"
                       }
                     },
                     "dao_members": {
@@ -980,7 +1045,7 @@
                         "null"
                       ],
                       "items": {
-                        "$ref": "#/definitions/Addr"
+                        "type": "string"
                       }
                     }
                   },

--- a/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
+++ b/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
@@ -6,7 +6,9 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["pre_propose_approval_contract"],
+    "required": [
+      "pre_propose_approval_contract"
+    ],
     "properties": {
       "pre_propose_approval_contract": {
         "type": "string"
@@ -21,11 +23,15 @@
       {
         "description": "Creates a new proposal in the pre-propose module. MSG will be serialized and used as the proposal creation message.",
         "type": "object",
-        "required": ["propose"],
+        "required": [
+          "propose"
+        ],
         "properties": {
           "propose": {
             "type": "object",
-            "required": ["msg"],
+            "required": [
+              "msg"
+            ],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/ApproverProposeMessage"
@@ -39,7 +45,9 @@
       {
         "description": "Updates the configuration of this module. This will completely override the existing configuration. This new configuration will only apply to proposals created after the config is updated. Only the DAO may execute this message.",
         "type": "object",
-        "required": ["update_config"],
+        "required": [
+          "update_config"
+        ],
         "properties": {
           "update_config": {
             "type": "object",
@@ -75,42 +83,59 @@
       {
         "description": "Perform more granular submission policy updates to allow for atomic operations that don't override others.",
         "type": "object",
-        "required": ["update_submission_policy"],
+        "required": [
+          "update_submission_policy"
+        ],
         "properties": {
           "update_submission_policy": {
             "type": "object",
             "properties": {
               "allowlist_add": {
                 "description": "If using specific policy, optionally add to the allowlist.",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "string"
                 }
               },
               "allowlist_remove": {
                 "description": "If using specific policy, optionally remove from the allowlist.",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "string"
                 }
               },
               "denylist_add": {
                 "description": "Optionally add to the denylist. Works for any submission policy.",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "string"
                 }
               },
               "denylist_remove": {
                 "description": "Optionally remove from denylist. Works for any submission policy.",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "string"
                 }
               },
               "set_dao_members": {
                 "description": "If using specific policy, optionally update the `dao_members` flag.",
-                "type": ["boolean", "null"]
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -121,7 +146,9 @@
       {
         "description": "Withdraws funds inside of this contract to the message sender. The contracts entire balance for the specifed DENOM is withdrawn to the message sender. Only the DAO may call this method.\n\nThis is intended only as an escape hatch in the event of a critical bug in this contract or it's proposal module. Withdrawing funds will cause future attempts to return proposal deposits to fail their transactions as the contract will have insufficent balance to return them. In the case of `cw-proposal-single` this transaction failure will cause the module to remove the pre-propose module from its proposal hook receivers.\n\nMore likely than not, this should NEVER BE CALLED unless a bug in this contract or the proposal module it is associated with has caused it to stop receiving proposal hook messages, or if a critical security vulnerability has been found that allows an attacker to drain proposal deposits.",
         "type": "object",
-        "required": ["withdraw"],
+        "required": [
+          "withdraw"
+        ],
         "properties": {
           "withdraw": {
             "type": "object",
@@ -146,11 +173,15 @@
       {
         "description": "Extension message. Contracts that extend this one should put their custom execute logic here. The default implementation will do nothing if this variant is executed.",
         "type": "object",
-        "required": ["extension"],
+        "required": [
+          "extension"
+        ],
         "properties": {
           "extension": {
             "type": "object",
-            "required": ["msg"],
+            "required": [
+              "msg"
+            ],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/ExecuteExt"
@@ -164,11 +195,15 @@
       {
         "description": "Adds a proposal submitted hook. Fires when a new proposal is submitted to the pre-propose contract. Only the DAO may call this method.",
         "type": "object",
-        "required": ["add_proposal_submitted_hook"],
+        "required": [
+          "add_proposal_submitted_hook"
+        ],
         "properties": {
           "add_proposal_submitted_hook": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -182,11 +217,15 @@
       {
         "description": "Removes a proposal submitted hook. Only the DAO may call this method.",
         "type": "object",
-        "required": ["remove_proposal_submitted_hook"],
+        "required": [
+          "remove_proposal_submitted_hook"
+        ],
         "properties": {
           "remove_proposal_submitted_hook": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -200,11 +239,16 @@
       {
         "description": "Handles proposal hook fired by the associated proposal module when a proposal is completed (ie executed or rejected). By default, the base contract will return deposits proposals, when they are closed, when proposals are executed, or, if it is refunding failed.",
         "type": "object",
-        "required": ["proposal_completed_hook"],
+        "required": [
+          "proposal_completed_hook"
+        ],
         "properties": {
           "proposal_completed_hook": {
             "type": "object",
-            "required": ["new_status", "proposal_id"],
+            "required": [
+              "new_status",
+              "proposal_id"
+            ],
             "properties": {
               "new_status": {
                 "$ref": "#/definitions/Status"
@@ -226,11 +270,17 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["propose"],
+            "required": [
+              "propose"
+            ],
             "properties": {
               "propose": {
                 "type": "object",
-                "required": ["approval_id", "description", "title"],
+                "required": [
+                  "approval_id",
+                  "description",
+                  "title"
+                ],
                 "properties": {
                   "approval_id": {
                     "type": "integer",
@@ -256,17 +306,23 @@
           {
             "description": "Deposits should always be refunded.",
             "type": "string",
-            "enum": ["always"]
+            "enum": [
+              "always"
+            ]
           },
           {
             "description": "Deposits should only be refunded for passed proposals.",
             "type": "string",
-            "enum": ["only_passed"]
+            "enum": [
+              "only_passed"
+            ]
           },
           {
             "description": "Deposits should never be refunded.",
             "type": "string",
-            "enum": ["never"]
+            "enum": [
+              "never"
+            ]
           }
         ]
       },
@@ -276,11 +332,15 @@
           {
             "description": "Use a specific token address as the deposit token.",
             "type": "object",
-            "required": ["token"],
+            "required": [
+              "token"
+            ],
             "properties": {
               "token": {
                 "type": "object",
-                "required": ["denom"],
+                "required": [
+                  "denom"
+                ],
                 "properties": {
                   "denom": {
                     "$ref": "#/definitions/UncheckedDenom"
@@ -294,11 +354,15 @@
           {
             "description": "Use the token native denom or cw20 contract address of the associated DAO's voting module. NOTE: in order to retrieve the token automatically via this variant, the voting module must either (1) use a native token and implement the `Denom {}` query type defined by `dao_dao_macros::native_token_query` OR (2) use a cw20 token and implement the `TokenContract {}` query type defined by `dao_dao_macros::cw20_token_query`. Failing to implement correctly will cause this option to fail to instantiate.",
             "type": "object",
-            "required": ["voting_module_token"],
+            "required": [
+              "voting_module_token"
+            ],
             "properties": {
               "voting_module_token": {
                 "type": "object",
-                "required": ["token_type"],
+                "required": [
+                  "token_type"
+                ],
                 "properties": {
                   "token_type": {
                     "$ref": "#/definitions/VotingModuleTokenType"
@@ -315,7 +379,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["reset_approver"],
+            "required": [
+              "reset_approver"
+            ],
             "properties": {
               "reset_approver": {
                 "type": "object",
@@ -332,7 +398,9 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": ["at_height"],
+            "required": [
+              "at_height"
+            ],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -345,7 +413,9 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": ["at_time"],
+            "required": [
+              "at_time"
+            ],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -356,7 +426,9 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": ["never"],
+            "required": [
+              "never"
+            ],
             "properties": {
               "never": {
                 "type": "object",
@@ -373,14 +445,19 @@
           {
             "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
-            "required": ["anyone"],
+            "required": [
+              "anyone"
+            ],
             "properties": {
               "anyone": {
                 "type": "object",
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -394,15 +471,22 @@
           {
             "description": "Specific people may create proposals.",
             "type": "object",
-            "required": ["specific"],
+            "required": [
+              "specific"
+            ],
             "properties": {
               "specific": {
                 "type": "object",
-                "required": ["dao_members"],
+                "required": [
+                  "dao_members"
+                ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -413,7 +497,10 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -431,41 +518,57 @@
           {
             "description": "The proposal is open for voting.",
             "type": "string",
-            "enum": ["open"]
+            "enum": [
+              "open"
+            ]
           },
           {
             "description": "The proposal has been rejected.",
             "type": "string",
-            "enum": ["rejected"]
+            "enum": [
+              "rejected"
+            ]
           },
           {
             "description": "The proposal has been passed but has not been executed.",
             "type": "string",
-            "enum": ["passed"]
+            "enum": [
+              "passed"
+            ]
           },
           {
             "description": "The proposal has been passed and executed.",
             "type": "string",
-            "enum": ["executed"]
+            "enum": [
+              "executed"
+            ]
           },
           {
             "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
             "type": "string",
-            "enum": ["closed"]
+            "enum": [
+              "closed"
+            ]
           },
           {
             "description": "The proposal's execution failed.",
             "type": "string",
-            "enum": ["execution_failed"]
+            "enum": [
+              "execution_failed"
+            ]
           },
           {
             "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
             "type": "object",
-            "required": ["veto_timelock"],
+            "required": [
+              "veto_timelock"
+            ],
             "properties": {
               "veto_timelock": {
                 "type": "object",
-                "required": ["expiration"],
+                "required": [
+                  "expiration"
+                ],
                 "properties": {
                   "expiration": {
                     "$ref": "#/definitions/Expiration"
@@ -479,7 +582,9 @@
           {
             "description": "The proposal has been vetoed.",
             "type": "string",
-            "enum": ["vetoed"]
+            "enum": [
+              "vetoed"
+            ]
           }
         ]
       },
@@ -505,7 +610,9 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": ["native"],
+            "required": [
+              "native"
+            ],
             "properties": {
               "native": {
                 "type": "string"
@@ -516,7 +623,9 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": ["cw20"],
+            "required": [
+              "cw20"
+            ],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -529,7 +638,11 @@
       "UncheckedDepositInfo": {
         "description": "Information about the deposit required to create a proposal.",
         "type": "object",
-        "required": ["amount", "denom", "refund_policy"],
+        "required": [
+          "amount",
+          "denom",
+          "refund_policy"
+        ],
         "properties": {
           "amount": {
             "description": "The number of tokens that must be deposited to create a proposal. Must be a positive, non-zero number.",
@@ -560,7 +673,10 @@
       },
       "VotingModuleTokenType": {
         "type": "string",
-        "enum": ["native", "cw20"]
+        "enum": [
+          "native",
+          "cw20"
+        ]
       }
     }
   },
@@ -571,7 +687,9 @@
       {
         "description": "Gets the proposal module that this pre propose module is associated with. Returns `Addr`.",
         "type": "object",
-        "required": ["proposal_module"],
+        "required": [
+          "proposal_module"
+        ],
         "properties": {
           "proposal_module": {
             "type": "object",
@@ -583,7 +701,9 @@
       {
         "description": "Gets the DAO (dao-dao-core) module this contract is associated with. Returns `Addr`.",
         "type": "object",
-        "required": ["dao"],
+        "required": [
+          "dao"
+        ],
         "properties": {
           "dao": {
             "type": "object",
@@ -595,7 +715,9 @@
       {
         "description": "Gets the module's configuration.",
         "type": "object",
-        "required": ["config"],
+        "required": [
+          "config"
+        ],
         "properties": {
           "config": {
             "type": "object",
@@ -607,11 +729,15 @@
       {
         "description": "Gets the deposit info for the proposal identified by PROPOSAL_ID.",
         "type": "object",
-        "required": ["deposit_info"],
+        "required": [
+          "deposit_info"
+        ],
         "properties": {
           "deposit_info": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -625,9 +751,33 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns whether or not the address can submit proposals.",
+        "type": "object",
+        "required": [
+          "can_propose"
+        ],
+        "properties": {
+          "can_propose": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Returns list of proposal submitted hooks.",
         "type": "object",
-        "required": ["proposal_submitted_hooks"],
+        "required": [
+          "proposal_submitted_hooks"
+        ],
         "properties": {
           "proposal_submitted_hooks": {
             "type": "object",
@@ -639,11 +789,15 @@
       {
         "description": "Extension for queries. The default implementation will do nothing if queried for will return `Binary::default()`.",
         "type": "object",
-        "required": ["query_extension"],
+        "required": [
+          "query_extension"
+        ],
         "properties": {
           "query_extension": {
             "type": "object",
-            "required": ["msg"],
+            "required": [
+              "msg"
+            ],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/QueryExt"
@@ -660,7 +814,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["pre_propose_approval_contract"],
+            "required": [
+              "pre_propose_approval_contract"
+            ],
             "properties": {
               "pre_propose_approval_contract": {
                 "type": "object",
@@ -671,11 +827,15 @@
           },
           {
             "type": "object",
-            "required": ["pre_propose_approval_id_for_approver_proposal_id"],
+            "required": [
+              "pre_propose_approval_id_for_approver_proposal_id"
+            ],
             "properties": {
               "pre_propose_approval_id_for_approver_proposal_id": {
                 "type": "object",
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -690,11 +850,15 @@
           },
           {
             "type": "object",
-            "required": ["approver_proposal_id_for_pre_propose_approval_id"],
+            "required": [
+              "approver_proposal_id_for_pre_propose_approval_id"
+            ],
             "properties": {
               "approver_proposal_id_for_pre_propose_approval_id": {
                 "type": "object",
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -714,11 +878,18 @@
   "migrate": null,
   "sudo": null,
   "responses": {
+    "can_propose": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Boolean",
+      "type": "boolean"
+    },
     "config": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Config",
       "type": "object",
-      "required": ["submission_policy"],
+      "required": [
+        "submission_policy"
+      ],
       "properties": {
         "deposit_info": {
           "description": "Information about the deposit required to create a proposal. If `None`, no deposit is required.",
@@ -752,7 +923,9 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": ["native"],
+              "required": [
+                "native"
+              ],
               "properties": {
                 "native": {
                   "type": "string"
@@ -763,7 +936,9 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": ["cw20"],
+              "required": [
+                "cw20"
+              ],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -776,7 +951,11 @@
         "CheckedDepositInfo": {
           "description": "Counterpart to the `DepositInfo` struct which has been processed. This type should never be constructed literally and should always by built by calling `into_checked` on a `DepositInfo` instance.",
           "type": "object",
-          "required": ["amount", "denom", "refund_policy"],
+          "required": [
+            "amount",
+            "denom",
+            "refund_policy"
+          ],
           "properties": {
             "amount": {
               "description": "The number of tokens that must be deposited to create a proposal. This is validated to be non-zero if this struct is constructed by converted via the `into_checked` method on `DepositInfo`.",
@@ -810,17 +989,23 @@
             {
               "description": "Deposits should always be refunded.",
               "type": "string",
-              "enum": ["always"]
+              "enum": [
+                "always"
+              ]
             },
             {
               "description": "Deposits should only be refunded for passed proposals.",
               "type": "string",
-              "enum": ["only_passed"]
+              "enum": [
+                "only_passed"
+              ]
             },
             {
               "description": "Deposits should never be refunded.",
               "type": "string",
-              "enum": ["never"]
+              "enum": [
+                "never"
+              ]
             }
           ]
         },
@@ -830,14 +1015,19 @@
             {
               "description": "Anyone may create proposals, except for those in the denylist.",
               "type": "object",
-              "required": ["anyone"],
+              "required": [
+                "anyone"
+              ],
               "properties": {
                 "anyone": {
                   "type": "object",
                   "properties": {
                     "denylist": {
                       "description": "Addresses that may not create proposals.",
-                      "type": ["array", "null"],
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "items": {
                         "type": "string"
                       }
@@ -851,15 +1041,22 @@
             {
               "description": "Specific people may create proposals.",
               "type": "object",
-              "required": ["specific"],
+              "required": [
+                "specific"
+              ],
               "properties": {
                 "specific": {
                   "type": "object",
-                  "required": ["dao_members"],
+                  "required": [
+                    "dao_members"
+                  ],
                   "properties": {
                     "allowlist": {
                       "description": "Addresses that may create proposals.",
-                      "type": ["array", "null"],
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "items": {
                         "type": "string"
                       }
@@ -870,7 +1067,10 @@
                     },
                     "denylist": {
                       "description": "Addresses that may not create proposals, overriding other settings.",
-                      "type": ["array", "null"],
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "items": {
                         "type": "string"
                       }
@@ -899,7 +1099,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "DepositInfoResponse",
       "type": "object",
-      "required": ["proposer"],
+      "required": [
+        "proposer"
+      ],
       "properties": {
         "deposit_info": {
           "description": "The deposit that has been paid for the specified proposal.",
@@ -933,7 +1135,9 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": ["native"],
+              "required": [
+                "native"
+              ],
               "properties": {
                 "native": {
                   "type": "string"
@@ -944,7 +1148,9 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": ["cw20"],
+              "required": [
+                "cw20"
+              ],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -957,7 +1163,11 @@
         "CheckedDepositInfo": {
           "description": "Counterpart to the `DepositInfo` struct which has been processed. This type should never be constructed literally and should always by built by calling `into_checked` on a `DepositInfo` instance.",
           "type": "object",
-          "required": ["amount", "denom", "refund_policy"],
+          "required": [
+            "amount",
+            "denom",
+            "refund_policy"
+          ],
           "properties": {
             "amount": {
               "description": "The number of tokens that must be deposited to create a proposal. This is validated to be non-zero if this struct is constructed by converted via the `into_checked` method on `DepositInfo`.",
@@ -991,17 +1201,23 @@
             {
               "description": "Deposits should always be refunded.",
               "type": "string",
-              "enum": ["always"]
+              "enum": [
+                "always"
+              ]
             },
             {
               "description": "Deposits should only be refunded for passed proposals.",
               "type": "string",
-              "enum": ["only_passed"]
+              "enum": [
+                "only_passed"
+              ]
             },
             {
               "description": "Deposits should never be refunded.",
               "type": "string",
-              "enum": ["never"]
+              "enum": [
+                "never"
+              ]
             }
           ]
         },
@@ -1021,7 +1237,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": ["hooks"],
+      "required": [
+        "hooks"
+      ],
       "properties": {
         "hooks": {
           "type": "array",

--- a/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
+++ b/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
@@ -1,14 +1,12 @@
 {
   "contract_name": "dao-pre-propose-approver",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "pre_propose_approval_contract"
-    ],
+    "required": ["pre_propose_approval_contract"],
     "properties": {
       "pre_propose_approval_contract": {
         "type": "string"
@@ -23,15 +21,11 @@
       {
         "description": "Creates a new proposal in the pre-propose module. MSG will be serialized and used as the proposal creation message.",
         "type": "object",
-        "required": [
-          "propose"
-        ],
+        "required": ["propose"],
         "properties": {
           "propose": {
             "type": "object",
-            "required": [
-              "msg"
-            ],
+            "required": ["msg"],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/ApproverProposeMessage"
@@ -45,9 +39,7 @@
       {
         "description": "Updates the configuration of this module. This will completely override the existing configuration. This new configuration will only apply to proposals created after the config is updated. Only the DAO may execute this message.",
         "type": "object",
-        "required": [
-          "update_config"
-        ],
+        "required": ["update_config"],
         "properties": {
           "update_config": {
             "type": "object",
@@ -83,59 +75,42 @@
       {
         "description": "Perform more granular submission policy updates to allow for atomic operations that don't override others.",
         "type": "object",
-        "required": [
-          "update_submission_policy"
-        ],
+        "required": ["update_submission_policy"],
         "properties": {
           "update_submission_policy": {
             "type": "object",
             "properties": {
               "allowlist_add": {
                 "description": "If using specific policy, optionally add to the allowlist.",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "allowlist_remove": {
                 "description": "If using specific policy, optionally remove from the allowlist.",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "denylist_add": {
                 "description": "Optionally add to the denylist. Works for any submission policy.",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "denylist_remove": {
                 "description": "Optionally remove from denylist. Works for any submission policy.",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "set_dao_members": {
                 "description": "If using specific policy, optionally update the `dao_members` flag.",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": ["boolean", "null"]
               }
             },
             "additionalProperties": false
@@ -146,9 +121,7 @@
       {
         "description": "Withdraws funds inside of this contract to the message sender. The contracts entire balance for the specifed DENOM is withdrawn to the message sender. Only the DAO may call this method.\n\nThis is intended only as an escape hatch in the event of a critical bug in this contract or it's proposal module. Withdrawing funds will cause future attempts to return proposal deposits to fail their transactions as the contract will have insufficent balance to return them. In the case of `cw-proposal-single` this transaction failure will cause the module to remove the pre-propose module from its proposal hook receivers.\n\nMore likely than not, this should NEVER BE CALLED unless a bug in this contract or the proposal module it is associated with has caused it to stop receiving proposal hook messages, or if a critical security vulnerability has been found that allows an attacker to drain proposal deposits.",
         "type": "object",
-        "required": [
-          "withdraw"
-        ],
+        "required": ["withdraw"],
         "properties": {
           "withdraw": {
             "type": "object",
@@ -173,15 +146,11 @@
       {
         "description": "Extension message. Contracts that extend this one should put their custom execute logic here. The default implementation will do nothing if this variant is executed.",
         "type": "object",
-        "required": [
-          "extension"
-        ],
+        "required": ["extension"],
         "properties": {
           "extension": {
             "type": "object",
-            "required": [
-              "msg"
-            ],
+            "required": ["msg"],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/ExecuteExt"
@@ -195,15 +164,11 @@
       {
         "description": "Adds a proposal submitted hook. Fires when a new proposal is submitted to the pre-propose contract. Only the DAO may call this method.",
         "type": "object",
-        "required": [
-          "add_proposal_submitted_hook"
-        ],
+        "required": ["add_proposal_submitted_hook"],
         "properties": {
           "add_proposal_submitted_hook": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -217,15 +182,11 @@
       {
         "description": "Removes a proposal submitted hook. Only the DAO may call this method.",
         "type": "object",
-        "required": [
-          "remove_proposal_submitted_hook"
-        ],
+        "required": ["remove_proposal_submitted_hook"],
         "properties": {
           "remove_proposal_submitted_hook": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -239,16 +200,11 @@
       {
         "description": "Handles proposal hook fired by the associated proposal module when a proposal is completed (ie executed or rejected). By default, the base contract will return deposits proposals, when they are closed, when proposals are executed, or, if it is refunding failed.",
         "type": "object",
-        "required": [
-          "proposal_completed_hook"
-        ],
+        "required": ["proposal_completed_hook"],
         "properties": {
           "proposal_completed_hook": {
             "type": "object",
-            "required": [
-              "new_status",
-              "proposal_id"
-            ],
+            "required": ["new_status", "proposal_id"],
             "properties": {
               "new_status": {
                 "$ref": "#/definitions/Status"
@@ -270,17 +226,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "propose"
-            ],
+            "required": ["propose"],
             "properties": {
               "propose": {
                 "type": "object",
-                "required": [
-                  "approval_id",
-                  "description",
-                  "title"
-                ],
+                "required": ["approval_id", "description", "title"],
                 "properties": {
                   "approval_id": {
                     "type": "integer",
@@ -306,23 +256,17 @@
           {
             "description": "Deposits should always be refunded.",
             "type": "string",
-            "enum": [
-              "always"
-            ]
+            "enum": ["always"]
           },
           {
             "description": "Deposits should only be refunded for passed proposals.",
             "type": "string",
-            "enum": [
-              "only_passed"
-            ]
+            "enum": ["only_passed"]
           },
           {
             "description": "Deposits should never be refunded.",
             "type": "string",
-            "enum": [
-              "never"
-            ]
+            "enum": ["never"]
           }
         ]
       },
@@ -332,15 +276,11 @@
           {
             "description": "Use a specific token address as the deposit token.",
             "type": "object",
-            "required": [
-              "token"
-            ],
+            "required": ["token"],
             "properties": {
               "token": {
                 "type": "object",
-                "required": [
-                  "denom"
-                ],
+                "required": ["denom"],
                 "properties": {
                   "denom": {
                     "$ref": "#/definitions/UncheckedDenom"
@@ -354,15 +294,11 @@
           {
             "description": "Use the token native denom or cw20 contract address of the associated DAO's voting module. NOTE: in order to retrieve the token automatically via this variant, the voting module must either (1) use a native token and implement the `Denom {}` query type defined by `dao_dao_macros::native_token_query` OR (2) use a cw20 token and implement the `TokenContract {}` query type defined by `dao_dao_macros::cw20_token_query`. Failing to implement correctly will cause this option to fail to instantiate.",
             "type": "object",
-            "required": [
-              "voting_module_token"
-            ],
+            "required": ["voting_module_token"],
             "properties": {
               "voting_module_token": {
                 "type": "object",
-                "required": [
-                  "token_type"
-                ],
+                "required": ["token_type"],
                 "properties": {
                   "token_type": {
                     "$ref": "#/definitions/VotingModuleTokenType"
@@ -379,9 +315,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "reset_approver"
-            ],
+            "required": ["reset_approver"],
             "properties": {
               "reset_approver": {
                 "type": "object",
@@ -398,9 +332,7 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": [
-              "at_height"
-            ],
+            "required": ["at_height"],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -413,9 +345,7 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": [
-              "at_time"
-            ],
+            "required": ["at_time"],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -426,9 +356,7 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": [
-              "never"
-            ],
+            "required": ["never"],
             "properties": {
               "never": {
                 "type": "object",
@@ -445,19 +373,14 @@
           {
             "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
-            "required": [
-              "anyone"
-            ],
+            "required": ["anyone"],
             "properties": {
               "anyone": {
                 "type": "object",
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -471,22 +394,15 @@
           {
             "description": "Specific people may create proposals.",
             "type": "object",
-            "required": [
-              "specific"
-            ],
+            "required": ["specific"],
             "properties": {
               "specific": {
                 "type": "object",
-                "required": [
-                  "dao_members"
-                ],
+                "required": ["dao_members"],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -497,10 +413,7 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -518,57 +431,41 @@
           {
             "description": "The proposal is open for voting.",
             "type": "string",
-            "enum": [
-              "open"
-            ]
+            "enum": ["open"]
           },
           {
             "description": "The proposal has been rejected.",
             "type": "string",
-            "enum": [
-              "rejected"
-            ]
+            "enum": ["rejected"]
           },
           {
             "description": "The proposal has been passed but has not been executed.",
             "type": "string",
-            "enum": [
-              "passed"
-            ]
+            "enum": ["passed"]
           },
           {
             "description": "The proposal has been passed and executed.",
             "type": "string",
-            "enum": [
-              "executed"
-            ]
+            "enum": ["executed"]
           },
           {
             "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
             "type": "string",
-            "enum": [
-              "closed"
-            ]
+            "enum": ["closed"]
           },
           {
             "description": "The proposal's execution failed.",
             "type": "string",
-            "enum": [
-              "execution_failed"
-            ]
+            "enum": ["execution_failed"]
           },
           {
             "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
             "type": "object",
-            "required": [
-              "veto_timelock"
-            ],
+            "required": ["veto_timelock"],
             "properties": {
               "veto_timelock": {
                 "type": "object",
-                "required": [
-                  "expiration"
-                ],
+                "required": ["expiration"],
                 "properties": {
                   "expiration": {
                     "$ref": "#/definitions/Expiration"
@@ -582,9 +479,7 @@
           {
             "description": "The proposal has been vetoed.",
             "type": "string",
-            "enum": [
-              "vetoed"
-            ]
+            "enum": ["vetoed"]
           }
         ]
       },
@@ -610,9 +505,7 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": [
-              "native"
-            ],
+            "required": ["native"],
             "properties": {
               "native": {
                 "type": "string"
@@ -623,9 +516,7 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": [
-              "cw20"
-            ],
+            "required": ["cw20"],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -638,11 +529,7 @@
       "UncheckedDepositInfo": {
         "description": "Information about the deposit required to create a proposal.",
         "type": "object",
-        "required": [
-          "amount",
-          "denom",
-          "refund_policy"
-        ],
+        "required": ["amount", "denom", "refund_policy"],
         "properties": {
           "amount": {
             "description": "The number of tokens that must be deposited to create a proposal. Must be a positive, non-zero number.",
@@ -673,10 +560,7 @@
       },
       "VotingModuleTokenType": {
         "type": "string",
-        "enum": [
-          "native",
-          "cw20"
-        ]
+        "enum": ["native", "cw20"]
       }
     }
   },
@@ -687,9 +571,7 @@
       {
         "description": "Gets the proposal module that this pre propose module is associated with. Returns `Addr`.",
         "type": "object",
-        "required": [
-          "proposal_module"
-        ],
+        "required": ["proposal_module"],
         "properties": {
           "proposal_module": {
             "type": "object",
@@ -701,9 +583,7 @@
       {
         "description": "Gets the DAO (dao-dao-core) module this contract is associated with. Returns `Addr`.",
         "type": "object",
-        "required": [
-          "dao"
-        ],
+        "required": ["dao"],
         "properties": {
           "dao": {
             "type": "object",
@@ -715,9 +595,7 @@
       {
         "description": "Gets the module's configuration.",
         "type": "object",
-        "required": [
-          "config"
-        ],
+        "required": ["config"],
         "properties": {
           "config": {
             "type": "object",
@@ -729,15 +607,11 @@
       {
         "description": "Gets the deposit info for the proposal identified by PROPOSAL_ID.",
         "type": "object",
-        "required": [
-          "deposit_info"
-        ],
+        "required": ["deposit_info"],
         "properties": {
           "deposit_info": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -753,9 +627,7 @@
       {
         "description": "Returns list of proposal submitted hooks.",
         "type": "object",
-        "required": [
-          "proposal_submitted_hooks"
-        ],
+        "required": ["proposal_submitted_hooks"],
         "properties": {
           "proposal_submitted_hooks": {
             "type": "object",
@@ -767,15 +639,11 @@
       {
         "description": "Extension for queries. The default implementation will do nothing if queried for will return `Binary::default()`.",
         "type": "object",
-        "required": [
-          "query_extension"
-        ],
+        "required": ["query_extension"],
         "properties": {
           "query_extension": {
             "type": "object",
-            "required": [
-              "msg"
-            ],
+            "required": ["msg"],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/QueryExt"
@@ -792,9 +660,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "pre_propose_approval_contract"
-            ],
+            "required": ["pre_propose_approval_contract"],
             "properties": {
               "pre_propose_approval_contract": {
                 "type": "object",
@@ -805,15 +671,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "pre_propose_approval_id_for_approver_proposal_id"
-            ],
+            "required": ["pre_propose_approval_id_for_approver_proposal_id"],
             "properties": {
               "pre_propose_approval_id_for_approver_proposal_id": {
                 "type": "object",
-                "required": [
-                  "id"
-                ],
+                "required": ["id"],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -828,15 +690,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "approver_proposal_id_for_pre_propose_approval_id"
-            ],
+            "required": ["approver_proposal_id_for_pre_propose_approval_id"],
             "properties": {
               "approver_proposal_id_for_pre_propose_approval_id": {
                 "type": "object",
-                "required": [
-                  "id"
-                ],
+                "required": ["id"],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -860,9 +718,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Config",
       "type": "object",
-      "required": [
-        "submission_policy"
-      ],
+      "required": ["submission_policy"],
       "properties": {
         "deposit_info": {
           "description": "Information about the deposit required to create a proposal. If `None`, no deposit is required.",
@@ -896,9 +752,7 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": [
-                "native"
-              ],
+              "required": ["native"],
               "properties": {
                 "native": {
                   "type": "string"
@@ -909,9 +763,7 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": [
-                "cw20"
-              ],
+              "required": ["cw20"],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -924,11 +776,7 @@
         "CheckedDepositInfo": {
           "description": "Counterpart to the `DepositInfo` struct which has been processed. This type should never be constructed literally and should always by built by calling `into_checked` on a `DepositInfo` instance.",
           "type": "object",
-          "required": [
-            "amount",
-            "denom",
-            "refund_policy"
-          ],
+          "required": ["amount", "denom", "refund_policy"],
           "properties": {
             "amount": {
               "description": "The number of tokens that must be deposited to create a proposal. This is validated to be non-zero if this struct is constructed by converted via the `into_checked` method on `DepositInfo`.",
@@ -962,23 +810,17 @@
             {
               "description": "Deposits should always be refunded.",
               "type": "string",
-              "enum": [
-                "always"
-              ]
+              "enum": ["always"]
             },
             {
               "description": "Deposits should only be refunded for passed proposals.",
               "type": "string",
-              "enum": [
-                "only_passed"
-              ]
+              "enum": ["only_passed"]
             },
             {
               "description": "Deposits should never be refunded.",
               "type": "string",
-              "enum": [
-                "never"
-              ]
+              "enum": ["never"]
             }
           ]
         },
@@ -988,19 +830,14 @@
             {
               "description": "Anyone may create proposals, except for those in the denylist.",
               "type": "object",
-              "required": [
-                "anyone"
-              ],
+              "required": ["anyone"],
               "properties": {
                 "anyone": {
                   "type": "object",
                   "properties": {
                     "denylist": {
                       "description": "Addresses that may not create proposals.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": ["array", "null"],
                       "items": {
                         "type": "string"
                       }
@@ -1014,22 +851,15 @@
             {
               "description": "Specific people may create proposals.",
               "type": "object",
-              "required": [
-                "specific"
-              ],
+              "required": ["specific"],
               "properties": {
                 "specific": {
                   "type": "object",
-                  "required": [
-                    "dao_members"
-                  ],
+                  "required": ["dao_members"],
                   "properties": {
                     "allowlist": {
                       "description": "Addresses that may create proposals.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": ["array", "null"],
                       "items": {
                         "type": "string"
                       }
@@ -1040,10 +870,7 @@
                     },
                     "denylist": {
                       "description": "Addresses that may not create proposals, overriding other settings.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": ["array", "null"],
                       "items": {
                         "type": "string"
                       }
@@ -1072,9 +899,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "DepositInfoResponse",
       "type": "object",
-      "required": [
-        "proposer"
-      ],
+      "required": ["proposer"],
       "properties": {
         "deposit_info": {
           "description": "The deposit that has been paid for the specified proposal.",
@@ -1108,9 +933,7 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": [
-                "native"
-              ],
+              "required": ["native"],
               "properties": {
                 "native": {
                   "type": "string"
@@ -1121,9 +944,7 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": [
-                "cw20"
-              ],
+              "required": ["cw20"],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -1136,11 +957,7 @@
         "CheckedDepositInfo": {
           "description": "Counterpart to the `DepositInfo` struct which has been processed. This type should never be constructed literally and should always by built by calling `into_checked` on a `DepositInfo` instance.",
           "type": "object",
-          "required": [
-            "amount",
-            "denom",
-            "refund_policy"
-          ],
+          "required": ["amount", "denom", "refund_policy"],
           "properties": {
             "amount": {
               "description": "The number of tokens that must be deposited to create a proposal. This is validated to be non-zero if this struct is constructed by converted via the `into_checked` method on `DepositInfo`.",
@@ -1174,23 +991,17 @@
             {
               "description": "Deposits should always be refunded.",
               "type": "string",
-              "enum": [
-                "always"
-              ]
+              "enum": ["always"]
             },
             {
               "description": "Deposits should only be refunded for passed proposals.",
               "type": "string",
-              "enum": [
-                "only_passed"
-              ]
+              "enum": ["only_passed"]
             },
             {
               "description": "Deposits should never be refunded.",
               "type": "string",
-              "enum": [
-                "never"
-              ]
+              "enum": ["never"]
             }
           ]
         },
@@ -1210,9 +1021,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": [
-        "hooks"
-      ],
+      "required": ["hooks"],
       "properties": {
         "hooks": {
           "type": "array",

--- a/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
+++ b/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
@@ -378,7 +378,7 @@
         "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
         "oneOf": [
           {
-            "description": "Anyone may create a proposal.",
+            "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
             "required": [
               "anyone"
@@ -386,40 +386,56 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "properties": {
+                  "denylist": {
+                    "description": "Addresses that may not create proposals.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  }
+                },
                 "additionalProperties": false
               }
             },
             "additionalProperties": false
           },
           {
-            "description": "Only members of the DAO may create a proposal.",
+            "description": "Specific people may create proposals.",
             "type": "object",
             "required": [
-              "dao_members"
+              "specific"
             ],
             "properties": {
-              "dao_members": {
-                "type": "object",
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Only the specified addresses may create a proposal.",
-            "type": "object",
-            "required": [
-              "allowlist"
-            ],
-            "properties": {
-              "allowlist": {
+              "specific": {
                 "type": "object",
                 "required": [
-                  "addresses"
+                  "dao_members"
                 ],
                 "properties": {
-                  "addresses": {
-                    "type": "array",
+                  "allowlist": {
+                    "description": "Addresses that may create proposals.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  },
+                  "dao_members": {
+                    "description": "Whether or not DAO members may create proposals.",
+                    "type": "boolean"
+                  },
+                  "denylist": {
+                    "description": "Addresses that may not create proposals, overriding other settings.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "$ref": "#/definitions/Addr"
                     }
@@ -905,7 +921,7 @@
           "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
           "oneOf": [
             {
-              "description": "Anyone may create a proposal.",
+              "description": "Anyone may create proposals, except for those in the denylist.",
               "type": "object",
               "required": [
                 "anyone"
@@ -913,40 +929,56 @@
               "properties": {
                 "anyone": {
                   "type": "object",
+                  "properties": {
+                    "denylist": {
+                      "description": "Addresses that may not create proposals.",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "$ref": "#/definitions/Addr"
+                      }
+                    }
+                  },
                   "additionalProperties": false
                 }
               },
               "additionalProperties": false
             },
             {
-              "description": "Only members of the DAO may create a proposal.",
+              "description": "Specific people may create proposals.",
               "type": "object",
               "required": [
-                "dao_members"
+                "specific"
               ],
               "properties": {
-                "dao_members": {
-                  "type": "object",
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "description": "Only the specified addresses may create a proposal.",
-              "type": "object",
-              "required": [
-                "allowlist"
-              ],
-              "properties": {
-                "allowlist": {
+                "specific": {
                   "type": "object",
                   "required": [
-                    "addresses"
+                    "dao_members"
                   ],
                   "properties": {
-                    "addresses": {
-                      "type": "array",
+                    "allowlist": {
+                      "description": "Addresses that may create proposals.",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "$ref": "#/definitions/Addr"
+                      }
+                    },
+                    "dao_members": {
+                      "description": "Whether or not DAO members may create proposals.",
+                      "type": "boolean"
+                    },
+                    "denylist": {
+                      "description": "Addresses that may not create proposals, overriding other settings.",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "items": {
                         "$ref": "#/definitions/Addr"
                       }

--- a/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
+++ b/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
@@ -52,7 +52,7 @@
           "update_config": {
             "type": "object",
             "required": [
-              "open_proposal_submission"
+              "submission_policy"
             ],
             "properties": {
               "deposit_info": {
@@ -65,8 +65,8 @@
                   }
                 ]
               },
-              "open_proposal_submission": {
-                "type": "boolean"
+              "submission_policy": {
+                "$ref": "#/definitions/PreProposeSubmissionPolicy"
               }
             },
             "additionalProperties": false
@@ -197,6 +197,10 @@
       }
     ],
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "ApproverProposeMessage": {
         "oneOf": [
           {
@@ -363,6 +367,64 @@
             "properties": {
               "never": {
                 "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "PreProposeSubmissionPolicy": {
+        "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
+        "oneOf": [
+          {
+            "description": "Anyone may create a proposal.",
+            "type": "object",
+            "required": [
+              "anyone"
+            ],
+            "properties": {
+              "anyone": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Only members of the DAO may create a proposal.",
+            "type": "object",
+            "required": [
+              "dao_members"
+            ],
+            "properties": {
+              "dao_members": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Only the specified addresses may create a proposal.",
+            "type": "object",
+            "required": [
+              "allowlist"
+            ],
+            "properties": {
+              "allowlist": {
+                "type": "object",
+                "required": [
+                  "addresses"
+                ],
+                "properties": {
+                  "addresses": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  }
+                },
                 "additionalProperties": false
               }
             },
@@ -718,7 +780,7 @@
       "title": "Config",
       "type": "object",
       "required": [
-        "open_proposal_submission"
+        "submission_policy"
       ],
       "properties": {
         "deposit_info": {
@@ -732,9 +794,13 @@
             }
           ]
         },
-        "open_proposal_submission": {
-          "description": "If false, only members (addresses with voting power) may create proposals in the DAO. Otherwise, any address may create a proposal so long as they pay the deposit.",
-          "type": "boolean"
+        "submission_policy": {
+          "description": "The policy dictating who is allowed to submit proposals.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PreProposeSubmissionPolicy"
+            }
+          ]
         }
       },
       "additionalProperties": false,
@@ -832,6 +898,64 @@
               "enum": [
                 "never"
               ]
+            }
+          ]
+        },
+        "PreProposeSubmissionPolicy": {
+          "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
+          "oneOf": [
+            {
+              "description": "Anyone may create a proposal.",
+              "type": "object",
+              "required": [
+                "anyone"
+              ],
+              "properties": {
+                "anyone": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Only members of the DAO may create a proposal.",
+              "type": "object",
+              "required": [
+                "dao_members"
+              ],
+              "properties": {
+                "dao_members": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Only the specified addresses may create a proposal.",
+              "type": "object",
+              "required": [
+                "allowlist"
+              ],
+              "properties": {
+                "allowlist": {
+                  "type": "object",
+                  "required": [
+                    "addresses"
+                  ],
+                  "properties": {
+                    "addresses": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Addr"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
             }
           ]
         },

--- a/contracts/pre-propose/dao-pre-propose-approver/src/contract.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/contract.rs
@@ -11,6 +11,7 @@ use dao_pre_propose_approval_single::msg::{
     ApproverProposeMessage, ExecuteExt as ApprovalExt, ExecuteMsg as PreProposeApprovalExecuteMsg,
 };
 use dao_pre_propose_base::{error::PreProposeError, state::PreProposeContract};
+use dao_voting::pre_propose::PreProposeSubmissionPolicy;
 use dao_voting::status::Status;
 
 use crate::msg::{
@@ -37,7 +38,7 @@ pub fn instantiate(
     // Here we hardcode the pre-propose-base instantiate message
     let base_instantiate_msg = BaseInstantiateMsg {
         deposit_info: None,
-        open_proposal_submission: false,
+        submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
         extension: Empty {},
     };
     // Default pre-propose-base instantiation

--- a/contracts/pre-propose/dao-pre-propose-approver/src/contract.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/contract.rs
@@ -237,6 +237,11 @@ pub fn execute_reset_approver(
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
+        QueryMsg::CanPropose { address } => {
+            let approval_contract = PRE_PROPOSE_APPROVAL_CONTRACT.load(deps.storage)?;
+            let can_propose = address == approval_contract;
+            to_json_binary(&can_propose)
+        }
         QueryMsg::QueryExtension { msg } => match msg {
             QueryExt::PreProposeApprovalContract {} => {
                 to_json_binary(&PRE_PROPOSE_APPROVAL_CONTRACT.load(deps.storage)?)

--- a/contracts/pre-propose/dao-pre-propose-approver/src/contract.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/contract.rs
@@ -38,7 +38,11 @@ pub fn instantiate(
     // Here we hardcode the pre-propose-base instantiate message
     let base_instantiate_msg = BaseInstantiateMsg {
         deposit_info: None,
-        submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
+        submission_policy: PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        },
         extension: Empty {},
     };
     // Default pre-propose-base instantiation

--- a/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
@@ -3,7 +3,7 @@ use cw2::ContractVersion;
 use cw20::Cw20Coin;
 use cw_denom::UncheckedDenom;
 use cw_multi_test::{App, BankSudo, Contract, ContractWrapper, Executor};
-use dao_voting::pre_propose::PreProposeSubmissionPolicy;
+use dao_voting::pre_propose::{PreProposeSubmissionPolicy, PreProposeSubmissionPolicyError};
 use dps::query::{ProposalListResponse, ProposalResponse};
 
 use dao_interface::state::ProposalModule;
@@ -1167,7 +1167,12 @@ fn test_permissions() {
         .unwrap_err()
         .downcast()
         .unwrap();
-    assert_eq!(err, PreProposeError::NotMember {});
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::UnauthorizedDaoMembers {}
+        )
+    );
 }
 
 #[test]

--- a/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
@@ -469,7 +469,7 @@ fn update_config(
         module.clone(),
         &ExecuteMsg::UpdateConfig {
             deposit_info,
-            submission_policy,
+            submission_policy: Some(submission_policy),
         },
         &[],
     )
@@ -490,7 +490,7 @@ fn update_config_should_fail(
         module,
         &ExecuteMsg::UpdateConfig {
             deposit_info,
-            submission_policy,
+            submission_policy: Some(submission_policy),
         },
         &[],
     )

--- a/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
@@ -1472,7 +1472,7 @@ fn test_update_config() {
 }
 
 #[test]
-fn test_update_submission_policy() {
+fn test_approver_unsupported_update_config() {
     let mut app = App::default();
 
     // Need to instantiate this so contract addresses match with cw20 test cases
@@ -1480,24 +1480,45 @@ fn test_update_submission_policy() {
 
     let DefaultTestSetup {
         core_addr,
-        pre_propose,
+        pre_propose_approver,
         ..
     } = setup_default_test(&mut app, None, true);
 
-    let config = get_config(&app, pre_propose.clone());
-    assert_eq!(
-        config,
-        Config {
-            deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
-        }
+    // Should fail because config is not supported for the approver pre-propose
+    // contract.
+    let err = update_config_should_fail(
+        &mut app,
+        pre_propose_approver,
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: false,
+            allowlist: Some(vec!["ekez".to_string()]),
+            denylist: None,
+        },
     );
+    assert_eq!(err, PreProposeError::Unsupported {});
+}
 
-    // Only the core module can update the submission policy.
+#[test]
+fn test_approver_unsupported_update_submission_policy() {
+    let mut app = App::default();
+
+    // Need to instantiate this so contract addresses match with cw20 test cases
+    let _ = instantiate_cw20_base_default(&mut app);
+
+    let DefaultTestSetup {
+        core_addr,
+        pre_propose_approver,
+        ..
+    } = setup_default_test(&mut app, None, true);
+
+    // Should fail because submission policy is not supported for the approver
+    // pre-propose contract.
     let err: PreProposeError = app
         .execute_contract(
-            Addr::unchecked("ekez"),
-            pre_propose.clone(),
+            core_addr,
+            pre_propose_approver,
             &ExecuteMsg::UpdateSubmissionPolicy {
                 denylist_add: Some(vec!["ekez".to_string()]),
                 denylist_remove: None,
@@ -1510,422 +1531,7 @@ fn test_update_submission_policy() {
         .unwrap_err()
         .downcast()
         .unwrap();
-    assert_eq!(err, PreProposeError::NotDao {});
-
-    // Append to denylist, with auto de-dupe.
-    app.execute_contract(
-        core_addr.clone(),
-        pre_propose.clone(),
-        &ExecuteMsg::UpdateSubmissionPolicy {
-            denylist_add: Some(vec!["ekez".to_string(), "ekez".to_string()]),
-            denylist_remove: None,
-            set_dao_members: None,
-            allowlist_add: None,
-            allowlist_remove: None,
-        },
-        &[],
-    )
-    .unwrap();
-
-    let config = get_config(&app, pre_propose.clone());
-    assert_eq!(
-        config,
-        Config {
-            deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Anyone {
-                denylist: Some(vec!["ekez".to_string()]),
-            },
-        }
-    );
-
-    // Add and remove to/from denylist.
-    app.execute_contract(
-        core_addr.clone(),
-        pre_propose.clone(),
-        &ExecuteMsg::UpdateSubmissionPolicy {
-            denylist_add: Some(vec!["someone".to_string(), "else".to_string()]),
-            denylist_remove: Some(vec!["ekez".to_string()]),
-            set_dao_members: None,
-            allowlist_add: None,
-            allowlist_remove: None,
-        },
-        &[],
-    )
-    .unwrap();
-
-    let config = get_config(&app, pre_propose.clone());
-    assert_eq!(
-        config,
-        Config {
-            deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Anyone {
-                denylist: Some(vec!["someone".to_string(), "else".to_string()]),
-            },
-        }
-    );
-
-    // Remove from denylist.
-    app.execute_contract(
-        core_addr.clone(),
-        pre_propose.clone(),
-        &ExecuteMsg::UpdateSubmissionPolicy {
-            denylist_add: None,
-            denylist_remove: Some(vec!["someone".to_string(), "else".to_string()]),
-            set_dao_members: None,
-            allowlist_add: None,
-            allowlist_remove: None,
-        },
-        &[],
-    )
-    .unwrap();
-
-    let config = get_config(&app, pre_propose.clone());
-    assert_eq!(
-        config,
-        Config {
-            deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
-        }
-    );
-
-    // Error if try to change Specific fields when set to Anyone.
-    let err: PreProposeError = app
-        .execute_contract(
-            core_addr.clone(),
-            pre_propose.clone(),
-            &ExecuteMsg::UpdateSubmissionPolicy {
-                denylist_add: None,
-                denylist_remove: None,
-                set_dao_members: Some(true),
-                allowlist_add: None,
-                allowlist_remove: None,
-            },
-            &[],
-        )
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    assert_eq!(
-        err,
-        PreProposeError::SubmissionPolicy(
-            PreProposeSubmissionPolicyError::AnyoneInvalidUpdateFields {}
-        )
-    );
-    let err: PreProposeError = app
-        .execute_contract(
-            core_addr.clone(),
-            pre_propose.clone(),
-            &ExecuteMsg::UpdateSubmissionPolicy {
-                denylist_add: None,
-                denylist_remove: None,
-                set_dao_members: None,
-                allowlist_add: Some(vec!["ekez".to_string()]),
-                allowlist_remove: None,
-            },
-            &[],
-        )
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    assert_eq!(
-        err,
-        PreProposeError::SubmissionPolicy(
-            PreProposeSubmissionPolicyError::AnyoneInvalidUpdateFields {}
-        )
-    );
-    let err: PreProposeError = app
-        .execute_contract(
-            core_addr.clone(),
-            pre_propose.clone(),
-            &ExecuteMsg::UpdateSubmissionPolicy {
-                denylist_add: None,
-                denylist_remove: None,
-                set_dao_members: None,
-                allowlist_add: None,
-                allowlist_remove: Some(vec!["ekez".to_string()]),
-            },
-            &[],
-        )
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    assert_eq!(
-        err,
-        PreProposeError::SubmissionPolicy(
-            PreProposeSubmissionPolicyError::AnyoneInvalidUpdateFields {}
-        )
-    );
-
-    // Change to Specific policy.
-    app.execute_contract(
-        core_addr.clone(),
-        pre_propose.clone(),
-        &ExecuteMsg::UpdateConfig {
-            deposit_info: None,
-            submission_policy: Some(PreProposeSubmissionPolicy::Specific {
-                dao_members: true,
-                allowlist: None,
-                denylist: None,
-            }),
-        },
-        &[],
-    )
-    .unwrap();
-
-    let config = get_config(&app, pre_propose.clone());
-    assert_eq!(
-        config,
-        Config {
-            deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Specific {
-                dao_members: true,
-                allowlist: None,
-                denylist: None,
-            },
-        }
-    );
-
-    // Append to denylist, with auto de-dupe.
-    app.execute_contract(
-        core_addr.clone(),
-        pre_propose.clone(),
-        &ExecuteMsg::UpdateSubmissionPolicy {
-            denylist_add: Some(vec!["ekez".to_string(), "ekez".to_string()]),
-            denylist_remove: None,
-            set_dao_members: None,
-            allowlist_add: None,
-            allowlist_remove: None,
-        },
-        &[],
-    )
-    .unwrap();
-
-    let config = get_config(&app, pre_propose.clone());
-    assert_eq!(
-        config,
-        Config {
-            deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Specific {
-                dao_members: true,
-                allowlist: None,
-                denylist: Some(vec!["ekez".to_string()]),
-            },
-        }
-    );
-
-    // Add and remove to/from denylist.
-    app.execute_contract(
-        core_addr.clone(),
-        pre_propose.clone(),
-        &ExecuteMsg::UpdateSubmissionPolicy {
-            denylist_add: Some(vec!["someone".to_string(), "else".to_string()]),
-            denylist_remove: Some(vec!["ekez".to_string()]),
-            set_dao_members: None,
-            allowlist_add: None,
-            allowlist_remove: None,
-        },
-        &[],
-    )
-    .unwrap();
-
-    let config = get_config(&app, pre_propose.clone());
-    assert_eq!(
-        config,
-        Config {
-            deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Specific {
-                dao_members: true,
-                allowlist: None,
-                denylist: Some(vec!["someone".to_string(), "else".to_string()]),
-            },
-        }
-    );
-
-    // Remove from denylist.
-    app.execute_contract(
-        core_addr.clone(),
-        pre_propose.clone(),
-        &ExecuteMsg::UpdateSubmissionPolicy {
-            denylist_add: None,
-            denylist_remove: Some(vec!["someone".to_string(), "else".to_string()]),
-            set_dao_members: None,
-            allowlist_add: None,
-            allowlist_remove: None,
-        },
-        &[],
-    )
-    .unwrap();
-
-    let config = get_config(&app, pre_propose.clone());
-    assert_eq!(
-        config,
-        Config {
-            deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Specific {
-                dao_members: true,
-                allowlist: None,
-                denylist: None
-            },
-        }
-    );
-
-    // Append to allowlist, with auto de-dupe.
-    app.execute_contract(
-        core_addr.clone(),
-        pre_propose.clone(),
-        &ExecuteMsg::UpdateSubmissionPolicy {
-            denylist_add: None,
-            denylist_remove: None,
-            set_dao_members: None,
-            allowlist_add: Some(vec!["ekez".to_string(), "ekez".to_string()]),
-            allowlist_remove: None,
-        },
-        &[],
-    )
-    .unwrap();
-
-    let config = get_config(&app, pre_propose.clone());
-    assert_eq!(
-        config,
-        Config {
-            deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Specific {
-                dao_members: true,
-                allowlist: Some(vec!["ekez".to_string()]),
-                denylist: None,
-            },
-        }
-    );
-
-    // Add and remove to/from allowlist.
-    app.execute_contract(
-        core_addr.clone(),
-        pre_propose.clone(),
-        &ExecuteMsg::UpdateSubmissionPolicy {
-            denylist_add: None,
-            denylist_remove: None,
-            set_dao_members: None,
-            allowlist_add: Some(vec!["someone".to_string(), "else".to_string()]),
-            allowlist_remove: Some(vec!["ekez".to_string()]),
-        },
-        &[],
-    )
-    .unwrap();
-
-    let config = get_config(&app, pre_propose.clone());
-    assert_eq!(
-        config,
-        Config {
-            deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Specific {
-                dao_members: true,
-                allowlist: Some(vec!["someone".to_string(), "else".to_string()]),
-                denylist: None,
-            },
-        }
-    );
-
-    // Remove from allowlist.
-    app.execute_contract(
-        core_addr.clone(),
-        pre_propose.clone(),
-        &ExecuteMsg::UpdateSubmissionPolicy {
-            denylist_add: None,
-            denylist_remove: None,
-            set_dao_members: None,
-            allowlist_add: None,
-            allowlist_remove: Some(vec!["someone".to_string(), "else".to_string()]),
-        },
-        &[],
-    )
-    .unwrap();
-
-    let config = get_config(&app, pre_propose.clone());
-    assert_eq!(
-        config,
-        Config {
-            deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Specific {
-                dao_members: true,
-                allowlist: None,
-                denylist: None
-            },
-        }
-    );
-
-    // Setting dao_members to false fails if allowlist is empty.
-    let err: PreProposeError = app
-        .execute_contract(
-            core_addr.clone(),
-            pre_propose.clone(),
-            &ExecuteMsg::UpdateSubmissionPolicy {
-                denylist_add: None,
-                denylist_remove: None,
-                set_dao_members: Some(false),
-                allowlist_add: None,
-                allowlist_remove: None,
-            },
-            &[],
-        )
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    assert_eq!(
-        err,
-        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::NoOneAllowed {})
-    );
-
-    // Set dao_members to false and add allowlist.
-    app.execute_contract(
-        core_addr.clone(),
-        pre_propose.clone(),
-        &ExecuteMsg::UpdateSubmissionPolicy {
-            denylist_add: None,
-            denylist_remove: None,
-            set_dao_members: Some(false),
-            allowlist_add: Some(vec!["ekez".to_string()]),
-            allowlist_remove: None,
-        },
-        &[],
-    )
-    .unwrap();
-
-    let config = get_config(&app, pre_propose.clone());
-    assert_eq!(
-        config,
-        Config {
-            deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Specific {
-                dao_members: false,
-                allowlist: Some(vec!["ekez".to_string()]),
-                denylist: None
-            },
-        }
-    );
-
-    // Errors when allowlist and denylist overlap.
-    let err: PreProposeError = app
-        .execute_contract(
-            core_addr.clone(),
-            pre_propose.clone(),
-            &ExecuteMsg::UpdateSubmissionPolicy {
-                denylist_add: Some(vec!["ekez".to_string()]),
-                denylist_remove: None,
-                set_dao_members: None,
-                allowlist_add: None,
-                allowlist_remove: None,
-            },
-            &[],
-        )
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    assert_eq!(
-        err,
-        PreProposeError::SubmissionPolicy(
-            PreProposeSubmissionPolicyError::DenylistAllowlistOverlap {}
-        )
-    );
+    assert_eq!(err, PreProposeError::Unsupported {});
 }
 
 #[test]

--- a/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
@@ -81,9 +81,13 @@ fn get_proposal_module_approval_single_instantiate(
     let pre_propose_id = app.store_code(cw_pre_propose_base_proposal_single());
 
     let submission_policy = if open_proposal_submission {
-        PreProposeSubmissionPolicy::Anyone {}
+        PreProposeSubmissionPolicy::Anyone { denylist: None }
     } else {
-        PreProposeSubmissionPolicy::DaoMembers {}
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        }
     };
 
     dps::msg::InstantiateMsg {
@@ -1169,9 +1173,7 @@ fn test_permissions() {
         .unwrap();
     assert_eq!(
         err,
-        PreProposeError::SubmissionPolicy(
-            PreProposeSubmissionPolicyError::UnauthorizedDaoMembers {}
-        )
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
     );
 }
 
@@ -1328,7 +1330,11 @@ fn test_update_config() {
         config,
         Config {
             deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::DaoMembers {}
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None
+            }
         }
     );
 
@@ -1355,7 +1361,7 @@ fn test_update_config() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Never,
         }),
-        PreProposeSubmissionPolicy::Anyone {},
+        PreProposeSubmissionPolicy::Anyone { denylist: None },
     );
 
     let config = get_config(&app, pre_propose.clone());
@@ -1367,7 +1373,7 @@ fn test_update_config() {
                 amount: Uint128::new(10),
                 refund_policy: DepositRefundPolicy::Never
             }),
-            submission_policy: PreProposeSubmissionPolicy::Anyone {},
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
         }
     );
 
@@ -1424,7 +1430,7 @@ fn test_update_config() {
         pre_propose,
         proposal_single.as_str(),
         None,
-        PreProposeSubmissionPolicy::Anyone {},
+        PreProposeSubmissionPolicy::Anyone { denylist: None },
     );
     assert_eq!(err, PreProposeError::NotDao {});
 }
@@ -1476,7 +1482,11 @@ fn test_withdraw() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Always,
         }),
-        PreProposeSubmissionPolicy::DaoMembers {},
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        },
     );
 
     // Withdraw with no specified denom - should fall back to the one
@@ -1525,7 +1535,11 @@ fn test_withdraw() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Always,
         }),
-        PreProposeSubmissionPolicy::DaoMembers {},
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        },
     );
 
     increase_allowance(

--- a/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
@@ -1427,12 +1427,505 @@ fn test_update_config() {
     // Only the core module can update the config.
     let err = update_config_should_fail(
         &mut app,
-        pre_propose,
+        pre_propose.clone(),
         proposal_single.as_str(),
         None,
         PreProposeSubmissionPolicy::Anyone { denylist: None },
     );
     assert_eq!(err, PreProposeError::NotDao {});
+
+    // Errors when no one is authorized to create proposals.
+    let err = update_config_should_fail(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: false,
+            allowlist: None,
+            denylist: None,
+        },
+    );
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::NoOneAllowed {})
+    );
+
+    // Errors when allowlist and denylist overlap.
+    let err = update_config_should_fail(
+        &mut app,
+        pre_propose,
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: false,
+            allowlist: Some(vec!["ekez".to_string()]),
+            denylist: Some(vec!["ekez".to_string()]),
+        },
+    );
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::DenylistAllowlistOverlap {}
+        )
+    );
+}
+
+#[test]
+fn test_update_submission_policy() {
+    let mut app = App::default();
+
+    // Need to instantiate this so contract addresses match with cw20 test cases
+    let _ = instantiate_cw20_base_default(&mut app);
+
+    let DefaultTestSetup {
+        core_addr,
+        pre_propose,
+        ..
+    } = setup_default_test(&mut app, None, true);
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+        }
+    );
+
+    // Only the core module can update the submission policy.
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("ekez"),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: Some(vec!["ekez".to_string()]),
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, PreProposeError::NotDao {});
+
+    // Append to denylist, with auto de-dupe.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: Some(vec!["ekez".to_string(), "ekez".to_string()]),
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone {
+                denylist: Some(vec!["ekez".to_string()]),
+            },
+        }
+    );
+
+    // Add and remove to/from denylist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: Some(vec!["someone".to_string(), "else".to_string()]),
+            denylist_remove: Some(vec!["ekez".to_string()]),
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone {
+                denylist: Some(vec!["someone".to_string(), "else".to_string()]),
+            },
+        }
+    );
+
+    // Remove from denylist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: Some(vec!["someone".to_string(), "else".to_string()]),
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+        }
+    );
+
+    // Error if try to change Specific fields when set to Anyone.
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: None,
+                denylist_remove: None,
+                set_dao_members: Some(true),
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::AnyoneInvalidUpdateFields {}
+        )
+    );
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: None,
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: Some(vec!["ekez".to_string()]),
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::AnyoneInvalidUpdateFields {}
+        )
+    );
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: None,
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: None,
+                allowlist_remove: Some(vec!["ekez".to_string()]),
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::AnyoneInvalidUpdateFields {}
+        )
+    );
+
+    // Change to Specific policy.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateConfig {
+            deposit_info: None,
+            submission_policy: Some(PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None,
+            }),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None,
+            },
+        }
+    );
+
+    // Append to denylist, with auto de-dupe.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: Some(vec!["ekez".to_string(), "ekez".to_string()]),
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: Some(vec!["ekez".to_string()]),
+            },
+        }
+    );
+
+    // Add and remove to/from denylist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: Some(vec!["someone".to_string(), "else".to_string()]),
+            denylist_remove: Some(vec!["ekez".to_string()]),
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: Some(vec!["someone".to_string(), "else".to_string()]),
+            },
+        }
+    );
+
+    // Remove from denylist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: Some(vec!["someone".to_string(), "else".to_string()]),
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None
+            },
+        }
+    );
+
+    // Append to allowlist, with auto de-dupe.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: Some(vec!["ekez".to_string(), "ekez".to_string()]),
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: Some(vec!["ekez".to_string()]),
+                denylist: None,
+            },
+        }
+    );
+
+    // Add and remove to/from allowlist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: Some(vec!["someone".to_string(), "else".to_string()]),
+            allowlist_remove: Some(vec!["ekez".to_string()]),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: Some(vec!["someone".to_string(), "else".to_string()]),
+                denylist: None,
+            },
+        }
+    );
+
+    // Remove from allowlist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: Some(vec!["someone".to_string(), "else".to_string()]),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None
+            },
+        }
+    );
+
+    // Setting dao_members to false fails if allowlist is empty.
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: None,
+                denylist_remove: None,
+                set_dao_members: Some(false),
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::NoOneAllowed {})
+    );
+
+    // Set dao_members to false and add allowlist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: None,
+            set_dao_members: Some(false),
+            allowlist_add: Some(vec!["ekez".to_string()]),
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: false,
+                allowlist: Some(vec!["ekez".to_string()]),
+                denylist: None
+            },
+        }
+    );
+
+    // Errors when allowlist and denylist overlap.
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: Some(vec!["ekez".to_string()]),
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::DenylistAllowlistOverlap {}
+        )
+    );
 }
 
 #[test]

--- a/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
@@ -1559,14 +1559,16 @@ fn test_approver_can_propose() {
     } = setup_default_test(&mut app, None, true);
 
     // Only the pre-propose-approval-single contract can propose.
-    assert_eq!(
-        query_can_propose(&app, pre_propose_approver.clone(), pre_propose),
-        true
-    );
-    assert_eq!(
-        query_can_propose(&app, pre_propose_approver, "someone_else"),
-        false
-    );
+    assert!(query_can_propose(
+        &app,
+        pre_propose_approver.clone(),
+        pre_propose
+    ));
+    assert!(!query_can_propose(
+        &app,
+        pre_propose_approver,
+        "someone_else"
+    ));
 }
 
 #[test]

--- a/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
@@ -41,10 +41,6 @@
     },
     "additionalProperties": false,
     "definitions": {
-      "Addr": {
-        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-        "type": "string"
-      },
       "DepositRefundPolicy": {
         "oneOf": [
           {
@@ -143,7 +139,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   }
                 },
@@ -172,7 +168,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   },
                   "dao_members": {
@@ -186,7 +182,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   }
                 },
@@ -312,11 +308,9 @@
         "properties": {
           "update_config": {
             "type": "object",
-            "required": [
-              "submission_policy"
-            ],
             "properties": {
               "deposit_info": {
+                "description": "If None, will remove the deposit. Backwards compatible.",
                 "anyOf": [
                   {
                     "$ref": "#/definitions/UncheckedDepositInfo"
@@ -327,7 +321,78 @@
                 ]
               },
               "submission_policy": {
-                "$ref": "#/definitions/PreProposeSubmissionPolicy"
+                "description": "If None, will leave the submission policy in the config as-is.",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/PreProposeSubmissionPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Perform more granular submission policy updates to allow for atomic operations that don't override others.",
+        "type": "object",
+        "required": [
+          "update_submission_policy"
+        ],
+        "properties": {
+          "update_submission_policy": {
+            "type": "object",
+            "properties": {
+              "allowlist_add": {
+                "description": "If using specific policy, optionally add to the allowlist.",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "allowlist_remove": {
+                "description": "If using specific policy, optionally remove from the allowlist.",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "denylist_add": {
+                "description": "Optionally add to the denylist. Works for any submission policy.",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "denylist_remove": {
+                "description": "Optionally remove from denylist. Works for any submission policy.",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "set_dao_members": {
+                "description": "If using specific policy, optionally update the `dao_members` flag.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -458,10 +523,6 @@
       }
     ],
     "definitions": {
-      "Addr": {
-        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-        "type": "string"
-      },
       "BankMsg": {
         "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
         "oneOf": [
@@ -1114,7 +1175,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   }
                 },
@@ -1143,7 +1204,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   },
                   "dao_members": {
@@ -1157,7 +1218,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   }
                 },
@@ -1909,7 +1970,7 @@
                         "null"
                       ],
                       "items": {
-                        "$ref": "#/definitions/Addr"
+                        "type": "string"
                       }
                     }
                   },
@@ -1938,7 +1999,7 @@
                         "null"
                       ],
                       "items": {
-                        "$ref": "#/definitions/Addr"
+                        "type": "string"
                       }
                     },
                     "dao_members": {
@@ -1952,7 +2013,7 @@
                         "null"
                       ],
                       "items": {
-                        "$ref": "#/definitions/Addr"
+                        "type": "string"
                       }
                     }
                   },

--- a/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
@@ -8,7 +8,7 @@
     "type": "object",
     "required": [
       "extension",
-      "open_proposal_submission"
+      "submission_policy"
     ],
     "properties": {
       "deposit_info": {
@@ -30,13 +30,21 @@
           }
         ]
       },
-      "open_proposal_submission": {
-        "description": "If false, only members (addresses with voting power) may create proposals in the DAO. Otherwise, any address may create a proposal so long as they pay the deposit.",
-        "type": "boolean"
+      "submission_policy": {
+        "description": "The policy dictating who is allowed to submit proposals.",
+        "allOf": [
+          {
+            "$ref": "#/definitions/PreProposeSubmissionPolicy"
+          }
+        ]
       }
     },
     "additionalProperties": false,
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "DepositRefundPolicy": {
         "oneOf": [
           {
@@ -114,6 +122,64 @@
       "Empty": {
         "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "object"
+      },
+      "PreProposeSubmissionPolicy": {
+        "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
+        "oneOf": [
+          {
+            "description": "Anyone may create a proposal.",
+            "type": "object",
+            "required": [
+              "anyone"
+            ],
+            "properties": {
+              "anyone": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Only members of the DAO may create a proposal.",
+            "type": "object",
+            "required": [
+              "dao_members"
+            ],
+            "properties": {
+              "dao_members": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Only the specified addresses may create a proposal.",
+            "type": "object",
+            "required": [
+              "allowlist"
+            ],
+            "properties": {
+              "allowlist": {
+                "type": "object",
+                "required": [
+                  "addresses"
+                ],
+                "properties": {
+                  "addresses": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "Uint128": {
         "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
@@ -231,7 +297,7 @@
           "update_config": {
             "type": "object",
             "required": [
-              "open_proposal_submission"
+              "submission_policy"
             ],
             "properties": {
               "deposit_info": {
@@ -244,8 +310,8 @@
                   }
                 ]
               },
-              "open_proposal_submission": {
-                "type": "boolean"
+              "submission_policy": {
+                "$ref": "#/definitions/PreProposeSubmissionPolicy"
               }
             },
             "additionalProperties": false
@@ -376,6 +442,10 @@
       }
     ],
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "BankMsg": {
         "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
         "oneOf": [
@@ -1008,6 +1078,64 @@
         },
         "additionalProperties": false
       },
+      "PreProposeSubmissionPolicy": {
+        "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
+        "oneOf": [
+          {
+            "description": "Anyone may create a proposal.",
+            "type": "object",
+            "required": [
+              "anyone"
+            ],
+            "properties": {
+              "anyone": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Only members of the DAO may create a proposal.",
+            "type": "object",
+            "required": [
+              "dao_members"
+            ],
+            "properties": {
+              "dao_members": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Only the specified addresses may create a proposal.",
+            "type": "object",
+            "required": [
+              "allowlist"
+            ],
+            "properties": {
+              "allowlist": {
+                "type": "object",
+                "required": [
+                  "addresses"
+                ],
+                "properties": {
+                  "addresses": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
       "ProposeMessage": {
         "oneOf": [
           {
@@ -1608,7 +1736,7 @@
       "title": "Config",
       "type": "object",
       "required": [
-        "open_proposal_submission"
+        "submission_policy"
       ],
       "properties": {
         "deposit_info": {
@@ -1622,9 +1750,13 @@
             }
           ]
         },
-        "open_proposal_submission": {
-          "description": "If false, only members (addresses with voting power) may create proposals in the DAO. Otherwise, any address may create a proposal so long as they pay the deposit.",
-          "type": "boolean"
+        "submission_policy": {
+          "description": "The policy dictating who is allowed to submit proposals.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PreProposeSubmissionPolicy"
+            }
+          ]
         }
       },
       "additionalProperties": false,
@@ -1722,6 +1854,64 @@
               "enum": [
                 "never"
               ]
+            }
+          ]
+        },
+        "PreProposeSubmissionPolicy": {
+          "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
+          "oneOf": [
+            {
+              "description": "Anyone may create a proposal.",
+              "type": "object",
+              "required": [
+                "anyone"
+              ],
+              "properties": {
+                "anyone": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Only members of the DAO may create a proposal.",
+              "type": "object",
+              "required": [
+                "dao_members"
+              ],
+              "properties": {
+                "dao_members": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Only the specified addresses may create a proposal.",
+              "type": "object",
+              "required": [
+                "allowlist"
+              ],
+              "properties": {
+                "allowlist": {
+                  "type": "object",
+                  "required": [
+                    "addresses"
+                  ],
+                  "properties": {
+                    "addresses": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Addr"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
             }
           ]
         },

--- a/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
@@ -127,7 +127,7 @@
         "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
         "oneOf": [
           {
-            "description": "Anyone may create a proposal.",
+            "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
             "required": [
               "anyone"
@@ -135,40 +135,56 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "properties": {
+                  "denylist": {
+                    "description": "Addresses that may not create proposals.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  }
+                },
                 "additionalProperties": false
               }
             },
             "additionalProperties": false
           },
           {
-            "description": "Only members of the DAO may create a proposal.",
+            "description": "Specific people may create proposals.",
             "type": "object",
             "required": [
-              "dao_members"
+              "specific"
             ],
             "properties": {
-              "dao_members": {
-                "type": "object",
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Only the specified addresses may create a proposal.",
-            "type": "object",
-            "required": [
-              "allowlist"
-            ],
-            "properties": {
-              "allowlist": {
+              "specific": {
                 "type": "object",
                 "required": [
-                  "addresses"
+                  "dao_members"
                 ],
                 "properties": {
-                  "addresses": {
-                    "type": "array",
+                  "allowlist": {
+                    "description": "Addresses that may create proposals.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  },
+                  "dao_members": {
+                    "description": "Whether or not DAO members may create proposals.",
+                    "type": "boolean"
+                  },
+                  "denylist": {
+                    "description": "Addresses that may not create proposals, overriding other settings.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "$ref": "#/definitions/Addr"
                     }
@@ -1082,7 +1098,7 @@
         "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
         "oneOf": [
           {
-            "description": "Anyone may create a proposal.",
+            "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
             "required": [
               "anyone"
@@ -1090,40 +1106,56 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "properties": {
+                  "denylist": {
+                    "description": "Addresses that may not create proposals.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  }
+                },
                 "additionalProperties": false
               }
             },
             "additionalProperties": false
           },
           {
-            "description": "Only members of the DAO may create a proposal.",
+            "description": "Specific people may create proposals.",
             "type": "object",
             "required": [
-              "dao_members"
+              "specific"
             ],
             "properties": {
-              "dao_members": {
-                "type": "object",
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Only the specified addresses may create a proposal.",
-            "type": "object",
-            "required": [
-              "allowlist"
-            ],
-            "properties": {
-              "allowlist": {
+              "specific": {
                 "type": "object",
                 "required": [
-                  "addresses"
+                  "dao_members"
                 ],
                 "properties": {
-                  "addresses": {
-                    "type": "array",
+                  "allowlist": {
+                    "description": "Addresses that may create proposals.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  },
+                  "dao_members": {
+                    "description": "Whether or not DAO members may create proposals.",
+                    "type": "boolean"
+                  },
+                  "denylist": {
+                    "description": "Addresses that may not create proposals, overriding other settings.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "$ref": "#/definitions/Addr"
                     }
@@ -1861,7 +1893,7 @@
           "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
           "oneOf": [
             {
-              "description": "Anyone may create a proposal.",
+              "description": "Anyone may create proposals, except for those in the denylist.",
               "type": "object",
               "required": [
                 "anyone"
@@ -1869,40 +1901,56 @@
               "properties": {
                 "anyone": {
                   "type": "object",
+                  "properties": {
+                    "denylist": {
+                      "description": "Addresses that may not create proposals.",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "$ref": "#/definitions/Addr"
+                      }
+                    }
+                  },
                   "additionalProperties": false
                 }
               },
               "additionalProperties": false
             },
             {
-              "description": "Only members of the DAO may create a proposal.",
+              "description": "Specific people may create proposals.",
               "type": "object",
               "required": [
-                "dao_members"
+                "specific"
               ],
               "properties": {
-                "dao_members": {
-                  "type": "object",
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "description": "Only the specified addresses may create a proposal.",
-              "type": "object",
-              "required": [
-                "allowlist"
-              ],
-              "properties": {
-                "allowlist": {
+                "specific": {
                   "type": "object",
                   "required": [
-                    "addresses"
+                    "dao_members"
                   ],
                   "properties": {
-                    "addresses": {
-                      "type": "array",
+                    "allowlist": {
+                      "description": "Addresses that may create proposals.",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "$ref": "#/definitions/Addr"
+                      }
+                    },
+                    "dao_members": {
+                      "description": "Whether or not DAO members may create proposals.",
+                      "type": "boolean"
+                    },
+                    "denylist": {
+                      "description": "Addresses that may not create proposals, overriding other settings.",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "items": {
                         "$ref": "#/definitions/Addr"
                       }

--- a/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
@@ -6,7 +6,10 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["extension", "submission_policy"],
+    "required": [
+      "extension",
+      "submission_policy"
+    ],
     "properties": {
       "deposit_info": {
         "description": "Information about the deposit requirements for this module. None if no deposit.",
@@ -43,17 +46,23 @@
           {
             "description": "Deposits should always be refunded.",
             "type": "string",
-            "enum": ["always"]
+            "enum": [
+              "always"
+            ]
           },
           {
             "description": "Deposits should only be refunded for passed proposals.",
             "type": "string",
-            "enum": ["only_passed"]
+            "enum": [
+              "only_passed"
+            ]
           },
           {
             "description": "Deposits should never be refunded.",
             "type": "string",
-            "enum": ["never"]
+            "enum": [
+              "never"
+            ]
           }
         ]
       },
@@ -63,11 +72,15 @@
           {
             "description": "Use a specific token address as the deposit token.",
             "type": "object",
-            "required": ["token"],
+            "required": [
+              "token"
+            ],
             "properties": {
               "token": {
                 "type": "object",
-                "required": ["denom"],
+                "required": [
+                  "denom"
+                ],
                 "properties": {
                   "denom": {
                     "$ref": "#/definitions/UncheckedDenom"
@@ -81,11 +94,15 @@
           {
             "description": "Use the token native denom or cw20 contract address of the associated DAO's voting module. NOTE: in order to retrieve the token automatically via this variant, the voting module must either (1) use a native token and implement the `Denom {}` query type defined by `dao_dao_macros::native_token_query` OR (2) use a cw20 token and implement the `TokenContract {}` query type defined by `dao_dao_macros::cw20_token_query`. Failing to implement correctly will cause this option to fail to instantiate.",
             "type": "object",
-            "required": ["voting_module_token"],
+            "required": [
+              "voting_module_token"
+            ],
             "properties": {
               "voting_module_token": {
                 "type": "object",
-                "required": ["token_type"],
+                "required": [
+                  "token_type"
+                ],
                 "properties": {
                   "token_type": {
                     "$ref": "#/definitions/VotingModuleTokenType"
@@ -108,14 +125,19 @@
           {
             "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
-            "required": ["anyone"],
+            "required": [
+              "anyone"
+            ],
             "properties": {
               "anyone": {
                 "type": "object",
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -129,15 +151,22 @@
           {
             "description": "Specific people may create proposals.",
             "type": "object",
-            "required": ["specific"],
+            "required": [
+              "specific"
+            ],
             "properties": {
               "specific": {
                 "type": "object",
-                "required": ["dao_members"],
+                "required": [
+                  "dao_members"
+                ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -148,7 +177,10 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -171,7 +203,9 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": ["native"],
+            "required": [
+              "native"
+            ],
             "properties": {
               "native": {
                 "type": "string"
@@ -182,7 +216,9 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": ["cw20"],
+            "required": [
+              "cw20"
+            ],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -195,7 +231,11 @@
       "UncheckedDepositInfo": {
         "description": "Information about the deposit required to create a proposal.",
         "type": "object",
-        "required": ["amount", "denom", "refund_policy"],
+        "required": [
+          "amount",
+          "denom",
+          "refund_policy"
+        ],
         "properties": {
           "amount": {
             "description": "The number of tokens that must be deposited to create a proposal. Must be a positive, non-zero number.",
@@ -226,7 +266,10 @@
       },
       "VotingModuleTokenType": {
         "type": "string",
-        "enum": ["native", "cw20"]
+        "enum": [
+          "native",
+          "cw20"
+        ]
       }
     }
   },
@@ -237,11 +280,15 @@
       {
         "description": "Creates a new proposal in the pre-propose module. MSG will be serialized and used as the proposal creation message.",
         "type": "object",
-        "required": ["propose"],
+        "required": [
+          "propose"
+        ],
         "properties": {
           "propose": {
             "type": "object",
-            "required": ["msg"],
+            "required": [
+              "msg"
+            ],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/ProposeMessage"
@@ -255,7 +302,9 @@
       {
         "description": "Updates the configuration of this module. This will completely override the existing configuration. This new configuration will only apply to proposals created after the config is updated. Only the DAO may execute this message.",
         "type": "object",
-        "required": ["update_config"],
+        "required": [
+          "update_config"
+        ],
         "properties": {
           "update_config": {
             "type": "object",
@@ -291,42 +340,59 @@
       {
         "description": "Perform more granular submission policy updates to allow for atomic operations that don't override others.",
         "type": "object",
-        "required": ["update_submission_policy"],
+        "required": [
+          "update_submission_policy"
+        ],
         "properties": {
           "update_submission_policy": {
             "type": "object",
             "properties": {
               "allowlist_add": {
                 "description": "If using specific policy, optionally add to the allowlist.",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "string"
                 }
               },
               "allowlist_remove": {
                 "description": "If using specific policy, optionally remove from the allowlist.",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "string"
                 }
               },
               "denylist_add": {
                 "description": "Optionally add to the denylist. Works for any submission policy.",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "string"
                 }
               },
               "denylist_remove": {
                 "description": "Optionally remove from denylist. Works for any submission policy.",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "string"
                 }
               },
               "set_dao_members": {
                 "description": "If using specific policy, optionally update the `dao_members` flag.",
-                "type": ["boolean", "null"]
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -337,7 +403,9 @@
       {
         "description": "Withdraws funds inside of this contract to the message sender. The contracts entire balance for the specifed DENOM is withdrawn to the message sender. Only the DAO may call this method.\n\nThis is intended only as an escape hatch in the event of a critical bug in this contract or it's proposal module. Withdrawing funds will cause future attempts to return proposal deposits to fail their transactions as the contract will have insufficent balance to return them. In the case of `cw-proposal-single` this transaction failure will cause the module to remove the pre-propose module from its proposal hook receivers.\n\nMore likely than not, this should NEVER BE CALLED unless a bug in this contract or the proposal module it is associated with has caused it to stop receiving proposal hook messages, or if a critical security vulnerability has been found that allows an attacker to drain proposal deposits.",
         "type": "object",
-        "required": ["withdraw"],
+        "required": [
+          "withdraw"
+        ],
         "properties": {
           "withdraw": {
             "type": "object",
@@ -362,11 +430,15 @@
       {
         "description": "Extension message. Contracts that extend this one should put their custom execute logic here. The default implementation will do nothing if this variant is executed.",
         "type": "object",
-        "required": ["extension"],
+        "required": [
+          "extension"
+        ],
         "properties": {
           "extension": {
             "type": "object",
-            "required": ["msg"],
+            "required": [
+              "msg"
+            ],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/Empty"
@@ -380,11 +452,15 @@
       {
         "description": "Adds a proposal submitted hook. Fires when a new proposal is submitted to the pre-propose contract. Only the DAO may call this method.",
         "type": "object",
-        "required": ["add_proposal_submitted_hook"],
+        "required": [
+          "add_proposal_submitted_hook"
+        ],
         "properties": {
           "add_proposal_submitted_hook": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -398,11 +474,15 @@
       {
         "description": "Removes a proposal submitted hook. Only the DAO may call this method.",
         "type": "object",
-        "required": ["remove_proposal_submitted_hook"],
+        "required": [
+          "remove_proposal_submitted_hook"
+        ],
         "properties": {
           "remove_proposal_submitted_hook": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -416,11 +496,16 @@
       {
         "description": "Handles proposal hook fired by the associated proposal module when a proposal is completed (ie executed or rejected). By default, the base contract will return deposits proposals, when they are closed, when proposals are executed, or, if it is refunding failed.",
         "type": "object",
-        "required": ["proposal_completed_hook"],
+        "required": [
+          "proposal_completed_hook"
+        ],
         "properties": {
           "proposal_completed_hook": {
             "type": "object",
-            "required": ["new_status", "proposal_id"],
+            "required": [
+              "new_status",
+              "proposal_id"
+            ],
             "properties": {
               "new_status": {
                 "$ref": "#/definitions/Status"
@@ -444,11 +529,16 @@
           {
             "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["send"],
+            "required": [
+              "send"
+            ],
             "properties": {
               "send": {
                 "type": "object",
-                "required": ["amount", "to_address"],
+                "required": [
+                  "amount",
+                  "to_address"
+                ],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -467,11 +557,15 @@
           {
             "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
             "type": "object",
-            "required": ["burn"],
+            "required": [
+              "burn"
+            ],
             "properties": {
               "burn": {
                 "type": "object",
-                "required": ["amount"],
+                "required": [
+                  "amount"
+                ],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -492,7 +586,10 @@
       },
       "Coin": {
         "type": "object",
-        "required": ["amount", "denom"],
+        "required": [
+          "amount",
+          "denom"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -506,7 +603,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["bank"],
+            "required": [
+              "bank"
+            ],
             "properties": {
               "bank": {
                 "$ref": "#/definitions/BankMsg"
@@ -516,7 +615,9 @@
           },
           {
             "type": "object",
-            "required": ["custom"],
+            "required": [
+              "custom"
+            ],
             "properties": {
               "custom": {
                 "$ref": "#/definitions/Empty"
@@ -526,7 +627,9 @@
           },
           {
             "type": "object",
-            "required": ["staking"],
+            "required": [
+              "staking"
+            ],
             "properties": {
               "staking": {
                 "$ref": "#/definitions/StakingMsg"
@@ -536,7 +639,9 @@
           },
           {
             "type": "object",
-            "required": ["distribution"],
+            "required": [
+              "distribution"
+            ],
             "properties": {
               "distribution": {
                 "$ref": "#/definitions/DistributionMsg"
@@ -547,11 +652,16 @@
           {
             "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
             "type": "object",
-            "required": ["stargate"],
+            "required": [
+              "stargate"
+            ],
             "properties": {
               "stargate": {
                 "type": "object",
-                "required": ["type_url", "value"],
+                "required": [
+                  "type_url",
+                  "value"
+                ],
                 "properties": {
                   "type_url": {
                     "type": "string"
@@ -566,7 +676,9 @@
           },
           {
             "type": "object",
-            "required": ["ibc"],
+            "required": [
+              "ibc"
+            ],
             "properties": {
               "ibc": {
                 "$ref": "#/definitions/IbcMsg"
@@ -576,7 +688,9 @@
           },
           {
             "type": "object",
-            "required": ["wasm"],
+            "required": [
+              "wasm"
+            ],
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmMsg"
@@ -586,7 +700,9 @@
           },
           {
             "type": "object",
-            "required": ["gov"],
+            "required": [
+              "gov"
+            ],
             "properties": {
               "gov": {
                 "$ref": "#/definitions/GovMsg"
@@ -601,17 +717,23 @@
           {
             "description": "Deposits should always be refunded.",
             "type": "string",
-            "enum": ["always"]
+            "enum": [
+              "always"
+            ]
           },
           {
             "description": "Deposits should only be refunded for passed proposals.",
             "type": "string",
-            "enum": ["only_passed"]
+            "enum": [
+              "only_passed"
+            ]
           },
           {
             "description": "Deposits should never be refunded.",
             "type": "string",
-            "enum": ["never"]
+            "enum": [
+              "never"
+            ]
           }
         ]
       },
@@ -621,11 +743,15 @@
           {
             "description": "Use a specific token address as the deposit token.",
             "type": "object",
-            "required": ["token"],
+            "required": [
+              "token"
+            ],
             "properties": {
               "token": {
                 "type": "object",
-                "required": ["denom"],
+                "required": [
+                  "denom"
+                ],
                 "properties": {
                   "denom": {
                     "$ref": "#/definitions/UncheckedDenom"
@@ -639,11 +765,15 @@
           {
             "description": "Use the token native denom or cw20 contract address of the associated DAO's voting module. NOTE: in order to retrieve the token automatically via this variant, the voting module must either (1) use a native token and implement the `Denom {}` query type defined by `dao_dao_macros::native_token_query` OR (2) use a cw20 token and implement the `TokenContract {}` query type defined by `dao_dao_macros::cw20_token_query`. Failing to implement correctly will cause this option to fail to instantiate.",
             "type": "object",
-            "required": ["voting_module_token"],
+            "required": [
+              "voting_module_token"
+            ],
             "properties": {
               "voting_module_token": {
                 "type": "object",
-                "required": ["token_type"],
+                "required": [
+                  "token_type"
+                ],
                 "properties": {
                   "token_type": {
                     "$ref": "#/definitions/VotingModuleTokenType"
@@ -662,11 +792,15 @@
           {
             "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["set_withdraw_address"],
+            "required": [
+              "set_withdraw_address"
+            ],
             "properties": {
               "set_withdraw_address": {
                 "type": "object",
-                "required": ["address"],
+                "required": [
+                  "address"
+                ],
                 "properties": {
                   "address": {
                     "description": "The `withdraw_address`",
@@ -680,11 +814,15 @@
           {
             "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["withdraw_delegator_reward"],
+            "required": [
+              "withdraw_delegator_reward"
+            ],
             "properties": {
               "withdraw_delegator_reward": {
                 "type": "object",
-                "required": ["validator"],
+                "required": [
+                  "validator"
+                ],
                 "properties": {
                   "validator": {
                     "description": "The `validator_address`",
@@ -707,7 +845,9 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": ["at_height"],
+            "required": [
+              "at_height"
+            ],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -720,7 +860,9 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": ["at_time"],
+            "required": [
+              "at_time"
+            ],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -731,7 +873,9 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": ["never"],
+            "required": [
+              "never"
+            ],
             "properties": {
               "never": {
                 "type": "object",
@@ -748,11 +892,16 @@
           {
             "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
             "type": "object",
-            "required": ["vote"],
+            "required": [
+              "vote"
+            ],
             "properties": {
               "vote": {
                 "type": "object",
-                "required": ["proposal_id", "vote"],
+                "required": [
+                  "proposal_id",
+                  "vote"
+                ],
                 "properties": {
                   "proposal_id": {
                     "type": "integer",
@@ -780,11 +929,18 @@
           {
             "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
             "type": "object",
-            "required": ["transfer"],
+            "required": [
+              "transfer"
+            ],
             "properties": {
               "transfer": {
                 "type": "object",
-                "required": ["amount", "channel_id", "timeout", "to_address"],
+                "required": [
+                  "amount",
+                  "channel_id",
+                  "timeout",
+                  "to_address"
+                ],
                 "properties": {
                   "amount": {
                     "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -818,11 +974,17 @@
           {
             "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
             "type": "object",
-            "required": ["send_packet"],
+            "required": [
+              "send_packet"
+            ],
             "properties": {
               "send_packet": {
                 "type": "object",
-                "required": ["channel_id", "data", "timeout"],
+                "required": [
+                  "channel_id",
+                  "data",
+                  "timeout"
+                ],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -846,11 +1008,15 @@
           {
             "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
             "type": "object",
-            "required": ["close_channel"],
+            "required": [
+              "close_channel"
+            ],
             "properties": {
               "close_channel": {
                 "type": "object",
-                "required": ["channel_id"],
+                "required": [
+                  "channel_id"
+                ],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -891,7 +1057,10 @@
       "IbcTimeoutBlock": {
         "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
         "type": "object",
-        "required": ["height", "revision"],
+        "required": [
+          "height",
+          "revision"
+        ],
         "properties": {
           "height": {
             "description": "block height after which the packet times out. the height within the given revision",
@@ -909,11 +1078,16 @@
       },
       "MultipleChoiceAutoVote": {
         "type": "object",
-        "required": ["vote"],
+        "required": [
+          "vote"
+        ],
         "properties": {
           "rationale": {
             "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "vote": {
             "description": "The proposer's position on the proposal.",
@@ -929,7 +1103,11 @@
       "MultipleChoiceOption": {
         "description": "Unchecked multiple choice option",
         "type": "object",
-        "required": ["description", "msgs", "title"],
+        "required": [
+          "description",
+          "msgs",
+          "title"
+        ],
         "properties": {
           "description": {
             "type": "string"
@@ -949,7 +1127,9 @@
       "MultipleChoiceOptions": {
         "description": "Represents unchecked multiple choice options",
         "type": "object",
-        "required": ["options"],
+        "required": [
+          "options"
+        ],
         "properties": {
           "options": {
             "type": "array",
@@ -963,7 +1143,9 @@
       "MultipleChoiceVote": {
         "description": "A multiple choice vote, picking the desired option",
         "type": "object",
-        "required": ["option_id"],
+        "required": [
+          "option_id"
+        ],
         "properties": {
           "option_id": {
             "type": "integer",
@@ -979,14 +1161,19 @@
           {
             "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
-            "required": ["anyone"],
+            "required": [
+              "anyone"
+            ],
             "properties": {
               "anyone": {
                 "type": "object",
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -1000,15 +1187,22 @@
           {
             "description": "Specific people may create proposals.",
             "type": "object",
-            "required": ["specific"],
+            "required": [
+              "specific"
+            ],
             "properties": {
               "specific": {
                 "type": "object",
-                "required": ["dao_members"],
+                "required": [
+                  "dao_members"
+                ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -1019,7 +1213,10 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -1036,11 +1233,17 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["propose"],
+            "required": [
+              "propose"
+            ],
             "properties": {
               "propose": {
                 "type": "object",
-                "required": ["choices", "description", "title"],
+                "required": [
+                  "choices",
+                  "description",
+                  "title"
+                ],
                 "properties": {
                   "choices": {
                     "$ref": "#/definitions/MultipleChoiceOptions"
@@ -1075,11 +1278,16 @@
           {
             "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["delegate"],
+            "required": [
+              "delegate"
+            ],
             "properties": {
               "delegate": {
                 "type": "object",
-                "required": ["amount", "validator"],
+                "required": [
+                  "amount",
+                  "validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1095,11 +1303,16 @@
           {
             "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["undelegate"],
+            "required": [
+              "undelegate"
+            ],
             "properties": {
               "undelegate": {
                 "type": "object",
-                "required": ["amount", "validator"],
+                "required": [
+                  "amount",
+                  "validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1115,11 +1328,17 @@
           {
             "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["redelegate"],
+            "required": [
+              "redelegate"
+            ],
             "properties": {
               "redelegate": {
                 "type": "object",
-                "required": ["amount", "dst_validator", "src_validator"],
+                "required": [
+                  "amount",
+                  "dst_validator",
+                  "src_validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1142,41 +1361,57 @@
           {
             "description": "The proposal is open for voting.",
             "type": "string",
-            "enum": ["open"]
+            "enum": [
+              "open"
+            ]
           },
           {
             "description": "The proposal has been rejected.",
             "type": "string",
-            "enum": ["rejected"]
+            "enum": [
+              "rejected"
+            ]
           },
           {
             "description": "The proposal has been passed but has not been executed.",
             "type": "string",
-            "enum": ["passed"]
+            "enum": [
+              "passed"
+            ]
           },
           {
             "description": "The proposal has been passed and executed.",
             "type": "string",
-            "enum": ["executed"]
+            "enum": [
+              "executed"
+            ]
           },
           {
             "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
             "type": "string",
-            "enum": ["closed"]
+            "enum": [
+              "closed"
+            ]
           },
           {
             "description": "The proposal's execution failed.",
             "type": "string",
-            "enum": ["execution_failed"]
+            "enum": [
+              "execution_failed"
+            ]
           },
           {
             "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
             "type": "object",
-            "required": ["veto_timelock"],
+            "required": [
+              "veto_timelock"
+            ],
             "properties": {
               "veto_timelock": {
                 "type": "object",
-                "required": ["expiration"],
+                "required": [
+                  "expiration"
+                ],
                 "properties": {
                   "expiration": {
                     "$ref": "#/definitions/Expiration"
@@ -1190,7 +1425,9 @@
           {
             "description": "The proposal has been vetoed.",
             "type": "string",
-            "enum": ["vetoed"]
+            "enum": [
+              "vetoed"
+            ]
           }
         ]
       },
@@ -1216,7 +1453,9 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": ["native"],
+            "required": [
+              "native"
+            ],
             "properties": {
               "native": {
                 "type": "string"
@@ -1227,7 +1466,9 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": ["cw20"],
+            "required": [
+              "cw20"
+            ],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -1240,7 +1481,11 @@
       "UncheckedDepositInfo": {
         "description": "Information about the deposit required to create a proposal.",
         "type": "object",
-        "required": ["amount", "denom", "refund_policy"],
+        "required": [
+          "amount",
+          "denom",
+          "refund_policy"
+        ],
         "properties": {
           "amount": {
             "description": "The number of tokens that must be deposited to create a proposal. Must be a positive, non-zero number.",
@@ -1271,11 +1516,19 @@
       },
       "VoteOption": {
         "type": "string",
-        "enum": ["yes", "no", "abstain", "no_with_veto"]
+        "enum": [
+          "yes",
+          "no",
+          "abstain",
+          "no_with_veto"
+        ]
       },
       "VotingModuleTokenType": {
         "type": "string",
-        "enum": ["native", "cw20"]
+        "enum": [
+          "native",
+          "cw20"
+        ]
       },
       "WasmMsg": {
         "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
@@ -1283,11 +1536,17 @@
           {
             "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["execute"],
+            "required": [
+              "execute"
+            ],
             "properties": {
               "execute": {
                 "type": "object",
-                "required": ["contract_addr", "funds", "msg"],
+                "required": [
+                  "contract_addr",
+                  "funds",
+                  "msg"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1314,14 +1573,24 @@
           {
             "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["instantiate"],
+            "required": [
+              "instantiate"
+            ],
             "properties": {
               "instantiate": {
                 "type": "object",
-                "required": ["code_id", "funds", "label", "msg"],
+                "required": [
+                  "code_id",
+                  "funds",
+                  "label",
+                  "msg"
+                ],
                 "properties": {
                   "admin": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "code_id": {
                     "type": "integer",
@@ -1354,11 +1623,17 @@
           {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["migrate"],
+            "required": [
+              "migrate"
+            ],
             "properties": {
               "migrate": {
                 "type": "object",
-                "required": ["contract_addr", "msg", "new_code_id"],
+                "required": [
+                  "contract_addr",
+                  "msg",
+                  "new_code_id"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1385,11 +1660,16 @@
           {
             "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": ["update_admin"],
+            "required": [
+              "update_admin"
+            ],
             "properties": {
               "update_admin": {
                 "type": "object",
-                "required": ["admin", "contract_addr"],
+                "required": [
+                  "admin",
+                  "contract_addr"
+                ],
                 "properties": {
                   "admin": {
                     "type": "string"
@@ -1405,11 +1685,15 @@
           {
             "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": ["clear_admin"],
+            "required": [
+              "clear_admin"
+            ],
             "properties": {
               "clear_admin": {
                 "type": "object",
-                "required": ["contract_addr"],
+                "required": [
+                  "contract_addr"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1430,7 +1714,9 @@
       {
         "description": "Gets the proposal module that this pre propose module is associated with. Returns `Addr`.",
         "type": "object",
-        "required": ["proposal_module"],
+        "required": [
+          "proposal_module"
+        ],
         "properties": {
           "proposal_module": {
             "type": "object",
@@ -1442,7 +1728,9 @@
       {
         "description": "Gets the DAO (dao-dao-core) module this contract is associated with. Returns `Addr`.",
         "type": "object",
-        "required": ["dao"],
+        "required": [
+          "dao"
+        ],
         "properties": {
           "dao": {
             "type": "object",
@@ -1454,7 +1742,9 @@
       {
         "description": "Gets the module's configuration.",
         "type": "object",
-        "required": ["config"],
+        "required": [
+          "config"
+        ],
         "properties": {
           "config": {
             "type": "object",
@@ -1466,11 +1756,15 @@
       {
         "description": "Gets the deposit info for the proposal identified by PROPOSAL_ID.",
         "type": "object",
-        "required": ["deposit_info"],
+        "required": [
+          "deposit_info"
+        ],
         "properties": {
           "deposit_info": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -1484,9 +1778,33 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns whether or not the address can submit proposals.",
+        "type": "object",
+        "required": [
+          "can_propose"
+        ],
+        "properties": {
+          "can_propose": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Returns list of proposal submitted hooks.",
         "type": "object",
-        "required": ["proposal_submitted_hooks"],
+        "required": [
+          "proposal_submitted_hooks"
+        ],
         "properties": {
           "proposal_submitted_hooks": {
             "type": "object",
@@ -1498,11 +1816,15 @@
       {
         "description": "Extension for queries. The default implementation will do nothing if queried for will return `Binary::default()`.",
         "type": "object",
-        "required": ["query_extension"],
+        "required": [
+          "query_extension"
+        ],
         "properties": {
           "query_extension": {
             "type": "object",
-            "required": ["msg"],
+            "required": [
+              "msg"
+            ],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/Empty"
@@ -1524,11 +1846,18 @@
   "migrate": null,
   "sudo": null,
   "responses": {
+    "can_propose": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Boolean",
+      "type": "boolean"
+    },
     "config": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Config",
       "type": "object",
-      "required": ["submission_policy"],
+      "required": [
+        "submission_policy"
+      ],
       "properties": {
         "deposit_info": {
           "description": "Information about the deposit required to create a proposal. If `None`, no deposit is required.",
@@ -1562,7 +1891,9 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": ["native"],
+              "required": [
+                "native"
+              ],
               "properties": {
                 "native": {
                   "type": "string"
@@ -1573,7 +1904,9 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": ["cw20"],
+              "required": [
+                "cw20"
+              ],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -1586,7 +1919,11 @@
         "CheckedDepositInfo": {
           "description": "Counterpart to the `DepositInfo` struct which has been processed. This type should never be constructed literally and should always by built by calling `into_checked` on a `DepositInfo` instance.",
           "type": "object",
-          "required": ["amount", "denom", "refund_policy"],
+          "required": [
+            "amount",
+            "denom",
+            "refund_policy"
+          ],
           "properties": {
             "amount": {
               "description": "The number of tokens that must be deposited to create a proposal. This is validated to be non-zero if this struct is constructed by converted via the `into_checked` method on `DepositInfo`.",
@@ -1620,17 +1957,23 @@
             {
               "description": "Deposits should always be refunded.",
               "type": "string",
-              "enum": ["always"]
+              "enum": [
+                "always"
+              ]
             },
             {
               "description": "Deposits should only be refunded for passed proposals.",
               "type": "string",
-              "enum": ["only_passed"]
+              "enum": [
+                "only_passed"
+              ]
             },
             {
               "description": "Deposits should never be refunded.",
               "type": "string",
-              "enum": ["never"]
+              "enum": [
+                "never"
+              ]
             }
           ]
         },
@@ -1640,14 +1983,19 @@
             {
               "description": "Anyone may create proposals, except for those in the denylist.",
               "type": "object",
-              "required": ["anyone"],
+              "required": [
+                "anyone"
+              ],
               "properties": {
                 "anyone": {
                   "type": "object",
                   "properties": {
                     "denylist": {
                       "description": "Addresses that may not create proposals.",
-                      "type": ["array", "null"],
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "items": {
                         "type": "string"
                       }
@@ -1661,15 +2009,22 @@
             {
               "description": "Specific people may create proposals.",
               "type": "object",
-              "required": ["specific"],
+              "required": [
+                "specific"
+              ],
               "properties": {
                 "specific": {
                   "type": "object",
-                  "required": ["dao_members"],
+                  "required": [
+                    "dao_members"
+                  ],
                   "properties": {
                     "allowlist": {
                       "description": "Addresses that may create proposals.",
-                      "type": ["array", "null"],
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "items": {
                         "type": "string"
                       }
@@ -1680,7 +2035,10 @@
                     },
                     "denylist": {
                       "description": "Addresses that may not create proposals, overriding other settings.",
-                      "type": ["array", "null"],
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "items": {
                         "type": "string"
                       }
@@ -1709,7 +2067,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "DepositInfoResponse",
       "type": "object",
-      "required": ["proposer"],
+      "required": [
+        "proposer"
+      ],
       "properties": {
         "deposit_info": {
           "description": "The deposit that has been paid for the specified proposal.",
@@ -1743,7 +2103,9 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": ["native"],
+              "required": [
+                "native"
+              ],
               "properties": {
                 "native": {
                   "type": "string"
@@ -1754,7 +2116,9 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": ["cw20"],
+              "required": [
+                "cw20"
+              ],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -1767,7 +2131,11 @@
         "CheckedDepositInfo": {
           "description": "Counterpart to the `DepositInfo` struct which has been processed. This type should never be constructed literally and should always by built by calling `into_checked` on a `DepositInfo` instance.",
           "type": "object",
-          "required": ["amount", "denom", "refund_policy"],
+          "required": [
+            "amount",
+            "denom",
+            "refund_policy"
+          ],
           "properties": {
             "amount": {
               "description": "The number of tokens that must be deposited to create a proposal. This is validated to be non-zero if this struct is constructed by converted via the `into_checked` method on `DepositInfo`.",
@@ -1801,17 +2169,23 @@
             {
               "description": "Deposits should always be refunded.",
               "type": "string",
-              "enum": ["always"]
+              "enum": [
+                "always"
+              ]
             },
             {
               "description": "Deposits should only be refunded for passed proposals.",
               "type": "string",
-              "enum": ["only_passed"]
+              "enum": [
+                "only_passed"
+              ]
             },
             {
               "description": "Deposits should never be refunded.",
               "type": "string",
-              "enum": ["never"]
+              "enum": [
+                "never"
+              ]
             }
           ]
         },
@@ -1831,7 +2205,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": ["hooks"],
+      "required": [
+        "hooks"
+      ],
       "properties": {
         "hooks": {
           "type": "array",

--- a/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
@@ -1,15 +1,12 @@
 {
   "contract_name": "dao-pre-propose-multiple",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "extension",
-      "submission_policy"
-    ],
+    "required": ["extension", "submission_policy"],
     "properties": {
       "deposit_info": {
         "description": "Information about the deposit requirements for this module. None if no deposit.",
@@ -46,23 +43,17 @@
           {
             "description": "Deposits should always be refunded.",
             "type": "string",
-            "enum": [
-              "always"
-            ]
+            "enum": ["always"]
           },
           {
             "description": "Deposits should only be refunded for passed proposals.",
             "type": "string",
-            "enum": [
-              "only_passed"
-            ]
+            "enum": ["only_passed"]
           },
           {
             "description": "Deposits should never be refunded.",
             "type": "string",
-            "enum": [
-              "never"
-            ]
+            "enum": ["never"]
           }
         ]
       },
@@ -72,15 +63,11 @@
           {
             "description": "Use a specific token address as the deposit token.",
             "type": "object",
-            "required": [
-              "token"
-            ],
+            "required": ["token"],
             "properties": {
               "token": {
                 "type": "object",
-                "required": [
-                  "denom"
-                ],
+                "required": ["denom"],
                 "properties": {
                   "denom": {
                     "$ref": "#/definitions/UncheckedDenom"
@@ -94,15 +81,11 @@
           {
             "description": "Use the token native denom or cw20 contract address of the associated DAO's voting module. NOTE: in order to retrieve the token automatically via this variant, the voting module must either (1) use a native token and implement the `Denom {}` query type defined by `dao_dao_macros::native_token_query` OR (2) use a cw20 token and implement the `TokenContract {}` query type defined by `dao_dao_macros::cw20_token_query`. Failing to implement correctly will cause this option to fail to instantiate.",
             "type": "object",
-            "required": [
-              "voting_module_token"
-            ],
+            "required": ["voting_module_token"],
             "properties": {
               "voting_module_token": {
                 "type": "object",
-                "required": [
-                  "token_type"
-                ],
+                "required": ["token_type"],
                 "properties": {
                   "token_type": {
                     "$ref": "#/definitions/VotingModuleTokenType"
@@ -125,19 +108,14 @@
           {
             "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
-            "required": [
-              "anyone"
-            ],
+            "required": ["anyone"],
             "properties": {
               "anyone": {
                 "type": "object",
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -151,22 +129,15 @@
           {
             "description": "Specific people may create proposals.",
             "type": "object",
-            "required": [
-              "specific"
-            ],
+            "required": ["specific"],
             "properties": {
               "specific": {
                 "type": "object",
-                "required": [
-                  "dao_members"
-                ],
+                "required": ["dao_members"],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -177,10 +148,7 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -203,9 +171,7 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": [
-              "native"
-            ],
+            "required": ["native"],
             "properties": {
               "native": {
                 "type": "string"
@@ -216,9 +182,7 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": [
-              "cw20"
-            ],
+            "required": ["cw20"],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -231,11 +195,7 @@
       "UncheckedDepositInfo": {
         "description": "Information about the deposit required to create a proposal.",
         "type": "object",
-        "required": [
-          "amount",
-          "denom",
-          "refund_policy"
-        ],
+        "required": ["amount", "denom", "refund_policy"],
         "properties": {
           "amount": {
             "description": "The number of tokens that must be deposited to create a proposal. Must be a positive, non-zero number.",
@@ -266,10 +226,7 @@
       },
       "VotingModuleTokenType": {
         "type": "string",
-        "enum": [
-          "native",
-          "cw20"
-        ]
+        "enum": ["native", "cw20"]
       }
     }
   },
@@ -280,15 +237,11 @@
       {
         "description": "Creates a new proposal in the pre-propose module. MSG will be serialized and used as the proposal creation message.",
         "type": "object",
-        "required": [
-          "propose"
-        ],
+        "required": ["propose"],
         "properties": {
           "propose": {
             "type": "object",
-            "required": [
-              "msg"
-            ],
+            "required": ["msg"],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/ProposeMessage"
@@ -302,9 +255,7 @@
       {
         "description": "Updates the configuration of this module. This will completely override the existing configuration. This new configuration will only apply to proposals created after the config is updated. Only the DAO may execute this message.",
         "type": "object",
-        "required": [
-          "update_config"
-        ],
+        "required": ["update_config"],
         "properties": {
           "update_config": {
             "type": "object",
@@ -340,59 +291,42 @@
       {
         "description": "Perform more granular submission policy updates to allow for atomic operations that don't override others.",
         "type": "object",
-        "required": [
-          "update_submission_policy"
-        ],
+        "required": ["update_submission_policy"],
         "properties": {
           "update_submission_policy": {
             "type": "object",
             "properties": {
               "allowlist_add": {
                 "description": "If using specific policy, optionally add to the allowlist.",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "allowlist_remove": {
                 "description": "If using specific policy, optionally remove from the allowlist.",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "denylist_add": {
                 "description": "Optionally add to the denylist. Works for any submission policy.",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "denylist_remove": {
                 "description": "Optionally remove from denylist. Works for any submission policy.",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "set_dao_members": {
                 "description": "If using specific policy, optionally update the `dao_members` flag.",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": ["boolean", "null"]
               }
             },
             "additionalProperties": false
@@ -403,9 +337,7 @@
       {
         "description": "Withdraws funds inside of this contract to the message sender. The contracts entire balance for the specifed DENOM is withdrawn to the message sender. Only the DAO may call this method.\n\nThis is intended only as an escape hatch in the event of a critical bug in this contract or it's proposal module. Withdrawing funds will cause future attempts to return proposal deposits to fail their transactions as the contract will have insufficent balance to return them. In the case of `cw-proposal-single` this transaction failure will cause the module to remove the pre-propose module from its proposal hook receivers.\n\nMore likely than not, this should NEVER BE CALLED unless a bug in this contract or the proposal module it is associated with has caused it to stop receiving proposal hook messages, or if a critical security vulnerability has been found that allows an attacker to drain proposal deposits.",
         "type": "object",
-        "required": [
-          "withdraw"
-        ],
+        "required": ["withdraw"],
         "properties": {
           "withdraw": {
             "type": "object",
@@ -430,15 +362,11 @@
       {
         "description": "Extension message. Contracts that extend this one should put their custom execute logic here. The default implementation will do nothing if this variant is executed.",
         "type": "object",
-        "required": [
-          "extension"
-        ],
+        "required": ["extension"],
         "properties": {
           "extension": {
             "type": "object",
-            "required": [
-              "msg"
-            ],
+            "required": ["msg"],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/Empty"
@@ -452,15 +380,11 @@
       {
         "description": "Adds a proposal submitted hook. Fires when a new proposal is submitted to the pre-propose contract. Only the DAO may call this method.",
         "type": "object",
-        "required": [
-          "add_proposal_submitted_hook"
-        ],
+        "required": ["add_proposal_submitted_hook"],
         "properties": {
           "add_proposal_submitted_hook": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -474,15 +398,11 @@
       {
         "description": "Removes a proposal submitted hook. Only the DAO may call this method.",
         "type": "object",
-        "required": [
-          "remove_proposal_submitted_hook"
-        ],
+        "required": ["remove_proposal_submitted_hook"],
         "properties": {
           "remove_proposal_submitted_hook": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -496,16 +416,11 @@
       {
         "description": "Handles proposal hook fired by the associated proposal module when a proposal is completed (ie executed or rejected). By default, the base contract will return deposits proposals, when they are closed, when proposals are executed, or, if it is refunding failed.",
         "type": "object",
-        "required": [
-          "proposal_completed_hook"
-        ],
+        "required": ["proposal_completed_hook"],
         "properties": {
           "proposal_completed_hook": {
             "type": "object",
-            "required": [
-              "new_status",
-              "proposal_id"
-            ],
+            "required": ["new_status", "proposal_id"],
             "properties": {
               "new_status": {
                 "$ref": "#/definitions/Status"
@@ -529,16 +444,11 @@
           {
             "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "send"
-            ],
+            "required": ["send"],
             "properties": {
               "send": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "to_address"
-                ],
+                "required": ["amount", "to_address"],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -557,15 +467,11 @@
           {
             "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
             "type": "object",
-            "required": [
-              "burn"
-            ],
+            "required": ["burn"],
             "properties": {
               "burn": {
                 "type": "object",
-                "required": [
-                  "amount"
-                ],
+                "required": ["amount"],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -586,10 +492,7 @@
       },
       "Coin": {
         "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
+        "required": ["amount", "denom"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -603,9 +506,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "bank"
-            ],
+            "required": ["bank"],
             "properties": {
               "bank": {
                 "$ref": "#/definitions/BankMsg"
@@ -615,9 +516,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "custom"
-            ],
+            "required": ["custom"],
             "properties": {
               "custom": {
                 "$ref": "#/definitions/Empty"
@@ -627,9 +526,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "staking"
-            ],
+            "required": ["staking"],
             "properties": {
               "staking": {
                 "$ref": "#/definitions/StakingMsg"
@@ -639,9 +536,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "distribution"
-            ],
+            "required": ["distribution"],
             "properties": {
               "distribution": {
                 "$ref": "#/definitions/DistributionMsg"
@@ -652,16 +547,11 @@
           {
             "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
             "type": "object",
-            "required": [
-              "stargate"
-            ],
+            "required": ["stargate"],
             "properties": {
               "stargate": {
                 "type": "object",
-                "required": [
-                  "type_url",
-                  "value"
-                ],
+                "required": ["type_url", "value"],
                 "properties": {
                   "type_url": {
                     "type": "string"
@@ -676,9 +566,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "ibc"
-            ],
+            "required": ["ibc"],
             "properties": {
               "ibc": {
                 "$ref": "#/definitions/IbcMsg"
@@ -688,9 +576,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "wasm"
-            ],
+            "required": ["wasm"],
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmMsg"
@@ -700,9 +586,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "gov"
-            ],
+            "required": ["gov"],
             "properties": {
               "gov": {
                 "$ref": "#/definitions/GovMsg"
@@ -717,23 +601,17 @@
           {
             "description": "Deposits should always be refunded.",
             "type": "string",
-            "enum": [
-              "always"
-            ]
+            "enum": ["always"]
           },
           {
             "description": "Deposits should only be refunded for passed proposals.",
             "type": "string",
-            "enum": [
-              "only_passed"
-            ]
+            "enum": ["only_passed"]
           },
           {
             "description": "Deposits should never be refunded.",
             "type": "string",
-            "enum": [
-              "never"
-            ]
+            "enum": ["never"]
           }
         ]
       },
@@ -743,15 +621,11 @@
           {
             "description": "Use a specific token address as the deposit token.",
             "type": "object",
-            "required": [
-              "token"
-            ],
+            "required": ["token"],
             "properties": {
               "token": {
                 "type": "object",
-                "required": [
-                  "denom"
-                ],
+                "required": ["denom"],
                 "properties": {
                   "denom": {
                     "$ref": "#/definitions/UncheckedDenom"
@@ -765,15 +639,11 @@
           {
             "description": "Use the token native denom or cw20 contract address of the associated DAO's voting module. NOTE: in order to retrieve the token automatically via this variant, the voting module must either (1) use a native token and implement the `Denom {}` query type defined by `dao_dao_macros::native_token_query` OR (2) use a cw20 token and implement the `TokenContract {}` query type defined by `dao_dao_macros::cw20_token_query`. Failing to implement correctly will cause this option to fail to instantiate.",
             "type": "object",
-            "required": [
-              "voting_module_token"
-            ],
+            "required": ["voting_module_token"],
             "properties": {
               "voting_module_token": {
                 "type": "object",
-                "required": [
-                  "token_type"
-                ],
+                "required": ["token_type"],
                 "properties": {
                   "token_type": {
                     "$ref": "#/definitions/VotingModuleTokenType"
@@ -792,15 +662,11 @@
           {
             "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "set_withdraw_address"
-            ],
+            "required": ["set_withdraw_address"],
             "properties": {
               "set_withdraw_address": {
                 "type": "object",
-                "required": [
-                  "address"
-                ],
+                "required": ["address"],
                 "properties": {
                   "address": {
                     "description": "The `withdraw_address`",
@@ -814,15 +680,11 @@
           {
             "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "withdraw_delegator_reward"
-            ],
+            "required": ["withdraw_delegator_reward"],
             "properties": {
               "withdraw_delegator_reward": {
                 "type": "object",
-                "required": [
-                  "validator"
-                ],
+                "required": ["validator"],
                 "properties": {
                   "validator": {
                     "description": "The `validator_address`",
@@ -845,9 +707,7 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": [
-              "at_height"
-            ],
+            "required": ["at_height"],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -860,9 +720,7 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": [
-              "at_time"
-            ],
+            "required": ["at_time"],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -873,9 +731,7 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": [
-              "never"
-            ],
+            "required": ["never"],
             "properties": {
               "never": {
                 "type": "object",
@@ -892,16 +748,11 @@
           {
             "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
             "type": "object",
-            "required": [
-              "vote"
-            ],
+            "required": ["vote"],
             "properties": {
               "vote": {
                 "type": "object",
-                "required": [
-                  "proposal_id",
-                  "vote"
-                ],
+                "required": ["proposal_id", "vote"],
                 "properties": {
                   "proposal_id": {
                     "type": "integer",
@@ -929,18 +780,11 @@
           {
             "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
             "type": "object",
-            "required": [
-              "transfer"
-            ],
+            "required": ["transfer"],
             "properties": {
               "transfer": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "channel_id",
-                  "timeout",
-                  "to_address"
-                ],
+                "required": ["amount", "channel_id", "timeout", "to_address"],
                 "properties": {
                   "amount": {
                     "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -974,17 +818,11 @@
           {
             "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
             "type": "object",
-            "required": [
-              "send_packet"
-            ],
+            "required": ["send_packet"],
             "properties": {
               "send_packet": {
                 "type": "object",
-                "required": [
-                  "channel_id",
-                  "data",
-                  "timeout"
-                ],
+                "required": ["channel_id", "data", "timeout"],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -1008,15 +846,11 @@
           {
             "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
             "type": "object",
-            "required": [
-              "close_channel"
-            ],
+            "required": ["close_channel"],
             "properties": {
               "close_channel": {
                 "type": "object",
-                "required": [
-                  "channel_id"
-                ],
+                "required": ["channel_id"],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -1057,10 +891,7 @@
       "IbcTimeoutBlock": {
         "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
         "type": "object",
-        "required": [
-          "height",
-          "revision"
-        ],
+        "required": ["height", "revision"],
         "properties": {
           "height": {
             "description": "block height after which the packet times out. the height within the given revision",
@@ -1078,16 +909,11 @@
       },
       "MultipleChoiceAutoVote": {
         "type": "object",
-        "required": [
-          "vote"
-        ],
+        "required": ["vote"],
         "properties": {
           "rationale": {
             "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "vote": {
             "description": "The proposer's position on the proposal.",
@@ -1103,11 +929,7 @@
       "MultipleChoiceOption": {
         "description": "Unchecked multiple choice option",
         "type": "object",
-        "required": [
-          "description",
-          "msgs",
-          "title"
-        ],
+        "required": ["description", "msgs", "title"],
         "properties": {
           "description": {
             "type": "string"
@@ -1127,9 +949,7 @@
       "MultipleChoiceOptions": {
         "description": "Represents unchecked multiple choice options",
         "type": "object",
-        "required": [
-          "options"
-        ],
+        "required": ["options"],
         "properties": {
           "options": {
             "type": "array",
@@ -1143,9 +963,7 @@
       "MultipleChoiceVote": {
         "description": "A multiple choice vote, picking the desired option",
         "type": "object",
-        "required": [
-          "option_id"
-        ],
+        "required": ["option_id"],
         "properties": {
           "option_id": {
             "type": "integer",
@@ -1161,19 +979,14 @@
           {
             "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
-            "required": [
-              "anyone"
-            ],
+            "required": ["anyone"],
             "properties": {
               "anyone": {
                 "type": "object",
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -1187,22 +1000,15 @@
           {
             "description": "Specific people may create proposals.",
             "type": "object",
-            "required": [
-              "specific"
-            ],
+            "required": ["specific"],
             "properties": {
               "specific": {
                 "type": "object",
-                "required": [
-                  "dao_members"
-                ],
+                "required": ["dao_members"],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -1213,10 +1019,7 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -1233,17 +1036,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "propose"
-            ],
+            "required": ["propose"],
             "properties": {
               "propose": {
                 "type": "object",
-                "required": [
-                  "choices",
-                  "description",
-                  "title"
-                ],
+                "required": ["choices", "description", "title"],
                 "properties": {
                   "choices": {
                     "$ref": "#/definitions/MultipleChoiceOptions"
@@ -1278,16 +1075,11 @@
           {
             "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "delegate"
-            ],
+            "required": ["delegate"],
             "properties": {
               "delegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "validator"
-                ],
+                "required": ["amount", "validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1303,16 +1095,11 @@
           {
             "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "undelegate"
-            ],
+            "required": ["undelegate"],
             "properties": {
               "undelegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "validator"
-                ],
+                "required": ["amount", "validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1328,17 +1115,11 @@
           {
             "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "redelegate"
-            ],
+            "required": ["redelegate"],
             "properties": {
               "redelegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "dst_validator",
-                  "src_validator"
-                ],
+                "required": ["amount", "dst_validator", "src_validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1361,57 +1142,41 @@
           {
             "description": "The proposal is open for voting.",
             "type": "string",
-            "enum": [
-              "open"
-            ]
+            "enum": ["open"]
           },
           {
             "description": "The proposal has been rejected.",
             "type": "string",
-            "enum": [
-              "rejected"
-            ]
+            "enum": ["rejected"]
           },
           {
             "description": "The proposal has been passed but has not been executed.",
             "type": "string",
-            "enum": [
-              "passed"
-            ]
+            "enum": ["passed"]
           },
           {
             "description": "The proposal has been passed and executed.",
             "type": "string",
-            "enum": [
-              "executed"
-            ]
+            "enum": ["executed"]
           },
           {
             "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
             "type": "string",
-            "enum": [
-              "closed"
-            ]
+            "enum": ["closed"]
           },
           {
             "description": "The proposal's execution failed.",
             "type": "string",
-            "enum": [
-              "execution_failed"
-            ]
+            "enum": ["execution_failed"]
           },
           {
             "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
             "type": "object",
-            "required": [
-              "veto_timelock"
-            ],
+            "required": ["veto_timelock"],
             "properties": {
               "veto_timelock": {
                 "type": "object",
-                "required": [
-                  "expiration"
-                ],
+                "required": ["expiration"],
                 "properties": {
                   "expiration": {
                     "$ref": "#/definitions/Expiration"
@@ -1425,9 +1190,7 @@
           {
             "description": "The proposal has been vetoed.",
             "type": "string",
-            "enum": [
-              "vetoed"
-            ]
+            "enum": ["vetoed"]
           }
         ]
       },
@@ -1453,9 +1216,7 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": [
-              "native"
-            ],
+            "required": ["native"],
             "properties": {
               "native": {
                 "type": "string"
@@ -1466,9 +1227,7 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": [
-              "cw20"
-            ],
+            "required": ["cw20"],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -1481,11 +1240,7 @@
       "UncheckedDepositInfo": {
         "description": "Information about the deposit required to create a proposal.",
         "type": "object",
-        "required": [
-          "amount",
-          "denom",
-          "refund_policy"
-        ],
+        "required": ["amount", "denom", "refund_policy"],
         "properties": {
           "amount": {
             "description": "The number of tokens that must be deposited to create a proposal. Must be a positive, non-zero number.",
@@ -1516,19 +1271,11 @@
       },
       "VoteOption": {
         "type": "string",
-        "enum": [
-          "yes",
-          "no",
-          "abstain",
-          "no_with_veto"
-        ]
+        "enum": ["yes", "no", "abstain", "no_with_veto"]
       },
       "VotingModuleTokenType": {
         "type": "string",
-        "enum": [
-          "native",
-          "cw20"
-        ]
+        "enum": ["native", "cw20"]
       },
       "WasmMsg": {
         "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
@@ -1536,17 +1283,11 @@
           {
             "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "execute"
-            ],
+            "required": ["execute"],
             "properties": {
               "execute": {
                 "type": "object",
-                "required": [
-                  "contract_addr",
-                  "funds",
-                  "msg"
-                ],
+                "required": ["contract_addr", "funds", "msg"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1573,24 +1314,14 @@
           {
             "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "instantiate"
-            ],
+            "required": ["instantiate"],
             "properties": {
               "instantiate": {
                 "type": "object",
-                "required": [
-                  "code_id",
-                  "funds",
-                  "label",
-                  "msg"
-                ],
+                "required": ["code_id", "funds", "label", "msg"],
                 "properties": {
                   "admin": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": ["string", "null"]
                   },
                   "code_id": {
                     "type": "integer",
@@ -1623,17 +1354,11 @@
           {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "migrate"
-            ],
+            "required": ["migrate"],
             "properties": {
               "migrate": {
                 "type": "object",
-                "required": [
-                  "contract_addr",
-                  "msg",
-                  "new_code_id"
-                ],
+                "required": ["contract_addr", "msg", "new_code_id"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1660,16 +1385,11 @@
           {
             "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": [
-              "update_admin"
-            ],
+            "required": ["update_admin"],
             "properties": {
               "update_admin": {
                 "type": "object",
-                "required": [
-                  "admin",
-                  "contract_addr"
-                ],
+                "required": ["admin", "contract_addr"],
                 "properties": {
                   "admin": {
                     "type": "string"
@@ -1685,15 +1405,11 @@
           {
             "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": [
-              "clear_admin"
-            ],
+            "required": ["clear_admin"],
             "properties": {
               "clear_admin": {
                 "type": "object",
-                "required": [
-                  "contract_addr"
-                ],
+                "required": ["contract_addr"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1714,9 +1430,7 @@
       {
         "description": "Gets the proposal module that this pre propose module is associated with. Returns `Addr`.",
         "type": "object",
-        "required": [
-          "proposal_module"
-        ],
+        "required": ["proposal_module"],
         "properties": {
           "proposal_module": {
             "type": "object",
@@ -1728,9 +1442,7 @@
       {
         "description": "Gets the DAO (dao-dao-core) module this contract is associated with. Returns `Addr`.",
         "type": "object",
-        "required": [
-          "dao"
-        ],
+        "required": ["dao"],
         "properties": {
           "dao": {
             "type": "object",
@@ -1742,9 +1454,7 @@
       {
         "description": "Gets the module's configuration.",
         "type": "object",
-        "required": [
-          "config"
-        ],
+        "required": ["config"],
         "properties": {
           "config": {
             "type": "object",
@@ -1756,15 +1466,11 @@
       {
         "description": "Gets the deposit info for the proposal identified by PROPOSAL_ID.",
         "type": "object",
-        "required": [
-          "deposit_info"
-        ],
+        "required": ["deposit_info"],
         "properties": {
           "deposit_info": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -1780,9 +1486,7 @@
       {
         "description": "Returns list of proposal submitted hooks.",
         "type": "object",
-        "required": [
-          "proposal_submitted_hooks"
-        ],
+        "required": ["proposal_submitted_hooks"],
         "properties": {
           "proposal_submitted_hooks": {
             "type": "object",
@@ -1794,15 +1498,11 @@
       {
         "description": "Extension for queries. The default implementation will do nothing if queried for will return `Binary::default()`.",
         "type": "object",
-        "required": [
-          "query_extension"
-        ],
+        "required": ["query_extension"],
         "properties": {
           "query_extension": {
             "type": "object",
-            "required": [
-              "msg"
-            ],
+            "required": ["msg"],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/Empty"
@@ -1828,9 +1528,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Config",
       "type": "object",
-      "required": [
-        "submission_policy"
-      ],
+      "required": ["submission_policy"],
       "properties": {
         "deposit_info": {
           "description": "Information about the deposit required to create a proposal. If `None`, no deposit is required.",
@@ -1864,9 +1562,7 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": [
-                "native"
-              ],
+              "required": ["native"],
               "properties": {
                 "native": {
                   "type": "string"
@@ -1877,9 +1573,7 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": [
-                "cw20"
-              ],
+              "required": ["cw20"],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -1892,11 +1586,7 @@
         "CheckedDepositInfo": {
           "description": "Counterpart to the `DepositInfo` struct which has been processed. This type should never be constructed literally and should always by built by calling `into_checked` on a `DepositInfo` instance.",
           "type": "object",
-          "required": [
-            "amount",
-            "denom",
-            "refund_policy"
-          ],
+          "required": ["amount", "denom", "refund_policy"],
           "properties": {
             "amount": {
               "description": "The number of tokens that must be deposited to create a proposal. This is validated to be non-zero if this struct is constructed by converted via the `into_checked` method on `DepositInfo`.",
@@ -1930,23 +1620,17 @@
             {
               "description": "Deposits should always be refunded.",
               "type": "string",
-              "enum": [
-                "always"
-              ]
+              "enum": ["always"]
             },
             {
               "description": "Deposits should only be refunded for passed proposals.",
               "type": "string",
-              "enum": [
-                "only_passed"
-              ]
+              "enum": ["only_passed"]
             },
             {
               "description": "Deposits should never be refunded.",
               "type": "string",
-              "enum": [
-                "never"
-              ]
+              "enum": ["never"]
             }
           ]
         },
@@ -1956,19 +1640,14 @@
             {
               "description": "Anyone may create proposals, except for those in the denylist.",
               "type": "object",
-              "required": [
-                "anyone"
-              ],
+              "required": ["anyone"],
               "properties": {
                 "anyone": {
                   "type": "object",
                   "properties": {
                     "denylist": {
                       "description": "Addresses that may not create proposals.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": ["array", "null"],
                       "items": {
                         "type": "string"
                       }
@@ -1982,22 +1661,15 @@
             {
               "description": "Specific people may create proposals.",
               "type": "object",
-              "required": [
-                "specific"
-              ],
+              "required": ["specific"],
               "properties": {
                 "specific": {
                   "type": "object",
-                  "required": [
-                    "dao_members"
-                  ],
+                  "required": ["dao_members"],
                   "properties": {
                     "allowlist": {
                       "description": "Addresses that may create proposals.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": ["array", "null"],
                       "items": {
                         "type": "string"
                       }
@@ -2008,10 +1680,7 @@
                     },
                     "denylist": {
                       "description": "Addresses that may not create proposals, overriding other settings.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": ["array", "null"],
                       "items": {
                         "type": "string"
                       }
@@ -2040,9 +1709,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "DepositInfoResponse",
       "type": "object",
-      "required": [
-        "proposer"
-      ],
+      "required": ["proposer"],
       "properties": {
         "deposit_info": {
           "description": "The deposit that has been paid for the specified proposal.",
@@ -2076,9 +1743,7 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": [
-                "native"
-              ],
+              "required": ["native"],
               "properties": {
                 "native": {
                   "type": "string"
@@ -2089,9 +1754,7 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": [
-                "cw20"
-              ],
+              "required": ["cw20"],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -2104,11 +1767,7 @@
         "CheckedDepositInfo": {
           "description": "Counterpart to the `DepositInfo` struct which has been processed. This type should never be constructed literally and should always by built by calling `into_checked` on a `DepositInfo` instance.",
           "type": "object",
-          "required": [
-            "amount",
-            "denom",
-            "refund_policy"
-          ],
+          "required": ["amount", "denom", "refund_policy"],
           "properties": {
             "amount": {
               "description": "The number of tokens that must be deposited to create a proposal. This is validated to be non-zero if this struct is constructed by converted via the `into_checked` method on `DepositInfo`.",
@@ -2142,23 +1801,17 @@
             {
               "description": "Deposits should always be refunded.",
               "type": "string",
-              "enum": [
-                "always"
-              ]
+              "enum": ["always"]
             },
             {
               "description": "Deposits should only be refunded for passed proposals.",
               "type": "string",
-              "enum": [
-                "only_passed"
-              ]
+              "enum": ["only_passed"]
             },
             {
               "description": "Deposits should never be refunded.",
               "type": "string",
-              "enum": [
-                "never"
-              ]
+              "enum": ["never"]
             }
           ]
         },
@@ -2178,9 +1831,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": [
-        "hooks"
-      ],
+      "required": ["hooks"],
       "properties": {
         "hooks": {
           "type": "array",

--- a/contracts/pre-propose/dao-pre-propose-multiple/src/contract.rs
+++ b/contracts/pre-propose/dao-pre-propose-multiple/src/contract.rs
@@ -92,6 +92,19 @@ pub fn execute(
             deposit_info,
             submission_policy,
         },
+        ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add,
+            denylist_remove,
+            set_dao_members,
+            allowlist_add,
+            allowlist_remove,
+        } => ExecuteInternal::UpdateSubmissionPolicy {
+            denylist_add,
+            denylist_remove,
+            set_dao_members,
+            allowlist_add,
+            allowlist_remove,
+        },
         ExecuteMsg::AddProposalSubmittedHook { address } => {
             ExecuteInternal::AddProposalSubmittedHook { address }
         }

--- a/contracts/pre-propose/dao-pre-propose-multiple/src/contract.rs
+++ b/contracts/pre-propose/dao-pre-propose-multiple/src/contract.rs
@@ -87,10 +87,10 @@ pub fn execute(
         ExecuteMsg::Withdraw { denom } => ExecuteInternal::Withdraw { denom },
         ExecuteMsg::UpdateConfig {
             deposit_info,
-            open_proposal_submission,
+            submission_policy,
         } => ExecuteInternal::UpdateConfig {
             deposit_info,
-            open_proposal_submission,
+            submission_policy,
         },
         ExecuteMsg::AddProposalSubmittedHook { address } => {
             ExecuteInternal::AddProposalSubmittedHook { address }

--- a/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
@@ -10,7 +10,7 @@ use dao_interface::state::{Admin, ModuleInstantiateInfo};
 use dao_pre_propose_base::{error::PreProposeError, msg::DepositInfoResponse, state::Config};
 use dao_proposal_multiple as cpm;
 use dao_testing::helpers::instantiate_with_cw4_groups_governance;
-use dao_voting::pre_propose::PreProposeSubmissionPolicy;
+use dao_voting::pre_propose::{PreProposeSubmissionPolicy, PreProposeSubmissionPolicyError};
 use dao_voting::{
     deposit::{CheckedDepositInfo, DepositRefundPolicy, DepositToken, UncheckedDepositInfo},
     multiple_choice::{
@@ -885,7 +885,12 @@ fn test_permissions() {
         .unwrap_err()
         .downcast()
         .unwrap();
-    assert_eq!(err, PreProposeError::NotMember {})
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::UnauthorizedDaoMembers {}
+        )
+    )
 }
 
 #[test]
@@ -992,7 +997,12 @@ fn test_no_deposit_required_members_submission() {
         .unwrap_err()
         .downcast()
         .unwrap();
-    assert_eq!(err, PreProposeError::NotMember {});
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::UnauthorizedDaoMembers {}
+        )
+    );
 
     let id = make_proposal(&mut app, pre_propose, proposal_single.clone(), "ekez", &[]);
     let new_status = vote(

--- a/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
@@ -362,6 +362,17 @@ fn get_deposit_info(app: &App, module: Addr, id: u64) -> DepositInfoResponse {
         .unwrap()
 }
 
+fn query_can_propose(app: &App, module: Addr, address: impl Into<String>) -> bool {
+    app.wrap()
+        .query_wasm_smart(
+            module,
+            &QueryMsg::CanPropose {
+                address: address.into(),
+            },
+        )
+        .unwrap()
+}
+
 fn update_config(
     app: &mut App,
     module: Addr,
@@ -1035,6 +1046,7 @@ fn test_anyone_denylist() {
     let rando = "rando";
 
     // Proposal succeeds when anyone can propose.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), true);
     make_proposal(
         &mut app,
         pre_propose.clone(),
@@ -1054,6 +1066,7 @@ fn test_anyone_denylist() {
     );
 
     // Proposing fails if on denylist.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), false);
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked(rando),
@@ -1083,6 +1096,7 @@ fn test_anyone_denylist() {
     );
 
     // Proposing succeeds if not on denylist.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), true);
     make_proposal(&mut app, pre_propose, proposal_single.clone(), "ekez", &[]);
 }
 
@@ -1108,6 +1122,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposal succeeds for member.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), true);
     make_proposal(
         &mut app,
         pre_propose.clone(),
@@ -1119,6 +1134,7 @@ fn test_specific_allowlist_denylist() {
     let rando = "rando";
 
     // Proposing fails for non-member.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), false);
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked(rando),
@@ -1160,6 +1176,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposal succeeds if on allowlist.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), true);
     make_proposal(
         &mut app,
         pre_propose.clone(),
@@ -1181,6 +1198,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposing fails if on denylist.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), false);
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked("ekez"),
@@ -1222,6 +1240,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposing fails if members not allowed.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), false);
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked("ekez"),
@@ -1251,6 +1270,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposal succeeds if on allowlist.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), true);
     make_proposal(
         &mut app,
         pre_propose.clone(),

--- a/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
@@ -1046,7 +1046,7 @@ fn test_anyone_denylist() {
     let rando = "rando";
 
     // Proposal succeeds when anyone can propose.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), true);
+    assert!(query_can_propose(&app, pre_propose.clone(), rando));
     make_proposal(
         &mut app,
         pre_propose.clone(),
@@ -1066,7 +1066,7 @@ fn test_anyone_denylist() {
     );
 
     // Proposing fails if on denylist.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), false);
+    assert!(!query_can_propose(&app, pre_propose.clone(), rando));
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked(rando),
@@ -1096,7 +1096,7 @@ fn test_anyone_denylist() {
     );
 
     // Proposing succeeds if not on denylist.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), true);
+    assert!(query_can_propose(&app, pre_propose.clone(), "ekez"));
     make_proposal(&mut app, pre_propose, proposal_single.clone(), "ekez", &[]);
 }
 
@@ -1122,7 +1122,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposal succeeds for member.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), true);
+    assert!(query_can_propose(&app, pre_propose.clone(), "ekez"));
     make_proposal(
         &mut app,
         pre_propose.clone(),
@@ -1134,7 +1134,7 @@ fn test_specific_allowlist_denylist() {
     let rando = "rando";
 
     // Proposing fails for non-member.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), false);
+    assert!(!query_can_propose(&app, pre_propose.clone(), rando));
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked(rando),
@@ -1176,7 +1176,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposal succeeds if on allowlist.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), true);
+    assert!(query_can_propose(&app, pre_propose.clone(), rando));
     make_proposal(
         &mut app,
         pre_propose.clone(),
@@ -1198,7 +1198,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposing fails if on denylist.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), false);
+    assert!(!query_can_propose(&app, pre_propose.clone(), "ekez"));
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked("ekez"),
@@ -1240,7 +1240,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposing fails if members not allowed.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), false);
+    assert!(!query_can_propose(&app, pre_propose.clone(), "ekez"));
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked("ekez"),
@@ -1270,7 +1270,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposal succeeds if on allowlist.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), true);
+    assert!(query_can_propose(&app, pre_propose.clone(), rando));
     make_proposal(
         &mut app,
         pre_propose.clone(),

--- a/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
@@ -1292,12 +1292,501 @@ fn test_update_config() {
     // Only the core module can update the config.
     let err = update_config_should_fail(
         &mut app,
-        pre_propose,
+        pre_propose.clone(),
         proposal_single.as_str(),
         None,
         PreProposeSubmissionPolicy::Anyone { denylist: None },
     );
     assert_eq!(err, PreProposeError::NotDao {});
+
+    // Errors when no one is authorized to create proposals.
+    let err = update_config_should_fail(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: false,
+            allowlist: None,
+            denylist: None,
+        },
+    );
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::NoOneAllowed {})
+    );
+
+    // Errors when allowlist and denylist overlap.
+    let err = update_config_should_fail(
+        &mut app,
+        pre_propose,
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: false,
+            allowlist: Some(vec!["ekez".to_string()]),
+            denylist: Some(vec!["ekez".to_string()]),
+        },
+    );
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::DenylistAllowlistOverlap {}
+        )
+    );
+}
+
+#[test]
+fn test_update_submission_policy() {
+    let mut app = App::default();
+    let DefaultTestSetup {
+        core_addr,
+        pre_propose,
+        ..
+    } = setup_default_test(&mut app, None, true);
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+        }
+    );
+
+    // Only the core module can update the submission policy.
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("ekez"),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: Some(vec!["ekez".to_string()]),
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, PreProposeError::NotDao {});
+
+    // Append to denylist, with auto de-dupe.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: Some(vec!["ekez".to_string(), "ekez".to_string()]),
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone {
+                denylist: Some(vec!["ekez".to_string()]),
+            },
+        }
+    );
+
+    // Add and remove to/from denylist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: Some(vec!["someone".to_string(), "else".to_string()]),
+            denylist_remove: Some(vec!["ekez".to_string()]),
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone {
+                denylist: Some(vec!["someone".to_string(), "else".to_string()]),
+            },
+        }
+    );
+
+    // Remove from denylist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: Some(vec!["someone".to_string(), "else".to_string()]),
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+        }
+    );
+
+    // Error if try to change Specific fields when set to Anyone.
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: None,
+                denylist_remove: None,
+                set_dao_members: Some(true),
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::AnyoneInvalidUpdateFields {}
+        )
+    );
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: None,
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: Some(vec!["ekez".to_string()]),
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::AnyoneInvalidUpdateFields {}
+        )
+    );
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: None,
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: None,
+                allowlist_remove: Some(vec!["ekez".to_string()]),
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::AnyoneInvalidUpdateFields {}
+        )
+    );
+
+    // Change to Specific policy.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateConfig {
+            deposit_info: None,
+            submission_policy: Some(PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None,
+            }),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None,
+            },
+        }
+    );
+
+    // Append to denylist, with auto de-dupe.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: Some(vec!["ekez".to_string(), "ekez".to_string()]),
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: Some(vec!["ekez".to_string()]),
+            },
+        }
+    );
+
+    // Add and remove to/from denylist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: Some(vec!["someone".to_string(), "else".to_string()]),
+            denylist_remove: Some(vec!["ekez".to_string()]),
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: Some(vec!["someone".to_string(), "else".to_string()]),
+            },
+        }
+    );
+
+    // Remove from denylist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: Some(vec!["someone".to_string(), "else".to_string()]),
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None
+            },
+        }
+    );
+
+    // Append to allowlist, with auto de-dupe.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: Some(vec!["ekez".to_string(), "ekez".to_string()]),
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: Some(vec!["ekez".to_string()]),
+                denylist: None,
+            },
+        }
+    );
+
+    // Add and remove to/from allowlist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: Some(vec!["someone".to_string(), "else".to_string()]),
+            allowlist_remove: Some(vec!["ekez".to_string()]),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: Some(vec!["someone".to_string(), "else".to_string()]),
+                denylist: None,
+            },
+        }
+    );
+
+    // Remove from allowlist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: Some(vec!["someone".to_string(), "else".to_string()]),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None
+            },
+        }
+    );
+
+    // Setting dao_members to false fails if allowlist is empty.
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: None,
+                denylist_remove: None,
+                set_dao_members: Some(false),
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::NoOneAllowed {})
+    );
+
+    // Set dao_members to false and add allowlist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: None,
+            set_dao_members: Some(false),
+            allowlist_add: Some(vec!["ekez".to_string()]),
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: false,
+                allowlist: Some(vec!["ekez".to_string()]),
+                denylist: None
+            },
+        }
+    );
+
+    // Errors when allowlist and denylist overlap.
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: Some(vec!["ekez".to_string()]),
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::DenylistAllowlistOverlap {}
+        )
+    );
 }
 
 #[test]

--- a/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
@@ -1016,6 +1016,251 @@ fn test_no_deposit_required_members_submission() {
 }
 
 #[test]
+fn test_anyone_denylist() {
+    let mut app = App::default();
+    let DefaultTestSetup {
+        core_addr,
+        proposal_single,
+        pre_propose,
+    } = setup_default_test(&mut app, None, false);
+
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Anyone { denylist: None },
+    );
+
+    let rando = "rando";
+
+    // Proposal succeeds when anyone can propose.
+    make_proposal(
+        &mut app,
+        pre_propose.clone(),
+        proposal_single.clone(),
+        rando,
+        &[],
+    );
+
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Anyone {
+            denylist: Some(vec![rando.to_string()]),
+        },
+    );
+
+    // Proposing fails if on denylist.
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked(rando),
+            pre_propose.clone(),
+            &ExecuteMsg::Propose {
+                msg: ProposeMessage::Propose {
+                    title: "I would like to join the DAO".to_string(),
+                    description: "though, I am currently not a member.".to_string(),
+                    choices: MultipleChoiceOptions {
+                        options: vec![MultipleChoiceOption {
+                            description: "multiple choice option 1".to_string(),
+                            msgs: vec![],
+                            title: "title".to_string(),
+                        }],
+                    },
+                    vote: None,
+                },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
+    );
+
+    // Proposing succeeds if not on denylist.
+    make_proposal(&mut app, pre_propose, proposal_single.clone(), "ekez", &[]);
+}
+
+#[test]
+fn test_specific_allowlist_denylist() {
+    let mut app = App::default();
+    let DefaultTestSetup {
+        core_addr,
+        proposal_single,
+        pre_propose,
+    } = setup_default_test(&mut app, None, false);
+
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        },
+    );
+
+    // Proposal succeeds for member.
+    make_proposal(
+        &mut app,
+        pre_propose.clone(),
+        proposal_single.clone(),
+        "ekez",
+        &[],
+    );
+
+    let rando = "rando";
+
+    // Proposing fails for non-member.
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked(rando),
+            pre_propose.clone(),
+            &ExecuteMsg::Propose {
+                msg: ProposeMessage::Propose {
+                    title: "I would like to join the DAO".to_string(),
+                    description: "though, I am currently not a member.".to_string(),
+                    choices: MultipleChoiceOptions {
+                        options: vec![MultipleChoiceOption {
+                            description: "multiple choice option 1".to_string(),
+                            msgs: vec![],
+                            title: "title".to_string(),
+                        }],
+                    },
+                    vote: None,
+                },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
+    );
+
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: Some(vec![rando.to_string()]),
+            denylist: None,
+        },
+    );
+
+    // Proposal succeeds if on allowlist.
+    make_proposal(
+        &mut app,
+        pre_propose.clone(),
+        proposal_single.clone(),
+        rando,
+        &[],
+    );
+
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: Some(vec![rando.to_string()]),
+            denylist: Some(vec!["ekez".to_string()]),
+        },
+    );
+
+    // Proposing fails if on denylist.
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("ekez"),
+            pre_propose.clone(),
+            &ExecuteMsg::Propose {
+                msg: ProposeMessage::Propose {
+                    title: "Let me propose!".to_string(),
+                    description: "I am a member!!!".to_string(),
+                    choices: MultipleChoiceOptions {
+                        options: vec![MultipleChoiceOption {
+                            description: "multiple choice option 1".to_string(),
+                            msgs: vec![],
+                            title: "title".to_string(),
+                        }],
+                    },
+                    vote: None,
+                },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
+    );
+
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: false,
+            allowlist: Some(vec![rando.to_string()]),
+            denylist: None,
+        },
+    );
+
+    // Proposing fails if members not allowed.
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("ekez"),
+            pre_propose.clone(),
+            &ExecuteMsg::Propose {
+                msg: ProposeMessage::Propose {
+                    title: "Let me propose!".to_string(),
+                    description: "I am a member!!!".to_string(),
+                    choices: MultipleChoiceOptions {
+                        options: vec![MultipleChoiceOption {
+                            description: "multiple choice option 1".to_string(),
+                            msgs: vec![],
+                            title: "title".to_string(),
+                        }],
+                    },
+                    vote: None,
+                },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
+    );
+
+    // Proposal succeeds if on allowlist.
+    make_proposal(
+        &mut app,
+        pre_propose.clone(),
+        proposal_single.clone(),
+        rando,
+        &[],
+    );
+}
+
+#[test]
 fn test_execute_extension_does_nothing() {
     let mut app = App::default();
     let DefaultTestSetup {

--- a/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
@@ -374,7 +374,7 @@ fn update_config(
         module.clone(),
         &ExecuteMsg::UpdateConfig {
             deposit_info,
-            submission_policy,
+            submission_policy: Some(submission_policy),
         },
         &[],
     )
@@ -395,7 +395,7 @@ fn update_config_should_fail(
         module,
         &ExecuteMsg::UpdateConfig {
             deposit_info,
-            submission_policy,
+            submission_policy: Some(submission_policy),
         },
         &[],
     )

--- a/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
@@ -56,9 +56,13 @@ fn get_default_proposal_module_instantiate(
     let pre_propose_id = app.store_code(cw_pre_propose_base_proposal_single());
 
     let submission_policy = if open_proposal_submission {
-        PreProposeSubmissionPolicy::Anyone {}
+        PreProposeSubmissionPolicy::Anyone { denylist: None }
     } else {
-        PreProposeSubmissionPolicy::DaoMembers {}
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        }
     };
 
     cpm::msg::InstantiateMsg {
@@ -887,9 +891,7 @@ fn test_permissions() {
         .unwrap();
     assert_eq!(
         err,
-        PreProposeError::SubmissionPolicy(
-            PreProposeSubmissionPolicyError::UnauthorizedDaoMembers {}
-        )
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
     )
 }
 
@@ -999,9 +1001,7 @@ fn test_no_deposit_required_members_submission() {
         .unwrap();
     assert_eq!(
         err,
-        PreProposeError::SubmissionPolicy(
-            PreProposeSubmissionPolicyError::UnauthorizedDaoMembers {}
-        )
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
     );
 
     let id = make_proposal(&mut app, pre_propose, proposal_single.clone(), "ekez", &[]);
@@ -1076,7 +1076,11 @@ fn test_instantiate_with_zero_native_deposit() {
                             amount: Uint128::zero(),
                             refund_policy: DepositRefundPolicy::OnlyPassed,
                         }),
-                        submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
+                        submission_policy: PreProposeSubmissionPolicy::Specific {
+                            dao_members: true,
+                            allowlist: None,
+                            denylist: None,
+                        },
                         extension: Empty::default(),
                     })
                     .unwrap(),
@@ -1139,7 +1143,11 @@ fn test_instantiate_with_zero_cw20_deposit() {
                             amount: Uint128::zero(),
                             refund_policy: DepositRefundPolicy::OnlyPassed,
                         }),
-                        submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
+                        submission_policy: PreProposeSubmissionPolicy::Specific {
+                            dao_members: true,
+                            allowlist: None,
+                            denylist: None,
+                        },
                         extension: Empty::default(),
                     })
                     .unwrap(),
@@ -1185,7 +1193,11 @@ fn test_update_config() {
         config,
         Config {
             deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::DaoMembers {}
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None
+            }
         }
     );
 
@@ -1208,7 +1220,7 @@ fn test_update_config() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Never,
         }),
-        PreProposeSubmissionPolicy::Anyone {},
+        PreProposeSubmissionPolicy::Anyone { denylist: None },
     );
 
     let config = get_config(&app, pre_propose.clone());
@@ -1220,7 +1232,7 @@ fn test_update_config() {
                 amount: Uint128::new(10),
                 refund_policy: DepositRefundPolicy::Never
             }),
-            submission_policy: PreProposeSubmissionPolicy::Anyone {},
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
         }
     );
 
@@ -1283,7 +1295,7 @@ fn test_update_config() {
         pre_propose,
         proposal_single.as_str(),
         None,
-        PreProposeSubmissionPolicy::Anyone {},
+        PreProposeSubmissionPolicy::Anyone { denylist: None },
     );
     assert_eq!(err, PreProposeError::NotDao {});
 }
@@ -1329,7 +1341,11 @@ fn test_withdraw() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Always,
         }),
-        PreProposeSubmissionPolicy::DaoMembers {},
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        },
     );
 
     // Withdraw with no specified denom - should fall back to the one
@@ -1373,7 +1389,11 @@ fn test_withdraw() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Always,
         }),
-        PreProposeSubmissionPolicy::DaoMembers {},
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        },
     );
 
     increase_allowance(

--- a/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
+++ b/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
@@ -127,7 +127,7 @@
         "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
         "oneOf": [
           {
-            "description": "Anyone may create a proposal.",
+            "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
             "required": [
               "anyone"
@@ -135,40 +135,56 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "properties": {
+                  "denylist": {
+                    "description": "Addresses that may not create proposals.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  }
+                },
                 "additionalProperties": false
               }
             },
             "additionalProperties": false
           },
           {
-            "description": "Only members of the DAO may create a proposal.",
+            "description": "Specific people may create proposals.",
             "type": "object",
             "required": [
-              "dao_members"
+              "specific"
             ],
             "properties": {
-              "dao_members": {
-                "type": "object",
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Only the specified addresses may create a proposal.",
-            "type": "object",
-            "required": [
-              "allowlist"
-            ],
-            "properties": {
-              "allowlist": {
+              "specific": {
                 "type": "object",
                 "required": [
-                  "addresses"
+                  "dao_members"
                 ],
                 "properties": {
-                  "addresses": {
-                    "type": "array",
+                  "allowlist": {
+                    "description": "Addresses that may create proposals.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  },
+                  "dao_members": {
+                    "description": "Whether or not DAO members may create proposals.",
+                    "type": "boolean"
+                  },
+                  "denylist": {
+                    "description": "Addresses that may not create proposals, overriding other settings.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "$ref": "#/definitions/Addr"
                     }
@@ -1003,7 +1019,7 @@
         "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
         "oneOf": [
           {
-            "description": "Anyone may create a proposal.",
+            "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
             "required": [
               "anyone"
@@ -1011,40 +1027,56 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "properties": {
+                  "denylist": {
+                    "description": "Addresses that may not create proposals.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  }
+                },
                 "additionalProperties": false
               }
             },
             "additionalProperties": false
           },
           {
-            "description": "Only members of the DAO may create a proposal.",
+            "description": "Specific people may create proposals.",
             "type": "object",
             "required": [
-              "dao_members"
+              "specific"
             ],
             "properties": {
-              "dao_members": {
-                "type": "object",
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "description": "Only the specified addresses may create a proposal.",
-            "type": "object",
-            "required": [
-              "allowlist"
-            ],
-            "properties": {
-              "allowlist": {
+              "specific": {
                 "type": "object",
                 "required": [
-                  "addresses"
+                  "dao_members"
                 ],
                 "properties": {
-                  "addresses": {
-                    "type": "array",
+                  "allowlist": {
+                    "description": "Addresses that may create proposals.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  },
+                  "dao_members": {
+                    "description": "Whether or not DAO members may create proposals.",
+                    "type": "boolean"
+                  },
+                  "denylist": {
+                    "description": "Addresses that may not create proposals, overriding other settings.",
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "$ref": "#/definitions/Addr"
                     }
@@ -1835,7 +1867,7 @@
           "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
           "oneOf": [
             {
-              "description": "Anyone may create a proposal.",
+              "description": "Anyone may create proposals, except for those in the denylist.",
               "type": "object",
               "required": [
                 "anyone"
@@ -1843,40 +1875,56 @@
               "properties": {
                 "anyone": {
                   "type": "object",
+                  "properties": {
+                    "denylist": {
+                      "description": "Addresses that may not create proposals.",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "$ref": "#/definitions/Addr"
+                      }
+                    }
+                  },
                   "additionalProperties": false
                 }
               },
               "additionalProperties": false
             },
             {
-              "description": "Only members of the DAO may create a proposal.",
+              "description": "Specific people may create proposals.",
               "type": "object",
               "required": [
-                "dao_members"
+                "specific"
               ],
               "properties": {
-                "dao_members": {
-                  "type": "object",
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
-            },
-            {
-              "description": "Only the specified addresses may create a proposal.",
-              "type": "object",
-              "required": [
-                "allowlist"
-              ],
-              "properties": {
-                "allowlist": {
+                "specific": {
                   "type": "object",
                   "required": [
-                    "addresses"
+                    "dao_members"
                   ],
                   "properties": {
-                    "addresses": {
-                      "type": "array",
+                    "allowlist": {
+                      "description": "Addresses that may create proposals.",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
+                      "items": {
+                        "$ref": "#/definitions/Addr"
+                      }
+                    },
+                    "dao_members": {
+                      "description": "Whether or not DAO members may create proposals.",
+                      "type": "boolean"
+                    },
+                    "denylist": {
+                      "description": "Addresses that may not create proposals, overriding other settings.",
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "items": {
                         "$ref": "#/definitions/Addr"
                       }

--- a/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
+++ b/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
@@ -8,7 +8,7 @@
     "type": "object",
     "required": [
       "extension",
-      "open_proposal_submission"
+      "submission_policy"
     ],
     "properties": {
       "deposit_info": {
@@ -30,13 +30,21 @@
           }
         ]
       },
-      "open_proposal_submission": {
-        "description": "If false, only members (addresses with voting power) may create proposals in the DAO. Otherwise, any address may create a proposal so long as they pay the deposit.",
-        "type": "boolean"
+      "submission_policy": {
+        "description": "The policy dictating who is allowed to submit proposals.",
+        "allOf": [
+          {
+            "$ref": "#/definitions/PreProposeSubmissionPolicy"
+          }
+        ]
       }
     },
     "additionalProperties": false,
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "DepositRefundPolicy": {
         "oneOf": [
           {
@@ -114,6 +122,64 @@
       "Empty": {
         "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "object"
+      },
+      "PreProposeSubmissionPolicy": {
+        "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
+        "oneOf": [
+          {
+            "description": "Anyone may create a proposal.",
+            "type": "object",
+            "required": [
+              "anyone"
+            ],
+            "properties": {
+              "anyone": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Only members of the DAO may create a proposal.",
+            "type": "object",
+            "required": [
+              "dao_members"
+            ],
+            "properties": {
+              "dao_members": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Only the specified addresses may create a proposal.",
+            "type": "object",
+            "required": [
+              "allowlist"
+            ],
+            "properties": {
+              "allowlist": {
+                "type": "object",
+                "required": [
+                  "addresses"
+                ],
+                "properties": {
+                  "addresses": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "Uint128": {
         "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
@@ -231,7 +297,7 @@
           "update_config": {
             "type": "object",
             "required": [
-              "open_proposal_submission"
+              "submission_policy"
             ],
             "properties": {
               "deposit_info": {
@@ -244,8 +310,8 @@
                   }
                 ]
               },
-              "open_proposal_submission": {
-                "type": "boolean"
+              "submission_policy": {
+                "$ref": "#/definitions/PreProposeSubmissionPolicy"
               }
             },
             "additionalProperties": false
@@ -376,6 +442,10 @@
       }
     ],
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "BankMsg": {
         "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
         "oneOf": [
@@ -928,6 +998,64 @@
             "minimum": 0.0
           }
         }
+      },
+      "PreProposeSubmissionPolicy": {
+        "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
+        "oneOf": [
+          {
+            "description": "Anyone may create a proposal.",
+            "type": "object",
+            "required": [
+              "anyone"
+            ],
+            "properties": {
+              "anyone": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Only members of the DAO may create a proposal.",
+            "type": "object",
+            "required": [
+              "dao_members"
+            ],
+            "properties": {
+              "dao_members": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "Only the specified addresses may create a proposal.",
+            "type": "object",
+            "required": [
+              "allowlist"
+            ],
+            "properties": {
+              "allowlist": {
+                "type": "object",
+                "required": [
+                  "addresses"
+                ],
+                "properties": {
+                  "addresses": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Addr"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
       },
       "ProposeMessage": {
         "oneOf": [
@@ -1582,7 +1710,7 @@
       "title": "Config",
       "type": "object",
       "required": [
-        "open_proposal_submission"
+        "submission_policy"
       ],
       "properties": {
         "deposit_info": {
@@ -1596,9 +1724,13 @@
             }
           ]
         },
-        "open_proposal_submission": {
-          "description": "If false, only members (addresses with voting power) may create proposals in the DAO. Otherwise, any address may create a proposal so long as they pay the deposit.",
-          "type": "boolean"
+        "submission_policy": {
+          "description": "The policy dictating who is allowed to submit proposals.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PreProposeSubmissionPolicy"
+            }
+          ]
         }
       },
       "additionalProperties": false,
@@ -1696,6 +1828,64 @@
               "enum": [
                 "never"
               ]
+            }
+          ]
+        },
+        "PreProposeSubmissionPolicy": {
+          "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
+          "oneOf": [
+            {
+              "description": "Anyone may create a proposal.",
+              "type": "object",
+              "required": [
+                "anyone"
+              ],
+              "properties": {
+                "anyone": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Only members of the DAO may create a proposal.",
+              "type": "object",
+              "required": [
+                "dao_members"
+              ],
+              "properties": {
+                "dao_members": {
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Only the specified addresses may create a proposal.",
+              "type": "object",
+              "required": [
+                "allowlist"
+              ],
+              "properties": {
+                "allowlist": {
+                  "type": "object",
+                  "required": [
+                    "addresses"
+                  ],
+                  "properties": {
+                    "addresses": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Addr"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
             }
           ]
         },

--- a/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
+++ b/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
@@ -1,15 +1,12 @@
 {
   "contract_name": "dao-pre-propose-single",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "extension",
-      "submission_policy"
-    ],
+    "required": ["extension", "submission_policy"],
     "properties": {
       "deposit_info": {
         "description": "Information about the deposit requirements for this module. None if no deposit.",
@@ -46,23 +43,17 @@
           {
             "description": "Deposits should always be refunded.",
             "type": "string",
-            "enum": [
-              "always"
-            ]
+            "enum": ["always"]
           },
           {
             "description": "Deposits should only be refunded for passed proposals.",
             "type": "string",
-            "enum": [
-              "only_passed"
-            ]
+            "enum": ["only_passed"]
           },
           {
             "description": "Deposits should never be refunded.",
             "type": "string",
-            "enum": [
-              "never"
-            ]
+            "enum": ["never"]
           }
         ]
       },
@@ -72,15 +63,11 @@
           {
             "description": "Use a specific token address as the deposit token.",
             "type": "object",
-            "required": [
-              "token"
-            ],
+            "required": ["token"],
             "properties": {
               "token": {
                 "type": "object",
-                "required": [
-                  "denom"
-                ],
+                "required": ["denom"],
                 "properties": {
                   "denom": {
                     "$ref": "#/definitions/UncheckedDenom"
@@ -94,15 +81,11 @@
           {
             "description": "Use the token native denom or cw20 contract address of the associated DAO's voting module. NOTE: in order to retrieve the token automatically via this variant, the voting module must either (1) use a native token and implement the `Denom {}` query type defined by `dao_dao_macros::native_token_query` OR (2) use a cw20 token and implement the `TokenContract {}` query type defined by `dao_dao_macros::cw20_token_query`. Failing to implement correctly will cause this option to fail to instantiate.",
             "type": "object",
-            "required": [
-              "voting_module_token"
-            ],
+            "required": ["voting_module_token"],
             "properties": {
               "voting_module_token": {
                 "type": "object",
-                "required": [
-                  "token_type"
-                ],
+                "required": ["token_type"],
                 "properties": {
                   "token_type": {
                     "$ref": "#/definitions/VotingModuleTokenType"
@@ -125,19 +108,14 @@
           {
             "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
-            "required": [
-              "anyone"
-            ],
+            "required": ["anyone"],
             "properties": {
               "anyone": {
                 "type": "object",
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -151,22 +129,15 @@
           {
             "description": "Specific people may create proposals.",
             "type": "object",
-            "required": [
-              "specific"
-            ],
+            "required": ["specific"],
             "properties": {
               "specific": {
                 "type": "object",
-                "required": [
-                  "dao_members"
-                ],
+                "required": ["dao_members"],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -177,10 +148,7 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -203,9 +171,7 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": [
-              "native"
-            ],
+            "required": ["native"],
             "properties": {
               "native": {
                 "type": "string"
@@ -216,9 +182,7 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": [
-              "cw20"
-            ],
+            "required": ["cw20"],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -231,11 +195,7 @@
       "UncheckedDepositInfo": {
         "description": "Information about the deposit required to create a proposal.",
         "type": "object",
-        "required": [
-          "amount",
-          "denom",
-          "refund_policy"
-        ],
+        "required": ["amount", "denom", "refund_policy"],
         "properties": {
           "amount": {
             "description": "The number of tokens that must be deposited to create a proposal. Must be a positive, non-zero number.",
@@ -266,10 +226,7 @@
       },
       "VotingModuleTokenType": {
         "type": "string",
-        "enum": [
-          "native",
-          "cw20"
-        ]
+        "enum": ["native", "cw20"]
       }
     }
   },
@@ -280,15 +237,11 @@
       {
         "description": "Creates a new proposal in the pre-propose module. MSG will be serialized and used as the proposal creation message.",
         "type": "object",
-        "required": [
-          "propose"
-        ],
+        "required": ["propose"],
         "properties": {
           "propose": {
             "type": "object",
-            "required": [
-              "msg"
-            ],
+            "required": ["msg"],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/ProposeMessage"
@@ -302,9 +255,7 @@
       {
         "description": "Updates the configuration of this module. This will completely override the existing configuration. This new configuration will only apply to proposals created after the config is updated. Only the DAO may execute this message.",
         "type": "object",
-        "required": [
-          "update_config"
-        ],
+        "required": ["update_config"],
         "properties": {
           "update_config": {
             "type": "object",
@@ -340,59 +291,42 @@
       {
         "description": "Perform more granular submission policy updates to allow for atomic operations that don't override others.",
         "type": "object",
-        "required": [
-          "update_submission_policy"
-        ],
+        "required": ["update_submission_policy"],
         "properties": {
           "update_submission_policy": {
             "type": "object",
             "properties": {
               "allowlist_add": {
                 "description": "If using specific policy, optionally add to the allowlist.",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "allowlist_remove": {
                 "description": "If using specific policy, optionally remove from the allowlist.",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "denylist_add": {
                 "description": "Optionally add to the denylist. Works for any submission policy.",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "denylist_remove": {
                 "description": "Optionally remove from denylist. Works for any submission policy.",
-                "type": [
-                  "array",
-                  "null"
-                ],
+                "type": ["array", "null"],
                 "items": {
                   "type": "string"
                 }
               },
               "set_dao_members": {
                 "description": "If using specific policy, optionally update the `dao_members` flag.",
-                "type": [
-                  "boolean",
-                  "null"
-                ]
+                "type": ["boolean", "null"]
               }
             },
             "additionalProperties": false
@@ -403,9 +337,7 @@
       {
         "description": "Withdraws funds inside of this contract to the message sender. The contracts entire balance for the specifed DENOM is withdrawn to the message sender. Only the DAO may call this method.\n\nThis is intended only as an escape hatch in the event of a critical bug in this contract or it's proposal module. Withdrawing funds will cause future attempts to return proposal deposits to fail their transactions as the contract will have insufficent balance to return them. In the case of `cw-proposal-single` this transaction failure will cause the module to remove the pre-propose module from its proposal hook receivers.\n\nMore likely than not, this should NEVER BE CALLED unless a bug in this contract or the proposal module it is associated with has caused it to stop receiving proposal hook messages, or if a critical security vulnerability has been found that allows an attacker to drain proposal deposits.",
         "type": "object",
-        "required": [
-          "withdraw"
-        ],
+        "required": ["withdraw"],
         "properties": {
           "withdraw": {
             "type": "object",
@@ -430,15 +362,11 @@
       {
         "description": "Extension message. Contracts that extend this one should put their custom execute logic here. The default implementation will do nothing if this variant is executed.",
         "type": "object",
-        "required": [
-          "extension"
-        ],
+        "required": ["extension"],
         "properties": {
           "extension": {
             "type": "object",
-            "required": [
-              "msg"
-            ],
+            "required": ["msg"],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/Empty"
@@ -452,15 +380,11 @@
       {
         "description": "Adds a proposal submitted hook. Fires when a new proposal is submitted to the pre-propose contract. Only the DAO may call this method.",
         "type": "object",
-        "required": [
-          "add_proposal_submitted_hook"
-        ],
+        "required": ["add_proposal_submitted_hook"],
         "properties": {
           "add_proposal_submitted_hook": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -474,15 +398,11 @@
       {
         "description": "Removes a proposal submitted hook. Only the DAO may call this method.",
         "type": "object",
-        "required": [
-          "remove_proposal_submitted_hook"
-        ],
+        "required": ["remove_proposal_submitted_hook"],
         "properties": {
           "remove_proposal_submitted_hook": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -496,16 +416,11 @@
       {
         "description": "Handles proposal hook fired by the associated proposal module when a proposal is completed (ie executed or rejected). By default, the base contract will return deposits proposals, when they are closed, when proposals are executed, or, if it is refunding failed.",
         "type": "object",
-        "required": [
-          "proposal_completed_hook"
-        ],
+        "required": ["proposal_completed_hook"],
         "properties": {
           "proposal_completed_hook": {
             "type": "object",
-            "required": [
-              "new_status",
-              "proposal_id"
-            ],
+            "required": ["new_status", "proposal_id"],
             "properties": {
               "new_status": {
                 "$ref": "#/definitions/Status"
@@ -529,16 +444,11 @@
           {
             "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "send"
-            ],
+            "required": ["send"],
             "properties": {
               "send": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "to_address"
-                ],
+                "required": ["amount", "to_address"],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -557,15 +467,11 @@
           {
             "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
             "type": "object",
-            "required": [
-              "burn"
-            ],
+            "required": ["burn"],
             "properties": {
               "burn": {
                 "type": "object",
-                "required": [
-                  "amount"
-                ],
+                "required": ["amount"],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -586,10 +492,7 @@
       },
       "Coin": {
         "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
+        "required": ["amount", "denom"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -603,9 +506,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "bank"
-            ],
+            "required": ["bank"],
             "properties": {
               "bank": {
                 "$ref": "#/definitions/BankMsg"
@@ -615,9 +516,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "custom"
-            ],
+            "required": ["custom"],
             "properties": {
               "custom": {
                 "$ref": "#/definitions/Empty"
@@ -627,9 +526,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "staking"
-            ],
+            "required": ["staking"],
             "properties": {
               "staking": {
                 "$ref": "#/definitions/StakingMsg"
@@ -639,9 +536,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "distribution"
-            ],
+            "required": ["distribution"],
             "properties": {
               "distribution": {
                 "$ref": "#/definitions/DistributionMsg"
@@ -652,16 +547,11 @@
           {
             "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
             "type": "object",
-            "required": [
-              "stargate"
-            ],
+            "required": ["stargate"],
             "properties": {
               "stargate": {
                 "type": "object",
-                "required": [
-                  "type_url",
-                  "value"
-                ],
+                "required": ["type_url", "value"],
                 "properties": {
                   "type_url": {
                     "type": "string"
@@ -676,9 +566,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "ibc"
-            ],
+            "required": ["ibc"],
             "properties": {
               "ibc": {
                 "$ref": "#/definitions/IbcMsg"
@@ -688,9 +576,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "wasm"
-            ],
+            "required": ["wasm"],
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmMsg"
@@ -700,9 +586,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "gov"
-            ],
+            "required": ["gov"],
             "properties": {
               "gov": {
                 "$ref": "#/definitions/GovMsg"
@@ -717,23 +601,17 @@
           {
             "description": "Deposits should always be refunded.",
             "type": "string",
-            "enum": [
-              "always"
-            ]
+            "enum": ["always"]
           },
           {
             "description": "Deposits should only be refunded for passed proposals.",
             "type": "string",
-            "enum": [
-              "only_passed"
-            ]
+            "enum": ["only_passed"]
           },
           {
             "description": "Deposits should never be refunded.",
             "type": "string",
-            "enum": [
-              "never"
-            ]
+            "enum": ["never"]
           }
         ]
       },
@@ -743,15 +621,11 @@
           {
             "description": "Use a specific token address as the deposit token.",
             "type": "object",
-            "required": [
-              "token"
-            ],
+            "required": ["token"],
             "properties": {
               "token": {
                 "type": "object",
-                "required": [
-                  "denom"
-                ],
+                "required": ["denom"],
                 "properties": {
                   "denom": {
                     "$ref": "#/definitions/UncheckedDenom"
@@ -765,15 +639,11 @@
           {
             "description": "Use the token native denom or cw20 contract address of the associated DAO's voting module. NOTE: in order to retrieve the token automatically via this variant, the voting module must either (1) use a native token and implement the `Denom {}` query type defined by `dao_dao_macros::native_token_query` OR (2) use a cw20 token and implement the `TokenContract {}` query type defined by `dao_dao_macros::cw20_token_query`. Failing to implement correctly will cause this option to fail to instantiate.",
             "type": "object",
-            "required": [
-              "voting_module_token"
-            ],
+            "required": ["voting_module_token"],
             "properties": {
               "voting_module_token": {
                 "type": "object",
-                "required": [
-                  "token_type"
-                ],
+                "required": ["token_type"],
                 "properties": {
                   "token_type": {
                     "$ref": "#/definitions/VotingModuleTokenType"
@@ -792,15 +662,11 @@
           {
             "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "set_withdraw_address"
-            ],
+            "required": ["set_withdraw_address"],
             "properties": {
               "set_withdraw_address": {
                 "type": "object",
-                "required": [
-                  "address"
-                ],
+                "required": ["address"],
                 "properties": {
                   "address": {
                     "description": "The `withdraw_address`",
@@ -814,15 +680,11 @@
           {
             "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "withdraw_delegator_reward"
-            ],
+            "required": ["withdraw_delegator_reward"],
             "properties": {
               "withdraw_delegator_reward": {
                 "type": "object",
-                "required": [
-                  "validator"
-                ],
+                "required": ["validator"],
                 "properties": {
                   "validator": {
                     "description": "The `validator_address`",
@@ -845,9 +707,7 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": [
-              "at_height"
-            ],
+            "required": ["at_height"],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -860,9 +720,7 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": [
-              "at_time"
-            ],
+            "required": ["at_time"],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -873,9 +731,7 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": [
-              "never"
-            ],
+            "required": ["never"],
             "properties": {
               "never": {
                 "type": "object",
@@ -892,16 +748,11 @@
           {
             "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
             "type": "object",
-            "required": [
-              "vote"
-            ],
+            "required": ["vote"],
             "properties": {
               "vote": {
                 "type": "object",
-                "required": [
-                  "proposal_id",
-                  "vote"
-                ],
+                "required": ["proposal_id", "vote"],
                 "properties": {
                   "proposal_id": {
                     "type": "integer",
@@ -929,18 +780,11 @@
           {
             "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
             "type": "object",
-            "required": [
-              "transfer"
-            ],
+            "required": ["transfer"],
             "properties": {
               "transfer": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "channel_id",
-                  "timeout",
-                  "to_address"
-                ],
+                "required": ["amount", "channel_id", "timeout", "to_address"],
                 "properties": {
                   "amount": {
                     "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -974,17 +818,11 @@
           {
             "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
             "type": "object",
-            "required": [
-              "send_packet"
-            ],
+            "required": ["send_packet"],
             "properties": {
               "send_packet": {
                 "type": "object",
-                "required": [
-                  "channel_id",
-                  "data",
-                  "timeout"
-                ],
+                "required": ["channel_id", "data", "timeout"],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -1008,15 +846,11 @@
           {
             "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
             "type": "object",
-            "required": [
-              "close_channel"
-            ],
+            "required": ["close_channel"],
             "properties": {
               "close_channel": {
                 "type": "object",
-                "required": [
-                  "channel_id"
-                ],
+                "required": ["channel_id"],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -1057,10 +891,7 @@
       "IbcTimeoutBlock": {
         "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
         "type": "object",
-        "required": [
-          "height",
-          "revision"
-        ],
+        "required": ["height", "revision"],
         "properties": {
           "height": {
             "description": "block height after which the packet times out. the height within the given revision",
@@ -1082,19 +913,14 @@
           {
             "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
-            "required": [
-              "anyone"
-            ],
+            "required": ["anyone"],
             "properties": {
               "anyone": {
                 "type": "object",
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -1108,22 +934,15 @@
           {
             "description": "Specific people may create proposals.",
             "type": "object",
-            "required": [
-              "specific"
-            ],
+            "required": ["specific"],
             "properties": {
               "specific": {
                 "type": "object",
-                "required": [
-                  "dao_members"
-                ],
+                "required": ["dao_members"],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -1134,10 +953,7 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": ["array", "null"],
                     "items": {
                       "type": "string"
                     }
@@ -1155,17 +971,11 @@
           {
             "description": "The propose message used to make a proposal to this module. Note that this is identical to the propose message used by dao-proposal-single, except that it omits the `proposer` field which it fills in for the sender.",
             "type": "object",
-            "required": [
-              "propose"
-            ],
+            "required": ["propose"],
             "properties": {
               "propose": {
                 "type": "object",
-                "required": [
-                  "description",
-                  "msgs",
-                  "title"
-                ],
+                "required": ["description", "msgs", "title"],
                 "properties": {
                   "description": {
                     "type": "string"
@@ -1199,16 +1009,11 @@
       },
       "SingleChoiceAutoVote": {
         "type": "object",
-        "required": [
-          "vote"
-        ],
+        "required": ["vote"],
         "properties": {
           "rationale": {
             "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "vote": {
             "description": "The proposer's position on the proposal.",
@@ -1227,16 +1032,11 @@
           {
             "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "delegate"
-            ],
+            "required": ["delegate"],
             "properties": {
               "delegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "validator"
-                ],
+                "required": ["amount", "validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1252,16 +1052,11 @@
           {
             "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "undelegate"
-            ],
+            "required": ["undelegate"],
             "properties": {
               "undelegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "validator"
-                ],
+                "required": ["amount", "validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1277,17 +1072,11 @@
           {
             "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "redelegate"
-            ],
+            "required": ["redelegate"],
             "properties": {
               "redelegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "dst_validator",
-                  "src_validator"
-                ],
+                "required": ["amount", "dst_validator", "src_validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1310,57 +1099,41 @@
           {
             "description": "The proposal is open for voting.",
             "type": "string",
-            "enum": [
-              "open"
-            ]
+            "enum": ["open"]
           },
           {
             "description": "The proposal has been rejected.",
             "type": "string",
-            "enum": [
-              "rejected"
-            ]
+            "enum": ["rejected"]
           },
           {
             "description": "The proposal has been passed but has not been executed.",
             "type": "string",
-            "enum": [
-              "passed"
-            ]
+            "enum": ["passed"]
           },
           {
             "description": "The proposal has been passed and executed.",
             "type": "string",
-            "enum": [
-              "executed"
-            ]
+            "enum": ["executed"]
           },
           {
             "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
             "type": "string",
-            "enum": [
-              "closed"
-            ]
+            "enum": ["closed"]
           },
           {
             "description": "The proposal's execution failed.",
             "type": "string",
-            "enum": [
-              "execution_failed"
-            ]
+            "enum": ["execution_failed"]
           },
           {
             "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
             "type": "object",
-            "required": [
-              "veto_timelock"
-            ],
+            "required": ["veto_timelock"],
             "properties": {
               "veto_timelock": {
                 "type": "object",
-                "required": [
-                  "expiration"
-                ],
+                "required": ["expiration"],
                 "properties": {
                   "expiration": {
                     "$ref": "#/definitions/Expiration"
@@ -1374,9 +1147,7 @@
           {
             "description": "The proposal has been vetoed.",
             "type": "string",
-            "enum": [
-              "vetoed"
-            ]
+            "enum": ["vetoed"]
           }
         ]
       },
@@ -1402,9 +1173,7 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": [
-              "native"
-            ],
+            "required": ["native"],
             "properties": {
               "native": {
                 "type": "string"
@@ -1415,9 +1184,7 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": [
-              "cw20"
-            ],
+            "required": ["cw20"],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -1430,11 +1197,7 @@
       "UncheckedDepositInfo": {
         "description": "Information about the deposit required to create a proposal.",
         "type": "object",
-        "required": [
-          "amount",
-          "denom",
-          "refund_policy"
-        ],
+        "required": ["amount", "denom", "refund_policy"],
         "properties": {
           "amount": {
             "description": "The number of tokens that must be deposited to create a proposal. Must be a positive, non-zero number.",
@@ -1468,41 +1231,27 @@
           {
             "description": "Marks support for the proposal.",
             "type": "string",
-            "enum": [
-              "yes"
-            ]
+            "enum": ["yes"]
           },
           {
             "description": "Marks opposition to the proposal.",
             "type": "string",
-            "enum": [
-              "no"
-            ]
+            "enum": ["no"]
           },
           {
             "description": "Marks participation but does not count towards the ratio of support / opposed.",
             "type": "string",
-            "enum": [
-              "abstain"
-            ]
+            "enum": ["abstain"]
           }
         ]
       },
       "VoteOption": {
         "type": "string",
-        "enum": [
-          "yes",
-          "no",
-          "abstain",
-          "no_with_veto"
-        ]
+        "enum": ["yes", "no", "abstain", "no_with_veto"]
       },
       "VotingModuleTokenType": {
         "type": "string",
-        "enum": [
-          "native",
-          "cw20"
-        ]
+        "enum": ["native", "cw20"]
       },
       "WasmMsg": {
         "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
@@ -1510,17 +1259,11 @@
           {
             "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "execute"
-            ],
+            "required": ["execute"],
             "properties": {
               "execute": {
                 "type": "object",
-                "required": [
-                  "contract_addr",
-                  "funds",
-                  "msg"
-                ],
+                "required": ["contract_addr", "funds", "msg"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1547,24 +1290,14 @@
           {
             "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "instantiate"
-            ],
+            "required": ["instantiate"],
             "properties": {
               "instantiate": {
                 "type": "object",
-                "required": [
-                  "code_id",
-                  "funds",
-                  "label",
-                  "msg"
-                ],
+                "required": ["code_id", "funds", "label", "msg"],
                 "properties": {
                   "admin": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": ["string", "null"]
                   },
                   "code_id": {
                     "type": "integer",
@@ -1597,17 +1330,11 @@
           {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "migrate"
-            ],
+            "required": ["migrate"],
             "properties": {
               "migrate": {
                 "type": "object",
-                "required": [
-                  "contract_addr",
-                  "msg",
-                  "new_code_id"
-                ],
+                "required": ["contract_addr", "msg", "new_code_id"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1634,16 +1361,11 @@
           {
             "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": [
-              "update_admin"
-            ],
+            "required": ["update_admin"],
             "properties": {
               "update_admin": {
                 "type": "object",
-                "required": [
-                  "admin",
-                  "contract_addr"
-                ],
+                "required": ["admin", "contract_addr"],
                 "properties": {
                   "admin": {
                     "type": "string"
@@ -1659,15 +1381,11 @@
           {
             "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": [
-              "clear_admin"
-            ],
+            "required": ["clear_admin"],
             "properties": {
               "clear_admin": {
                 "type": "object",
-                "required": [
-                  "contract_addr"
-                ],
+                "required": ["contract_addr"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1688,9 +1406,7 @@
       {
         "description": "Gets the proposal module that this pre propose module is associated with. Returns `Addr`.",
         "type": "object",
-        "required": [
-          "proposal_module"
-        ],
+        "required": ["proposal_module"],
         "properties": {
           "proposal_module": {
             "type": "object",
@@ -1702,9 +1418,7 @@
       {
         "description": "Gets the DAO (dao-dao-core) module this contract is associated with. Returns `Addr`.",
         "type": "object",
-        "required": [
-          "dao"
-        ],
+        "required": ["dao"],
         "properties": {
           "dao": {
             "type": "object",
@@ -1716,9 +1430,7 @@
       {
         "description": "Gets the module's configuration.",
         "type": "object",
-        "required": [
-          "config"
-        ],
+        "required": ["config"],
         "properties": {
           "config": {
             "type": "object",
@@ -1730,15 +1442,11 @@
       {
         "description": "Gets the deposit info for the proposal identified by PROPOSAL_ID.",
         "type": "object",
-        "required": [
-          "deposit_info"
-        ],
+        "required": ["deposit_info"],
         "properties": {
           "deposit_info": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -1754,9 +1462,7 @@
       {
         "description": "Returns list of proposal submitted hooks.",
         "type": "object",
-        "required": [
-          "proposal_submitted_hooks"
-        ],
+        "required": ["proposal_submitted_hooks"],
         "properties": {
           "proposal_submitted_hooks": {
             "type": "object",
@@ -1768,15 +1474,11 @@
       {
         "description": "Extension for queries. The default implementation will do nothing if queried for will return `Binary::default()`.",
         "type": "object",
-        "required": [
-          "query_extension"
-        ],
+        "required": ["query_extension"],
         "properties": {
           "query_extension": {
             "type": "object",
-            "required": [
-              "msg"
-            ],
+            "required": ["msg"],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/Empty"
@@ -1802,9 +1504,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Config",
       "type": "object",
-      "required": [
-        "submission_policy"
-      ],
+      "required": ["submission_policy"],
       "properties": {
         "deposit_info": {
           "description": "Information about the deposit required to create a proposal. If `None`, no deposit is required.",
@@ -1838,9 +1538,7 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": [
-                "native"
-              ],
+              "required": ["native"],
               "properties": {
                 "native": {
                   "type": "string"
@@ -1851,9 +1549,7 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": [
-                "cw20"
-              ],
+              "required": ["cw20"],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -1866,11 +1562,7 @@
         "CheckedDepositInfo": {
           "description": "Counterpart to the `DepositInfo` struct which has been processed. This type should never be constructed literally and should always by built by calling `into_checked` on a `DepositInfo` instance.",
           "type": "object",
-          "required": [
-            "amount",
-            "denom",
-            "refund_policy"
-          ],
+          "required": ["amount", "denom", "refund_policy"],
           "properties": {
             "amount": {
               "description": "The number of tokens that must be deposited to create a proposal. This is validated to be non-zero if this struct is constructed by converted via the `into_checked` method on `DepositInfo`.",
@@ -1904,23 +1596,17 @@
             {
               "description": "Deposits should always be refunded.",
               "type": "string",
-              "enum": [
-                "always"
-              ]
+              "enum": ["always"]
             },
             {
               "description": "Deposits should only be refunded for passed proposals.",
               "type": "string",
-              "enum": [
-                "only_passed"
-              ]
+              "enum": ["only_passed"]
             },
             {
               "description": "Deposits should never be refunded.",
               "type": "string",
-              "enum": [
-                "never"
-              ]
+              "enum": ["never"]
             }
           ]
         },
@@ -1930,19 +1616,14 @@
             {
               "description": "Anyone may create proposals, except for those in the denylist.",
               "type": "object",
-              "required": [
-                "anyone"
-              ],
+              "required": ["anyone"],
               "properties": {
                 "anyone": {
                   "type": "object",
                   "properties": {
                     "denylist": {
                       "description": "Addresses that may not create proposals.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": ["array", "null"],
                       "items": {
                         "type": "string"
                       }
@@ -1956,22 +1637,15 @@
             {
               "description": "Specific people may create proposals.",
               "type": "object",
-              "required": [
-                "specific"
-              ],
+              "required": ["specific"],
               "properties": {
                 "specific": {
                   "type": "object",
-                  "required": [
-                    "dao_members"
-                  ],
+                  "required": ["dao_members"],
                   "properties": {
                     "allowlist": {
                       "description": "Addresses that may create proposals.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": ["array", "null"],
                       "items": {
                         "type": "string"
                       }
@@ -1982,10 +1656,7 @@
                     },
                     "denylist": {
                       "description": "Addresses that may not create proposals, overriding other settings.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": ["array", "null"],
                       "items": {
                         "type": "string"
                       }
@@ -2014,9 +1685,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "DepositInfoResponse",
       "type": "object",
-      "required": [
-        "proposer"
-      ],
+      "required": ["proposer"],
       "properties": {
         "deposit_info": {
           "description": "The deposit that has been paid for the specified proposal.",
@@ -2050,9 +1719,7 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": [
-                "native"
-              ],
+              "required": ["native"],
               "properties": {
                 "native": {
                   "type": "string"
@@ -2063,9 +1730,7 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": [
-                "cw20"
-              ],
+              "required": ["cw20"],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -2078,11 +1743,7 @@
         "CheckedDepositInfo": {
           "description": "Counterpart to the `DepositInfo` struct which has been processed. This type should never be constructed literally and should always by built by calling `into_checked` on a `DepositInfo` instance.",
           "type": "object",
-          "required": [
-            "amount",
-            "denom",
-            "refund_policy"
-          ],
+          "required": ["amount", "denom", "refund_policy"],
           "properties": {
             "amount": {
               "description": "The number of tokens that must be deposited to create a proposal. This is validated to be non-zero if this struct is constructed by converted via the `into_checked` method on `DepositInfo`.",
@@ -2116,23 +1777,17 @@
             {
               "description": "Deposits should always be refunded.",
               "type": "string",
-              "enum": [
-                "always"
-              ]
+              "enum": ["always"]
             },
             {
               "description": "Deposits should only be refunded for passed proposals.",
               "type": "string",
-              "enum": [
-                "only_passed"
-              ]
+              "enum": ["only_passed"]
             },
             {
               "description": "Deposits should never be refunded.",
               "type": "string",
-              "enum": [
-                "never"
-              ]
+              "enum": ["never"]
             }
           ]
         },
@@ -2152,9 +1807,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": [
-        "hooks"
-      ],
+      "required": ["hooks"],
       "properties": {
         "hooks": {
           "type": "array",

--- a/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
+++ b/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
@@ -41,10 +41,6 @@
     },
     "additionalProperties": false,
     "definitions": {
-      "Addr": {
-        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-        "type": "string"
-      },
       "DepositRefundPolicy": {
         "oneOf": [
           {
@@ -143,7 +139,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   }
                 },
@@ -172,7 +168,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   },
                   "dao_members": {
@@ -186,7 +182,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   }
                 },
@@ -312,11 +308,9 @@
         "properties": {
           "update_config": {
             "type": "object",
-            "required": [
-              "submission_policy"
-            ],
             "properties": {
               "deposit_info": {
+                "description": "If None, will remove the deposit. Backwards compatible.",
                 "anyOf": [
                   {
                     "$ref": "#/definitions/UncheckedDepositInfo"
@@ -327,7 +321,78 @@
                 ]
               },
               "submission_policy": {
-                "$ref": "#/definitions/PreProposeSubmissionPolicy"
+                "description": "If None, will leave the submission policy in the config as-is.",
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/PreProposeSubmissionPolicy"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Perform more granular submission policy updates to allow for atomic operations that don't override others.",
+        "type": "object",
+        "required": [
+          "update_submission_policy"
+        ],
+        "properties": {
+          "update_submission_policy": {
+            "type": "object",
+            "properties": {
+              "allowlist_add": {
+                "description": "If using specific policy, optionally add to the allowlist.",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "allowlist_remove": {
+                "description": "If using specific policy, optionally remove from the allowlist.",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "denylist_add": {
+                "description": "Optionally add to the denylist. Works for any submission policy.",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "denylist_remove": {
+                "description": "Optionally remove from denylist. Works for any submission policy.",
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "set_dao_members": {
+                "description": "If using specific policy, optionally update the `dao_members` flag.",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -458,10 +523,6 @@
       }
     ],
     "definitions": {
-      "Addr": {
-        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
-        "type": "string"
-      },
       "BankMsg": {
         "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
         "oneOf": [
@@ -1035,7 +1096,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   }
                 },
@@ -1064,7 +1125,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   },
                   "dao_members": {
@@ -1078,7 +1139,7 @@
                       "null"
                     ],
                     "items": {
-                      "$ref": "#/definitions/Addr"
+                      "type": "string"
                     }
                   }
                 },
@@ -1883,7 +1944,7 @@
                         "null"
                       ],
                       "items": {
-                        "$ref": "#/definitions/Addr"
+                        "type": "string"
                       }
                     }
                   },
@@ -1912,7 +1973,7 @@
                         "null"
                       ],
                       "items": {
-                        "$ref": "#/definitions/Addr"
+                        "type": "string"
                       }
                     },
                     "dao_members": {
@@ -1926,7 +1987,7 @@
                         "null"
                       ],
                       "items": {
-                        "$ref": "#/definitions/Addr"
+                        "type": "string"
                       }
                     }
                   },

--- a/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
+++ b/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
@@ -6,7 +6,10 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["extension", "submission_policy"],
+    "required": [
+      "extension",
+      "submission_policy"
+    ],
     "properties": {
       "deposit_info": {
         "description": "Information about the deposit requirements for this module. None if no deposit.",
@@ -43,17 +46,23 @@
           {
             "description": "Deposits should always be refunded.",
             "type": "string",
-            "enum": ["always"]
+            "enum": [
+              "always"
+            ]
           },
           {
             "description": "Deposits should only be refunded for passed proposals.",
             "type": "string",
-            "enum": ["only_passed"]
+            "enum": [
+              "only_passed"
+            ]
           },
           {
             "description": "Deposits should never be refunded.",
             "type": "string",
-            "enum": ["never"]
+            "enum": [
+              "never"
+            ]
           }
         ]
       },
@@ -63,11 +72,15 @@
           {
             "description": "Use a specific token address as the deposit token.",
             "type": "object",
-            "required": ["token"],
+            "required": [
+              "token"
+            ],
             "properties": {
               "token": {
                 "type": "object",
-                "required": ["denom"],
+                "required": [
+                  "denom"
+                ],
                 "properties": {
                   "denom": {
                     "$ref": "#/definitions/UncheckedDenom"
@@ -81,11 +94,15 @@
           {
             "description": "Use the token native denom or cw20 contract address of the associated DAO's voting module. NOTE: in order to retrieve the token automatically via this variant, the voting module must either (1) use a native token and implement the `Denom {}` query type defined by `dao_dao_macros::native_token_query` OR (2) use a cw20 token and implement the `TokenContract {}` query type defined by `dao_dao_macros::cw20_token_query`. Failing to implement correctly will cause this option to fail to instantiate.",
             "type": "object",
-            "required": ["voting_module_token"],
+            "required": [
+              "voting_module_token"
+            ],
             "properties": {
               "voting_module_token": {
                 "type": "object",
-                "required": ["token_type"],
+                "required": [
+                  "token_type"
+                ],
                 "properties": {
                   "token_type": {
                     "$ref": "#/definitions/VotingModuleTokenType"
@@ -108,14 +125,19 @@
           {
             "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
-            "required": ["anyone"],
+            "required": [
+              "anyone"
+            ],
             "properties": {
               "anyone": {
                 "type": "object",
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -129,15 +151,22 @@
           {
             "description": "Specific people may create proposals.",
             "type": "object",
-            "required": ["specific"],
+            "required": [
+              "specific"
+            ],
             "properties": {
               "specific": {
                 "type": "object",
-                "required": ["dao_members"],
+                "required": [
+                  "dao_members"
+                ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -148,7 +177,10 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -171,7 +203,9 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": ["native"],
+            "required": [
+              "native"
+            ],
             "properties": {
               "native": {
                 "type": "string"
@@ -182,7 +216,9 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": ["cw20"],
+            "required": [
+              "cw20"
+            ],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -195,7 +231,11 @@
       "UncheckedDepositInfo": {
         "description": "Information about the deposit required to create a proposal.",
         "type": "object",
-        "required": ["amount", "denom", "refund_policy"],
+        "required": [
+          "amount",
+          "denom",
+          "refund_policy"
+        ],
         "properties": {
           "amount": {
             "description": "The number of tokens that must be deposited to create a proposal. Must be a positive, non-zero number.",
@@ -226,7 +266,10 @@
       },
       "VotingModuleTokenType": {
         "type": "string",
-        "enum": ["native", "cw20"]
+        "enum": [
+          "native",
+          "cw20"
+        ]
       }
     }
   },
@@ -237,11 +280,15 @@
       {
         "description": "Creates a new proposal in the pre-propose module. MSG will be serialized and used as the proposal creation message.",
         "type": "object",
-        "required": ["propose"],
+        "required": [
+          "propose"
+        ],
         "properties": {
           "propose": {
             "type": "object",
-            "required": ["msg"],
+            "required": [
+              "msg"
+            ],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/ProposeMessage"
@@ -255,7 +302,9 @@
       {
         "description": "Updates the configuration of this module. This will completely override the existing configuration. This new configuration will only apply to proposals created after the config is updated. Only the DAO may execute this message.",
         "type": "object",
-        "required": ["update_config"],
+        "required": [
+          "update_config"
+        ],
         "properties": {
           "update_config": {
             "type": "object",
@@ -291,42 +340,59 @@
       {
         "description": "Perform more granular submission policy updates to allow for atomic operations that don't override others.",
         "type": "object",
-        "required": ["update_submission_policy"],
+        "required": [
+          "update_submission_policy"
+        ],
         "properties": {
           "update_submission_policy": {
             "type": "object",
             "properties": {
               "allowlist_add": {
                 "description": "If using specific policy, optionally add to the allowlist.",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "string"
                 }
               },
               "allowlist_remove": {
                 "description": "If using specific policy, optionally remove from the allowlist.",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "string"
                 }
               },
               "denylist_add": {
                 "description": "Optionally add to the denylist. Works for any submission policy.",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "string"
                 }
               },
               "denylist_remove": {
                 "description": "Optionally remove from denylist. Works for any submission policy.",
-                "type": ["array", "null"],
+                "type": [
+                  "array",
+                  "null"
+                ],
                 "items": {
                   "type": "string"
                 }
               },
               "set_dao_members": {
                 "description": "If using specific policy, optionally update the `dao_members` flag.",
-                "type": ["boolean", "null"]
+                "type": [
+                  "boolean",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -337,7 +403,9 @@
       {
         "description": "Withdraws funds inside of this contract to the message sender. The contracts entire balance for the specifed DENOM is withdrawn to the message sender. Only the DAO may call this method.\n\nThis is intended only as an escape hatch in the event of a critical bug in this contract or it's proposal module. Withdrawing funds will cause future attempts to return proposal deposits to fail their transactions as the contract will have insufficent balance to return them. In the case of `cw-proposal-single` this transaction failure will cause the module to remove the pre-propose module from its proposal hook receivers.\n\nMore likely than not, this should NEVER BE CALLED unless a bug in this contract or the proposal module it is associated with has caused it to stop receiving proposal hook messages, or if a critical security vulnerability has been found that allows an attacker to drain proposal deposits.",
         "type": "object",
-        "required": ["withdraw"],
+        "required": [
+          "withdraw"
+        ],
         "properties": {
           "withdraw": {
             "type": "object",
@@ -362,11 +430,15 @@
       {
         "description": "Extension message. Contracts that extend this one should put their custom execute logic here. The default implementation will do nothing if this variant is executed.",
         "type": "object",
-        "required": ["extension"],
+        "required": [
+          "extension"
+        ],
         "properties": {
           "extension": {
             "type": "object",
-            "required": ["msg"],
+            "required": [
+              "msg"
+            ],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/Empty"
@@ -380,11 +452,15 @@
       {
         "description": "Adds a proposal submitted hook. Fires when a new proposal is submitted to the pre-propose contract. Only the DAO may call this method.",
         "type": "object",
-        "required": ["add_proposal_submitted_hook"],
+        "required": [
+          "add_proposal_submitted_hook"
+        ],
         "properties": {
           "add_proposal_submitted_hook": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -398,11 +474,15 @@
       {
         "description": "Removes a proposal submitted hook. Only the DAO may call this method.",
         "type": "object",
-        "required": ["remove_proposal_submitted_hook"],
+        "required": [
+          "remove_proposal_submitted_hook"
+        ],
         "properties": {
           "remove_proposal_submitted_hook": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -416,11 +496,16 @@
       {
         "description": "Handles proposal hook fired by the associated proposal module when a proposal is completed (ie executed or rejected). By default, the base contract will return deposits proposals, when they are closed, when proposals are executed, or, if it is refunding failed.",
         "type": "object",
-        "required": ["proposal_completed_hook"],
+        "required": [
+          "proposal_completed_hook"
+        ],
         "properties": {
           "proposal_completed_hook": {
             "type": "object",
-            "required": ["new_status", "proposal_id"],
+            "required": [
+              "new_status",
+              "proposal_id"
+            ],
             "properties": {
               "new_status": {
                 "$ref": "#/definitions/Status"
@@ -444,11 +529,16 @@
           {
             "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["send"],
+            "required": [
+              "send"
+            ],
             "properties": {
               "send": {
                 "type": "object",
-                "required": ["amount", "to_address"],
+                "required": [
+                  "amount",
+                  "to_address"
+                ],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -467,11 +557,15 @@
           {
             "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
             "type": "object",
-            "required": ["burn"],
+            "required": [
+              "burn"
+            ],
             "properties": {
               "burn": {
                 "type": "object",
-                "required": ["amount"],
+                "required": [
+                  "amount"
+                ],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -492,7 +586,10 @@
       },
       "Coin": {
         "type": "object",
-        "required": ["amount", "denom"],
+        "required": [
+          "amount",
+          "denom"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -506,7 +603,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["bank"],
+            "required": [
+              "bank"
+            ],
             "properties": {
               "bank": {
                 "$ref": "#/definitions/BankMsg"
@@ -516,7 +615,9 @@
           },
           {
             "type": "object",
-            "required": ["custom"],
+            "required": [
+              "custom"
+            ],
             "properties": {
               "custom": {
                 "$ref": "#/definitions/Empty"
@@ -526,7 +627,9 @@
           },
           {
             "type": "object",
-            "required": ["staking"],
+            "required": [
+              "staking"
+            ],
             "properties": {
               "staking": {
                 "$ref": "#/definitions/StakingMsg"
@@ -536,7 +639,9 @@
           },
           {
             "type": "object",
-            "required": ["distribution"],
+            "required": [
+              "distribution"
+            ],
             "properties": {
               "distribution": {
                 "$ref": "#/definitions/DistributionMsg"
@@ -547,11 +652,16 @@
           {
             "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
             "type": "object",
-            "required": ["stargate"],
+            "required": [
+              "stargate"
+            ],
             "properties": {
               "stargate": {
                 "type": "object",
-                "required": ["type_url", "value"],
+                "required": [
+                  "type_url",
+                  "value"
+                ],
                 "properties": {
                   "type_url": {
                     "type": "string"
@@ -566,7 +676,9 @@
           },
           {
             "type": "object",
-            "required": ["ibc"],
+            "required": [
+              "ibc"
+            ],
             "properties": {
               "ibc": {
                 "$ref": "#/definitions/IbcMsg"
@@ -576,7 +688,9 @@
           },
           {
             "type": "object",
-            "required": ["wasm"],
+            "required": [
+              "wasm"
+            ],
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmMsg"
@@ -586,7 +700,9 @@
           },
           {
             "type": "object",
-            "required": ["gov"],
+            "required": [
+              "gov"
+            ],
             "properties": {
               "gov": {
                 "$ref": "#/definitions/GovMsg"
@@ -601,17 +717,23 @@
           {
             "description": "Deposits should always be refunded.",
             "type": "string",
-            "enum": ["always"]
+            "enum": [
+              "always"
+            ]
           },
           {
             "description": "Deposits should only be refunded for passed proposals.",
             "type": "string",
-            "enum": ["only_passed"]
+            "enum": [
+              "only_passed"
+            ]
           },
           {
             "description": "Deposits should never be refunded.",
             "type": "string",
-            "enum": ["never"]
+            "enum": [
+              "never"
+            ]
           }
         ]
       },
@@ -621,11 +743,15 @@
           {
             "description": "Use a specific token address as the deposit token.",
             "type": "object",
-            "required": ["token"],
+            "required": [
+              "token"
+            ],
             "properties": {
               "token": {
                 "type": "object",
-                "required": ["denom"],
+                "required": [
+                  "denom"
+                ],
                 "properties": {
                   "denom": {
                     "$ref": "#/definitions/UncheckedDenom"
@@ -639,11 +765,15 @@
           {
             "description": "Use the token native denom or cw20 contract address of the associated DAO's voting module. NOTE: in order to retrieve the token automatically via this variant, the voting module must either (1) use a native token and implement the `Denom {}` query type defined by `dao_dao_macros::native_token_query` OR (2) use a cw20 token and implement the `TokenContract {}` query type defined by `dao_dao_macros::cw20_token_query`. Failing to implement correctly will cause this option to fail to instantiate.",
             "type": "object",
-            "required": ["voting_module_token"],
+            "required": [
+              "voting_module_token"
+            ],
             "properties": {
               "voting_module_token": {
                 "type": "object",
-                "required": ["token_type"],
+                "required": [
+                  "token_type"
+                ],
                 "properties": {
                   "token_type": {
                     "$ref": "#/definitions/VotingModuleTokenType"
@@ -662,11 +792,15 @@
           {
             "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["set_withdraw_address"],
+            "required": [
+              "set_withdraw_address"
+            ],
             "properties": {
               "set_withdraw_address": {
                 "type": "object",
-                "required": ["address"],
+                "required": [
+                  "address"
+                ],
                 "properties": {
                   "address": {
                     "description": "The `withdraw_address`",
@@ -680,11 +814,15 @@
           {
             "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["withdraw_delegator_reward"],
+            "required": [
+              "withdraw_delegator_reward"
+            ],
             "properties": {
               "withdraw_delegator_reward": {
                 "type": "object",
-                "required": ["validator"],
+                "required": [
+                  "validator"
+                ],
                 "properties": {
                   "validator": {
                     "description": "The `validator_address`",
@@ -707,7 +845,9 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": ["at_height"],
+            "required": [
+              "at_height"
+            ],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -720,7 +860,9 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": ["at_time"],
+            "required": [
+              "at_time"
+            ],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -731,7 +873,9 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": ["never"],
+            "required": [
+              "never"
+            ],
             "properties": {
               "never": {
                 "type": "object",
@@ -748,11 +892,16 @@
           {
             "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
             "type": "object",
-            "required": ["vote"],
+            "required": [
+              "vote"
+            ],
             "properties": {
               "vote": {
                 "type": "object",
-                "required": ["proposal_id", "vote"],
+                "required": [
+                  "proposal_id",
+                  "vote"
+                ],
                 "properties": {
                   "proposal_id": {
                     "type": "integer",
@@ -780,11 +929,18 @@
           {
             "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
             "type": "object",
-            "required": ["transfer"],
+            "required": [
+              "transfer"
+            ],
             "properties": {
               "transfer": {
                 "type": "object",
-                "required": ["amount", "channel_id", "timeout", "to_address"],
+                "required": [
+                  "amount",
+                  "channel_id",
+                  "timeout",
+                  "to_address"
+                ],
                 "properties": {
                   "amount": {
                     "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -818,11 +974,17 @@
           {
             "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
             "type": "object",
-            "required": ["send_packet"],
+            "required": [
+              "send_packet"
+            ],
             "properties": {
               "send_packet": {
                 "type": "object",
-                "required": ["channel_id", "data", "timeout"],
+                "required": [
+                  "channel_id",
+                  "data",
+                  "timeout"
+                ],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -846,11 +1008,15 @@
           {
             "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
             "type": "object",
-            "required": ["close_channel"],
+            "required": [
+              "close_channel"
+            ],
             "properties": {
               "close_channel": {
                 "type": "object",
-                "required": ["channel_id"],
+                "required": [
+                  "channel_id"
+                ],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -891,7 +1057,10 @@
       "IbcTimeoutBlock": {
         "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
         "type": "object",
-        "required": ["height", "revision"],
+        "required": [
+          "height",
+          "revision"
+        ],
         "properties": {
           "height": {
             "description": "block height after which the packet times out. the height within the given revision",
@@ -913,14 +1082,19 @@
           {
             "description": "Anyone may create proposals, except for those in the denylist.",
             "type": "object",
-            "required": ["anyone"],
+            "required": [
+              "anyone"
+            ],
             "properties": {
               "anyone": {
                 "type": "object",
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -934,15 +1108,22 @@
           {
             "description": "Specific people may create proposals.",
             "type": "object",
-            "required": ["specific"],
+            "required": [
+              "specific"
+            ],
             "properties": {
               "specific": {
                 "type": "object",
-                "required": ["dao_members"],
+                "required": [
+                  "dao_members"
+                ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -953,7 +1134,10 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": ["array", "null"],
+                    "type": [
+                      "array",
+                      "null"
+                    ],
                     "items": {
                       "type": "string"
                     }
@@ -971,11 +1155,17 @@
           {
             "description": "The propose message used to make a proposal to this module. Note that this is identical to the propose message used by dao-proposal-single, except that it omits the `proposer` field which it fills in for the sender.",
             "type": "object",
-            "required": ["propose"],
+            "required": [
+              "propose"
+            ],
             "properties": {
               "propose": {
                 "type": "object",
-                "required": ["description", "msgs", "title"],
+                "required": [
+                  "description",
+                  "msgs",
+                  "title"
+                ],
                 "properties": {
                   "description": {
                     "type": "string"
@@ -1009,11 +1199,16 @@
       },
       "SingleChoiceAutoVote": {
         "type": "object",
-        "required": ["vote"],
+        "required": [
+          "vote"
+        ],
         "properties": {
           "rationale": {
             "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "vote": {
             "description": "The proposer's position on the proposal.",
@@ -1032,11 +1227,16 @@
           {
             "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["delegate"],
+            "required": [
+              "delegate"
+            ],
             "properties": {
               "delegate": {
                 "type": "object",
-                "required": ["amount", "validator"],
+                "required": [
+                  "amount",
+                  "validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1052,11 +1252,16 @@
           {
             "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["undelegate"],
+            "required": [
+              "undelegate"
+            ],
             "properties": {
               "undelegate": {
                 "type": "object",
-                "required": ["amount", "validator"],
+                "required": [
+                  "amount",
+                  "validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1072,11 +1277,17 @@
           {
             "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["redelegate"],
+            "required": [
+              "redelegate"
+            ],
             "properties": {
               "redelegate": {
                 "type": "object",
-                "required": ["amount", "dst_validator", "src_validator"],
+                "required": [
+                  "amount",
+                  "dst_validator",
+                  "src_validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1099,41 +1310,57 @@
           {
             "description": "The proposal is open for voting.",
             "type": "string",
-            "enum": ["open"]
+            "enum": [
+              "open"
+            ]
           },
           {
             "description": "The proposal has been rejected.",
             "type": "string",
-            "enum": ["rejected"]
+            "enum": [
+              "rejected"
+            ]
           },
           {
             "description": "The proposal has been passed but has not been executed.",
             "type": "string",
-            "enum": ["passed"]
+            "enum": [
+              "passed"
+            ]
           },
           {
             "description": "The proposal has been passed and executed.",
             "type": "string",
-            "enum": ["executed"]
+            "enum": [
+              "executed"
+            ]
           },
           {
             "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
             "type": "string",
-            "enum": ["closed"]
+            "enum": [
+              "closed"
+            ]
           },
           {
             "description": "The proposal's execution failed.",
             "type": "string",
-            "enum": ["execution_failed"]
+            "enum": [
+              "execution_failed"
+            ]
           },
           {
             "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
             "type": "object",
-            "required": ["veto_timelock"],
+            "required": [
+              "veto_timelock"
+            ],
             "properties": {
               "veto_timelock": {
                 "type": "object",
-                "required": ["expiration"],
+                "required": [
+                  "expiration"
+                ],
                 "properties": {
                   "expiration": {
                     "$ref": "#/definitions/Expiration"
@@ -1147,7 +1374,9 @@
           {
             "description": "The proposal has been vetoed.",
             "type": "string",
-            "enum": ["vetoed"]
+            "enum": [
+              "vetoed"
+            ]
           }
         ]
       },
@@ -1173,7 +1402,9 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": ["native"],
+            "required": [
+              "native"
+            ],
             "properties": {
               "native": {
                 "type": "string"
@@ -1184,7 +1415,9 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": ["cw20"],
+            "required": [
+              "cw20"
+            ],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -1197,7 +1430,11 @@
       "UncheckedDepositInfo": {
         "description": "Information about the deposit required to create a proposal.",
         "type": "object",
-        "required": ["amount", "denom", "refund_policy"],
+        "required": [
+          "amount",
+          "denom",
+          "refund_policy"
+        ],
         "properties": {
           "amount": {
             "description": "The number of tokens that must be deposited to create a proposal. Must be a positive, non-zero number.",
@@ -1231,27 +1468,41 @@
           {
             "description": "Marks support for the proposal.",
             "type": "string",
-            "enum": ["yes"]
+            "enum": [
+              "yes"
+            ]
           },
           {
             "description": "Marks opposition to the proposal.",
             "type": "string",
-            "enum": ["no"]
+            "enum": [
+              "no"
+            ]
           },
           {
             "description": "Marks participation but does not count towards the ratio of support / opposed.",
             "type": "string",
-            "enum": ["abstain"]
+            "enum": [
+              "abstain"
+            ]
           }
         ]
       },
       "VoteOption": {
         "type": "string",
-        "enum": ["yes", "no", "abstain", "no_with_veto"]
+        "enum": [
+          "yes",
+          "no",
+          "abstain",
+          "no_with_veto"
+        ]
       },
       "VotingModuleTokenType": {
         "type": "string",
-        "enum": ["native", "cw20"]
+        "enum": [
+          "native",
+          "cw20"
+        ]
       },
       "WasmMsg": {
         "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
@@ -1259,11 +1510,17 @@
           {
             "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["execute"],
+            "required": [
+              "execute"
+            ],
             "properties": {
               "execute": {
                 "type": "object",
-                "required": ["contract_addr", "funds", "msg"],
+                "required": [
+                  "contract_addr",
+                  "funds",
+                  "msg"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1290,14 +1547,24 @@
           {
             "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["instantiate"],
+            "required": [
+              "instantiate"
+            ],
             "properties": {
               "instantiate": {
                 "type": "object",
-                "required": ["code_id", "funds", "label", "msg"],
+                "required": [
+                  "code_id",
+                  "funds",
+                  "label",
+                  "msg"
+                ],
                 "properties": {
                   "admin": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "code_id": {
                     "type": "integer",
@@ -1330,11 +1597,17 @@
           {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["migrate"],
+            "required": [
+              "migrate"
+            ],
             "properties": {
               "migrate": {
                 "type": "object",
-                "required": ["contract_addr", "msg", "new_code_id"],
+                "required": [
+                  "contract_addr",
+                  "msg",
+                  "new_code_id"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1361,11 +1634,16 @@
           {
             "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": ["update_admin"],
+            "required": [
+              "update_admin"
+            ],
             "properties": {
               "update_admin": {
                 "type": "object",
-                "required": ["admin", "contract_addr"],
+                "required": [
+                  "admin",
+                  "contract_addr"
+                ],
                 "properties": {
                   "admin": {
                     "type": "string"
@@ -1381,11 +1659,15 @@
           {
             "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": ["clear_admin"],
+            "required": [
+              "clear_admin"
+            ],
             "properties": {
               "clear_admin": {
                 "type": "object",
-                "required": ["contract_addr"],
+                "required": [
+                  "contract_addr"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1406,7 +1688,9 @@
       {
         "description": "Gets the proposal module that this pre propose module is associated with. Returns `Addr`.",
         "type": "object",
-        "required": ["proposal_module"],
+        "required": [
+          "proposal_module"
+        ],
         "properties": {
           "proposal_module": {
             "type": "object",
@@ -1418,7 +1702,9 @@
       {
         "description": "Gets the DAO (dao-dao-core) module this contract is associated with. Returns `Addr`.",
         "type": "object",
-        "required": ["dao"],
+        "required": [
+          "dao"
+        ],
         "properties": {
           "dao": {
             "type": "object",
@@ -1430,7 +1716,9 @@
       {
         "description": "Gets the module's configuration.",
         "type": "object",
-        "required": ["config"],
+        "required": [
+          "config"
+        ],
         "properties": {
           "config": {
             "type": "object",
@@ -1442,11 +1730,15 @@
       {
         "description": "Gets the deposit info for the proposal identified by PROPOSAL_ID.",
         "type": "object",
-        "required": ["deposit_info"],
+        "required": [
+          "deposit_info"
+        ],
         "properties": {
           "deposit_info": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -1460,9 +1752,33 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns whether or not the address can submit proposals.",
+        "type": "object",
+        "required": [
+          "can_propose"
+        ],
+        "properties": {
+          "can_propose": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Returns list of proposal submitted hooks.",
         "type": "object",
-        "required": ["proposal_submitted_hooks"],
+        "required": [
+          "proposal_submitted_hooks"
+        ],
         "properties": {
           "proposal_submitted_hooks": {
             "type": "object",
@@ -1474,11 +1790,15 @@
       {
         "description": "Extension for queries. The default implementation will do nothing if queried for will return `Binary::default()`.",
         "type": "object",
-        "required": ["query_extension"],
+        "required": [
+          "query_extension"
+        ],
         "properties": {
           "query_extension": {
             "type": "object",
-            "required": ["msg"],
+            "required": [
+              "msg"
+            ],
             "properties": {
               "msg": {
                 "$ref": "#/definitions/Empty"
@@ -1500,11 +1820,18 @@
   "migrate": null,
   "sudo": null,
   "responses": {
+    "can_propose": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Boolean",
+      "type": "boolean"
+    },
     "config": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Config",
       "type": "object",
-      "required": ["submission_policy"],
+      "required": [
+        "submission_policy"
+      ],
       "properties": {
         "deposit_info": {
           "description": "Information about the deposit required to create a proposal. If `None`, no deposit is required.",
@@ -1538,7 +1865,9 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": ["native"],
+              "required": [
+                "native"
+              ],
               "properties": {
                 "native": {
                   "type": "string"
@@ -1549,7 +1878,9 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": ["cw20"],
+              "required": [
+                "cw20"
+              ],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -1562,7 +1893,11 @@
         "CheckedDepositInfo": {
           "description": "Counterpart to the `DepositInfo` struct which has been processed. This type should never be constructed literally and should always by built by calling `into_checked` on a `DepositInfo` instance.",
           "type": "object",
-          "required": ["amount", "denom", "refund_policy"],
+          "required": [
+            "amount",
+            "denom",
+            "refund_policy"
+          ],
           "properties": {
             "amount": {
               "description": "The number of tokens that must be deposited to create a proposal. This is validated to be non-zero if this struct is constructed by converted via the `into_checked` method on `DepositInfo`.",
@@ -1596,17 +1931,23 @@
             {
               "description": "Deposits should always be refunded.",
               "type": "string",
-              "enum": ["always"]
+              "enum": [
+                "always"
+              ]
             },
             {
               "description": "Deposits should only be refunded for passed proposals.",
               "type": "string",
-              "enum": ["only_passed"]
+              "enum": [
+                "only_passed"
+              ]
             },
             {
               "description": "Deposits should never be refunded.",
               "type": "string",
-              "enum": ["never"]
+              "enum": [
+                "never"
+              ]
             }
           ]
         },
@@ -1616,14 +1957,19 @@
             {
               "description": "Anyone may create proposals, except for those in the denylist.",
               "type": "object",
-              "required": ["anyone"],
+              "required": [
+                "anyone"
+              ],
               "properties": {
                 "anyone": {
                   "type": "object",
                   "properties": {
                     "denylist": {
                       "description": "Addresses that may not create proposals.",
-                      "type": ["array", "null"],
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "items": {
                         "type": "string"
                       }
@@ -1637,15 +1983,22 @@
             {
               "description": "Specific people may create proposals.",
               "type": "object",
-              "required": ["specific"],
+              "required": [
+                "specific"
+              ],
               "properties": {
                 "specific": {
                   "type": "object",
-                  "required": ["dao_members"],
+                  "required": [
+                    "dao_members"
+                  ],
                   "properties": {
                     "allowlist": {
                       "description": "Addresses that may create proposals.",
-                      "type": ["array", "null"],
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "items": {
                         "type": "string"
                       }
@@ -1656,7 +2009,10 @@
                     },
                     "denylist": {
                       "description": "Addresses that may not create proposals, overriding other settings.",
-                      "type": ["array", "null"],
+                      "type": [
+                        "array",
+                        "null"
+                      ],
                       "items": {
                         "type": "string"
                       }
@@ -1685,7 +2041,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "DepositInfoResponse",
       "type": "object",
-      "required": ["proposer"],
+      "required": [
+        "proposer"
+      ],
       "properties": {
         "deposit_info": {
           "description": "The deposit that has been paid for the specified proposal.",
@@ -1719,7 +2077,9 @@
             {
               "description": "A native (bank module) asset.",
               "type": "object",
-              "required": ["native"],
+              "required": [
+                "native"
+              ],
               "properties": {
                 "native": {
                   "type": "string"
@@ -1730,7 +2090,9 @@
             {
               "description": "A cw20 asset.",
               "type": "object",
-              "required": ["cw20"],
+              "required": [
+                "cw20"
+              ],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -1743,7 +2105,11 @@
         "CheckedDepositInfo": {
           "description": "Counterpart to the `DepositInfo` struct which has been processed. This type should never be constructed literally and should always by built by calling `into_checked` on a `DepositInfo` instance.",
           "type": "object",
-          "required": ["amount", "denom", "refund_policy"],
+          "required": [
+            "amount",
+            "denom",
+            "refund_policy"
+          ],
           "properties": {
             "amount": {
               "description": "The number of tokens that must be deposited to create a proposal. This is validated to be non-zero if this struct is constructed by converted via the `into_checked` method on `DepositInfo`.",
@@ -1777,17 +2143,23 @@
             {
               "description": "Deposits should always be refunded.",
               "type": "string",
-              "enum": ["always"]
+              "enum": [
+                "always"
+              ]
             },
             {
               "description": "Deposits should only be refunded for passed proposals.",
               "type": "string",
-              "enum": ["only_passed"]
+              "enum": [
+                "only_passed"
+              ]
             },
             {
               "description": "Deposits should never be refunded.",
               "type": "string",
-              "enum": ["never"]
+              "enum": [
+                "never"
+              ]
             }
           ]
         },
@@ -1807,7 +2179,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": ["hooks"],
+      "required": [
+        "hooks"
+      ],
       "properties": {
         "hooks": {
           "type": "array",

--- a/contracts/pre-propose/dao-pre-propose-single/src/contract.rs
+++ b/contracts/pre-propose/dao-pre-propose-single/src/contract.rs
@@ -91,10 +91,10 @@ pub fn execute(
         ExecuteMsg::Withdraw { denom } => ExecuteInternal::Withdraw { denom },
         ExecuteMsg::UpdateConfig {
             deposit_info,
-            open_proposal_submission,
+            submission_policy,
         } => ExecuteInternal::UpdateConfig {
             deposit_info,
-            open_proposal_submission,
+            submission_policy,
         },
         ExecuteMsg::AddProposalSubmittedHook { address } => {
             ExecuteInternal::AddProposalSubmittedHook { address }

--- a/contracts/pre-propose/dao-pre-propose-single/src/contract.rs
+++ b/contracts/pre-propose/dao-pre-propose-single/src/contract.rs
@@ -96,6 +96,19 @@ pub fn execute(
             deposit_info,
             submission_policy,
         },
+        ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add,
+            denylist_remove,
+            set_dao_members,
+            allowlist_add,
+            allowlist_remove,
+        } => ExecuteInternal::UpdateSubmissionPolicy {
+            denylist_add,
+            denylist_remove,
+            set_dao_members,
+            allowlist_add,
+            allowlist_remove,
+        },
         ExecuteMsg::AddProposalSubmittedHook { address } => {
             ExecuteInternal::AddProposalSubmittedHook { address }
         }

--- a/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
@@ -355,7 +355,7 @@ fn update_config(
         module.clone(),
         &ExecuteMsg::UpdateConfig {
             deposit_info,
-            submission_policy,
+            submission_policy: Some(submission_policy),
         },
         &[],
     )
@@ -376,7 +376,7 @@ fn update_config_should_fail(
         module,
         &ExecuteMsg::UpdateConfig {
             deposit_info,
-            submission_policy,
+            submission_policy: Some(submission_policy),
         },
         &[],
     )

--- a/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
@@ -952,6 +952,69 @@ fn test_no_deposit_required_members_submission() {
 }
 
 #[test]
+fn test_anyone_denylist() {
+    let mut app = App::default();
+    let DefaultTestSetup {
+        core_addr,
+        proposal_single,
+        pre_propose,
+    } = setup_default_test(&mut app, None, false);
+
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Anyone { denylist: None },
+    );
+
+    // Proposal succeeds when anyone can propose.
+    make_proposal(
+        &mut app,
+        pre_propose.clone(),
+        proposal_single.clone(),
+        "rando",
+        &[],
+    );
+
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Anyone {
+            denylist: Some(vec!["rando".to_string()]),
+        },
+    );
+
+    // Proposing fails if on denylist.
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("rando"),
+            pre_propose.clone(),
+            &ExecuteMsg::Propose {
+                msg: ProposeMessage::Propose {
+                    title: "I would like to join the DAO".to_string(),
+                    description: "though, I am currently not a member.".to_string(),
+                    msgs: vec![],
+                    vote: None,
+                },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
+    );
+
+    // Proposing succeeds if not on denylist.
+    make_proposal(&mut app, pre_propose, proposal_single.clone(), "ekez", &[]);
+}
+
+#[test]
 fn test_execute_extension_does_nothing() {
     let mut app = App::default();
     let DefaultTestSetup {
@@ -1216,12 +1279,501 @@ fn test_update_config() {
     // Only the core module can update the config.
     let err = update_config_should_fail(
         &mut app,
-        pre_propose,
+        pre_propose.clone(),
         proposal_single.as_str(),
         None,
         PreProposeSubmissionPolicy::Anyone { denylist: None },
     );
     assert_eq!(err, PreProposeError::NotDao {});
+
+    // Errors when no one is authorized to create proposals.
+    let err = update_config_should_fail(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: false,
+            allowlist: None,
+            denylist: None,
+        },
+    );
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::NoOneAllowed {})
+    );
+
+    // Errors when allowlist and denylist overlap.
+    let err = update_config_should_fail(
+        &mut app,
+        pre_propose,
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: false,
+            allowlist: Some(vec!["ekez".to_string()]),
+            denylist: Some(vec!["ekez".to_string()]),
+        },
+    );
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::DenylistAllowlistOverlap {}
+        )
+    );
+}
+
+#[test]
+fn test_update_submission_policy() {
+    let mut app = App::default();
+    let DefaultTestSetup {
+        core_addr,
+        pre_propose,
+        ..
+    } = setup_default_test(&mut app, None, true);
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+        }
+    );
+
+    // Only the core module can update the submission policy.
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("ekez"),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: Some(vec!["ekez".to_string()]),
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, PreProposeError::NotDao {});
+
+    // Append to denylist, with auto de-dupe.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: Some(vec!["ekez".to_string(), "ekez".to_string()]),
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone {
+                denylist: Some(vec!["ekez".to_string()]),
+            },
+        }
+    );
+
+    // Add and remove to/from denylist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: Some(vec!["someone".to_string(), "else".to_string()]),
+            denylist_remove: Some(vec!["ekez".to_string()]),
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone {
+                denylist: Some(vec!["someone".to_string(), "else".to_string()]),
+            },
+        }
+    );
+
+    // Remove from denylist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: Some(vec!["someone".to_string(), "else".to_string()]),
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+        }
+    );
+
+    // Error if try to change Specific fields when set to Anyone.
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: None,
+                denylist_remove: None,
+                set_dao_members: Some(true),
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::AnyoneInvalidUpdateFields {}
+        )
+    );
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: None,
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: Some(vec!["ekez".to_string()]),
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::AnyoneInvalidUpdateFields {}
+        )
+    );
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: None,
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: None,
+                allowlist_remove: Some(vec!["ekez".to_string()]),
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::AnyoneInvalidUpdateFields {}
+        )
+    );
+
+    // Change to Specific policy.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateConfig {
+            deposit_info: None,
+            submission_policy: Some(PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None,
+            }),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None,
+            },
+        }
+    );
+
+    // Append to denylist, with auto de-dupe.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: Some(vec!["ekez".to_string(), "ekez".to_string()]),
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: Some(vec!["ekez".to_string()]),
+            },
+        }
+    );
+
+    // Add and remove to/from denylist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: Some(vec!["someone".to_string(), "else".to_string()]),
+            denylist_remove: Some(vec!["ekez".to_string()]),
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: Some(vec!["someone".to_string(), "else".to_string()]),
+            },
+        }
+    );
+
+    // Remove from denylist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: Some(vec!["someone".to_string(), "else".to_string()]),
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None
+            },
+        }
+    );
+
+    // Append to allowlist, with auto de-dupe.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: Some(vec!["ekez".to_string(), "ekez".to_string()]),
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: Some(vec!["ekez".to_string()]),
+                denylist: None,
+            },
+        }
+    );
+
+    // Add and remove to/from allowlist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: Some(vec!["someone".to_string(), "else".to_string()]),
+            allowlist_remove: Some(vec!["ekez".to_string()]),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: Some(vec!["someone".to_string(), "else".to_string()]),
+                denylist: None,
+            },
+        }
+    );
+
+    // Remove from allowlist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: Some(vec!["someone".to_string(), "else".to_string()]),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None
+            },
+        }
+    );
+
+    // Setting dao_members to false fails if allowlist is empty.
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: None,
+                denylist_remove: None,
+                set_dao_members: Some(false),
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::NoOneAllowed {})
+    );
+
+    // Set dao_members to false and add allowlist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: None,
+            set_dao_members: Some(false),
+            allowlist_add: Some(vec!["ekez".to_string()]),
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: false,
+                allowlist: Some(vec!["ekez".to_string()]),
+                denylist: None
+            },
+        }
+    );
+
+    // Errors when allowlist and denylist overlap.
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: Some(vec!["ekez".to_string()]),
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::DenylistAllowlistOverlap {}
+        )
+    );
 }
 
 #[test]

--- a/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
@@ -54,9 +54,13 @@ fn get_default_proposal_module_instantiate(
     let pre_propose_id = app.store_code(cw_pre_propose_base_proposal_single());
 
     let submission_policy = if open_proposal_submission {
-        PreProposeSubmissionPolicy::Anyone {}
+        PreProposeSubmissionPolicy::Anyone { denylist: None }
     } else {
-        PreProposeSubmissionPolicy::DaoMembers {}
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        }
     };
 
     dps::msg::InstantiateMsg {
@@ -847,9 +851,7 @@ fn test_permissions() {
         .unwrap();
     assert_eq!(
         err,
-        PreProposeError::SubmissionPolicy(
-            PreProposeSubmissionPolicyError::UnauthorizedDaoMembers {}
-        )
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
     )
 }
 
@@ -941,9 +943,7 @@ fn test_no_deposit_required_members_submission() {
         .unwrap();
     assert_eq!(
         err,
-        PreProposeError::SubmissionPolicy(
-            PreProposeSubmissionPolicyError::UnauthorizedDaoMembers {}
-        )
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
     );
 
     let id = make_proposal(&mut app, pre_propose, proposal_single.clone(), "ekez", &[]);
@@ -1012,7 +1012,11 @@ fn test_instantiate_with_zero_native_deposit() {
                             amount: Uint128::zero(),
                             refund_policy: DepositRefundPolicy::OnlyPassed,
                         }),
-                        submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
+                        submission_policy: PreProposeSubmissionPolicy::Specific {
+                            dao_members: true,
+                            allowlist: None,
+                            denylist: None,
+                        },
                         extension: Empty::default(),
                     })
                     .unwrap(),
@@ -1075,7 +1079,11 @@ fn test_instantiate_with_zero_cw20_deposit() {
                             amount: Uint128::zero(),
                             refund_policy: DepositRefundPolicy::OnlyPassed,
                         }),
-                        submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
+                        submission_policy: PreProposeSubmissionPolicy::Specific {
+                            dao_members: true,
+                            allowlist: None,
+                            denylist: None,
+                        },
                         extension: Empty::default(),
                     })
                     .unwrap(),
@@ -1121,7 +1129,11 @@ fn test_update_config() {
         config,
         Config {
             deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None
+            },
         }
     );
 
@@ -1144,7 +1156,7 @@ fn test_update_config() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Never,
         }),
-        PreProposeSubmissionPolicy::Anyone {},
+        PreProposeSubmissionPolicy::Anyone { denylist: None },
     );
 
     let config = get_config(&app, pre_propose.clone());
@@ -1156,7 +1168,7 @@ fn test_update_config() {
                 amount: Uint128::new(10),
                 refund_policy: DepositRefundPolicy::Never
             }),
-            submission_policy: PreProposeSubmissionPolicy::Anyone {},
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
         }
     );
 
@@ -1207,7 +1219,7 @@ fn test_update_config() {
         pre_propose,
         proposal_single.as_str(),
         None,
-        PreProposeSubmissionPolicy::Anyone {},
+        PreProposeSubmissionPolicy::Anyone { denylist: None },
     );
     assert_eq!(err, PreProposeError::NotDao {});
 }
@@ -1253,7 +1265,11 @@ fn test_withdraw() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Always,
         }),
-        PreProposeSubmissionPolicy::DaoMembers {},
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        },
     );
 
     // Withdraw with no specified denom - should fall back to the one
@@ -1297,7 +1313,11 @@ fn test_withdraw() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Always,
         }),
-        PreProposeSubmissionPolicy::DaoMembers {},
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        },
     );
 
     increase_allowance(

--- a/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
@@ -9,7 +9,7 @@ use dao_interface::state::{Admin, ModuleInstantiateInfo};
 use dao_pre_propose_base::{error::PreProposeError, msg::DepositInfoResponse, state::Config};
 use dao_proposal_single as dps;
 use dao_testing::helpers::instantiate_with_cw4_groups_governance;
-use dao_voting::pre_propose::PreProposeSubmissionPolicy;
+use dao_voting::pre_propose::{PreProposeSubmissionPolicy, PreProposeSubmissionPolicyError};
 use dao_voting::{
     deposit::{CheckedDepositInfo, DepositRefundPolicy, DepositToken, UncheckedDepositInfo},
     pre_propose::{PreProposeInfo, ProposalCreationPolicy},
@@ -845,7 +845,12 @@ fn test_permissions() {
         .unwrap_err()
         .downcast()
         .unwrap();
-    assert_eq!(err, PreProposeError::NotMember {})
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::UnauthorizedDaoMembers {}
+        )
+    )
 }
 
 #[test]
@@ -934,7 +939,12 @@ fn test_no_deposit_required_members_submission() {
         .unwrap_err()
         .downcast()
         .unwrap();
-    assert_eq!(err, PreProposeError::NotMember {});
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::UnauthorizedDaoMembers {}
+        )
+    );
 
     let id = make_proposal(&mut app, pre_propose, proposal_single.clone(), "ekez", &[]);
     let new_status = vote(&mut app, proposal_single, "ekez", id, Vote::Yes);

--- a/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
@@ -343,6 +343,17 @@ fn get_deposit_info(app: &App, module: Addr, id: u64) -> DepositInfoResponse {
         .unwrap()
 }
 
+fn query_can_propose(app: &App, module: Addr, address: impl Into<String>) -> bool {
+    app.wrap()
+        .query_wasm_smart(
+            module,
+            &QueryMsg::CanPropose {
+                address: address.into(),
+            },
+        )
+        .unwrap()
+}
+
 fn update_config(
     app: &mut App,
     module: Addr,
@@ -971,6 +982,7 @@ fn test_anyone_denylist() {
     let rando = "rando";
 
     // Proposal succeeds when anyone can propose.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), true);
     make_proposal(
         &mut app,
         pre_propose.clone(),
@@ -990,6 +1002,7 @@ fn test_anyone_denylist() {
     );
 
     // Proposing fails if on denylist.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), false);
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked(rando),
@@ -1013,6 +1026,7 @@ fn test_anyone_denylist() {
     );
 
     // Proposing succeeds if not on denylist.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), true);
     make_proposal(&mut app, pre_propose, proposal_single.clone(), "ekez", &[]);
 }
 
@@ -1038,6 +1052,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposal succeeds for member.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), true);
     make_proposal(
         &mut app,
         pre_propose.clone(),
@@ -1049,6 +1064,7 @@ fn test_specific_allowlist_denylist() {
     let rando = "rando";
 
     // Proposing fails for non-member.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), false);
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked(rando),
@@ -1084,6 +1100,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposal succeeds if on allowlist.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), true);
     make_proposal(
         &mut app,
         pre_propose.clone(),
@@ -1105,6 +1122,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposing fails if on denylist.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), false);
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked("ekez"),
@@ -1140,6 +1158,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposing fails if members not allowed.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), false);
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked("ekez"),
@@ -1163,6 +1182,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposal succeeds if on allowlist.
+    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), true);
     make_proposal(
         &mut app,
         pre_propose.clone(),

--- a/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
@@ -982,7 +982,7 @@ fn test_anyone_denylist() {
     let rando = "rando";
 
     // Proposal succeeds when anyone can propose.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), true);
+    assert!(query_can_propose(&app, pre_propose.clone(), rando));
     make_proposal(
         &mut app,
         pre_propose.clone(),
@@ -1002,7 +1002,7 @@ fn test_anyone_denylist() {
     );
 
     // Proposing fails if on denylist.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), false);
+    assert!(!query_can_propose(&app, pre_propose.clone(), rando));
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked(rando),
@@ -1026,7 +1026,7 @@ fn test_anyone_denylist() {
     );
 
     // Proposing succeeds if not on denylist.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), true);
+    assert!(query_can_propose(&app, pre_propose.clone(), "ekez"));
     make_proposal(&mut app, pre_propose, proposal_single.clone(), "ekez", &[]);
 }
 
@@ -1052,7 +1052,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposal succeeds for member.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), true);
+    assert!(query_can_propose(&app, pre_propose.clone(), "ekez"));
     make_proposal(
         &mut app,
         pre_propose.clone(),
@@ -1064,7 +1064,7 @@ fn test_specific_allowlist_denylist() {
     let rando = "rando";
 
     // Proposing fails for non-member.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), false);
+    assert!(!query_can_propose(&app, pre_propose.clone(), rando));
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked(rando),
@@ -1100,7 +1100,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposal succeeds if on allowlist.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), true);
+    assert!(query_can_propose(&app, pre_propose.clone(), rando));
     make_proposal(
         &mut app,
         pre_propose.clone(),
@@ -1122,7 +1122,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposing fails if on denylist.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), false);
+    assert!(!query_can_propose(&app, pre_propose.clone(), "ekez"));
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked("ekez"),
@@ -1158,7 +1158,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposing fails if members not allowed.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), "ekez"), false);
+    assert!(!query_can_propose(&app, pre_propose.clone(), "ekez"));
     let err: PreProposeError = app
         .execute_contract(
             Addr::unchecked("ekez"),
@@ -1182,7 +1182,7 @@ fn test_specific_allowlist_denylist() {
     );
 
     // Proposal succeeds if on allowlist.
-    assert_eq!(query_can_propose(&app, pre_propose.clone(), rando), true);
+    assert!(query_can_propose(&app, pre_propose.clone(), rando));
     make_proposal(
         &mut app,
         pre_propose.clone(),

--- a/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
@@ -1464,7 +1464,7 @@ fn test_update_config() {
     // Errors when allowlist and denylist overlap.
     let err = update_config_should_fail(
         &mut app,
-        pre_propose,
+        pre_propose.clone(),
         core_addr.as_str(),
         None,
         PreProposeSubmissionPolicy::Specific {
@@ -1478,6 +1478,27 @@ fn test_update_config() {
         PreProposeError::SubmissionPolicy(
             PreProposeSubmissionPolicyError::DenylistAllowlistOverlap {}
         )
+    );
+
+    // Doesn't change submission policy if omitted.
+    app.execute_contract(
+        core_addr,
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateConfig {
+            deposit_info: None,
+            submission_policy: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose);
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+        }
     );
 }
 

--- a/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
+++ b/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
@@ -43,7 +43,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -56,7 +58,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -74,7 +78,9 @@
           {
             "description": "The majority of voters must vote yes for the proposal to pass.",
             "type": "object",
-            "required": ["majority"],
+            "required": [
+              "majority"
+            ],
             "properties": {
               "majority": {
                 "type": "object",
@@ -86,7 +92,9 @@
           {
             "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
             "type": "object",
-            "required": ["percent"],
+            "required": [
+              "percent"
+            ],
             "properties": {
               "percent": {
                 "$ref": "#/definitions/Decimal"
@@ -104,11 +112,15 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["propose"],
+        "required": [
+          "propose"
+        ],
         "properties": {
           "propose": {
             "type": "object",
-            "required": ["choices"],
+            "required": [
+              "choices"
+            ],
             "properties": {
               "choices": {
                 "type": "array",
@@ -124,11 +136,16 @@
       },
       {
         "type": "object",
-        "required": ["vote"],
+        "required": [
+          "vote"
+        ],
         "properties": {
           "vote": {
             "type": "object",
-            "required": ["proposal_id", "vote"],
+            "required": [
+              "proposal_id",
+              "vote"
+            ],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -151,11 +168,15 @@
       },
       {
         "type": "object",
-        "required": ["execute"],
+        "required": [
+          "execute"
+        ],
         "properties": {
           "execute": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -170,11 +191,15 @@
       },
       {
         "type": "object",
-        "required": ["close"],
+        "required": [
+          "close"
+        ],
         "properties": {
           "close": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -189,7 +214,9 @@
       },
       {
         "type": "object",
-        "required": ["set_config"],
+        "required": [
+          "set_config"
+        ],
         "properties": {
           "set_config": {
             "$ref": "#/definitions/UncheckedConfig"
@@ -205,11 +232,16 @@
           {
             "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["send"],
+            "required": [
+              "send"
+            ],
             "properties": {
               "send": {
                 "type": "object",
-                "required": ["amount", "to_address"],
+                "required": [
+                  "amount",
+                  "to_address"
+                ],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -228,11 +260,15 @@
           {
             "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
             "type": "object",
-            "required": ["burn"],
+            "required": [
+              "burn"
+            ],
             "properties": {
               "burn": {
                 "type": "object",
-                "required": ["amount"],
+                "required": [
+                  "amount"
+                ],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -253,7 +289,9 @@
       },
       "Choice": {
         "type": "object",
-        "required": ["msgs"],
+        "required": [
+          "msgs"
+        ],
         "properties": {
           "msgs": {
             "type": "array",
@@ -266,7 +304,10 @@
       },
       "Coin": {
         "type": "object",
-        "required": ["amount", "denom"],
+        "required": [
+          "amount",
+          "denom"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -280,7 +321,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["bank"],
+            "required": [
+              "bank"
+            ],
             "properties": {
               "bank": {
                 "$ref": "#/definitions/BankMsg"
@@ -290,7 +333,9 @@
           },
           {
             "type": "object",
-            "required": ["custom"],
+            "required": [
+              "custom"
+            ],
             "properties": {
               "custom": {
                 "$ref": "#/definitions/Empty"
@@ -300,7 +345,9 @@
           },
           {
             "type": "object",
-            "required": ["staking"],
+            "required": [
+              "staking"
+            ],
             "properties": {
               "staking": {
                 "$ref": "#/definitions/StakingMsg"
@@ -310,7 +357,9 @@
           },
           {
             "type": "object",
-            "required": ["distribution"],
+            "required": [
+              "distribution"
+            ],
             "properties": {
               "distribution": {
                 "$ref": "#/definitions/DistributionMsg"
@@ -321,11 +370,16 @@
           {
             "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
             "type": "object",
-            "required": ["stargate"],
+            "required": [
+              "stargate"
+            ],
             "properties": {
               "stargate": {
                 "type": "object",
-                "required": ["type_url", "value"],
+                "required": [
+                  "type_url",
+                  "value"
+                ],
                 "properties": {
                   "type_url": {
                     "type": "string"
@@ -340,7 +394,9 @@
           },
           {
             "type": "object",
-            "required": ["ibc"],
+            "required": [
+              "ibc"
+            ],
             "properties": {
               "ibc": {
                 "$ref": "#/definitions/IbcMsg"
@@ -350,7 +406,9 @@
           },
           {
             "type": "object",
-            "required": ["wasm"],
+            "required": [
+              "wasm"
+            ],
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmMsg"
@@ -360,7 +418,9 @@
           },
           {
             "type": "object",
-            "required": ["gov"],
+            "required": [
+              "gov"
+            ],
             "properties": {
               "gov": {
                 "$ref": "#/definitions/GovMsg"
@@ -380,11 +440,15 @@
           {
             "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["set_withdraw_address"],
+            "required": [
+              "set_withdraw_address"
+            ],
             "properties": {
               "set_withdraw_address": {
                 "type": "object",
-                "required": ["address"],
+                "required": [
+                  "address"
+                ],
                 "properties": {
                   "address": {
                     "description": "The `withdraw_address`",
@@ -398,11 +462,15 @@
           {
             "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["withdraw_delegator_reward"],
+            "required": [
+              "withdraw_delegator_reward"
+            ],
             "properties": {
               "withdraw_delegator_reward": {
                 "type": "object",
-                "required": ["validator"],
+                "required": [
+                  "validator"
+                ],
                 "properties": {
                   "validator": {
                     "description": "The `validator_address`",
@@ -420,7 +488,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -433,7 +503,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -455,11 +527,16 @@
           {
             "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
             "type": "object",
-            "required": ["vote"],
+            "required": [
+              "vote"
+            ],
             "properties": {
               "vote": {
                 "type": "object",
-                "required": ["proposal_id", "vote"],
+                "required": [
+                  "proposal_id",
+                  "vote"
+                ],
                 "properties": {
                   "proposal_id": {
                     "type": "integer",
@@ -487,11 +564,18 @@
           {
             "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
             "type": "object",
-            "required": ["transfer"],
+            "required": [
+              "transfer"
+            ],
             "properties": {
               "transfer": {
                 "type": "object",
-                "required": ["amount", "channel_id", "timeout", "to_address"],
+                "required": [
+                  "amount",
+                  "channel_id",
+                  "timeout",
+                  "to_address"
+                ],
                 "properties": {
                   "amount": {
                     "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -525,11 +609,17 @@
           {
             "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
             "type": "object",
-            "required": ["send_packet"],
+            "required": [
+              "send_packet"
+            ],
             "properties": {
               "send_packet": {
                 "type": "object",
-                "required": ["channel_id", "data", "timeout"],
+                "required": [
+                  "channel_id",
+                  "data",
+                  "timeout"
+                ],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -553,11 +643,15 @@
           {
             "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
             "type": "object",
-            "required": ["close_channel"],
+            "required": [
+              "close_channel"
+            ],
             "properties": {
               "close_channel": {
                 "type": "object",
-                "required": ["channel_id"],
+                "required": [
+                  "channel_id"
+                ],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -598,7 +692,10 @@
       "IbcTimeoutBlock": {
         "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
         "type": "object",
-        "required": ["height", "revision"],
+        "required": [
+          "height",
+          "revision"
+        ],
         "properties": {
           "height": {
             "description": "block height after which the packet times out. the height within the given revision",
@@ -620,7 +717,9 @@
           {
             "description": "The majority of voters must vote yes for the proposal to pass.",
             "type": "object",
-            "required": ["majority"],
+            "required": [
+              "majority"
+            ],
             "properties": {
               "majority": {
                 "type": "object",
@@ -632,7 +731,9 @@
           {
             "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
             "type": "object",
-            "required": ["percent"],
+            "required": [
+              "percent"
+            ],
             "properties": {
               "percent": {
                 "$ref": "#/definitions/Decimal"
@@ -648,11 +749,16 @@
           {
             "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["delegate"],
+            "required": [
+              "delegate"
+            ],
             "properties": {
               "delegate": {
                 "type": "object",
-                "required": ["amount", "validator"],
+                "required": [
+                  "amount",
+                  "validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -668,11 +774,16 @@
           {
             "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["undelegate"],
+            "required": [
+              "undelegate"
+            ],
             "properties": {
               "undelegate": {
                 "type": "object",
-                "required": ["amount", "validator"],
+                "required": [
+                  "amount",
+                  "validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -688,11 +799,17 @@
           {
             "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["redelegate"],
+            "required": [
+              "redelegate"
+            ],
             "properties": {
               "redelegate": {
                 "type": "object",
-                "required": ["amount", "dst_validator", "src_validator"],
+                "required": [
+                  "amount",
+                  "dst_validator",
+                  "src_validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -758,7 +875,12 @@
       },
       "VoteOption": {
         "type": "string",
-        "enum": ["yes", "no", "abstain", "no_with_veto"]
+        "enum": [
+          "yes",
+          "no",
+          "abstain",
+          "no_with_veto"
+        ]
       },
       "WasmMsg": {
         "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
@@ -766,11 +888,17 @@
           {
             "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["execute"],
+            "required": [
+              "execute"
+            ],
             "properties": {
               "execute": {
                 "type": "object",
-                "required": ["contract_addr", "funds", "msg"],
+                "required": [
+                  "contract_addr",
+                  "funds",
+                  "msg"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -797,14 +925,24 @@
           {
             "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["instantiate"],
+            "required": [
+              "instantiate"
+            ],
             "properties": {
               "instantiate": {
                 "type": "object",
-                "required": ["code_id", "funds", "label", "msg"],
+                "required": [
+                  "code_id",
+                  "funds",
+                  "label",
+                  "msg"
+                ],
                 "properties": {
                   "admin": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "code_id": {
                     "type": "integer",
@@ -837,11 +975,17 @@
           {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["migrate"],
+            "required": [
+              "migrate"
+            ],
             "properties": {
               "migrate": {
                 "type": "object",
-                "required": ["contract_addr", "msg", "new_code_id"],
+                "required": [
+                  "contract_addr",
+                  "msg",
+                  "new_code_id"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -868,11 +1012,16 @@
           {
             "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": ["update_admin"],
+            "required": [
+              "update_admin"
+            ],
             "properties": {
               "update_admin": {
                 "type": "object",
-                "required": ["admin", "contract_addr"],
+                "required": [
+                  "admin",
+                  "contract_addr"
+                ],
                 "properties": {
                   "admin": {
                     "type": "string"
@@ -888,11 +1037,15 @@
           {
             "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": ["clear_admin"],
+            "required": [
+              "clear_admin"
+            ],
             "properties": {
               "clear_admin": {
                 "type": "object",
-                "required": ["contract_addr"],
+                "required": [
+                  "contract_addr"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -912,11 +1065,15 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["proposal"],
+        "required": [
+          "proposal"
+        ],
         "properties": {
           "proposal": {
             "type": "object",
-            "required": ["id"],
+            "required": [
+              "id"
+            ],
             "properties": {
               "id": {
                 "type": "integer",
@@ -931,7 +1088,9 @@
       },
       {
         "type": "object",
-        "required": ["config"],
+        "required": [
+          "config"
+        ],
         "properties": {
           "config": {
             "type": "object",
@@ -943,7 +1102,9 @@
       {
         "description": "Returns the address of the DAO this module belongs to",
         "type": "object",
-        "required": ["dao"],
+        "required": [
+          "dao"
+        ],
         "properties": {
           "dao": {
             "type": "object",
@@ -955,7 +1116,9 @@
       {
         "description": "Returns contract version info",
         "type": "object",
-        "required": ["info"],
+        "required": [
+          "info"
+        ],
         "properties": {
           "info": {
             "type": "object",
@@ -967,7 +1130,9 @@
       {
         "description": "Returns the proposal ID that will be assigned to the next proposal created.",
         "type": "object",
-        "required": ["next_proposal_id"],
+        "required": [
+          "next_proposal_id"
+        ],
         "properties": {
           "next_proposal_id": {
             "type": "object",
@@ -1022,7 +1187,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["height"],
+              "required": [
+                "height"
+              ],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -1035,7 +1202,9 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": ["time"],
+              "required": [
+                "time"
+              ],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -1053,7 +1222,9 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["majority"],
+              "required": [
+                "majority"
+              ],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -1065,7 +1236,9 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["percent"],
+              "required": [
+                "percent"
+              ],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -1087,7 +1260,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": ["info"],
+      "required": [
+        "info"
+      ],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -1097,7 +1272,10 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": ["contract", "version"],
+          "required": [
+            "contract",
+            "version"
+          ],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -1123,7 +1301,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ProposalResponse",
       "type": "object",
-      "required": ["proposal", "tally"],
+      "required": [
+        "proposal",
+        "tally"
+      ],
       "properties": {
         "proposal": {
           "$ref": "#/definitions/Proposal"
@@ -1144,11 +1325,16 @@
             {
               "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["send"],
+              "required": [
+                "send"
+              ],
               "properties": {
                 "send": {
                   "type": "object",
-                  "required": ["amount", "to_address"],
+                  "required": [
+                    "amount",
+                    "to_address"
+                  ],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -1167,11 +1353,15 @@
             {
               "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
               "type": "object",
-              "required": ["burn"],
+              "required": [
+                "burn"
+              ],
               "properties": {
                 "burn": {
                   "type": "object",
-                  "required": ["amount"],
+                  "required": [
+                    "amount"
+                  ],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -1195,11 +1385,15 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": ["zero"]
+              "enum": [
+                "zero"
+              ]
             },
             {
               "type": "object",
-              "required": ["positive"],
+              "required": [
+                "positive"
+              ],
               "properties": {
                 "positive": {
                   "$ref": "#/definitions/Uint128"
@@ -1209,7 +1403,9 @@
             },
             {
               "type": "object",
-              "required": ["negative"],
+              "required": [
+                "negative"
+              ],
               "properties": {
                 "negative": {
                   "$ref": "#/definitions/Uint128"
@@ -1221,7 +1417,9 @@
         },
         "Choice": {
           "type": "object",
-          "required": ["msgs"],
+          "required": [
+            "msgs"
+          ],
           "properties": {
             "msgs": {
               "type": "array",
@@ -1234,7 +1432,10 @@
         },
         "Coin": {
           "type": "object",
-          "required": ["amount", "denom"],
+          "required": [
+            "amount",
+            "denom"
+          ],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -1248,7 +1449,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["bank"],
+              "required": [
+                "bank"
+              ],
               "properties": {
                 "bank": {
                   "$ref": "#/definitions/BankMsg"
@@ -1258,7 +1461,9 @@
             },
             {
               "type": "object",
-              "required": ["custom"],
+              "required": [
+                "custom"
+              ],
               "properties": {
                 "custom": {
                   "$ref": "#/definitions/Empty"
@@ -1268,7 +1473,9 @@
             },
             {
               "type": "object",
-              "required": ["staking"],
+              "required": [
+                "staking"
+              ],
               "properties": {
                 "staking": {
                   "$ref": "#/definitions/StakingMsg"
@@ -1278,7 +1485,9 @@
             },
             {
               "type": "object",
-              "required": ["distribution"],
+              "required": [
+                "distribution"
+              ],
               "properties": {
                 "distribution": {
                   "$ref": "#/definitions/DistributionMsg"
@@ -1289,11 +1498,16 @@
             {
               "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
               "type": "object",
-              "required": ["stargate"],
+              "required": [
+                "stargate"
+              ],
               "properties": {
                 "stargate": {
                   "type": "object",
-                  "required": ["type_url", "value"],
+                  "required": [
+                    "type_url",
+                    "value"
+                  ],
                   "properties": {
                     "type_url": {
                       "type": "string"
@@ -1308,7 +1522,9 @@
             },
             {
               "type": "object",
-              "required": ["ibc"],
+              "required": [
+                "ibc"
+              ],
               "properties": {
                 "ibc": {
                   "$ref": "#/definitions/IbcMsg"
@@ -1318,7 +1534,9 @@
             },
             {
               "type": "object",
-              "required": ["wasm"],
+              "required": [
+                "wasm"
+              ],
               "properties": {
                 "wasm": {
                   "$ref": "#/definitions/WasmMsg"
@@ -1328,7 +1546,9 @@
             },
             {
               "type": "object",
-              "required": ["gov"],
+              "required": [
+                "gov"
+              ],
               "properties": {
                 "gov": {
                   "$ref": "#/definitions/GovMsg"
@@ -1348,11 +1568,15 @@
             {
               "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["set_withdraw_address"],
+              "required": [
+                "set_withdraw_address"
+              ],
               "properties": {
                 "set_withdraw_address": {
                   "type": "object",
-                  "required": ["address"],
+                  "required": [
+                    "address"
+                  ],
                   "properties": {
                     "address": {
                       "description": "The `withdraw_address`",
@@ -1366,11 +1590,15 @@
             {
               "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["withdraw_delegator_reward"],
+              "required": [
+                "withdraw_delegator_reward"
+              ],
               "properties": {
                 "withdraw_delegator_reward": {
                   "type": "object",
-                  "required": ["validator"],
+                  "required": [
+                    "validator"
+                  ],
                   "properties": {
                     "validator": {
                       "description": "The `validator_address`",
@@ -1393,7 +1621,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1406,7 +1636,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1417,7 +1649,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -1434,11 +1668,16 @@
             {
               "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
               "type": "object",
-              "required": ["vote"],
+              "required": [
+                "vote"
+              ],
               "properties": {
                 "vote": {
                   "type": "object",
-                  "required": ["proposal_id", "vote"],
+                  "required": [
+                    "proposal_id",
+                    "vote"
+                  ],
                   "properties": {
                     "proposal_id": {
                       "type": "integer",
@@ -1466,11 +1705,18 @@
             {
               "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
               "type": "object",
-              "required": ["transfer"],
+              "required": [
+                "transfer"
+              ],
               "properties": {
                 "transfer": {
                   "type": "object",
-                  "required": ["amount", "channel_id", "timeout", "to_address"],
+                  "required": [
+                    "amount",
+                    "channel_id",
+                    "timeout",
+                    "to_address"
+                  ],
                   "properties": {
                     "amount": {
                       "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -1504,11 +1750,17 @@
             {
               "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
               "type": "object",
-              "required": ["send_packet"],
+              "required": [
+                "send_packet"
+              ],
               "properties": {
                 "send_packet": {
                   "type": "object",
-                  "required": ["channel_id", "data", "timeout"],
+                  "required": [
+                    "channel_id",
+                    "data",
+                    "timeout"
+                  ],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -1532,11 +1784,15 @@
             {
               "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
               "type": "object",
-              "required": ["close_channel"],
+              "required": [
+                "close_channel"
+              ],
               "properties": {
                 "close_channel": {
                   "type": "object",
-                  "required": ["channel_id"],
+                  "required": [
+                    "channel_id"
+                  ],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -1577,7 +1833,10 @@
         "IbcTimeoutBlock": {
           "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
           "type": "object",
-          "required": ["height", "revision"],
+          "required": [
+            "height",
+            "revision"
+          ],
           "properties": {
             "height": {
               "description": "block height after which the packet times out. the height within the given revision",
@@ -1596,7 +1855,10 @@
         "M": {
           "description": "M\n\nA NxN matrix for which M[x, y] == -M[y, x].\n\nIndicies may be incremented or decremented. When index (x, y) is incremented, index (y, x) is decremented with the reverse applying when decrementing an index.\n\nInvariant: indicies along the diagonal must never be incremented or decremented.\n\nThe contents of the matrix are not avaliable, though consumers may call the `stats` method which returns information about the first positive column, or the column closest to containing all positive values.",
           "type": "object",
-          "required": ["cells", "n"],
+          "required": [
+            "cells",
+            "n"
+          ],
           "properties": {
             "cells": {
               "type": "array",
@@ -1618,7 +1880,9 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["majority"],
+              "required": [
+                "majority"
+              ],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -1630,7 +1894,9 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["percent"],
+              "required": [
+                "percent"
+              ],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -1697,11 +1963,16 @@
             {
               "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["delegate"],
+              "required": [
+                "delegate"
+              ],
               "properties": {
                 "delegate": {
                   "type": "object",
-                  "required": ["amount", "validator"],
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -1717,11 +1988,16 @@
             {
               "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["undelegate"],
+              "required": [
+                "undelegate"
+              ],
               "properties": {
                 "undelegate": {
                   "type": "object",
-                  "required": ["amount", "validator"],
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -1737,11 +2013,17 @@
             {
               "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["redelegate"],
+              "required": [
+                "redelegate"
+              ],
               "properties": {
                 "redelegate": {
                   "type": "object",
-                  "required": ["amount", "dst_validator", "src_validator"],
+                  "required": [
+                    "amount",
+                    "dst_validator",
+                    "src_validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -1764,21 +2046,29 @@
             {
               "description": "The proposal is open for voting.",
               "type": "string",
-              "enum": ["open"]
+              "enum": [
+                "open"
+              ]
             },
             {
               "description": "The proposal has been rejected.",
               "type": "string",
-              "enum": ["rejected"]
+              "enum": [
+                "rejected"
+              ]
             },
             {
               "description": "The proposal has passed.",
               "type": "object",
-              "required": ["passed"],
+              "required": [
+                "passed"
+              ],
               "properties": {
                 "passed": {
                   "type": "object",
-                  "required": ["winner"],
+                  "required": [
+                    "winner"
+                  ],
                   "properties": {
                     "winner": {
                       "type": "integer",
@@ -1794,17 +2084,23 @@
             {
               "description": "The proposal has been passed and executed.",
               "type": "string",
-              "enum": ["executed"]
+              "enum": [
+                "executed"
+              ]
             },
             {
               "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
               "type": "string",
-              "enum": ["closed"]
+              "enum": [
+                "closed"
+              ]
             },
             {
               "description": "The proposal's execution failed.",
               "type": "string",
-              "enum": ["execution_failed"]
+              "enum": [
+                "execution_failed"
+              ]
             }
           ]
         },
@@ -1873,7 +2169,12 @@
         },
         "VoteOption": {
           "type": "string",
-          "enum": ["yes", "no", "abstain", "no_with_veto"]
+          "enum": [
+            "yes",
+            "no",
+            "abstain",
+            "no_with_veto"
+          ]
         },
         "WasmMsg": {
           "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
@@ -1881,11 +2182,17 @@
             {
               "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["execute"],
+              "required": [
+                "execute"
+              ],
               "properties": {
                 "execute": {
                   "type": "object",
-                  "required": ["contract_addr", "funds", "msg"],
+                  "required": [
+                    "contract_addr",
+                    "funds",
+                    "msg"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -1912,14 +2219,24 @@
             {
               "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["instantiate"],
+              "required": [
+                "instantiate"
+              ],
               "properties": {
                 "instantiate": {
                   "type": "object",
-                  "required": ["code_id", "funds", "label", "msg"],
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg"
+                  ],
                   "properties": {
                     "admin": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "code_id": {
                       "type": "integer",
@@ -1952,11 +2269,17 @@
             {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["migrate"],
+              "required": [
+                "migrate"
+              ],
               "properties": {
                 "migrate": {
                   "type": "object",
-                  "required": ["contract_addr", "msg", "new_code_id"],
+                  "required": [
+                    "contract_addr",
+                    "msg",
+                    "new_code_id"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -1983,11 +2306,16 @@
             {
               "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": ["update_admin"],
+              "required": [
+                "update_admin"
+              ],
               "properties": {
                 "update_admin": {
                   "type": "object",
-                  "required": ["admin", "contract_addr"],
+                  "required": [
+                    "admin",
+                    "contract_addr"
+                  ],
                   "properties": {
                     "admin": {
                       "type": "string"
@@ -2003,11 +2331,15 @@
             {
               "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": ["clear_admin"],
+              "required": [
+                "clear_admin"
+              ],
               "properties": {
                 "clear_admin": {
                   "type": "object",
-                  "required": ["contract_addr"],
+                  "required": [
+                    "contract_addr"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -2023,11 +2355,16 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": ["never", "none"]
+              "enum": [
+                "never",
+                "none"
+              ]
             },
             {
               "type": "object",
-              "required": ["some"],
+              "required": [
+                "some"
+              ],
               "properties": {
                 "some": {
                   "type": "integer",
@@ -2039,7 +2376,9 @@
             },
             {
               "type": "object",
-              "required": ["undisputed"],
+              "required": [
+                "undisputed"
+              ],
               "properties": {
                 "undisputed": {
                   "type": "integer",

--- a/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
+++ b/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-condorcet",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -43,9 +43,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -58,9 +56,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -78,9 +74,7 @@
           {
             "description": "The majority of voters must vote yes for the proposal to pass.",
             "type": "object",
-            "required": [
-              "majority"
-            ],
+            "required": ["majority"],
             "properties": {
               "majority": {
                 "type": "object",
@@ -92,9 +86,7 @@
           {
             "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
             "type": "object",
-            "required": [
-              "percent"
-            ],
+            "required": ["percent"],
             "properties": {
               "percent": {
                 "$ref": "#/definitions/Decimal"
@@ -112,15 +104,11 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "propose"
-        ],
+        "required": ["propose"],
         "properties": {
           "propose": {
             "type": "object",
-            "required": [
-              "choices"
-            ],
+            "required": ["choices"],
             "properties": {
               "choices": {
                 "type": "array",
@@ -136,16 +124,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "vote"
-        ],
+        "required": ["vote"],
         "properties": {
           "vote": {
             "type": "object",
-            "required": [
-              "proposal_id",
-              "vote"
-            ],
+            "required": ["proposal_id", "vote"],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -168,15 +151,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "execute"
-        ],
+        "required": ["execute"],
         "properties": {
           "execute": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -191,15 +170,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "close"
-        ],
+        "required": ["close"],
         "properties": {
           "close": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -214,9 +189,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "set_config"
-        ],
+        "required": ["set_config"],
         "properties": {
           "set_config": {
             "$ref": "#/definitions/UncheckedConfig"
@@ -232,16 +205,11 @@
           {
             "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "send"
-            ],
+            "required": ["send"],
             "properties": {
               "send": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "to_address"
-                ],
+                "required": ["amount", "to_address"],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -260,15 +228,11 @@
           {
             "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
             "type": "object",
-            "required": [
-              "burn"
-            ],
+            "required": ["burn"],
             "properties": {
               "burn": {
                 "type": "object",
-                "required": [
-                  "amount"
-                ],
+                "required": ["amount"],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -289,9 +253,7 @@
       },
       "Choice": {
         "type": "object",
-        "required": [
-          "msgs"
-        ],
+        "required": ["msgs"],
         "properties": {
           "msgs": {
             "type": "array",
@@ -304,10 +266,7 @@
       },
       "Coin": {
         "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
+        "required": ["amount", "denom"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -321,9 +280,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "bank"
-            ],
+            "required": ["bank"],
             "properties": {
               "bank": {
                 "$ref": "#/definitions/BankMsg"
@@ -333,9 +290,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "custom"
-            ],
+            "required": ["custom"],
             "properties": {
               "custom": {
                 "$ref": "#/definitions/Empty"
@@ -345,9 +300,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "staking"
-            ],
+            "required": ["staking"],
             "properties": {
               "staking": {
                 "$ref": "#/definitions/StakingMsg"
@@ -357,9 +310,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "distribution"
-            ],
+            "required": ["distribution"],
             "properties": {
               "distribution": {
                 "$ref": "#/definitions/DistributionMsg"
@@ -370,16 +321,11 @@
           {
             "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
             "type": "object",
-            "required": [
-              "stargate"
-            ],
+            "required": ["stargate"],
             "properties": {
               "stargate": {
                 "type": "object",
-                "required": [
-                  "type_url",
-                  "value"
-                ],
+                "required": ["type_url", "value"],
                 "properties": {
                   "type_url": {
                     "type": "string"
@@ -394,9 +340,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "ibc"
-            ],
+            "required": ["ibc"],
             "properties": {
               "ibc": {
                 "$ref": "#/definitions/IbcMsg"
@@ -406,9 +350,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "wasm"
-            ],
+            "required": ["wasm"],
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmMsg"
@@ -418,9 +360,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "gov"
-            ],
+            "required": ["gov"],
             "properties": {
               "gov": {
                 "$ref": "#/definitions/GovMsg"
@@ -440,15 +380,11 @@
           {
             "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "set_withdraw_address"
-            ],
+            "required": ["set_withdraw_address"],
             "properties": {
               "set_withdraw_address": {
                 "type": "object",
-                "required": [
-                  "address"
-                ],
+                "required": ["address"],
                 "properties": {
                   "address": {
                     "description": "The `withdraw_address`",
@@ -462,15 +398,11 @@
           {
             "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "withdraw_delegator_reward"
-            ],
+            "required": ["withdraw_delegator_reward"],
             "properties": {
               "withdraw_delegator_reward": {
                 "type": "object",
-                "required": [
-                  "validator"
-                ],
+                "required": ["validator"],
                 "properties": {
                   "validator": {
                     "description": "The `validator_address`",
@@ -488,9 +420,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -503,9 +433,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -527,16 +455,11 @@
           {
             "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
             "type": "object",
-            "required": [
-              "vote"
-            ],
+            "required": ["vote"],
             "properties": {
               "vote": {
                 "type": "object",
-                "required": [
-                  "proposal_id",
-                  "vote"
-                ],
+                "required": ["proposal_id", "vote"],
                 "properties": {
                   "proposal_id": {
                     "type": "integer",
@@ -564,18 +487,11 @@
           {
             "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
             "type": "object",
-            "required": [
-              "transfer"
-            ],
+            "required": ["transfer"],
             "properties": {
               "transfer": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "channel_id",
-                  "timeout",
-                  "to_address"
-                ],
+                "required": ["amount", "channel_id", "timeout", "to_address"],
                 "properties": {
                   "amount": {
                     "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -609,17 +525,11 @@
           {
             "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
             "type": "object",
-            "required": [
-              "send_packet"
-            ],
+            "required": ["send_packet"],
             "properties": {
               "send_packet": {
                 "type": "object",
-                "required": [
-                  "channel_id",
-                  "data",
-                  "timeout"
-                ],
+                "required": ["channel_id", "data", "timeout"],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -643,15 +553,11 @@
           {
             "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
             "type": "object",
-            "required": [
-              "close_channel"
-            ],
+            "required": ["close_channel"],
             "properties": {
               "close_channel": {
                 "type": "object",
-                "required": [
-                  "channel_id"
-                ],
+                "required": ["channel_id"],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -692,10 +598,7 @@
       "IbcTimeoutBlock": {
         "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
         "type": "object",
-        "required": [
-          "height",
-          "revision"
-        ],
+        "required": ["height", "revision"],
         "properties": {
           "height": {
             "description": "block height after which the packet times out. the height within the given revision",
@@ -717,9 +620,7 @@
           {
             "description": "The majority of voters must vote yes for the proposal to pass.",
             "type": "object",
-            "required": [
-              "majority"
-            ],
+            "required": ["majority"],
             "properties": {
               "majority": {
                 "type": "object",
@@ -731,9 +632,7 @@
           {
             "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
             "type": "object",
-            "required": [
-              "percent"
-            ],
+            "required": ["percent"],
             "properties": {
               "percent": {
                 "$ref": "#/definitions/Decimal"
@@ -749,16 +648,11 @@
           {
             "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "delegate"
-            ],
+            "required": ["delegate"],
             "properties": {
               "delegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "validator"
-                ],
+                "required": ["amount", "validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -774,16 +668,11 @@
           {
             "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "undelegate"
-            ],
+            "required": ["undelegate"],
             "properties": {
               "undelegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "validator"
-                ],
+                "required": ["amount", "validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -799,17 +688,11 @@
           {
             "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "redelegate"
-            ],
+            "required": ["redelegate"],
             "properties": {
               "redelegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "dst_validator",
-                  "src_validator"
-                ],
+                "required": ["amount", "dst_validator", "src_validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -875,12 +758,7 @@
       },
       "VoteOption": {
         "type": "string",
-        "enum": [
-          "yes",
-          "no",
-          "abstain",
-          "no_with_veto"
-        ]
+        "enum": ["yes", "no", "abstain", "no_with_veto"]
       },
       "WasmMsg": {
         "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
@@ -888,17 +766,11 @@
           {
             "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "execute"
-            ],
+            "required": ["execute"],
             "properties": {
               "execute": {
                 "type": "object",
-                "required": [
-                  "contract_addr",
-                  "funds",
-                  "msg"
-                ],
+                "required": ["contract_addr", "funds", "msg"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -925,24 +797,14 @@
           {
             "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "instantiate"
-            ],
+            "required": ["instantiate"],
             "properties": {
               "instantiate": {
                 "type": "object",
-                "required": [
-                  "code_id",
-                  "funds",
-                  "label",
-                  "msg"
-                ],
+                "required": ["code_id", "funds", "label", "msg"],
                 "properties": {
                   "admin": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": ["string", "null"]
                   },
                   "code_id": {
                     "type": "integer",
@@ -975,17 +837,11 @@
           {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "migrate"
-            ],
+            "required": ["migrate"],
             "properties": {
               "migrate": {
                 "type": "object",
-                "required": [
-                  "contract_addr",
-                  "msg",
-                  "new_code_id"
-                ],
+                "required": ["contract_addr", "msg", "new_code_id"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1012,16 +868,11 @@
           {
             "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": [
-              "update_admin"
-            ],
+            "required": ["update_admin"],
             "properties": {
               "update_admin": {
                 "type": "object",
-                "required": [
-                  "admin",
-                  "contract_addr"
-                ],
+                "required": ["admin", "contract_addr"],
                 "properties": {
                   "admin": {
                     "type": "string"
@@ -1037,15 +888,11 @@
           {
             "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": [
-              "clear_admin"
-            ],
+            "required": ["clear_admin"],
             "properties": {
               "clear_admin": {
                 "type": "object",
-                "required": [
-                  "contract_addr"
-                ],
+                "required": ["contract_addr"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1065,15 +912,11 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "proposal"
-        ],
+        "required": ["proposal"],
         "properties": {
           "proposal": {
             "type": "object",
-            "required": [
-              "id"
-            ],
+            "required": ["id"],
             "properties": {
               "id": {
                 "type": "integer",
@@ -1088,9 +931,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "config"
-        ],
+        "required": ["config"],
         "properties": {
           "config": {
             "type": "object",
@@ -1102,9 +943,7 @@
       {
         "description": "Returns the address of the DAO this module belongs to",
         "type": "object",
-        "required": [
-          "dao"
-        ],
+        "required": ["dao"],
         "properties": {
           "dao": {
             "type": "object",
@@ -1116,9 +955,7 @@
       {
         "description": "Returns contract version info",
         "type": "object",
-        "required": [
-          "info"
-        ],
+        "required": ["info"],
         "properties": {
           "info": {
             "type": "object",
@@ -1130,9 +967,7 @@
       {
         "description": "Returns the proposal ID that will be assigned to the next proposal created.",
         "type": "object",
-        "required": [
-          "next_proposal_id"
-        ],
+        "required": ["next_proposal_id"],
         "properties": {
           "next_proposal_id": {
             "type": "object",
@@ -1187,9 +1022,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "height"
-              ],
+              "required": ["height"],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -1202,9 +1035,7 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": [
-                "time"
-              ],
+              "required": ["time"],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -1222,9 +1053,7 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "majority"
-              ],
+              "required": ["majority"],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -1236,9 +1065,7 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "percent"
-              ],
+              "required": ["percent"],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -1260,9 +1087,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": [
-        "info"
-      ],
+      "required": ["info"],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -1272,10 +1097,7 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": [
-            "contract",
-            "version"
-          ],
+          "required": ["contract", "version"],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -1301,10 +1123,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ProposalResponse",
       "type": "object",
-      "required": [
-        "proposal",
-        "tally"
-      ],
+      "required": ["proposal", "tally"],
       "properties": {
         "proposal": {
           "$ref": "#/definitions/Proposal"
@@ -1325,16 +1144,11 @@
             {
               "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "send"
-              ],
+              "required": ["send"],
               "properties": {
                 "send": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "to_address"
-                  ],
+                  "required": ["amount", "to_address"],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -1353,15 +1167,11 @@
             {
               "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
               "type": "object",
-              "required": [
-                "burn"
-              ],
+              "required": ["burn"],
               "properties": {
                 "burn": {
                   "type": "object",
-                  "required": [
-                    "amount"
-                  ],
+                  "required": ["amount"],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -1385,15 +1195,11 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": [
-                "zero"
-              ]
+              "enum": ["zero"]
             },
             {
               "type": "object",
-              "required": [
-                "positive"
-              ],
+              "required": ["positive"],
               "properties": {
                 "positive": {
                   "$ref": "#/definitions/Uint128"
@@ -1403,9 +1209,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "negative"
-              ],
+              "required": ["negative"],
               "properties": {
                 "negative": {
                   "$ref": "#/definitions/Uint128"
@@ -1417,9 +1221,7 @@
         },
         "Choice": {
           "type": "object",
-          "required": [
-            "msgs"
-          ],
+          "required": ["msgs"],
           "properties": {
             "msgs": {
               "type": "array",
@@ -1432,10 +1234,7 @@
         },
         "Coin": {
           "type": "object",
-          "required": [
-            "amount",
-            "denom"
-          ],
+          "required": ["amount", "denom"],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -1449,9 +1248,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "bank"
-              ],
+              "required": ["bank"],
               "properties": {
                 "bank": {
                   "$ref": "#/definitions/BankMsg"
@@ -1461,9 +1258,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "custom"
-              ],
+              "required": ["custom"],
               "properties": {
                 "custom": {
                   "$ref": "#/definitions/Empty"
@@ -1473,9 +1268,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "staking"
-              ],
+              "required": ["staking"],
               "properties": {
                 "staking": {
                   "$ref": "#/definitions/StakingMsg"
@@ -1485,9 +1278,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "distribution"
-              ],
+              "required": ["distribution"],
               "properties": {
                 "distribution": {
                   "$ref": "#/definitions/DistributionMsg"
@@ -1498,16 +1289,11 @@
             {
               "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
               "type": "object",
-              "required": [
-                "stargate"
-              ],
+              "required": ["stargate"],
               "properties": {
                 "stargate": {
                   "type": "object",
-                  "required": [
-                    "type_url",
-                    "value"
-                  ],
+                  "required": ["type_url", "value"],
                   "properties": {
                     "type_url": {
                       "type": "string"
@@ -1522,9 +1308,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "ibc"
-              ],
+              "required": ["ibc"],
               "properties": {
                 "ibc": {
                   "$ref": "#/definitions/IbcMsg"
@@ -1534,9 +1318,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "wasm"
-              ],
+              "required": ["wasm"],
               "properties": {
                 "wasm": {
                   "$ref": "#/definitions/WasmMsg"
@@ -1546,9 +1328,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "gov"
-              ],
+              "required": ["gov"],
               "properties": {
                 "gov": {
                   "$ref": "#/definitions/GovMsg"
@@ -1568,15 +1348,11 @@
             {
               "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "set_withdraw_address"
-              ],
+              "required": ["set_withdraw_address"],
               "properties": {
                 "set_withdraw_address": {
                   "type": "object",
-                  "required": [
-                    "address"
-                  ],
+                  "required": ["address"],
                   "properties": {
                     "address": {
                       "description": "The `withdraw_address`",
@@ -1590,15 +1366,11 @@
             {
               "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "withdraw_delegator_reward"
-              ],
+              "required": ["withdraw_delegator_reward"],
               "properties": {
                 "withdraw_delegator_reward": {
                   "type": "object",
-                  "required": [
-                    "validator"
-                  ],
+                  "required": ["validator"],
                   "properties": {
                     "validator": {
                       "description": "The `validator_address`",
@@ -1621,9 +1393,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -1636,9 +1406,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -1649,9 +1417,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -1668,16 +1434,11 @@
             {
               "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
               "type": "object",
-              "required": [
-                "vote"
-              ],
+              "required": ["vote"],
               "properties": {
                 "vote": {
                   "type": "object",
-                  "required": [
-                    "proposal_id",
-                    "vote"
-                  ],
+                  "required": ["proposal_id", "vote"],
                   "properties": {
                     "proposal_id": {
                       "type": "integer",
@@ -1705,18 +1466,11 @@
             {
               "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
               "type": "object",
-              "required": [
-                "transfer"
-              ],
+              "required": ["transfer"],
               "properties": {
                 "transfer": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "channel_id",
-                    "timeout",
-                    "to_address"
-                  ],
+                  "required": ["amount", "channel_id", "timeout", "to_address"],
                   "properties": {
                     "amount": {
                       "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -1750,17 +1504,11 @@
             {
               "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
               "type": "object",
-              "required": [
-                "send_packet"
-              ],
+              "required": ["send_packet"],
               "properties": {
                 "send_packet": {
                   "type": "object",
-                  "required": [
-                    "channel_id",
-                    "data",
-                    "timeout"
-                  ],
+                  "required": ["channel_id", "data", "timeout"],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -1784,15 +1532,11 @@
             {
               "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
               "type": "object",
-              "required": [
-                "close_channel"
-              ],
+              "required": ["close_channel"],
               "properties": {
                 "close_channel": {
                   "type": "object",
-                  "required": [
-                    "channel_id"
-                  ],
+                  "required": ["channel_id"],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -1833,10 +1577,7 @@
         "IbcTimeoutBlock": {
           "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
           "type": "object",
-          "required": [
-            "height",
-            "revision"
-          ],
+          "required": ["height", "revision"],
           "properties": {
             "height": {
               "description": "block height after which the packet times out. the height within the given revision",
@@ -1855,10 +1596,7 @@
         "M": {
           "description": "M\n\nA NxN matrix for which M[x, y] == -M[y, x].\n\nIndicies may be incremented or decremented. When index (x, y) is incremented, index (y, x) is decremented with the reverse applying when decrementing an index.\n\nInvariant: indicies along the diagonal must never be incremented or decremented.\n\nThe contents of the matrix are not avaliable, though consumers may call the `stats` method which returns information about the first positive column, or the column closest to containing all positive values.",
           "type": "object",
-          "required": [
-            "cells",
-            "n"
-          ],
+          "required": ["cells", "n"],
           "properties": {
             "cells": {
               "type": "array",
@@ -1880,9 +1618,7 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "majority"
-              ],
+              "required": ["majority"],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -1894,9 +1630,7 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "percent"
-              ],
+              "required": ["percent"],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -1963,16 +1697,11 @@
             {
               "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "delegate"
-              ],
+              "required": ["delegate"],
               "properties": {
                 "delegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "validator"
-                  ],
+                  "required": ["amount", "validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -1988,16 +1717,11 @@
             {
               "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "undelegate"
-              ],
+              "required": ["undelegate"],
               "properties": {
                 "undelegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "validator"
-                  ],
+                  "required": ["amount", "validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -2013,17 +1737,11 @@
             {
               "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "redelegate"
-              ],
+              "required": ["redelegate"],
               "properties": {
                 "redelegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "dst_validator",
-                    "src_validator"
-                  ],
+                  "required": ["amount", "dst_validator", "src_validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -2046,29 +1764,21 @@
             {
               "description": "The proposal is open for voting.",
               "type": "string",
-              "enum": [
-                "open"
-              ]
+              "enum": ["open"]
             },
             {
               "description": "The proposal has been rejected.",
               "type": "string",
-              "enum": [
-                "rejected"
-              ]
+              "enum": ["rejected"]
             },
             {
               "description": "The proposal has passed.",
               "type": "object",
-              "required": [
-                "passed"
-              ],
+              "required": ["passed"],
               "properties": {
                 "passed": {
                   "type": "object",
-                  "required": [
-                    "winner"
-                  ],
+                  "required": ["winner"],
                   "properties": {
                     "winner": {
                       "type": "integer",
@@ -2084,23 +1794,17 @@
             {
               "description": "The proposal has been passed and executed.",
               "type": "string",
-              "enum": [
-                "executed"
-              ]
+              "enum": ["executed"]
             },
             {
               "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
               "type": "string",
-              "enum": [
-                "closed"
-              ]
+              "enum": ["closed"]
             },
             {
               "description": "The proposal's execution failed.",
               "type": "string",
-              "enum": [
-                "execution_failed"
-              ]
+              "enum": ["execution_failed"]
             }
           ]
         },
@@ -2169,12 +1873,7 @@
         },
         "VoteOption": {
           "type": "string",
-          "enum": [
-            "yes",
-            "no",
-            "abstain",
-            "no_with_veto"
-          ]
+          "enum": ["yes", "no", "abstain", "no_with_veto"]
         },
         "WasmMsg": {
           "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
@@ -2182,17 +1881,11 @@
             {
               "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "execute"
-              ],
+              "required": ["execute"],
               "properties": {
                 "execute": {
                   "type": "object",
-                  "required": [
-                    "contract_addr",
-                    "funds",
-                    "msg"
-                  ],
+                  "required": ["contract_addr", "funds", "msg"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -2219,24 +1912,14 @@
             {
               "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "instantiate"
-              ],
+              "required": ["instantiate"],
               "properties": {
                 "instantiate": {
                   "type": "object",
-                  "required": [
-                    "code_id",
-                    "funds",
-                    "label",
-                    "msg"
-                  ],
+                  "required": ["code_id", "funds", "label", "msg"],
                   "properties": {
                     "admin": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": ["string", "null"]
                     },
                     "code_id": {
                       "type": "integer",
@@ -2269,17 +1952,11 @@
             {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "migrate"
-              ],
+              "required": ["migrate"],
               "properties": {
                 "migrate": {
                   "type": "object",
-                  "required": [
-                    "contract_addr",
-                    "msg",
-                    "new_code_id"
-                  ],
+                  "required": ["contract_addr", "msg", "new_code_id"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -2306,16 +1983,11 @@
             {
               "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": [
-                "update_admin"
-              ],
+              "required": ["update_admin"],
               "properties": {
                 "update_admin": {
                   "type": "object",
-                  "required": [
-                    "admin",
-                    "contract_addr"
-                  ],
+                  "required": ["admin", "contract_addr"],
                   "properties": {
                     "admin": {
                       "type": "string"
@@ -2331,15 +2003,11 @@
             {
               "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": [
-                "clear_admin"
-              ],
+              "required": ["clear_admin"],
               "properties": {
                 "clear_admin": {
                   "type": "object",
-                  "required": [
-                    "contract_addr"
-                  ],
+                  "required": ["contract_addr"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -2355,16 +2023,11 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": [
-                "never",
-                "none"
-              ]
+              "enum": ["never", "none"]
             },
             {
               "type": "object",
-              "required": [
-                "some"
-              ],
+              "required": ["some"],
               "properties": {
                 "some": {
                   "type": "integer",
@@ -2376,9 +2039,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "undisputed"
-              ],
+              "required": ["undisputed"],
               "properties": {
                 "undisputed": {
                   "type": "integer",

--- a/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
+++ b/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
@@ -82,11 +82,15 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "object",
-                "required": ["addr"],
+                "required": [
+                  "addr"
+                ],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -100,7 +104,9 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": ["core_module"],
+            "required": [
+              "core_module"
+            ],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -117,7 +123,10 @@
       },
       "Coin": {
         "type": "object",
-        "required": ["amount", "denom"],
+        "required": [
+          "amount",
+          "denom"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -136,7 +145,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -149,7 +160,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -164,7 +177,12 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": ["code_id", "funds", "label", "msg"],
+        "required": [
+          "code_id",
+          "funds",
+          "label",
+          "msg"
+        ],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -211,7 +229,9 @@
           {
             "description": "The majority of voters must vote yes for the proposal to pass.",
             "type": "object",
-            "required": ["majority"],
+            "required": [
+              "majority"
+            ],
             "properties": {
               "majority": {
                 "type": "object",
@@ -223,7 +243,9 @@
           {
             "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
             "type": "object",
-            "required": ["percent"],
+            "required": [
+              "percent"
+            ],
             "properties": {
               "percent": {
                 "$ref": "#/definitions/Decimal"
@@ -238,7 +260,9 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": ["anyone_may_propose"],
+            "required": [
+              "anyone_may_propose"
+            ],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -250,11 +274,15 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": ["module_may_propose"],
+            "required": [
+              "module_may_propose"
+            ],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": ["info"],
+                "required": [
+                  "info"
+                ],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -308,11 +336,15 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["single_choice"],
+            "required": [
+              "single_choice"
+            ],
             "properties": {
               "single_choice": {
                 "type": "object",
-                "required": ["quorum"],
+                "required": [
+                  "quorum"
+                ],
                 "properties": {
                   "quorum": {
                     "$ref": "#/definitions/PercentageThreshold"
@@ -334,7 +366,9 @@
       {
         "description": "Creates a proposal in the governance module.",
         "type": "object",
-        "required": ["propose"],
+        "required": [
+          "propose"
+        ],
         "properties": {
           "propose": {
             "$ref": "#/definitions/MultipleChoiceProposeMsg"
@@ -345,11 +379,16 @@
       {
         "description": "Votes on a proposal. Voting power is determined by the DAO's voting power module.",
         "type": "object",
-        "required": ["vote"],
+        "required": [
+          "vote"
+        ],
         "properties": {
           "vote": {
             "type": "object",
-            "required": ["proposal_id", "vote"],
+            "required": [
+              "proposal_id",
+              "vote"
+            ],
             "properties": {
               "proposal_id": {
                 "description": "The ID of the proposal to vote on.",
@@ -359,7 +398,10 @@
               },
               "rationale": {
                 "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "vote": {
                 "description": "The senders position on the proposal.",
@@ -378,11 +420,15 @@
       {
         "description": "Causes the messages associated with a passed proposal to be executed by the DAO.",
         "type": "object",
-        "required": ["execute"],
+        "required": [
+          "execute"
+        ],
         "properties": {
           "execute": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "proposal_id": {
                 "description": "The ID of the proposal to execute.",
@@ -399,11 +445,15 @@
       {
         "description": "Callable only if veto is configured",
         "type": "object",
-        "required": ["veto"],
+        "required": [
+          "veto"
+        ],
         "properties": {
           "veto": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "proposal_id": {
                 "description": "The ID of the proposal to veto.",
@@ -420,11 +470,15 @@
       {
         "description": "Closes a proposal that has failed (either not passed or timed out). If applicable this will cause the proposal deposit associated wth said proposal to be returned.",
         "type": "object",
-        "required": ["close"],
+        "required": [
+          "close"
+        ],
         "properties": {
           "close": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "proposal_id": {
                 "description": "The ID of the proposal to close.",
@@ -441,7 +495,9 @@
       {
         "description": "Updates the governance module's config.",
         "type": "object",
-        "required": ["update_config"],
+        "required": [
+          "update_config"
+        ],
         "properties": {
           "update_config": {
             "type": "object",
@@ -517,11 +573,15 @@
       {
         "description": "Updates the sender's rationale for their vote on the specified proposal. Errors if no vote vote has been cast.",
         "type": "object",
-        "required": ["update_rationale"],
+        "required": [
+          "update_rationale"
+        ],
         "properties": {
           "update_rationale": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -529,7 +589,10 @@
                 "minimum": 0.0
               },
               "rationale": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -540,11 +603,15 @@
       {
         "description": "Update's the proposal creation policy used for this module. Only the DAO may call this method.",
         "type": "object",
-        "required": ["update_pre_propose_info"],
+        "required": [
+          "update_pre_propose_info"
+        ],
         "properties": {
           "update_pre_propose_info": {
             "type": "object",
-            "required": ["info"],
+            "required": [
+              "info"
+            ],
             "properties": {
               "info": {
                 "$ref": "#/definitions/PreProposeInfo"
@@ -557,11 +624,15 @@
       },
       {
         "type": "object",
-        "required": ["add_proposal_hook"],
+        "required": [
+          "add_proposal_hook"
+        ],
         "properties": {
           "add_proposal_hook": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -574,11 +645,15 @@
       },
       {
         "type": "object",
-        "required": ["remove_proposal_hook"],
+        "required": [
+          "remove_proposal_hook"
+        ],
         "properties": {
           "remove_proposal_hook": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -591,11 +666,15 @@
       },
       {
         "type": "object",
-        "required": ["add_vote_hook"],
+        "required": [
+          "add_vote_hook"
+        ],
         "properties": {
           "add_vote_hook": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -608,11 +687,15 @@
       },
       {
         "type": "object",
-        "required": ["remove_vote_hook"],
+        "required": [
+          "remove_vote_hook"
+        ],
         "properties": {
           "remove_vote_hook": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -631,11 +714,15 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "object",
-                "required": ["addr"],
+                "required": [
+                  "addr"
+                ],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -649,7 +736,9 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": ["core_module"],
+            "required": [
+              "core_module"
+            ],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -666,11 +755,16 @@
           {
             "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["send"],
+            "required": [
+              "send"
+            ],
             "properties": {
               "send": {
                 "type": "object",
-                "required": ["amount", "to_address"],
+                "required": [
+                  "amount",
+                  "to_address"
+                ],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -689,11 +783,15 @@
           {
             "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
             "type": "object",
-            "required": ["burn"],
+            "required": [
+              "burn"
+            ],
             "properties": {
               "burn": {
                 "type": "object",
-                "required": ["amount"],
+                "required": [
+                  "amount"
+                ],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -714,7 +812,10 @@
       },
       "Coin": {
         "type": "object",
-        "required": ["amount", "denom"],
+        "required": [
+          "amount",
+          "denom"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -728,7 +829,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["bank"],
+            "required": [
+              "bank"
+            ],
             "properties": {
               "bank": {
                 "$ref": "#/definitions/BankMsg"
@@ -738,7 +841,9 @@
           },
           {
             "type": "object",
-            "required": ["custom"],
+            "required": [
+              "custom"
+            ],
             "properties": {
               "custom": {
                 "$ref": "#/definitions/Empty"
@@ -748,7 +853,9 @@
           },
           {
             "type": "object",
-            "required": ["staking"],
+            "required": [
+              "staking"
+            ],
             "properties": {
               "staking": {
                 "$ref": "#/definitions/StakingMsg"
@@ -758,7 +865,9 @@
           },
           {
             "type": "object",
-            "required": ["distribution"],
+            "required": [
+              "distribution"
+            ],
             "properties": {
               "distribution": {
                 "$ref": "#/definitions/DistributionMsg"
@@ -769,11 +878,16 @@
           {
             "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
             "type": "object",
-            "required": ["stargate"],
+            "required": [
+              "stargate"
+            ],
             "properties": {
               "stargate": {
                 "type": "object",
-                "required": ["type_url", "value"],
+                "required": [
+                  "type_url",
+                  "value"
+                ],
                 "properties": {
                   "type_url": {
                     "type": "string"
@@ -788,7 +902,9 @@
           },
           {
             "type": "object",
-            "required": ["ibc"],
+            "required": [
+              "ibc"
+            ],
             "properties": {
               "ibc": {
                 "$ref": "#/definitions/IbcMsg"
@@ -798,7 +914,9 @@
           },
           {
             "type": "object",
-            "required": ["wasm"],
+            "required": [
+              "wasm"
+            ],
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmMsg"
@@ -808,7 +926,9 @@
           },
           {
             "type": "object",
-            "required": ["gov"],
+            "required": [
+              "gov"
+            ],
             "properties": {
               "gov": {
                 "$ref": "#/definitions/GovMsg"
@@ -828,11 +948,15 @@
           {
             "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["set_withdraw_address"],
+            "required": [
+              "set_withdraw_address"
+            ],
             "properties": {
               "set_withdraw_address": {
                 "type": "object",
-                "required": ["address"],
+                "required": [
+                  "address"
+                ],
                 "properties": {
                   "address": {
                     "description": "The `withdraw_address`",
@@ -846,11 +970,15 @@
           {
             "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["withdraw_delegator_reward"],
+            "required": [
+              "withdraw_delegator_reward"
+            ],
             "properties": {
               "withdraw_delegator_reward": {
                 "type": "object",
-                "required": ["validator"],
+                "required": [
+                  "validator"
+                ],
                 "properties": {
                   "validator": {
                     "description": "The `validator_address`",
@@ -868,7 +996,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -881,7 +1011,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -903,11 +1035,16 @@
           {
             "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
             "type": "object",
-            "required": ["vote"],
+            "required": [
+              "vote"
+            ],
             "properties": {
               "vote": {
                 "type": "object",
-                "required": ["proposal_id", "vote"],
+                "required": [
+                  "proposal_id",
+                  "vote"
+                ],
                 "properties": {
                   "proposal_id": {
                     "type": "integer",
@@ -935,11 +1072,18 @@
           {
             "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
             "type": "object",
-            "required": ["transfer"],
+            "required": [
+              "transfer"
+            ],
             "properties": {
               "transfer": {
                 "type": "object",
-                "required": ["amount", "channel_id", "timeout", "to_address"],
+                "required": [
+                  "amount",
+                  "channel_id",
+                  "timeout",
+                  "to_address"
+                ],
                 "properties": {
                   "amount": {
                     "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -973,11 +1117,17 @@
           {
             "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
             "type": "object",
-            "required": ["send_packet"],
+            "required": [
+              "send_packet"
+            ],
             "properties": {
               "send_packet": {
                 "type": "object",
-                "required": ["channel_id", "data", "timeout"],
+                "required": [
+                  "channel_id",
+                  "data",
+                  "timeout"
+                ],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -1001,11 +1151,15 @@
           {
             "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
             "type": "object",
-            "required": ["close_channel"],
+            "required": [
+              "close_channel"
+            ],
             "properties": {
               "close_channel": {
                 "type": "object",
-                "required": ["channel_id"],
+                "required": [
+                  "channel_id"
+                ],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -1046,7 +1200,10 @@
       "IbcTimeoutBlock": {
         "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
         "type": "object",
-        "required": ["height", "revision"],
+        "required": [
+          "height",
+          "revision"
+        ],
         "properties": {
           "height": {
             "description": "block height after which the packet times out. the height within the given revision",
@@ -1065,7 +1222,12 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": ["code_id", "funds", "label", "msg"],
+        "required": [
+          "code_id",
+          "funds",
+          "label",
+          "msg"
+        ],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -1108,11 +1270,16 @@
       },
       "MultipleChoiceAutoVote": {
         "type": "object",
-        "required": ["vote"],
+        "required": [
+          "vote"
+        ],
         "properties": {
           "rationale": {
             "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "vote": {
             "description": "The proposer's position on the proposal.",
@@ -1128,7 +1295,11 @@
       "MultipleChoiceOption": {
         "description": "Unchecked multiple choice option",
         "type": "object",
-        "required": ["description", "msgs", "title"],
+        "required": [
+          "description",
+          "msgs",
+          "title"
+        ],
         "properties": {
           "description": {
             "type": "string"
@@ -1148,7 +1319,9 @@
       "MultipleChoiceOptions": {
         "description": "Represents unchecked multiple choice options",
         "type": "object",
-        "required": ["options"],
+        "required": [
+          "options"
+        ],
         "properties": {
           "options": {
             "type": "array",
@@ -1162,7 +1335,11 @@
       "MultipleChoiceProposeMsg": {
         "description": "The contents of a message to create a proposal in the multiple choice proposal module.\n\nWe break this type out of `ExecuteMsg` because we want pre-propose modules that interact with this contract to be able to get type checking on their propose messages.\n\nWe move this type to this package so that pre-propose modules can import it without importing dao-proposal-multiple with the library feature which (as it is not additive) cause the execute exports to not be included in wasm builds.",
         "type": "object",
-        "required": ["choices", "description", "title"],
+        "required": [
+          "choices",
+          "description",
+          "title"
+        ],
         "properties": {
           "choices": {
             "description": "The multiple choices.",
@@ -1178,7 +1355,10 @@
           },
           "proposer": {
             "description": "The address creating the proposal. If no pre-propose module is attached to this module this must always be None as the proposer is the sender of the propose message. If a pre-propose module is attached, this must be Some and will set the proposer of the proposal it creates.",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "title": {
             "description": "The title of the proposal.",
@@ -1201,7 +1381,9 @@
       "MultipleChoiceVote": {
         "description": "A multiple choice vote, picking the desired option",
         "type": "object",
-        "required": ["option_id"],
+        "required": [
+          "option_id"
+        ],
         "properties": {
           "option_id": {
             "type": "integer",
@@ -1217,7 +1399,9 @@
           {
             "description": "The majority of voters must vote yes for the proposal to pass.",
             "type": "object",
-            "required": ["majority"],
+            "required": [
+              "majority"
+            ],
             "properties": {
               "majority": {
                 "type": "object",
@@ -1229,7 +1413,9 @@
           {
             "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
             "type": "object",
-            "required": ["percent"],
+            "required": [
+              "percent"
+            ],
             "properties": {
               "percent": {
                 "$ref": "#/definitions/Decimal"
@@ -1244,7 +1430,9 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": ["anyone_may_propose"],
+            "required": [
+              "anyone_may_propose"
+            ],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -1256,11 +1444,15 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": ["module_may_propose"],
+            "required": [
+              "module_may_propose"
+            ],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": ["info"],
+                "required": [
+                  "info"
+                ],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -1279,11 +1471,16 @@
           {
             "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["delegate"],
+            "required": [
+              "delegate"
+            ],
             "properties": {
               "delegate": {
                 "type": "object",
-                "required": ["amount", "validator"],
+                "required": [
+                  "amount",
+                  "validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1299,11 +1496,16 @@
           {
             "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["undelegate"],
+            "required": [
+              "undelegate"
+            ],
             "properties": {
               "undelegate": {
                 "type": "object",
-                "required": ["amount", "validator"],
+                "required": [
+                  "amount",
+                  "validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1319,11 +1521,17 @@
           {
             "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["redelegate"],
+            "required": [
+              "redelegate"
+            ],
             "properties": {
               "redelegate": {
                 "type": "object",
-                "required": ["amount", "dst_validator", "src_validator"],
+                "required": [
+                  "amount",
+                  "dst_validator",
+                  "src_validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1391,18 +1599,27 @@
       },
       "VoteOption": {
         "type": "string",
-        "enum": ["yes", "no", "abstain", "no_with_veto"]
+        "enum": [
+          "yes",
+          "no",
+          "abstain",
+          "no_with_veto"
+        ]
       },
       "VotingStrategy": {
         "description": "Determines how many choices may be selected.",
         "oneOf": [
           {
             "type": "object",
-            "required": ["single_choice"],
+            "required": [
+              "single_choice"
+            ],
             "properties": {
               "single_choice": {
                 "type": "object",
-                "required": ["quorum"],
+                "required": [
+                  "quorum"
+                ],
                 "properties": {
                   "quorum": {
                     "$ref": "#/definitions/PercentageThreshold"
@@ -1421,11 +1638,17 @@
           {
             "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["execute"],
+            "required": [
+              "execute"
+            ],
             "properties": {
               "execute": {
                 "type": "object",
-                "required": ["contract_addr", "funds", "msg"],
+                "required": [
+                  "contract_addr",
+                  "funds",
+                  "msg"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1452,14 +1675,24 @@
           {
             "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["instantiate"],
+            "required": [
+              "instantiate"
+            ],
             "properties": {
               "instantiate": {
                 "type": "object",
-                "required": ["code_id", "funds", "label", "msg"],
+                "required": [
+                  "code_id",
+                  "funds",
+                  "label",
+                  "msg"
+                ],
                 "properties": {
                   "admin": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "code_id": {
                     "type": "integer",
@@ -1492,11 +1725,17 @@
           {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["migrate"],
+            "required": [
+              "migrate"
+            ],
             "properties": {
               "migrate": {
                 "type": "object",
-                "required": ["contract_addr", "msg", "new_code_id"],
+                "required": [
+                  "contract_addr",
+                  "msg",
+                  "new_code_id"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1523,11 +1762,16 @@
           {
             "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": ["update_admin"],
+            "required": [
+              "update_admin"
+            ],
             "properties": {
               "update_admin": {
                 "type": "object",
-                "required": ["admin", "contract_addr"],
+                "required": [
+                  "admin",
+                  "contract_addr"
+                ],
                 "properties": {
                   "admin": {
                     "type": "string"
@@ -1543,11 +1787,15 @@
           {
             "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": ["clear_admin"],
+            "required": [
+              "clear_admin"
+            ],
             "properties": {
               "clear_admin": {
                 "type": "object",
-                "required": ["contract_addr"],
+                "required": [
+                  "contract_addr"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1568,7 +1816,9 @@
       {
         "description": "Gets the governance module's config.",
         "type": "object",
-        "required": ["config"],
+        "required": [
+          "config"
+        ],
         "properties": {
           "config": {
             "type": "object",
@@ -1580,11 +1830,15 @@
       {
         "description": "Gets information about a proposal.",
         "type": "object",
-        "required": ["proposal"],
+        "required": [
+          "proposal"
+        ],
         "properties": {
           "proposal": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -1600,18 +1854,26 @@
       {
         "description": "Lists all the proposals that have been cast in this module.",
         "type": "object",
-        "required": ["list_proposals"],
+        "required": [
+          "list_proposals"
+        ],
         "properties": {
           "list_proposals": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -1624,18 +1886,26 @@
       {
         "description": "Lists all of the proposals that have been cast in this module in decending order of proposal ID.",
         "type": "object",
-        "required": ["reverse_proposals"],
+        "required": [
+          "reverse_proposals"
+        ],
         "properties": {
           "reverse_proposals": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               },
               "start_before": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -1648,11 +1918,16 @@
       {
         "description": "Returns a voters position on a proposal.",
         "type": "object",
-        "required": ["get_vote"],
+        "required": [
+          "get_vote"
+        ],
         "properties": {
           "get_vote": {
             "type": "object",
-            "required": ["proposal_id", "voter"],
+            "required": [
+              "proposal_id",
+              "voter"
+            ],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -1671,14 +1946,21 @@
       {
         "description": "Lists all of the votes that have been cast on a proposal.",
         "type": "object",
-        "required": ["list_votes"],
+        "required": [
+          "list_votes"
+        ],
         "properties": {
           "list_votes": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               },
@@ -1688,7 +1970,10 @@
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -1699,7 +1984,9 @@
       {
         "description": "Returns the number of proposals that have been created in this module.",
         "type": "object",
-        "required": ["proposal_count"],
+        "required": [
+          "proposal_count"
+        ],
         "properties": {
           "proposal_count": {
             "type": "object",
@@ -1711,7 +1998,9 @@
       {
         "description": "Gets the current proposal creation policy for this module.",
         "type": "object",
-        "required": ["proposal_creation_policy"],
+        "required": [
+          "proposal_creation_policy"
+        ],
         "properties": {
           "proposal_creation_policy": {
             "type": "object",
@@ -1723,7 +2012,9 @@
       {
         "description": "Lists all of the consumers of proposal hooks for this module.",
         "type": "object",
-        "required": ["proposal_hooks"],
+        "required": [
+          "proposal_hooks"
+        ],
         "properties": {
           "proposal_hooks": {
             "type": "object",
@@ -1735,7 +2026,9 @@
       {
         "description": "Lists all of the consumers of vote hooks for this module.",
         "type": "object",
-        "required": ["vote_hooks"],
+        "required": [
+          "vote_hooks"
+        ],
         "properties": {
           "vote_hooks": {
             "type": "object",
@@ -1747,7 +2040,9 @@
       {
         "description": "Returns the address of the DAO this module belongs to",
         "type": "object",
-        "required": ["dao"],
+        "required": [
+          "dao"
+        ],
         "properties": {
           "dao": {
             "type": "object",
@@ -1759,7 +2054,9 @@
       {
         "description": "Returns contract version info",
         "type": "object",
-        "required": ["info"],
+        "required": [
+          "info"
+        ],
         "properties": {
           "info": {
             "type": "object",
@@ -1771,7 +2068,9 @@
       {
         "description": "Returns the proposal ID that will be assigned to the next proposal created.",
         "type": "object",
-        "required": ["next_proposal_id"],
+        "required": [
+          "next_proposal_id"
+        ],
         "properties": {
           "next_proposal_id": {
             "type": "object",
@@ -1788,7 +2087,9 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["from_v1"],
+        "required": [
+          "from_v1"
+        ],
         "properties": {
           "from_v1": {
             "type": "object",
@@ -1828,7 +2129,9 @@
       },
       {
         "type": "object",
-        "required": ["from_compatible"],
+        "required": [
+          "from_compatible"
+        ],
         "properties": {
           "from_compatible": {
             "type": "object",
@@ -1845,11 +2148,15 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "object",
-                "required": ["addr"],
+                "required": [
+                  "addr"
+                ],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -1863,7 +2170,9 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": ["core_module"],
+            "required": [
+              "core_module"
+            ],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -1880,7 +2189,10 @@
       },
       "Coin": {
         "type": "object",
-        "required": ["amount", "denom"],
+        "required": [
+          "amount",
+          "denom"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -1895,7 +2207,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -1908,7 +2222,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -1923,7 +2239,12 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": ["code_id", "funds", "label", "msg"],
+        "required": [
+          "code_id",
+          "funds",
+          "label",
+          "msg"
+        ],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -1969,7 +2290,9 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": ["anyone_may_propose"],
+            "required": [
+              "anyone_may_propose"
+            ],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -1981,11 +2304,15 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": ["module_may_propose"],
+            "required": [
+              "module_may_propose"
+            ],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": ["info"],
+                "required": [
+                  "info"
+                ],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -2126,7 +2453,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["height"],
+              "required": [
+                "height"
+              ],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -2139,7 +2468,9 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": ["time"],
+              "required": [
+                "time"
+              ],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -2157,7 +2488,9 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["majority"],
+              "required": [
+                "majority"
+              ],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -2169,7 +2502,9 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["percent"],
+              "required": [
+                "percent"
+              ],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -2216,11 +2551,15 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["single_choice"],
+              "required": [
+                "single_choice"
+              ],
               "properties": {
                 "single_choice": {
                   "type": "object",
-                  "required": ["quorum"],
+                  "required": [
+                    "quorum"
+                  ],
                   "properties": {
                     "quorum": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -2266,7 +2605,9 @@
         "MultipleChoiceVote": {
           "description": "A multiple choice vote, picking the desired option",
           "type": "object",
-          "required": ["option_id"],
+          "required": [
+            "option_id"
+          ],
           "properties": {
             "option_id": {
               "type": "integer",
@@ -2283,7 +2624,11 @@
         "VoteInfo": {
           "description": "Information about a vote that was cast.",
           "type": "object",
-          "required": ["power", "vote", "voter"],
+          "required": [
+            "power",
+            "vote",
+            "voter"
+          ],
           "properties": {
             "power": {
               "description": "The voting power behind the vote.",
@@ -2295,7 +2640,10 @@
             },
             "rationale": {
               "description": "The rationale behind the vote.",
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "vote": {
               "description": "Position on the vote.",
@@ -2322,7 +2670,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": ["info"],
+      "required": [
+        "info"
+      ],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -2332,7 +2682,10 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": ["contract", "version"],
+          "required": [
+            "contract",
+            "version"
+          ],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -2351,7 +2704,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ProposalListResponse",
       "type": "object",
-      "required": ["proposals"],
+      "required": [
+        "proposals"
+      ],
       "properties": {
         "proposals": {
           "type": "array",
@@ -2372,11 +2727,16 @@
             {
               "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["send"],
+              "required": [
+                "send"
+              ],
               "properties": {
                 "send": {
                   "type": "object",
-                  "required": ["amount", "to_address"],
+                  "required": [
+                    "amount",
+                    "to_address"
+                  ],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -2395,11 +2755,15 @@
             {
               "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
               "type": "object",
-              "required": ["burn"],
+              "required": [
+                "burn"
+              ],
               "properties": {
                 "burn": {
                   "type": "object",
-                  "required": ["amount"],
+                  "required": [
+                    "amount"
+                  ],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -2458,7 +2822,10 @@
         },
         "Coin": {
           "type": "object",
-          "required": ["amount", "denom"],
+          "required": [
+            "amount",
+            "denom"
+          ],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -2472,7 +2839,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["bank"],
+              "required": [
+                "bank"
+              ],
               "properties": {
                 "bank": {
                   "$ref": "#/definitions/BankMsg"
@@ -2482,7 +2851,9 @@
             },
             {
               "type": "object",
-              "required": ["custom"],
+              "required": [
+                "custom"
+              ],
               "properties": {
                 "custom": {
                   "$ref": "#/definitions/Empty"
@@ -2492,7 +2863,9 @@
             },
             {
               "type": "object",
-              "required": ["staking"],
+              "required": [
+                "staking"
+              ],
               "properties": {
                 "staking": {
                   "$ref": "#/definitions/StakingMsg"
@@ -2502,7 +2875,9 @@
             },
             {
               "type": "object",
-              "required": ["distribution"],
+              "required": [
+                "distribution"
+              ],
               "properties": {
                 "distribution": {
                   "$ref": "#/definitions/DistributionMsg"
@@ -2513,11 +2888,16 @@
             {
               "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
               "type": "object",
-              "required": ["stargate"],
+              "required": [
+                "stargate"
+              ],
               "properties": {
                 "stargate": {
                   "type": "object",
-                  "required": ["type_url", "value"],
+                  "required": [
+                    "type_url",
+                    "value"
+                  ],
                   "properties": {
                     "type_url": {
                       "type": "string"
@@ -2532,7 +2912,9 @@
             },
             {
               "type": "object",
-              "required": ["ibc"],
+              "required": [
+                "ibc"
+              ],
               "properties": {
                 "ibc": {
                   "$ref": "#/definitions/IbcMsg"
@@ -2542,7 +2924,9 @@
             },
             {
               "type": "object",
-              "required": ["wasm"],
+              "required": [
+                "wasm"
+              ],
               "properties": {
                 "wasm": {
                   "$ref": "#/definitions/WasmMsg"
@@ -2552,7 +2936,9 @@
             },
             {
               "type": "object",
-              "required": ["gov"],
+              "required": [
+                "gov"
+              ],
               "properties": {
                 "gov": {
                   "$ref": "#/definitions/GovMsg"
@@ -2572,11 +2958,15 @@
             {
               "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["set_withdraw_address"],
+              "required": [
+                "set_withdraw_address"
+              ],
               "properties": {
                 "set_withdraw_address": {
                   "type": "object",
-                  "required": ["address"],
+                  "required": [
+                    "address"
+                  ],
                   "properties": {
                     "address": {
                       "description": "The `withdraw_address`",
@@ -2590,11 +2980,15 @@
             {
               "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["withdraw_delegator_reward"],
+              "required": [
+                "withdraw_delegator_reward"
+              ],
               "properties": {
                 "withdraw_delegator_reward": {
                   "type": "object",
-                  "required": ["validator"],
+                  "required": [
+                    "validator"
+                  ],
                   "properties": {
                     "validator": {
                       "description": "The `validator_address`",
@@ -2612,7 +3006,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["height"],
+              "required": [
+                "height"
+              ],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -2625,7 +3021,9 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": ["time"],
+              "required": [
+                "time"
+              ],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -2647,7 +3045,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -2660,7 +3060,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -2671,7 +3073,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -2688,11 +3092,16 @@
             {
               "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
               "type": "object",
-              "required": ["vote"],
+              "required": [
+                "vote"
+              ],
               "properties": {
                 "vote": {
                   "type": "object",
-                  "required": ["proposal_id", "vote"],
+                  "required": [
+                    "proposal_id",
+                    "vote"
+                  ],
                   "properties": {
                     "proposal_id": {
                       "type": "integer",
@@ -2720,11 +3129,18 @@
             {
               "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
               "type": "object",
-              "required": ["transfer"],
+              "required": [
+                "transfer"
+              ],
               "properties": {
                 "transfer": {
                   "type": "object",
-                  "required": ["amount", "channel_id", "timeout", "to_address"],
+                  "required": [
+                    "amount",
+                    "channel_id",
+                    "timeout",
+                    "to_address"
+                  ],
                   "properties": {
                     "amount": {
                       "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -2758,11 +3174,17 @@
             {
               "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
               "type": "object",
-              "required": ["send_packet"],
+              "required": [
+                "send_packet"
+              ],
               "properties": {
                 "send_packet": {
                   "type": "object",
-                  "required": ["channel_id", "data", "timeout"],
+                  "required": [
+                    "channel_id",
+                    "data",
+                    "timeout"
+                  ],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -2786,11 +3208,15 @@
             {
               "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
               "type": "object",
-              "required": ["close_channel"],
+              "required": [
+                "close_channel"
+              ],
               "properties": {
                 "close_channel": {
                   "type": "object",
-                  "required": ["channel_id"],
+                  "required": [
+                    "channel_id"
+                  ],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -2831,7 +3257,10 @@
         "IbcTimeoutBlock": {
           "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
           "type": "object",
-          "required": ["height", "revision"],
+          "required": [
+            "height",
+            "revision"
+          ],
           "properties": {
             "height": {
               "description": "block height after which the packet times out. the height within the given revision",
@@ -2852,12 +3281,16 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": ["standard"]
+              "enum": [
+                "standard"
+              ]
             },
             {
               "description": "Choice that represents selecting none of the options; still counts toward quorum and allows proposals with all bad options to be voted against.",
               "type": "string",
-              "enum": ["none"]
+              "enum": [
+                "none"
+              ]
             }
           ]
         },
@@ -2977,7 +3410,9 @@
         },
         "MultipleChoiceVotes": {
           "type": "object",
-          "required": ["vote_weights"],
+          "required": [
+            "vote_weights"
+          ],
           "properties": {
             "vote_weights": {
               "type": "array",
@@ -2994,7 +3429,9 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["majority"],
+              "required": [
+                "majority"
+              ],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -3006,7 +3443,9 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["percent"],
+              "required": [
+                "percent"
+              ],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -3019,7 +3458,10 @@
         "ProposalResponse": {
           "description": "Information about a proposal returned by proposal queries.",
           "type": "object",
-          "required": ["id", "proposal"],
+          "required": [
+            "id",
+            "proposal"
+          ],
           "properties": {
             "id": {
               "type": "integer",
@@ -3038,11 +3480,16 @@
             {
               "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["delegate"],
+              "required": [
+                "delegate"
+              ],
               "properties": {
                 "delegate": {
                   "type": "object",
-                  "required": ["amount", "validator"],
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -3058,11 +3505,16 @@
             {
               "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["undelegate"],
+              "required": [
+                "undelegate"
+              ],
               "properties": {
                 "undelegate": {
                   "type": "object",
-                  "required": ["amount", "validator"],
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -3078,11 +3530,17 @@
             {
               "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["redelegate"],
+              "required": [
+                "redelegate"
+              ],
               "properties": {
                 "redelegate": {
                   "type": "object",
-                  "required": ["amount", "dst_validator", "src_validator"],
+                  "required": [
+                    "amount",
+                    "dst_validator",
+                    "src_validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -3105,41 +3563,57 @@
             {
               "description": "The proposal is open for voting.",
               "type": "string",
-              "enum": ["open"]
+              "enum": [
+                "open"
+              ]
             },
             {
               "description": "The proposal has been rejected.",
               "type": "string",
-              "enum": ["rejected"]
+              "enum": [
+                "rejected"
+              ]
             },
             {
               "description": "The proposal has been passed but has not been executed.",
               "type": "string",
-              "enum": ["passed"]
+              "enum": [
+                "passed"
+              ]
             },
             {
               "description": "The proposal has been passed and executed.",
               "type": "string",
-              "enum": ["executed"]
+              "enum": [
+                "executed"
+              ]
             },
             {
               "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
               "type": "string",
-              "enum": ["closed"]
+              "enum": [
+                "closed"
+              ]
             },
             {
               "description": "The proposal's execution failed.",
               "type": "string",
-              "enum": ["execution_failed"]
+              "enum": [
+                "execution_failed"
+              ]
             },
             {
               "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
               "type": "object",
-              "required": ["veto_timelock"],
+              "required": [
+                "veto_timelock"
+              ],
               "properties": {
                 "veto_timelock": {
                   "type": "object",
-                  "required": ["expiration"],
+                  "required": [
+                    "expiration"
+                  ],
                   "properties": {
                     "expiration": {
                       "$ref": "#/definitions/Expiration"
@@ -3153,7 +3627,9 @@
             {
               "description": "The proposal has been vetoed.",
               "type": "string",
-              "enum": ["vetoed"]
+              "enum": [
+                "vetoed"
+              ]
             }
           ]
         },
@@ -3207,18 +3683,27 @@
         },
         "VoteOption": {
           "type": "string",
-          "enum": ["yes", "no", "abstain", "no_with_veto"]
+          "enum": [
+            "yes",
+            "no",
+            "abstain",
+            "no_with_veto"
+          ]
         },
         "VotingStrategy": {
           "description": "Determines how many choices may be selected.",
           "oneOf": [
             {
               "type": "object",
-              "required": ["single_choice"],
+              "required": [
+                "single_choice"
+              ],
               "properties": {
                 "single_choice": {
                   "type": "object",
-                  "required": ["quorum"],
+                  "required": [
+                    "quorum"
+                  ],
                   "properties": {
                     "quorum": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -3237,11 +3722,17 @@
             {
               "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["execute"],
+              "required": [
+                "execute"
+              ],
               "properties": {
                 "execute": {
                   "type": "object",
-                  "required": ["contract_addr", "funds", "msg"],
+                  "required": [
+                    "contract_addr",
+                    "funds",
+                    "msg"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -3268,14 +3759,24 @@
             {
               "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["instantiate"],
+              "required": [
+                "instantiate"
+              ],
               "properties": {
                 "instantiate": {
                   "type": "object",
-                  "required": ["code_id", "funds", "label", "msg"],
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg"
+                  ],
                   "properties": {
                     "admin": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "code_id": {
                       "type": "integer",
@@ -3308,11 +3809,17 @@
             {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["migrate"],
+              "required": [
+                "migrate"
+              ],
               "properties": {
                 "migrate": {
                   "type": "object",
-                  "required": ["contract_addr", "msg", "new_code_id"],
+                  "required": [
+                    "contract_addr",
+                    "msg",
+                    "new_code_id"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -3339,11 +3846,16 @@
             {
               "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": ["update_admin"],
+              "required": [
+                "update_admin"
+              ],
               "properties": {
                 "update_admin": {
                   "type": "object",
-                  "required": ["admin", "contract_addr"],
+                  "required": [
+                    "admin",
+                    "contract_addr"
+                  ],
                   "properties": {
                     "admin": {
                       "type": "string"
@@ -3359,11 +3871,15 @@
             {
               "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": ["clear_admin"],
+              "required": [
+                "clear_admin"
+              ],
               "properties": {
                 "clear_admin": {
                   "type": "object",
-                  "required": ["contract_addr"],
+                  "required": [
+                    "contract_addr"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -3381,7 +3897,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VoteListResponse",
       "type": "object",
-      "required": ["votes"],
+      "required": [
+        "votes"
+      ],
       "properties": {
         "votes": {
           "type": "array",
@@ -3399,7 +3917,9 @@
         "MultipleChoiceVote": {
           "description": "A multiple choice vote, picking the desired option",
           "type": "object",
-          "required": ["option_id"],
+          "required": [
+            "option_id"
+          ],
           "properties": {
             "option_id": {
               "type": "integer",
@@ -3416,7 +3936,11 @@
         "VoteInfo": {
           "description": "Information about a vote that was cast.",
           "type": "object",
-          "required": ["power", "vote", "voter"],
+          "required": [
+            "power",
+            "vote",
+            "voter"
+          ],
           "properties": {
             "power": {
               "description": "The voting power behind the vote.",
@@ -3428,7 +3952,10 @@
             },
             "rationale": {
               "description": "The rationale behind the vote.",
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "vote": {
               "description": "Position on the vote.",
@@ -3463,7 +3990,10 @@
       "title": "ProposalResponse",
       "description": "Information about a proposal returned by proposal queries.",
       "type": "object",
-      "required": ["id", "proposal"],
+      "required": [
+        "id",
+        "proposal"
+      ],
       "properties": {
         "id": {
           "type": "integer",
@@ -3486,11 +4016,16 @@
             {
               "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["send"],
+              "required": [
+                "send"
+              ],
               "properties": {
                 "send": {
                   "type": "object",
-                  "required": ["amount", "to_address"],
+                  "required": [
+                    "amount",
+                    "to_address"
+                  ],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -3509,11 +4044,15 @@
             {
               "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
               "type": "object",
-              "required": ["burn"],
+              "required": [
+                "burn"
+              ],
               "properties": {
                 "burn": {
                   "type": "object",
-                  "required": ["amount"],
+                  "required": [
+                    "amount"
+                  ],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -3572,7 +4111,10 @@
         },
         "Coin": {
           "type": "object",
-          "required": ["amount", "denom"],
+          "required": [
+            "amount",
+            "denom"
+          ],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -3586,7 +4128,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["bank"],
+              "required": [
+                "bank"
+              ],
               "properties": {
                 "bank": {
                   "$ref": "#/definitions/BankMsg"
@@ -3596,7 +4140,9 @@
             },
             {
               "type": "object",
-              "required": ["custom"],
+              "required": [
+                "custom"
+              ],
               "properties": {
                 "custom": {
                   "$ref": "#/definitions/Empty"
@@ -3606,7 +4152,9 @@
             },
             {
               "type": "object",
-              "required": ["staking"],
+              "required": [
+                "staking"
+              ],
               "properties": {
                 "staking": {
                   "$ref": "#/definitions/StakingMsg"
@@ -3616,7 +4164,9 @@
             },
             {
               "type": "object",
-              "required": ["distribution"],
+              "required": [
+                "distribution"
+              ],
               "properties": {
                 "distribution": {
                   "$ref": "#/definitions/DistributionMsg"
@@ -3627,11 +4177,16 @@
             {
               "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
               "type": "object",
-              "required": ["stargate"],
+              "required": [
+                "stargate"
+              ],
               "properties": {
                 "stargate": {
                   "type": "object",
-                  "required": ["type_url", "value"],
+                  "required": [
+                    "type_url",
+                    "value"
+                  ],
                   "properties": {
                     "type_url": {
                       "type": "string"
@@ -3646,7 +4201,9 @@
             },
             {
               "type": "object",
-              "required": ["ibc"],
+              "required": [
+                "ibc"
+              ],
               "properties": {
                 "ibc": {
                   "$ref": "#/definitions/IbcMsg"
@@ -3656,7 +4213,9 @@
             },
             {
               "type": "object",
-              "required": ["wasm"],
+              "required": [
+                "wasm"
+              ],
               "properties": {
                 "wasm": {
                   "$ref": "#/definitions/WasmMsg"
@@ -3666,7 +4225,9 @@
             },
             {
               "type": "object",
-              "required": ["gov"],
+              "required": [
+                "gov"
+              ],
               "properties": {
                 "gov": {
                   "$ref": "#/definitions/GovMsg"
@@ -3686,11 +4247,15 @@
             {
               "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["set_withdraw_address"],
+              "required": [
+                "set_withdraw_address"
+              ],
               "properties": {
                 "set_withdraw_address": {
                   "type": "object",
-                  "required": ["address"],
+                  "required": [
+                    "address"
+                  ],
                   "properties": {
                     "address": {
                       "description": "The `withdraw_address`",
@@ -3704,11 +4269,15 @@
             {
               "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["withdraw_delegator_reward"],
+              "required": [
+                "withdraw_delegator_reward"
+              ],
               "properties": {
                 "withdraw_delegator_reward": {
                   "type": "object",
-                  "required": ["validator"],
+                  "required": [
+                    "validator"
+                  ],
                   "properties": {
                     "validator": {
                       "description": "The `validator_address`",
@@ -3726,7 +4295,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["height"],
+              "required": [
+                "height"
+              ],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -3739,7 +4310,9 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": ["time"],
+              "required": [
+                "time"
+              ],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -3761,7 +4334,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -3774,7 +4349,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -3785,7 +4362,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -3802,11 +4381,16 @@
             {
               "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
               "type": "object",
-              "required": ["vote"],
+              "required": [
+                "vote"
+              ],
               "properties": {
                 "vote": {
                   "type": "object",
-                  "required": ["proposal_id", "vote"],
+                  "required": [
+                    "proposal_id",
+                    "vote"
+                  ],
                   "properties": {
                     "proposal_id": {
                       "type": "integer",
@@ -3834,11 +4418,18 @@
             {
               "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
               "type": "object",
-              "required": ["transfer"],
+              "required": [
+                "transfer"
+              ],
               "properties": {
                 "transfer": {
                   "type": "object",
-                  "required": ["amount", "channel_id", "timeout", "to_address"],
+                  "required": [
+                    "amount",
+                    "channel_id",
+                    "timeout",
+                    "to_address"
+                  ],
                   "properties": {
                     "amount": {
                       "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -3872,11 +4463,17 @@
             {
               "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
               "type": "object",
-              "required": ["send_packet"],
+              "required": [
+                "send_packet"
+              ],
               "properties": {
                 "send_packet": {
                   "type": "object",
-                  "required": ["channel_id", "data", "timeout"],
+                  "required": [
+                    "channel_id",
+                    "data",
+                    "timeout"
+                  ],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -3900,11 +4497,15 @@
             {
               "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
               "type": "object",
-              "required": ["close_channel"],
+              "required": [
+                "close_channel"
+              ],
               "properties": {
                 "close_channel": {
                   "type": "object",
-                  "required": ["channel_id"],
+                  "required": [
+                    "channel_id"
+                  ],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -3945,7 +4546,10 @@
         "IbcTimeoutBlock": {
           "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
           "type": "object",
-          "required": ["height", "revision"],
+          "required": [
+            "height",
+            "revision"
+          ],
           "properties": {
             "height": {
               "description": "block height after which the packet times out. the height within the given revision",
@@ -3966,12 +4570,16 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": ["standard"]
+              "enum": [
+                "standard"
+              ]
             },
             {
               "description": "Choice that represents selecting none of the options; still counts toward quorum and allows proposals with all bad options to be voted against.",
               "type": "string",
-              "enum": ["none"]
+              "enum": [
+                "none"
+              ]
             }
           ]
         },
@@ -4091,7 +4699,9 @@
         },
         "MultipleChoiceVotes": {
           "type": "object",
-          "required": ["vote_weights"],
+          "required": [
+            "vote_weights"
+          ],
           "properties": {
             "vote_weights": {
               "type": "array",
@@ -4108,7 +4718,9 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["majority"],
+              "required": [
+                "majority"
+              ],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -4120,7 +4732,9 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["percent"],
+              "required": [
+                "percent"
+              ],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -4136,11 +4750,16 @@
             {
               "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["delegate"],
+              "required": [
+                "delegate"
+              ],
               "properties": {
                 "delegate": {
                   "type": "object",
-                  "required": ["amount", "validator"],
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -4156,11 +4775,16 @@
             {
               "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["undelegate"],
+              "required": [
+                "undelegate"
+              ],
               "properties": {
                 "undelegate": {
                   "type": "object",
-                  "required": ["amount", "validator"],
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -4176,11 +4800,17 @@
             {
               "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["redelegate"],
+              "required": [
+                "redelegate"
+              ],
               "properties": {
                 "redelegate": {
                   "type": "object",
-                  "required": ["amount", "dst_validator", "src_validator"],
+                  "required": [
+                    "amount",
+                    "dst_validator",
+                    "src_validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -4203,41 +4833,57 @@
             {
               "description": "The proposal is open for voting.",
               "type": "string",
-              "enum": ["open"]
+              "enum": [
+                "open"
+              ]
             },
             {
               "description": "The proposal has been rejected.",
               "type": "string",
-              "enum": ["rejected"]
+              "enum": [
+                "rejected"
+              ]
             },
             {
               "description": "The proposal has been passed but has not been executed.",
               "type": "string",
-              "enum": ["passed"]
+              "enum": [
+                "passed"
+              ]
             },
             {
               "description": "The proposal has been passed and executed.",
               "type": "string",
-              "enum": ["executed"]
+              "enum": [
+                "executed"
+              ]
             },
             {
               "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
               "type": "string",
-              "enum": ["closed"]
+              "enum": [
+                "closed"
+              ]
             },
             {
               "description": "The proposal's execution failed.",
               "type": "string",
-              "enum": ["execution_failed"]
+              "enum": [
+                "execution_failed"
+              ]
             },
             {
               "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
               "type": "object",
-              "required": ["veto_timelock"],
+              "required": [
+                "veto_timelock"
+              ],
               "properties": {
                 "veto_timelock": {
                   "type": "object",
-                  "required": ["expiration"],
+                  "required": [
+                    "expiration"
+                  ],
                   "properties": {
                     "expiration": {
                       "$ref": "#/definitions/Expiration"
@@ -4251,7 +4897,9 @@
             {
               "description": "The proposal has been vetoed.",
               "type": "string",
-              "enum": ["vetoed"]
+              "enum": [
+                "vetoed"
+              ]
             }
           ]
         },
@@ -4305,18 +4953,27 @@
         },
         "VoteOption": {
           "type": "string",
-          "enum": ["yes", "no", "abstain", "no_with_veto"]
+          "enum": [
+            "yes",
+            "no",
+            "abstain",
+            "no_with_veto"
+          ]
         },
         "VotingStrategy": {
           "description": "Determines how many choices may be selected.",
           "oneOf": [
             {
               "type": "object",
-              "required": ["single_choice"],
+              "required": [
+                "single_choice"
+              ],
               "properties": {
                 "single_choice": {
                   "type": "object",
-                  "required": ["quorum"],
+                  "required": [
+                    "quorum"
+                  ],
                   "properties": {
                     "quorum": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -4335,11 +4992,17 @@
             {
               "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["execute"],
+              "required": [
+                "execute"
+              ],
               "properties": {
                 "execute": {
                   "type": "object",
-                  "required": ["contract_addr", "funds", "msg"],
+                  "required": [
+                    "contract_addr",
+                    "funds",
+                    "msg"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -4366,14 +5029,24 @@
             {
               "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["instantiate"],
+              "required": [
+                "instantiate"
+              ],
               "properties": {
                 "instantiate": {
                   "type": "object",
-                  "required": ["code_id", "funds", "label", "msg"],
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg"
+                  ],
                   "properties": {
                     "admin": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "code_id": {
                       "type": "integer",
@@ -4406,11 +5079,17 @@
             {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["migrate"],
+              "required": [
+                "migrate"
+              ],
               "properties": {
                 "migrate": {
                   "type": "object",
-                  "required": ["contract_addr", "msg", "new_code_id"],
+                  "required": [
+                    "contract_addr",
+                    "msg",
+                    "new_code_id"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -4437,11 +5116,16 @@
             {
               "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": ["update_admin"],
+              "required": [
+                "update_admin"
+              ],
               "properties": {
                 "update_admin": {
                   "type": "object",
-                  "required": ["admin", "contract_addr"],
+                  "required": [
+                    "admin",
+                    "contract_addr"
+                  ],
                   "properties": {
                     "admin": {
                       "type": "string"
@@ -4457,11 +5141,15 @@
             {
               "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": ["clear_admin"],
+              "required": [
+                "clear_admin"
+              ],
               "properties": {
                 "clear_admin": {
                   "type": "object",
-                  "required": ["contract_addr"],
+                  "required": [
+                    "contract_addr"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -4490,7 +5178,9 @@
         {
           "description": "Anyone may create a proposal, free of charge.",
           "type": "object",
-          "required": ["anyone"],
+          "required": [
+            "anyone"
+          ],
           "properties": {
             "anyone": {
               "type": "object",
@@ -4502,11 +5192,15 @@
         {
           "description": "Only ADDR may create proposals. It is expected that ADDR is a pre-propose module, though we only require that it is a valid address.",
           "type": "object",
-          "required": ["module"],
+          "required": [
+            "module"
+          ],
           "properties": {
             "module": {
               "type": "object",
-              "required": ["addr"],
+              "required": [
+                "addr"
+              ],
               "properties": {
                 "addr": {
                   "$ref": "#/definitions/Addr"
@@ -4529,7 +5223,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": ["hooks"],
+      "required": [
+        "hooks"
+      ],
       "properties": {
         "hooks": {
           "type": "array",
@@ -4544,7 +5240,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ProposalListResponse",
       "type": "object",
-      "required": ["proposals"],
+      "required": [
+        "proposals"
+      ],
       "properties": {
         "proposals": {
           "type": "array",
@@ -4565,11 +5263,16 @@
             {
               "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["send"],
+              "required": [
+                "send"
+              ],
               "properties": {
                 "send": {
                   "type": "object",
-                  "required": ["amount", "to_address"],
+                  "required": [
+                    "amount",
+                    "to_address"
+                  ],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -4588,11 +5291,15 @@
             {
               "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
               "type": "object",
-              "required": ["burn"],
+              "required": [
+                "burn"
+              ],
               "properties": {
                 "burn": {
                   "type": "object",
-                  "required": ["amount"],
+                  "required": [
+                    "amount"
+                  ],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -4651,7 +5358,10 @@
         },
         "Coin": {
           "type": "object",
-          "required": ["amount", "denom"],
+          "required": [
+            "amount",
+            "denom"
+          ],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -4665,7 +5375,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["bank"],
+              "required": [
+                "bank"
+              ],
               "properties": {
                 "bank": {
                   "$ref": "#/definitions/BankMsg"
@@ -4675,7 +5387,9 @@
             },
             {
               "type": "object",
-              "required": ["custom"],
+              "required": [
+                "custom"
+              ],
               "properties": {
                 "custom": {
                   "$ref": "#/definitions/Empty"
@@ -4685,7 +5399,9 @@
             },
             {
               "type": "object",
-              "required": ["staking"],
+              "required": [
+                "staking"
+              ],
               "properties": {
                 "staking": {
                   "$ref": "#/definitions/StakingMsg"
@@ -4695,7 +5411,9 @@
             },
             {
               "type": "object",
-              "required": ["distribution"],
+              "required": [
+                "distribution"
+              ],
               "properties": {
                 "distribution": {
                   "$ref": "#/definitions/DistributionMsg"
@@ -4706,11 +5424,16 @@
             {
               "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
               "type": "object",
-              "required": ["stargate"],
+              "required": [
+                "stargate"
+              ],
               "properties": {
                 "stargate": {
                   "type": "object",
-                  "required": ["type_url", "value"],
+                  "required": [
+                    "type_url",
+                    "value"
+                  ],
                   "properties": {
                     "type_url": {
                       "type": "string"
@@ -4725,7 +5448,9 @@
             },
             {
               "type": "object",
-              "required": ["ibc"],
+              "required": [
+                "ibc"
+              ],
               "properties": {
                 "ibc": {
                   "$ref": "#/definitions/IbcMsg"
@@ -4735,7 +5460,9 @@
             },
             {
               "type": "object",
-              "required": ["wasm"],
+              "required": [
+                "wasm"
+              ],
               "properties": {
                 "wasm": {
                   "$ref": "#/definitions/WasmMsg"
@@ -4745,7 +5472,9 @@
             },
             {
               "type": "object",
-              "required": ["gov"],
+              "required": [
+                "gov"
+              ],
               "properties": {
                 "gov": {
                   "$ref": "#/definitions/GovMsg"
@@ -4765,11 +5494,15 @@
             {
               "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["set_withdraw_address"],
+              "required": [
+                "set_withdraw_address"
+              ],
               "properties": {
                 "set_withdraw_address": {
                   "type": "object",
-                  "required": ["address"],
+                  "required": [
+                    "address"
+                  ],
                   "properties": {
                     "address": {
                       "description": "The `withdraw_address`",
@@ -4783,11 +5516,15 @@
             {
               "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["withdraw_delegator_reward"],
+              "required": [
+                "withdraw_delegator_reward"
+              ],
               "properties": {
                 "withdraw_delegator_reward": {
                   "type": "object",
-                  "required": ["validator"],
+                  "required": [
+                    "validator"
+                  ],
                   "properties": {
                     "validator": {
                       "description": "The `validator_address`",
@@ -4805,7 +5542,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["height"],
+              "required": [
+                "height"
+              ],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -4818,7 +5557,9 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": ["time"],
+              "required": [
+                "time"
+              ],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -4840,7 +5581,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -4853,7 +5596,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -4864,7 +5609,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -4881,11 +5628,16 @@
             {
               "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
               "type": "object",
-              "required": ["vote"],
+              "required": [
+                "vote"
+              ],
               "properties": {
                 "vote": {
                   "type": "object",
-                  "required": ["proposal_id", "vote"],
+                  "required": [
+                    "proposal_id",
+                    "vote"
+                  ],
                   "properties": {
                     "proposal_id": {
                       "type": "integer",
@@ -4913,11 +5665,18 @@
             {
               "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
               "type": "object",
-              "required": ["transfer"],
+              "required": [
+                "transfer"
+              ],
               "properties": {
                 "transfer": {
                   "type": "object",
-                  "required": ["amount", "channel_id", "timeout", "to_address"],
+                  "required": [
+                    "amount",
+                    "channel_id",
+                    "timeout",
+                    "to_address"
+                  ],
                   "properties": {
                     "amount": {
                       "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -4951,11 +5710,17 @@
             {
               "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
               "type": "object",
-              "required": ["send_packet"],
+              "required": [
+                "send_packet"
+              ],
               "properties": {
                 "send_packet": {
                   "type": "object",
-                  "required": ["channel_id", "data", "timeout"],
+                  "required": [
+                    "channel_id",
+                    "data",
+                    "timeout"
+                  ],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -4979,11 +5744,15 @@
             {
               "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
               "type": "object",
-              "required": ["close_channel"],
+              "required": [
+                "close_channel"
+              ],
               "properties": {
                 "close_channel": {
                   "type": "object",
-                  "required": ["channel_id"],
+                  "required": [
+                    "channel_id"
+                  ],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -5024,7 +5793,10 @@
         "IbcTimeoutBlock": {
           "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
           "type": "object",
-          "required": ["height", "revision"],
+          "required": [
+            "height",
+            "revision"
+          ],
           "properties": {
             "height": {
               "description": "block height after which the packet times out. the height within the given revision",
@@ -5045,12 +5817,16 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": ["standard"]
+              "enum": [
+                "standard"
+              ]
             },
             {
               "description": "Choice that represents selecting none of the options; still counts toward quorum and allows proposals with all bad options to be voted against.",
               "type": "string",
-              "enum": ["none"]
+              "enum": [
+                "none"
+              ]
             }
           ]
         },
@@ -5170,7 +5946,9 @@
         },
         "MultipleChoiceVotes": {
           "type": "object",
-          "required": ["vote_weights"],
+          "required": [
+            "vote_weights"
+          ],
           "properties": {
             "vote_weights": {
               "type": "array",
@@ -5187,7 +5965,9 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["majority"],
+              "required": [
+                "majority"
+              ],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -5199,7 +5979,9 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["percent"],
+              "required": [
+                "percent"
+              ],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -5212,7 +5994,10 @@
         "ProposalResponse": {
           "description": "Information about a proposal returned by proposal queries.",
           "type": "object",
-          "required": ["id", "proposal"],
+          "required": [
+            "id",
+            "proposal"
+          ],
           "properties": {
             "id": {
               "type": "integer",
@@ -5231,11 +6016,16 @@
             {
               "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["delegate"],
+              "required": [
+                "delegate"
+              ],
               "properties": {
                 "delegate": {
                   "type": "object",
-                  "required": ["amount", "validator"],
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -5251,11 +6041,16 @@
             {
               "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["undelegate"],
+              "required": [
+                "undelegate"
+              ],
               "properties": {
                 "undelegate": {
                   "type": "object",
-                  "required": ["amount", "validator"],
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -5271,11 +6066,17 @@
             {
               "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["redelegate"],
+              "required": [
+                "redelegate"
+              ],
               "properties": {
                 "redelegate": {
                   "type": "object",
-                  "required": ["amount", "dst_validator", "src_validator"],
+                  "required": [
+                    "amount",
+                    "dst_validator",
+                    "src_validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -5298,41 +6099,57 @@
             {
               "description": "The proposal is open for voting.",
               "type": "string",
-              "enum": ["open"]
+              "enum": [
+                "open"
+              ]
             },
             {
               "description": "The proposal has been rejected.",
               "type": "string",
-              "enum": ["rejected"]
+              "enum": [
+                "rejected"
+              ]
             },
             {
               "description": "The proposal has been passed but has not been executed.",
               "type": "string",
-              "enum": ["passed"]
+              "enum": [
+                "passed"
+              ]
             },
             {
               "description": "The proposal has been passed and executed.",
               "type": "string",
-              "enum": ["executed"]
+              "enum": [
+                "executed"
+              ]
             },
             {
               "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
               "type": "string",
-              "enum": ["closed"]
+              "enum": [
+                "closed"
+              ]
             },
             {
               "description": "The proposal's execution failed.",
               "type": "string",
-              "enum": ["execution_failed"]
+              "enum": [
+                "execution_failed"
+              ]
             },
             {
               "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
               "type": "object",
-              "required": ["veto_timelock"],
+              "required": [
+                "veto_timelock"
+              ],
               "properties": {
                 "veto_timelock": {
                   "type": "object",
-                  "required": ["expiration"],
+                  "required": [
+                    "expiration"
+                  ],
                   "properties": {
                     "expiration": {
                       "$ref": "#/definitions/Expiration"
@@ -5346,7 +6163,9 @@
             {
               "description": "The proposal has been vetoed.",
               "type": "string",
-              "enum": ["vetoed"]
+              "enum": [
+                "vetoed"
+              ]
             }
           ]
         },
@@ -5400,18 +6219,27 @@
         },
         "VoteOption": {
           "type": "string",
-          "enum": ["yes", "no", "abstain", "no_with_veto"]
+          "enum": [
+            "yes",
+            "no",
+            "abstain",
+            "no_with_veto"
+          ]
         },
         "VotingStrategy": {
           "description": "Determines how many choices may be selected.",
           "oneOf": [
             {
               "type": "object",
-              "required": ["single_choice"],
+              "required": [
+                "single_choice"
+              ],
               "properties": {
                 "single_choice": {
                   "type": "object",
-                  "required": ["quorum"],
+                  "required": [
+                    "quorum"
+                  ],
                   "properties": {
                     "quorum": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -5430,11 +6258,17 @@
             {
               "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["execute"],
+              "required": [
+                "execute"
+              ],
               "properties": {
                 "execute": {
                   "type": "object",
-                  "required": ["contract_addr", "funds", "msg"],
+                  "required": [
+                    "contract_addr",
+                    "funds",
+                    "msg"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -5461,14 +6295,24 @@
             {
               "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["instantiate"],
+              "required": [
+                "instantiate"
+              ],
               "properties": {
                 "instantiate": {
                   "type": "object",
-                  "required": ["code_id", "funds", "label", "msg"],
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg"
+                  ],
                   "properties": {
                     "admin": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "code_id": {
                       "type": "integer",
@@ -5501,11 +6345,17 @@
             {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["migrate"],
+              "required": [
+                "migrate"
+              ],
               "properties": {
                 "migrate": {
                   "type": "object",
-                  "required": ["contract_addr", "msg", "new_code_id"],
+                  "required": [
+                    "contract_addr",
+                    "msg",
+                    "new_code_id"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -5532,11 +6382,16 @@
             {
               "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": ["update_admin"],
+              "required": [
+                "update_admin"
+              ],
               "properties": {
                 "update_admin": {
                   "type": "object",
-                  "required": ["admin", "contract_addr"],
+                  "required": [
+                    "admin",
+                    "contract_addr"
+                  ],
                   "properties": {
                     "admin": {
                       "type": "string"
@@ -5552,11 +6407,15 @@
             {
               "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": ["clear_admin"],
+              "required": [
+                "clear_admin"
+              ],
               "properties": {
                 "clear_admin": {
                   "type": "object",
-                  "required": ["contract_addr"],
+                  "required": [
+                    "contract_addr"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -5574,7 +6433,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": ["hooks"],
+      "required": [
+        "hooks"
+      ],
       "properties": {
         "hooks": {
           "type": "array",

--- a/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
+++ b/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-multiple",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -82,15 +82,11 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "object",
-                "required": [
-                  "addr"
-                ],
+                "required": ["addr"],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -104,9 +100,7 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": [
-              "core_module"
-            ],
+            "required": ["core_module"],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -123,10 +117,7 @@
       },
       "Coin": {
         "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
+        "required": ["amount", "denom"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -145,9 +136,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -160,9 +149,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -177,12 +164,7 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": [
-          "code_id",
-          "funds",
-          "label",
-          "msg"
-        ],
+        "required": ["code_id", "funds", "label", "msg"],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -229,9 +211,7 @@
           {
             "description": "The majority of voters must vote yes for the proposal to pass.",
             "type": "object",
-            "required": [
-              "majority"
-            ],
+            "required": ["majority"],
             "properties": {
               "majority": {
                 "type": "object",
@@ -243,9 +223,7 @@
           {
             "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
             "type": "object",
-            "required": [
-              "percent"
-            ],
+            "required": ["percent"],
             "properties": {
               "percent": {
                 "$ref": "#/definitions/Decimal"
@@ -260,9 +238,7 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": [
-              "anyone_may_propose"
-            ],
+            "required": ["anyone_may_propose"],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -274,15 +250,11 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": [
-              "module_may_propose"
-            ],
+            "required": ["module_may_propose"],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": [
-                  "info"
-                ],
+                "required": ["info"],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -336,15 +308,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "single_choice"
-            ],
+            "required": ["single_choice"],
             "properties": {
               "single_choice": {
                 "type": "object",
-                "required": [
-                  "quorum"
-                ],
+                "required": ["quorum"],
                 "properties": {
                   "quorum": {
                     "$ref": "#/definitions/PercentageThreshold"
@@ -366,9 +334,7 @@
       {
         "description": "Creates a proposal in the governance module.",
         "type": "object",
-        "required": [
-          "propose"
-        ],
+        "required": ["propose"],
         "properties": {
           "propose": {
             "$ref": "#/definitions/MultipleChoiceProposeMsg"
@@ -379,16 +345,11 @@
       {
         "description": "Votes on a proposal. Voting power is determined by the DAO's voting power module.",
         "type": "object",
-        "required": [
-          "vote"
-        ],
+        "required": ["vote"],
         "properties": {
           "vote": {
             "type": "object",
-            "required": [
-              "proposal_id",
-              "vote"
-            ],
+            "required": ["proposal_id", "vote"],
             "properties": {
               "proposal_id": {
                 "description": "The ID of the proposal to vote on.",
@@ -398,10 +359,7 @@
               },
               "rationale": {
                 "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               },
               "vote": {
                 "description": "The senders position on the proposal.",
@@ -420,15 +378,11 @@
       {
         "description": "Causes the messages associated with a passed proposal to be executed by the DAO.",
         "type": "object",
-        "required": [
-          "execute"
-        ],
+        "required": ["execute"],
         "properties": {
           "execute": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "proposal_id": {
                 "description": "The ID of the proposal to execute.",
@@ -445,15 +399,11 @@
       {
         "description": "Callable only if veto is configured",
         "type": "object",
-        "required": [
-          "veto"
-        ],
+        "required": ["veto"],
         "properties": {
           "veto": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "proposal_id": {
                 "description": "The ID of the proposal to veto.",
@@ -470,15 +420,11 @@
       {
         "description": "Closes a proposal that has failed (either not passed or timed out). If applicable this will cause the proposal deposit associated wth said proposal to be returned.",
         "type": "object",
-        "required": [
-          "close"
-        ],
+        "required": ["close"],
         "properties": {
           "close": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "proposal_id": {
                 "description": "The ID of the proposal to close.",
@@ -495,9 +441,7 @@
       {
         "description": "Updates the governance module's config.",
         "type": "object",
-        "required": [
-          "update_config"
-        ],
+        "required": ["update_config"],
         "properties": {
           "update_config": {
             "type": "object",
@@ -573,15 +517,11 @@
       {
         "description": "Updates the sender's rationale for their vote on the specified proposal. Errors if no vote vote has been cast.",
         "type": "object",
-        "required": [
-          "update_rationale"
-        ],
+        "required": ["update_rationale"],
         "properties": {
           "update_rationale": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -589,10 +529,7 @@
                 "minimum": 0.0
               },
               "rationale": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -603,15 +540,11 @@
       {
         "description": "Update's the proposal creation policy used for this module. Only the DAO may call this method.",
         "type": "object",
-        "required": [
-          "update_pre_propose_info"
-        ],
+        "required": ["update_pre_propose_info"],
         "properties": {
           "update_pre_propose_info": {
             "type": "object",
-            "required": [
-              "info"
-            ],
+            "required": ["info"],
             "properties": {
               "info": {
                 "$ref": "#/definitions/PreProposeInfo"
@@ -624,15 +557,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "add_proposal_hook"
-        ],
+        "required": ["add_proposal_hook"],
         "properties": {
           "add_proposal_hook": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -645,15 +574,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "remove_proposal_hook"
-        ],
+        "required": ["remove_proposal_hook"],
         "properties": {
           "remove_proposal_hook": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -666,15 +591,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "add_vote_hook"
-        ],
+        "required": ["add_vote_hook"],
         "properties": {
           "add_vote_hook": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -687,15 +608,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "remove_vote_hook"
-        ],
+        "required": ["remove_vote_hook"],
         "properties": {
           "remove_vote_hook": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -714,15 +631,11 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "object",
-                "required": [
-                  "addr"
-                ],
+                "required": ["addr"],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -736,9 +649,7 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": [
-              "core_module"
-            ],
+            "required": ["core_module"],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -755,16 +666,11 @@
           {
             "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "send"
-            ],
+            "required": ["send"],
             "properties": {
               "send": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "to_address"
-                ],
+                "required": ["amount", "to_address"],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -783,15 +689,11 @@
           {
             "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
             "type": "object",
-            "required": [
-              "burn"
-            ],
+            "required": ["burn"],
             "properties": {
               "burn": {
                 "type": "object",
-                "required": [
-                  "amount"
-                ],
+                "required": ["amount"],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -812,10 +714,7 @@
       },
       "Coin": {
         "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
+        "required": ["amount", "denom"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -829,9 +728,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "bank"
-            ],
+            "required": ["bank"],
             "properties": {
               "bank": {
                 "$ref": "#/definitions/BankMsg"
@@ -841,9 +738,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "custom"
-            ],
+            "required": ["custom"],
             "properties": {
               "custom": {
                 "$ref": "#/definitions/Empty"
@@ -853,9 +748,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "staking"
-            ],
+            "required": ["staking"],
             "properties": {
               "staking": {
                 "$ref": "#/definitions/StakingMsg"
@@ -865,9 +758,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "distribution"
-            ],
+            "required": ["distribution"],
             "properties": {
               "distribution": {
                 "$ref": "#/definitions/DistributionMsg"
@@ -878,16 +769,11 @@
           {
             "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
             "type": "object",
-            "required": [
-              "stargate"
-            ],
+            "required": ["stargate"],
             "properties": {
               "stargate": {
                 "type": "object",
-                "required": [
-                  "type_url",
-                  "value"
-                ],
+                "required": ["type_url", "value"],
                 "properties": {
                   "type_url": {
                     "type": "string"
@@ -902,9 +788,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "ibc"
-            ],
+            "required": ["ibc"],
             "properties": {
               "ibc": {
                 "$ref": "#/definitions/IbcMsg"
@@ -914,9 +798,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "wasm"
-            ],
+            "required": ["wasm"],
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmMsg"
@@ -926,9 +808,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "gov"
-            ],
+            "required": ["gov"],
             "properties": {
               "gov": {
                 "$ref": "#/definitions/GovMsg"
@@ -948,15 +828,11 @@
           {
             "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "set_withdraw_address"
-            ],
+            "required": ["set_withdraw_address"],
             "properties": {
               "set_withdraw_address": {
                 "type": "object",
-                "required": [
-                  "address"
-                ],
+                "required": ["address"],
                 "properties": {
                   "address": {
                     "description": "The `withdraw_address`",
@@ -970,15 +846,11 @@
           {
             "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "withdraw_delegator_reward"
-            ],
+            "required": ["withdraw_delegator_reward"],
             "properties": {
               "withdraw_delegator_reward": {
                 "type": "object",
-                "required": [
-                  "validator"
-                ],
+                "required": ["validator"],
                 "properties": {
                   "validator": {
                     "description": "The `validator_address`",
@@ -996,9 +868,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -1011,9 +881,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -1035,16 +903,11 @@
           {
             "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
             "type": "object",
-            "required": [
-              "vote"
-            ],
+            "required": ["vote"],
             "properties": {
               "vote": {
                 "type": "object",
-                "required": [
-                  "proposal_id",
-                  "vote"
-                ],
+                "required": ["proposal_id", "vote"],
                 "properties": {
                   "proposal_id": {
                     "type": "integer",
@@ -1072,18 +935,11 @@
           {
             "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
             "type": "object",
-            "required": [
-              "transfer"
-            ],
+            "required": ["transfer"],
             "properties": {
               "transfer": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "channel_id",
-                  "timeout",
-                  "to_address"
-                ],
+                "required": ["amount", "channel_id", "timeout", "to_address"],
                 "properties": {
                   "amount": {
                     "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -1117,17 +973,11 @@
           {
             "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
             "type": "object",
-            "required": [
-              "send_packet"
-            ],
+            "required": ["send_packet"],
             "properties": {
               "send_packet": {
                 "type": "object",
-                "required": [
-                  "channel_id",
-                  "data",
-                  "timeout"
-                ],
+                "required": ["channel_id", "data", "timeout"],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -1151,15 +1001,11 @@
           {
             "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
             "type": "object",
-            "required": [
-              "close_channel"
-            ],
+            "required": ["close_channel"],
             "properties": {
               "close_channel": {
                 "type": "object",
-                "required": [
-                  "channel_id"
-                ],
+                "required": ["channel_id"],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -1200,10 +1046,7 @@
       "IbcTimeoutBlock": {
         "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
         "type": "object",
-        "required": [
-          "height",
-          "revision"
-        ],
+        "required": ["height", "revision"],
         "properties": {
           "height": {
             "description": "block height after which the packet times out. the height within the given revision",
@@ -1222,12 +1065,7 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": [
-          "code_id",
-          "funds",
-          "label",
-          "msg"
-        ],
+        "required": ["code_id", "funds", "label", "msg"],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -1270,16 +1108,11 @@
       },
       "MultipleChoiceAutoVote": {
         "type": "object",
-        "required": [
-          "vote"
-        ],
+        "required": ["vote"],
         "properties": {
           "rationale": {
             "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "vote": {
             "description": "The proposer's position on the proposal.",
@@ -1295,11 +1128,7 @@
       "MultipleChoiceOption": {
         "description": "Unchecked multiple choice option",
         "type": "object",
-        "required": [
-          "description",
-          "msgs",
-          "title"
-        ],
+        "required": ["description", "msgs", "title"],
         "properties": {
           "description": {
             "type": "string"
@@ -1319,9 +1148,7 @@
       "MultipleChoiceOptions": {
         "description": "Represents unchecked multiple choice options",
         "type": "object",
-        "required": [
-          "options"
-        ],
+        "required": ["options"],
         "properties": {
           "options": {
             "type": "array",
@@ -1335,11 +1162,7 @@
       "MultipleChoiceProposeMsg": {
         "description": "The contents of a message to create a proposal in the multiple choice proposal module.\n\nWe break this type out of `ExecuteMsg` because we want pre-propose modules that interact with this contract to be able to get type checking on their propose messages.\n\nWe move this type to this package so that pre-propose modules can import it without importing dao-proposal-multiple with the library feature which (as it is not additive) cause the execute exports to not be included in wasm builds.",
         "type": "object",
-        "required": [
-          "choices",
-          "description",
-          "title"
-        ],
+        "required": ["choices", "description", "title"],
         "properties": {
           "choices": {
             "description": "The multiple choices.",
@@ -1355,10 +1178,7 @@
           },
           "proposer": {
             "description": "The address creating the proposal. If no pre-propose module is attached to this module this must always be None as the proposer is the sender of the propose message. If a pre-propose module is attached, this must be Some and will set the proposer of the proposal it creates.",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "title": {
             "description": "The title of the proposal.",
@@ -1381,9 +1201,7 @@
       "MultipleChoiceVote": {
         "description": "A multiple choice vote, picking the desired option",
         "type": "object",
-        "required": [
-          "option_id"
-        ],
+        "required": ["option_id"],
         "properties": {
           "option_id": {
             "type": "integer",
@@ -1399,9 +1217,7 @@
           {
             "description": "The majority of voters must vote yes for the proposal to pass.",
             "type": "object",
-            "required": [
-              "majority"
-            ],
+            "required": ["majority"],
             "properties": {
               "majority": {
                 "type": "object",
@@ -1413,9 +1229,7 @@
           {
             "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
             "type": "object",
-            "required": [
-              "percent"
-            ],
+            "required": ["percent"],
             "properties": {
               "percent": {
                 "$ref": "#/definitions/Decimal"
@@ -1430,9 +1244,7 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": [
-              "anyone_may_propose"
-            ],
+            "required": ["anyone_may_propose"],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -1444,15 +1256,11 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": [
-              "module_may_propose"
-            ],
+            "required": ["module_may_propose"],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": [
-                  "info"
-                ],
+                "required": ["info"],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -1471,16 +1279,11 @@
           {
             "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "delegate"
-            ],
+            "required": ["delegate"],
             "properties": {
               "delegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "validator"
-                ],
+                "required": ["amount", "validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1496,16 +1299,11 @@
           {
             "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "undelegate"
-            ],
+            "required": ["undelegate"],
             "properties": {
               "undelegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "validator"
-                ],
+                "required": ["amount", "validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1521,17 +1319,11 @@
           {
             "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "redelegate"
-            ],
+            "required": ["redelegate"],
             "properties": {
               "redelegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "dst_validator",
-                  "src_validator"
-                ],
+                "required": ["amount", "dst_validator", "src_validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1599,27 +1391,18 @@
       },
       "VoteOption": {
         "type": "string",
-        "enum": [
-          "yes",
-          "no",
-          "abstain",
-          "no_with_veto"
-        ]
+        "enum": ["yes", "no", "abstain", "no_with_veto"]
       },
       "VotingStrategy": {
         "description": "Determines how many choices may be selected.",
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "single_choice"
-            ],
+            "required": ["single_choice"],
             "properties": {
               "single_choice": {
                 "type": "object",
-                "required": [
-                  "quorum"
-                ],
+                "required": ["quorum"],
                 "properties": {
                   "quorum": {
                     "$ref": "#/definitions/PercentageThreshold"
@@ -1638,17 +1421,11 @@
           {
             "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "execute"
-            ],
+            "required": ["execute"],
             "properties": {
               "execute": {
                 "type": "object",
-                "required": [
-                  "contract_addr",
-                  "funds",
-                  "msg"
-                ],
+                "required": ["contract_addr", "funds", "msg"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1675,24 +1452,14 @@
           {
             "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "instantiate"
-            ],
+            "required": ["instantiate"],
             "properties": {
               "instantiate": {
                 "type": "object",
-                "required": [
-                  "code_id",
-                  "funds",
-                  "label",
-                  "msg"
-                ],
+                "required": ["code_id", "funds", "label", "msg"],
                 "properties": {
                   "admin": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": ["string", "null"]
                   },
                   "code_id": {
                     "type": "integer",
@@ -1725,17 +1492,11 @@
           {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "migrate"
-            ],
+            "required": ["migrate"],
             "properties": {
               "migrate": {
                 "type": "object",
-                "required": [
-                  "contract_addr",
-                  "msg",
-                  "new_code_id"
-                ],
+                "required": ["contract_addr", "msg", "new_code_id"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1762,16 +1523,11 @@
           {
             "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": [
-              "update_admin"
-            ],
+            "required": ["update_admin"],
             "properties": {
               "update_admin": {
                 "type": "object",
-                "required": [
-                  "admin",
-                  "contract_addr"
-                ],
+                "required": ["admin", "contract_addr"],
                 "properties": {
                   "admin": {
                     "type": "string"
@@ -1787,15 +1543,11 @@
           {
             "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": [
-              "clear_admin"
-            ],
+            "required": ["clear_admin"],
             "properties": {
               "clear_admin": {
                 "type": "object",
-                "required": [
-                  "contract_addr"
-                ],
+                "required": ["contract_addr"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1816,9 +1568,7 @@
       {
         "description": "Gets the governance module's config.",
         "type": "object",
-        "required": [
-          "config"
-        ],
+        "required": ["config"],
         "properties": {
           "config": {
             "type": "object",
@@ -1830,15 +1580,11 @@
       {
         "description": "Gets information about a proposal.",
         "type": "object",
-        "required": [
-          "proposal"
-        ],
+        "required": ["proposal"],
         "properties": {
           "proposal": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -1854,26 +1600,18 @@
       {
         "description": "Lists all the proposals that have been cast in this module.",
         "type": "object",
-        "required": [
-          "list_proposals"
-        ],
+        "required": ["list_proposals"],
         "properties": {
           "list_proposals": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -1886,26 +1624,18 @@
       {
         "description": "Lists all of the proposals that have been cast in this module in decending order of proposal ID.",
         "type": "object",
-        "required": [
-          "reverse_proposals"
-        ],
+        "required": ["reverse_proposals"],
         "properties": {
           "reverse_proposals": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               },
               "start_before": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -1918,16 +1648,11 @@
       {
         "description": "Returns a voters position on a proposal.",
         "type": "object",
-        "required": [
-          "get_vote"
-        ],
+        "required": ["get_vote"],
         "properties": {
           "get_vote": {
             "type": "object",
-            "required": [
-              "proposal_id",
-              "voter"
-            ],
+            "required": ["proposal_id", "voter"],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -1946,21 +1671,14 @@
       {
         "description": "Lists all of the votes that have been cast on a proposal.",
         "type": "object",
-        "required": [
-          "list_votes"
-        ],
+        "required": ["list_votes"],
         "properties": {
           "list_votes": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               },
@@ -1970,10 +1688,7 @@
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -1984,9 +1699,7 @@
       {
         "description": "Returns the number of proposals that have been created in this module.",
         "type": "object",
-        "required": [
-          "proposal_count"
-        ],
+        "required": ["proposal_count"],
         "properties": {
           "proposal_count": {
             "type": "object",
@@ -1998,9 +1711,7 @@
       {
         "description": "Gets the current proposal creation policy for this module.",
         "type": "object",
-        "required": [
-          "proposal_creation_policy"
-        ],
+        "required": ["proposal_creation_policy"],
         "properties": {
           "proposal_creation_policy": {
             "type": "object",
@@ -2012,9 +1723,7 @@
       {
         "description": "Lists all of the consumers of proposal hooks for this module.",
         "type": "object",
-        "required": [
-          "proposal_hooks"
-        ],
+        "required": ["proposal_hooks"],
         "properties": {
           "proposal_hooks": {
             "type": "object",
@@ -2026,9 +1735,7 @@
       {
         "description": "Lists all of the consumers of vote hooks for this module.",
         "type": "object",
-        "required": [
-          "vote_hooks"
-        ],
+        "required": ["vote_hooks"],
         "properties": {
           "vote_hooks": {
             "type": "object",
@@ -2040,9 +1747,7 @@
       {
         "description": "Returns the address of the DAO this module belongs to",
         "type": "object",
-        "required": [
-          "dao"
-        ],
+        "required": ["dao"],
         "properties": {
           "dao": {
             "type": "object",
@@ -2054,9 +1759,7 @@
       {
         "description": "Returns contract version info",
         "type": "object",
-        "required": [
-          "info"
-        ],
+        "required": ["info"],
         "properties": {
           "info": {
             "type": "object",
@@ -2068,9 +1771,7 @@
       {
         "description": "Returns the proposal ID that will be assigned to the next proposal created.",
         "type": "object",
-        "required": [
-          "next_proposal_id"
-        ],
+        "required": ["next_proposal_id"],
         "properties": {
           "next_proposal_id": {
             "type": "object",
@@ -2087,9 +1788,7 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "from_v1"
-        ],
+        "required": ["from_v1"],
         "properties": {
           "from_v1": {
             "type": "object",
@@ -2129,9 +1828,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "from_compatible"
-        ],
+        "required": ["from_compatible"],
         "properties": {
           "from_compatible": {
             "type": "object",
@@ -2148,15 +1845,11 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "object",
-                "required": [
-                  "addr"
-                ],
+                "required": ["addr"],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -2170,9 +1863,7 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": [
-              "core_module"
-            ],
+            "required": ["core_module"],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -2189,10 +1880,7 @@
       },
       "Coin": {
         "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
+        "required": ["amount", "denom"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -2207,9 +1895,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -2222,9 +1908,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -2239,12 +1923,7 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": [
-          "code_id",
-          "funds",
-          "label",
-          "msg"
-        ],
+        "required": ["code_id", "funds", "label", "msg"],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -2290,9 +1969,7 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": [
-              "anyone_may_propose"
-            ],
+            "required": ["anyone_may_propose"],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -2304,15 +1981,11 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": [
-              "module_may_propose"
-            ],
+            "required": ["module_may_propose"],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": [
-                  "info"
-                ],
+                "required": ["info"],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -2453,9 +2126,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "height"
-              ],
+              "required": ["height"],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -2468,9 +2139,7 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": [
-                "time"
-              ],
+              "required": ["time"],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -2488,9 +2157,7 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "majority"
-              ],
+              "required": ["majority"],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -2502,9 +2169,7 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "percent"
-              ],
+              "required": ["percent"],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -2551,15 +2216,11 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "single_choice"
-              ],
+              "required": ["single_choice"],
               "properties": {
                 "single_choice": {
                   "type": "object",
-                  "required": [
-                    "quorum"
-                  ],
+                  "required": ["quorum"],
                   "properties": {
                     "quorum": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -2605,9 +2266,7 @@
         "MultipleChoiceVote": {
           "description": "A multiple choice vote, picking the desired option",
           "type": "object",
-          "required": [
-            "option_id"
-          ],
+          "required": ["option_id"],
           "properties": {
             "option_id": {
               "type": "integer",
@@ -2624,11 +2283,7 @@
         "VoteInfo": {
           "description": "Information about a vote that was cast.",
           "type": "object",
-          "required": [
-            "power",
-            "vote",
-            "voter"
-          ],
+          "required": ["power", "vote", "voter"],
           "properties": {
             "power": {
               "description": "The voting power behind the vote.",
@@ -2640,10 +2295,7 @@
             },
             "rationale": {
               "description": "The rationale behind the vote.",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "vote": {
               "description": "Position on the vote.",
@@ -2670,9 +2322,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": [
-        "info"
-      ],
+      "required": ["info"],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -2682,10 +2332,7 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": [
-            "contract",
-            "version"
-          ],
+          "required": ["contract", "version"],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -2704,9 +2351,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ProposalListResponse",
       "type": "object",
-      "required": [
-        "proposals"
-      ],
+      "required": ["proposals"],
       "properties": {
         "proposals": {
           "type": "array",
@@ -2727,16 +2372,11 @@
             {
               "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "send"
-              ],
+              "required": ["send"],
               "properties": {
                 "send": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "to_address"
-                  ],
+                  "required": ["amount", "to_address"],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -2755,15 +2395,11 @@
             {
               "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
               "type": "object",
-              "required": [
-                "burn"
-              ],
+              "required": ["burn"],
               "properties": {
                 "burn": {
                   "type": "object",
-                  "required": [
-                    "amount"
-                  ],
+                  "required": ["amount"],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -2822,10 +2458,7 @@
         },
         "Coin": {
           "type": "object",
-          "required": [
-            "amount",
-            "denom"
-          ],
+          "required": ["amount", "denom"],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -2839,9 +2472,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "bank"
-              ],
+              "required": ["bank"],
               "properties": {
                 "bank": {
                   "$ref": "#/definitions/BankMsg"
@@ -2851,9 +2482,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "custom"
-              ],
+              "required": ["custom"],
               "properties": {
                 "custom": {
                   "$ref": "#/definitions/Empty"
@@ -2863,9 +2492,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "staking"
-              ],
+              "required": ["staking"],
               "properties": {
                 "staking": {
                   "$ref": "#/definitions/StakingMsg"
@@ -2875,9 +2502,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "distribution"
-              ],
+              "required": ["distribution"],
               "properties": {
                 "distribution": {
                   "$ref": "#/definitions/DistributionMsg"
@@ -2888,16 +2513,11 @@
             {
               "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
               "type": "object",
-              "required": [
-                "stargate"
-              ],
+              "required": ["stargate"],
               "properties": {
                 "stargate": {
                   "type": "object",
-                  "required": [
-                    "type_url",
-                    "value"
-                  ],
+                  "required": ["type_url", "value"],
                   "properties": {
                     "type_url": {
                       "type": "string"
@@ -2912,9 +2532,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "ibc"
-              ],
+              "required": ["ibc"],
               "properties": {
                 "ibc": {
                   "$ref": "#/definitions/IbcMsg"
@@ -2924,9 +2542,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "wasm"
-              ],
+              "required": ["wasm"],
               "properties": {
                 "wasm": {
                   "$ref": "#/definitions/WasmMsg"
@@ -2936,9 +2552,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "gov"
-              ],
+              "required": ["gov"],
               "properties": {
                 "gov": {
                   "$ref": "#/definitions/GovMsg"
@@ -2958,15 +2572,11 @@
             {
               "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "set_withdraw_address"
-              ],
+              "required": ["set_withdraw_address"],
               "properties": {
                 "set_withdraw_address": {
                   "type": "object",
-                  "required": [
-                    "address"
-                  ],
+                  "required": ["address"],
                   "properties": {
                     "address": {
                       "description": "The `withdraw_address`",
@@ -2980,15 +2590,11 @@
             {
               "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "withdraw_delegator_reward"
-              ],
+              "required": ["withdraw_delegator_reward"],
               "properties": {
                 "withdraw_delegator_reward": {
                   "type": "object",
-                  "required": [
-                    "validator"
-                  ],
+                  "required": ["validator"],
                   "properties": {
                     "validator": {
                       "description": "The `validator_address`",
@@ -3006,9 +2612,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "height"
-              ],
+              "required": ["height"],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -3021,9 +2625,7 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": [
-                "time"
-              ],
+              "required": ["time"],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -3045,9 +2647,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -3060,9 +2660,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -3073,9 +2671,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -3092,16 +2688,11 @@
             {
               "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
               "type": "object",
-              "required": [
-                "vote"
-              ],
+              "required": ["vote"],
               "properties": {
                 "vote": {
                   "type": "object",
-                  "required": [
-                    "proposal_id",
-                    "vote"
-                  ],
+                  "required": ["proposal_id", "vote"],
                   "properties": {
                     "proposal_id": {
                       "type": "integer",
@@ -3129,18 +2720,11 @@
             {
               "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
               "type": "object",
-              "required": [
-                "transfer"
-              ],
+              "required": ["transfer"],
               "properties": {
                 "transfer": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "channel_id",
-                    "timeout",
-                    "to_address"
-                  ],
+                  "required": ["amount", "channel_id", "timeout", "to_address"],
                   "properties": {
                     "amount": {
                       "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -3174,17 +2758,11 @@
             {
               "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
               "type": "object",
-              "required": [
-                "send_packet"
-              ],
+              "required": ["send_packet"],
               "properties": {
                 "send_packet": {
                   "type": "object",
-                  "required": [
-                    "channel_id",
-                    "data",
-                    "timeout"
-                  ],
+                  "required": ["channel_id", "data", "timeout"],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -3208,15 +2786,11 @@
             {
               "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
               "type": "object",
-              "required": [
-                "close_channel"
-              ],
+              "required": ["close_channel"],
               "properties": {
                 "close_channel": {
                   "type": "object",
-                  "required": [
-                    "channel_id"
-                  ],
+                  "required": ["channel_id"],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -3257,10 +2831,7 @@
         "IbcTimeoutBlock": {
           "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
           "type": "object",
-          "required": [
-            "height",
-            "revision"
-          ],
+          "required": ["height", "revision"],
           "properties": {
             "height": {
               "description": "block height after which the packet times out. the height within the given revision",
@@ -3281,16 +2852,12 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": [
-                "standard"
-              ]
+              "enum": ["standard"]
             },
             {
               "description": "Choice that represents selecting none of the options; still counts toward quorum and allows proposals with all bad options to be voted against.",
               "type": "string",
-              "enum": [
-                "none"
-              ]
+              "enum": ["none"]
             }
           ]
         },
@@ -3410,9 +2977,7 @@
         },
         "MultipleChoiceVotes": {
           "type": "object",
-          "required": [
-            "vote_weights"
-          ],
+          "required": ["vote_weights"],
           "properties": {
             "vote_weights": {
               "type": "array",
@@ -3429,9 +2994,7 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "majority"
-              ],
+              "required": ["majority"],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -3443,9 +3006,7 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "percent"
-              ],
+              "required": ["percent"],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -3458,10 +3019,7 @@
         "ProposalResponse": {
           "description": "Information about a proposal returned by proposal queries.",
           "type": "object",
-          "required": [
-            "id",
-            "proposal"
-          ],
+          "required": ["id", "proposal"],
           "properties": {
             "id": {
               "type": "integer",
@@ -3480,16 +3038,11 @@
             {
               "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "delegate"
-              ],
+              "required": ["delegate"],
               "properties": {
                 "delegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "validator"
-                  ],
+                  "required": ["amount", "validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -3505,16 +3058,11 @@
             {
               "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "undelegate"
-              ],
+              "required": ["undelegate"],
               "properties": {
                 "undelegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "validator"
-                  ],
+                  "required": ["amount", "validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -3530,17 +3078,11 @@
             {
               "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "redelegate"
-              ],
+              "required": ["redelegate"],
               "properties": {
                 "redelegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "dst_validator",
-                    "src_validator"
-                  ],
+                  "required": ["amount", "dst_validator", "src_validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -3563,57 +3105,41 @@
             {
               "description": "The proposal is open for voting.",
               "type": "string",
-              "enum": [
-                "open"
-              ]
+              "enum": ["open"]
             },
             {
               "description": "The proposal has been rejected.",
               "type": "string",
-              "enum": [
-                "rejected"
-              ]
+              "enum": ["rejected"]
             },
             {
               "description": "The proposal has been passed but has not been executed.",
               "type": "string",
-              "enum": [
-                "passed"
-              ]
+              "enum": ["passed"]
             },
             {
               "description": "The proposal has been passed and executed.",
               "type": "string",
-              "enum": [
-                "executed"
-              ]
+              "enum": ["executed"]
             },
             {
               "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
               "type": "string",
-              "enum": [
-                "closed"
-              ]
+              "enum": ["closed"]
             },
             {
               "description": "The proposal's execution failed.",
               "type": "string",
-              "enum": [
-                "execution_failed"
-              ]
+              "enum": ["execution_failed"]
             },
             {
               "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
               "type": "object",
-              "required": [
-                "veto_timelock"
-              ],
+              "required": ["veto_timelock"],
               "properties": {
                 "veto_timelock": {
                   "type": "object",
-                  "required": [
-                    "expiration"
-                  ],
+                  "required": ["expiration"],
                   "properties": {
                     "expiration": {
                       "$ref": "#/definitions/Expiration"
@@ -3627,9 +3153,7 @@
             {
               "description": "The proposal has been vetoed.",
               "type": "string",
-              "enum": [
-                "vetoed"
-              ]
+              "enum": ["vetoed"]
             }
           ]
         },
@@ -3683,27 +3207,18 @@
         },
         "VoteOption": {
           "type": "string",
-          "enum": [
-            "yes",
-            "no",
-            "abstain",
-            "no_with_veto"
-          ]
+          "enum": ["yes", "no", "abstain", "no_with_veto"]
         },
         "VotingStrategy": {
           "description": "Determines how many choices may be selected.",
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "single_choice"
-              ],
+              "required": ["single_choice"],
               "properties": {
                 "single_choice": {
                   "type": "object",
-                  "required": [
-                    "quorum"
-                  ],
+                  "required": ["quorum"],
                   "properties": {
                     "quorum": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -3722,17 +3237,11 @@
             {
               "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "execute"
-              ],
+              "required": ["execute"],
               "properties": {
                 "execute": {
                   "type": "object",
-                  "required": [
-                    "contract_addr",
-                    "funds",
-                    "msg"
-                  ],
+                  "required": ["contract_addr", "funds", "msg"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -3759,24 +3268,14 @@
             {
               "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "instantiate"
-              ],
+              "required": ["instantiate"],
               "properties": {
                 "instantiate": {
                   "type": "object",
-                  "required": [
-                    "code_id",
-                    "funds",
-                    "label",
-                    "msg"
-                  ],
+                  "required": ["code_id", "funds", "label", "msg"],
                   "properties": {
                     "admin": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": ["string", "null"]
                     },
                     "code_id": {
                       "type": "integer",
@@ -3809,17 +3308,11 @@
             {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "migrate"
-              ],
+              "required": ["migrate"],
               "properties": {
                 "migrate": {
                   "type": "object",
-                  "required": [
-                    "contract_addr",
-                    "msg",
-                    "new_code_id"
-                  ],
+                  "required": ["contract_addr", "msg", "new_code_id"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -3846,16 +3339,11 @@
             {
               "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": [
-                "update_admin"
-              ],
+              "required": ["update_admin"],
               "properties": {
                 "update_admin": {
                   "type": "object",
-                  "required": [
-                    "admin",
-                    "contract_addr"
-                  ],
+                  "required": ["admin", "contract_addr"],
                   "properties": {
                     "admin": {
                       "type": "string"
@@ -3871,15 +3359,11 @@
             {
               "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": [
-                "clear_admin"
-              ],
+              "required": ["clear_admin"],
               "properties": {
                 "clear_admin": {
                   "type": "object",
-                  "required": [
-                    "contract_addr"
-                  ],
+                  "required": ["contract_addr"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -3897,9 +3381,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VoteListResponse",
       "type": "object",
-      "required": [
-        "votes"
-      ],
+      "required": ["votes"],
       "properties": {
         "votes": {
           "type": "array",
@@ -3917,9 +3399,7 @@
         "MultipleChoiceVote": {
           "description": "A multiple choice vote, picking the desired option",
           "type": "object",
-          "required": [
-            "option_id"
-          ],
+          "required": ["option_id"],
           "properties": {
             "option_id": {
               "type": "integer",
@@ -3936,11 +3416,7 @@
         "VoteInfo": {
           "description": "Information about a vote that was cast.",
           "type": "object",
-          "required": [
-            "power",
-            "vote",
-            "voter"
-          ],
+          "required": ["power", "vote", "voter"],
           "properties": {
             "power": {
               "description": "The voting power behind the vote.",
@@ -3952,10 +3428,7 @@
             },
             "rationale": {
               "description": "The rationale behind the vote.",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "vote": {
               "description": "Position on the vote.",
@@ -3990,10 +3463,7 @@
       "title": "ProposalResponse",
       "description": "Information about a proposal returned by proposal queries.",
       "type": "object",
-      "required": [
-        "id",
-        "proposal"
-      ],
+      "required": ["id", "proposal"],
       "properties": {
         "id": {
           "type": "integer",
@@ -4016,16 +3486,11 @@
             {
               "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "send"
-              ],
+              "required": ["send"],
               "properties": {
                 "send": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "to_address"
-                  ],
+                  "required": ["amount", "to_address"],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -4044,15 +3509,11 @@
             {
               "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
               "type": "object",
-              "required": [
-                "burn"
-              ],
+              "required": ["burn"],
               "properties": {
                 "burn": {
                   "type": "object",
-                  "required": [
-                    "amount"
-                  ],
+                  "required": ["amount"],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -4111,10 +3572,7 @@
         },
         "Coin": {
           "type": "object",
-          "required": [
-            "amount",
-            "denom"
-          ],
+          "required": ["amount", "denom"],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -4128,9 +3586,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "bank"
-              ],
+              "required": ["bank"],
               "properties": {
                 "bank": {
                   "$ref": "#/definitions/BankMsg"
@@ -4140,9 +3596,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "custom"
-              ],
+              "required": ["custom"],
               "properties": {
                 "custom": {
                   "$ref": "#/definitions/Empty"
@@ -4152,9 +3606,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "staking"
-              ],
+              "required": ["staking"],
               "properties": {
                 "staking": {
                   "$ref": "#/definitions/StakingMsg"
@@ -4164,9 +3616,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "distribution"
-              ],
+              "required": ["distribution"],
               "properties": {
                 "distribution": {
                   "$ref": "#/definitions/DistributionMsg"
@@ -4177,16 +3627,11 @@
             {
               "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
               "type": "object",
-              "required": [
-                "stargate"
-              ],
+              "required": ["stargate"],
               "properties": {
                 "stargate": {
                   "type": "object",
-                  "required": [
-                    "type_url",
-                    "value"
-                  ],
+                  "required": ["type_url", "value"],
                   "properties": {
                     "type_url": {
                       "type": "string"
@@ -4201,9 +3646,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "ibc"
-              ],
+              "required": ["ibc"],
               "properties": {
                 "ibc": {
                   "$ref": "#/definitions/IbcMsg"
@@ -4213,9 +3656,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "wasm"
-              ],
+              "required": ["wasm"],
               "properties": {
                 "wasm": {
                   "$ref": "#/definitions/WasmMsg"
@@ -4225,9 +3666,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "gov"
-              ],
+              "required": ["gov"],
               "properties": {
                 "gov": {
                   "$ref": "#/definitions/GovMsg"
@@ -4247,15 +3686,11 @@
             {
               "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "set_withdraw_address"
-              ],
+              "required": ["set_withdraw_address"],
               "properties": {
                 "set_withdraw_address": {
                   "type": "object",
-                  "required": [
-                    "address"
-                  ],
+                  "required": ["address"],
                   "properties": {
                     "address": {
                       "description": "The `withdraw_address`",
@@ -4269,15 +3704,11 @@
             {
               "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "withdraw_delegator_reward"
-              ],
+              "required": ["withdraw_delegator_reward"],
               "properties": {
                 "withdraw_delegator_reward": {
                   "type": "object",
-                  "required": [
-                    "validator"
-                  ],
+                  "required": ["validator"],
                   "properties": {
                     "validator": {
                       "description": "The `validator_address`",
@@ -4295,9 +3726,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "height"
-              ],
+              "required": ["height"],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -4310,9 +3739,7 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": [
-                "time"
-              ],
+              "required": ["time"],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -4334,9 +3761,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -4349,9 +3774,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -4362,9 +3785,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -4381,16 +3802,11 @@
             {
               "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
               "type": "object",
-              "required": [
-                "vote"
-              ],
+              "required": ["vote"],
               "properties": {
                 "vote": {
                   "type": "object",
-                  "required": [
-                    "proposal_id",
-                    "vote"
-                  ],
+                  "required": ["proposal_id", "vote"],
                   "properties": {
                     "proposal_id": {
                       "type": "integer",
@@ -4418,18 +3834,11 @@
             {
               "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
               "type": "object",
-              "required": [
-                "transfer"
-              ],
+              "required": ["transfer"],
               "properties": {
                 "transfer": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "channel_id",
-                    "timeout",
-                    "to_address"
-                  ],
+                  "required": ["amount", "channel_id", "timeout", "to_address"],
                   "properties": {
                     "amount": {
                       "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -4463,17 +3872,11 @@
             {
               "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
               "type": "object",
-              "required": [
-                "send_packet"
-              ],
+              "required": ["send_packet"],
               "properties": {
                 "send_packet": {
                   "type": "object",
-                  "required": [
-                    "channel_id",
-                    "data",
-                    "timeout"
-                  ],
+                  "required": ["channel_id", "data", "timeout"],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -4497,15 +3900,11 @@
             {
               "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
               "type": "object",
-              "required": [
-                "close_channel"
-              ],
+              "required": ["close_channel"],
               "properties": {
                 "close_channel": {
                   "type": "object",
-                  "required": [
-                    "channel_id"
-                  ],
+                  "required": ["channel_id"],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -4546,10 +3945,7 @@
         "IbcTimeoutBlock": {
           "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
           "type": "object",
-          "required": [
-            "height",
-            "revision"
-          ],
+          "required": ["height", "revision"],
           "properties": {
             "height": {
               "description": "block height after which the packet times out. the height within the given revision",
@@ -4570,16 +3966,12 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": [
-                "standard"
-              ]
+              "enum": ["standard"]
             },
             {
               "description": "Choice that represents selecting none of the options; still counts toward quorum and allows proposals with all bad options to be voted against.",
               "type": "string",
-              "enum": [
-                "none"
-              ]
+              "enum": ["none"]
             }
           ]
         },
@@ -4699,9 +4091,7 @@
         },
         "MultipleChoiceVotes": {
           "type": "object",
-          "required": [
-            "vote_weights"
-          ],
+          "required": ["vote_weights"],
           "properties": {
             "vote_weights": {
               "type": "array",
@@ -4718,9 +4108,7 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "majority"
-              ],
+              "required": ["majority"],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -4732,9 +4120,7 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "percent"
-              ],
+              "required": ["percent"],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -4750,16 +4136,11 @@
             {
               "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "delegate"
-              ],
+              "required": ["delegate"],
               "properties": {
                 "delegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "validator"
-                  ],
+                  "required": ["amount", "validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -4775,16 +4156,11 @@
             {
               "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "undelegate"
-              ],
+              "required": ["undelegate"],
               "properties": {
                 "undelegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "validator"
-                  ],
+                  "required": ["amount", "validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -4800,17 +4176,11 @@
             {
               "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "redelegate"
-              ],
+              "required": ["redelegate"],
               "properties": {
                 "redelegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "dst_validator",
-                    "src_validator"
-                  ],
+                  "required": ["amount", "dst_validator", "src_validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -4833,57 +4203,41 @@
             {
               "description": "The proposal is open for voting.",
               "type": "string",
-              "enum": [
-                "open"
-              ]
+              "enum": ["open"]
             },
             {
               "description": "The proposal has been rejected.",
               "type": "string",
-              "enum": [
-                "rejected"
-              ]
+              "enum": ["rejected"]
             },
             {
               "description": "The proposal has been passed but has not been executed.",
               "type": "string",
-              "enum": [
-                "passed"
-              ]
+              "enum": ["passed"]
             },
             {
               "description": "The proposal has been passed and executed.",
               "type": "string",
-              "enum": [
-                "executed"
-              ]
+              "enum": ["executed"]
             },
             {
               "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
               "type": "string",
-              "enum": [
-                "closed"
-              ]
+              "enum": ["closed"]
             },
             {
               "description": "The proposal's execution failed.",
               "type": "string",
-              "enum": [
-                "execution_failed"
-              ]
+              "enum": ["execution_failed"]
             },
             {
               "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
               "type": "object",
-              "required": [
-                "veto_timelock"
-              ],
+              "required": ["veto_timelock"],
               "properties": {
                 "veto_timelock": {
                   "type": "object",
-                  "required": [
-                    "expiration"
-                  ],
+                  "required": ["expiration"],
                   "properties": {
                     "expiration": {
                       "$ref": "#/definitions/Expiration"
@@ -4897,9 +4251,7 @@
             {
               "description": "The proposal has been vetoed.",
               "type": "string",
-              "enum": [
-                "vetoed"
-              ]
+              "enum": ["vetoed"]
             }
           ]
         },
@@ -4953,27 +4305,18 @@
         },
         "VoteOption": {
           "type": "string",
-          "enum": [
-            "yes",
-            "no",
-            "abstain",
-            "no_with_veto"
-          ]
+          "enum": ["yes", "no", "abstain", "no_with_veto"]
         },
         "VotingStrategy": {
           "description": "Determines how many choices may be selected.",
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "single_choice"
-              ],
+              "required": ["single_choice"],
               "properties": {
                 "single_choice": {
                   "type": "object",
-                  "required": [
-                    "quorum"
-                  ],
+                  "required": ["quorum"],
                   "properties": {
                     "quorum": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -4992,17 +4335,11 @@
             {
               "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "execute"
-              ],
+              "required": ["execute"],
               "properties": {
                 "execute": {
                   "type": "object",
-                  "required": [
-                    "contract_addr",
-                    "funds",
-                    "msg"
-                  ],
+                  "required": ["contract_addr", "funds", "msg"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -5029,24 +4366,14 @@
             {
               "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "instantiate"
-              ],
+              "required": ["instantiate"],
               "properties": {
                 "instantiate": {
                   "type": "object",
-                  "required": [
-                    "code_id",
-                    "funds",
-                    "label",
-                    "msg"
-                  ],
+                  "required": ["code_id", "funds", "label", "msg"],
                   "properties": {
                     "admin": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": ["string", "null"]
                     },
                     "code_id": {
                       "type": "integer",
@@ -5079,17 +4406,11 @@
             {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "migrate"
-              ],
+              "required": ["migrate"],
               "properties": {
                 "migrate": {
                   "type": "object",
-                  "required": [
-                    "contract_addr",
-                    "msg",
-                    "new_code_id"
-                  ],
+                  "required": ["contract_addr", "msg", "new_code_id"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -5116,16 +4437,11 @@
             {
               "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": [
-                "update_admin"
-              ],
+              "required": ["update_admin"],
               "properties": {
                 "update_admin": {
                   "type": "object",
-                  "required": [
-                    "admin",
-                    "contract_addr"
-                  ],
+                  "required": ["admin", "contract_addr"],
                   "properties": {
                     "admin": {
                       "type": "string"
@@ -5141,15 +4457,11 @@
             {
               "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": [
-                "clear_admin"
-              ],
+              "required": ["clear_admin"],
               "properties": {
                 "clear_admin": {
                   "type": "object",
-                  "required": [
-                    "contract_addr"
-                  ],
+                  "required": ["contract_addr"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -5178,9 +4490,7 @@
         {
           "description": "Anyone may create a proposal, free of charge.",
           "type": "object",
-          "required": [
-            "anyone"
-          ],
+          "required": ["anyone"],
           "properties": {
             "anyone": {
               "type": "object",
@@ -5192,15 +4502,11 @@
         {
           "description": "Only ADDR may create proposals. It is expected that ADDR is a pre-propose module, though we only require that it is a valid address.",
           "type": "object",
-          "required": [
-            "module"
-          ],
+          "required": ["module"],
           "properties": {
             "module": {
               "type": "object",
-              "required": [
-                "addr"
-              ],
+              "required": ["addr"],
               "properties": {
                 "addr": {
                   "$ref": "#/definitions/Addr"
@@ -5223,9 +4529,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": [
-        "hooks"
-      ],
+      "required": ["hooks"],
       "properties": {
         "hooks": {
           "type": "array",
@@ -5240,9 +4544,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ProposalListResponse",
       "type": "object",
-      "required": [
-        "proposals"
-      ],
+      "required": ["proposals"],
       "properties": {
         "proposals": {
           "type": "array",
@@ -5263,16 +4565,11 @@
             {
               "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "send"
-              ],
+              "required": ["send"],
               "properties": {
                 "send": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "to_address"
-                  ],
+                  "required": ["amount", "to_address"],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -5291,15 +4588,11 @@
             {
               "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
               "type": "object",
-              "required": [
-                "burn"
-              ],
+              "required": ["burn"],
               "properties": {
                 "burn": {
                   "type": "object",
-                  "required": [
-                    "amount"
-                  ],
+                  "required": ["amount"],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -5358,10 +4651,7 @@
         },
         "Coin": {
           "type": "object",
-          "required": [
-            "amount",
-            "denom"
-          ],
+          "required": ["amount", "denom"],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -5375,9 +4665,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "bank"
-              ],
+              "required": ["bank"],
               "properties": {
                 "bank": {
                   "$ref": "#/definitions/BankMsg"
@@ -5387,9 +4675,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "custom"
-              ],
+              "required": ["custom"],
               "properties": {
                 "custom": {
                   "$ref": "#/definitions/Empty"
@@ -5399,9 +4685,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "staking"
-              ],
+              "required": ["staking"],
               "properties": {
                 "staking": {
                   "$ref": "#/definitions/StakingMsg"
@@ -5411,9 +4695,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "distribution"
-              ],
+              "required": ["distribution"],
               "properties": {
                 "distribution": {
                   "$ref": "#/definitions/DistributionMsg"
@@ -5424,16 +4706,11 @@
             {
               "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
               "type": "object",
-              "required": [
-                "stargate"
-              ],
+              "required": ["stargate"],
               "properties": {
                 "stargate": {
                   "type": "object",
-                  "required": [
-                    "type_url",
-                    "value"
-                  ],
+                  "required": ["type_url", "value"],
                   "properties": {
                     "type_url": {
                       "type": "string"
@@ -5448,9 +4725,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "ibc"
-              ],
+              "required": ["ibc"],
               "properties": {
                 "ibc": {
                   "$ref": "#/definitions/IbcMsg"
@@ -5460,9 +4735,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "wasm"
-              ],
+              "required": ["wasm"],
               "properties": {
                 "wasm": {
                   "$ref": "#/definitions/WasmMsg"
@@ -5472,9 +4745,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "gov"
-              ],
+              "required": ["gov"],
               "properties": {
                 "gov": {
                   "$ref": "#/definitions/GovMsg"
@@ -5494,15 +4765,11 @@
             {
               "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "set_withdraw_address"
-              ],
+              "required": ["set_withdraw_address"],
               "properties": {
                 "set_withdraw_address": {
                   "type": "object",
-                  "required": [
-                    "address"
-                  ],
+                  "required": ["address"],
                   "properties": {
                     "address": {
                       "description": "The `withdraw_address`",
@@ -5516,15 +4783,11 @@
             {
               "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "withdraw_delegator_reward"
-              ],
+              "required": ["withdraw_delegator_reward"],
               "properties": {
                 "withdraw_delegator_reward": {
                   "type": "object",
-                  "required": [
-                    "validator"
-                  ],
+                  "required": ["validator"],
                   "properties": {
                     "validator": {
                       "description": "The `validator_address`",
@@ -5542,9 +4805,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "height"
-              ],
+              "required": ["height"],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -5557,9 +4818,7 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": [
-                "time"
-              ],
+              "required": ["time"],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -5581,9 +4840,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -5596,9 +4853,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -5609,9 +4864,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -5628,16 +4881,11 @@
             {
               "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
               "type": "object",
-              "required": [
-                "vote"
-              ],
+              "required": ["vote"],
               "properties": {
                 "vote": {
                   "type": "object",
-                  "required": [
-                    "proposal_id",
-                    "vote"
-                  ],
+                  "required": ["proposal_id", "vote"],
                   "properties": {
                     "proposal_id": {
                       "type": "integer",
@@ -5665,18 +4913,11 @@
             {
               "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
               "type": "object",
-              "required": [
-                "transfer"
-              ],
+              "required": ["transfer"],
               "properties": {
                 "transfer": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "channel_id",
-                    "timeout",
-                    "to_address"
-                  ],
+                  "required": ["amount", "channel_id", "timeout", "to_address"],
                   "properties": {
                     "amount": {
                       "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -5710,17 +4951,11 @@
             {
               "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
               "type": "object",
-              "required": [
-                "send_packet"
-              ],
+              "required": ["send_packet"],
               "properties": {
                 "send_packet": {
                   "type": "object",
-                  "required": [
-                    "channel_id",
-                    "data",
-                    "timeout"
-                  ],
+                  "required": ["channel_id", "data", "timeout"],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -5744,15 +4979,11 @@
             {
               "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
               "type": "object",
-              "required": [
-                "close_channel"
-              ],
+              "required": ["close_channel"],
               "properties": {
                 "close_channel": {
                   "type": "object",
-                  "required": [
-                    "channel_id"
-                  ],
+                  "required": ["channel_id"],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -5793,10 +5024,7 @@
         "IbcTimeoutBlock": {
           "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
           "type": "object",
-          "required": [
-            "height",
-            "revision"
-          ],
+          "required": ["height", "revision"],
           "properties": {
             "height": {
               "description": "block height after which the packet times out. the height within the given revision",
@@ -5817,16 +5045,12 @@
           "oneOf": [
             {
               "type": "string",
-              "enum": [
-                "standard"
-              ]
+              "enum": ["standard"]
             },
             {
               "description": "Choice that represents selecting none of the options; still counts toward quorum and allows proposals with all bad options to be voted against.",
               "type": "string",
-              "enum": [
-                "none"
-              ]
+              "enum": ["none"]
             }
           ]
         },
@@ -5946,9 +5170,7 @@
         },
         "MultipleChoiceVotes": {
           "type": "object",
-          "required": [
-            "vote_weights"
-          ],
+          "required": ["vote_weights"],
           "properties": {
             "vote_weights": {
               "type": "array",
@@ -5965,9 +5187,7 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "majority"
-              ],
+              "required": ["majority"],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -5979,9 +5199,7 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "percent"
-              ],
+              "required": ["percent"],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -5994,10 +5212,7 @@
         "ProposalResponse": {
           "description": "Information about a proposal returned by proposal queries.",
           "type": "object",
-          "required": [
-            "id",
-            "proposal"
-          ],
+          "required": ["id", "proposal"],
           "properties": {
             "id": {
               "type": "integer",
@@ -6016,16 +5231,11 @@
             {
               "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "delegate"
-              ],
+              "required": ["delegate"],
               "properties": {
                 "delegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "validator"
-                  ],
+                  "required": ["amount", "validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -6041,16 +5251,11 @@
             {
               "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "undelegate"
-              ],
+              "required": ["undelegate"],
               "properties": {
                 "undelegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "validator"
-                  ],
+                  "required": ["amount", "validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -6066,17 +5271,11 @@
             {
               "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "redelegate"
-              ],
+              "required": ["redelegate"],
               "properties": {
                 "redelegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "dst_validator",
-                    "src_validator"
-                  ],
+                  "required": ["amount", "dst_validator", "src_validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -6099,57 +5298,41 @@
             {
               "description": "The proposal is open for voting.",
               "type": "string",
-              "enum": [
-                "open"
-              ]
+              "enum": ["open"]
             },
             {
               "description": "The proposal has been rejected.",
               "type": "string",
-              "enum": [
-                "rejected"
-              ]
+              "enum": ["rejected"]
             },
             {
               "description": "The proposal has been passed but has not been executed.",
               "type": "string",
-              "enum": [
-                "passed"
-              ]
+              "enum": ["passed"]
             },
             {
               "description": "The proposal has been passed and executed.",
               "type": "string",
-              "enum": [
-                "executed"
-              ]
+              "enum": ["executed"]
             },
             {
               "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
               "type": "string",
-              "enum": [
-                "closed"
-              ]
+              "enum": ["closed"]
             },
             {
               "description": "The proposal's execution failed.",
               "type": "string",
-              "enum": [
-                "execution_failed"
-              ]
+              "enum": ["execution_failed"]
             },
             {
               "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
               "type": "object",
-              "required": [
-                "veto_timelock"
-              ],
+              "required": ["veto_timelock"],
               "properties": {
                 "veto_timelock": {
                   "type": "object",
-                  "required": [
-                    "expiration"
-                  ],
+                  "required": ["expiration"],
                   "properties": {
                     "expiration": {
                       "$ref": "#/definitions/Expiration"
@@ -6163,9 +5346,7 @@
             {
               "description": "The proposal has been vetoed.",
               "type": "string",
-              "enum": [
-                "vetoed"
-              ]
+              "enum": ["vetoed"]
             }
           ]
         },
@@ -6219,27 +5400,18 @@
         },
         "VoteOption": {
           "type": "string",
-          "enum": [
-            "yes",
-            "no",
-            "abstain",
-            "no_with_veto"
-          ]
+          "enum": ["yes", "no", "abstain", "no_with_veto"]
         },
         "VotingStrategy": {
           "description": "Determines how many choices may be selected.",
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "single_choice"
-              ],
+              "required": ["single_choice"],
               "properties": {
                 "single_choice": {
                   "type": "object",
-                  "required": [
-                    "quorum"
-                  ],
+                  "required": ["quorum"],
                   "properties": {
                     "quorum": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -6258,17 +5430,11 @@
             {
               "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "execute"
-              ],
+              "required": ["execute"],
               "properties": {
                 "execute": {
                   "type": "object",
-                  "required": [
-                    "contract_addr",
-                    "funds",
-                    "msg"
-                  ],
+                  "required": ["contract_addr", "funds", "msg"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -6295,24 +5461,14 @@
             {
               "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "instantiate"
-              ],
+              "required": ["instantiate"],
               "properties": {
                 "instantiate": {
                   "type": "object",
-                  "required": [
-                    "code_id",
-                    "funds",
-                    "label",
-                    "msg"
-                  ],
+                  "required": ["code_id", "funds", "label", "msg"],
                   "properties": {
                     "admin": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": ["string", "null"]
                     },
                     "code_id": {
                       "type": "integer",
@@ -6345,17 +5501,11 @@
             {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "migrate"
-              ],
+              "required": ["migrate"],
               "properties": {
                 "migrate": {
                   "type": "object",
-                  "required": [
-                    "contract_addr",
-                    "msg",
-                    "new_code_id"
-                  ],
+                  "required": ["contract_addr", "msg", "new_code_id"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -6382,16 +5532,11 @@
             {
               "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": [
-                "update_admin"
-              ],
+              "required": ["update_admin"],
               "properties": {
                 "update_admin": {
                   "type": "object",
-                  "required": [
-                    "admin",
-                    "contract_addr"
-                  ],
+                  "required": ["admin", "contract_addr"],
                   "properties": {
                     "admin": {
                       "type": "string"
@@ -6407,15 +5552,11 @@
             {
               "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": [
-                "clear_admin"
-              ],
+              "required": ["clear_admin"],
               "properties": {
                 "clear_admin": {
                   "type": "object",
-                  "required": [
-                    "contract_addr"
-                  ],
+                  "required": ["contract_addr"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -6433,9 +5574,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": [
-        "hooks"
-      ],
+      "required": ["hooks"],
       "properties": {
         "hooks": {
           "type": "array",

--- a/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
+++ b/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
@@ -5173,6 +5173,7 @@
     "proposal_creation_policy": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ProposalCreationPolicy",
+      "description": "The policy configured in a proposal module that determines whether or not a pre-propose module is in use. If so, only the module can create new proposals. Otherwise, there is no restriction on proposal creation.",
       "oneOf": [
         {
           "description": "Anyone may create a proposal, free of charge.",

--- a/contracts/proposal/dao-proposal-multiple/src/testing/instantiate.rs
+++ b/contracts/proposal/dao-proposal-multiple/src/testing/instantiate.rs
@@ -12,8 +12,11 @@ use dao_testing::contracts::{
 use dao_voting::{
     deposit::{DepositRefundPolicy, UncheckedDepositInfo, VotingModuleTokenType},
     multiple_choice::VotingStrategy,
-    pre_propose::PreProposeInfo,
-    threshold::{ActiveThreshold, ActiveThreshold::AbsoluteCount, PercentageThreshold},
+    pre_propose::{PreProposeInfo, PreProposeSubmissionPolicy},
+    threshold::{
+        ActiveThreshold::{self, AbsoluteCount},
+        PercentageThreshold,
+    },
 };
 use dao_voting_cw4::msg::GroupContract;
 
@@ -29,12 +32,19 @@ fn get_pre_propose_info(
     open_proposal_submission: bool,
 ) -> PreProposeInfo {
     let pre_propose_contract = app.store_code(pre_propose_multiple_contract());
+
+    let submission_policy = if open_proposal_submission {
+        PreProposeSubmissionPolicy::Anyone {}
+    } else {
+        PreProposeSubmissionPolicy::DaoMembers {}
+    };
+
     PreProposeInfo::ModuleMayPropose {
         info: ModuleInstantiateInfo {
             code_id: pre_propose_contract,
             msg: to_json_binary(&cppm::InstantiateMsg {
                 deposit_info,
-                open_proposal_submission,
+                submission_policy,
                 extension: Empty::default(),
             })
             .unwrap(),

--- a/contracts/proposal/dao-proposal-multiple/src/testing/instantiate.rs
+++ b/contracts/proposal/dao-proposal-multiple/src/testing/instantiate.rs
@@ -34,9 +34,13 @@ fn get_pre_propose_info(
     let pre_propose_contract = app.store_code(pre_propose_multiple_contract());
 
     let submission_policy = if open_proposal_submission {
-        PreProposeSubmissionPolicy::Anyone {}
+        PreProposeSubmissionPolicy::Anyone { denylist: None }
     } else {
-        PreProposeSubmissionPolicy::DaoMembers {}
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        }
     };
 
     PreProposeInfo::ModuleMayPropose {

--- a/contracts/proposal/dao-proposal-multiple/src/testing/tests.rs
+++ b/contracts/proposal/dao-proposal-multiple/src/testing/tests.rs
@@ -99,9 +99,13 @@ pub fn get_pre_propose_info(
     let pre_propose_contract = app.store_code(pre_propose_multiple_contract());
 
     let submission_policy = if open_proposal_submission {
-        PreProposeSubmissionPolicy::Anyone {}
+        PreProposeSubmissionPolicy::Anyone { denylist: None }
     } else {
-        PreProposeSubmissionPolicy::DaoMembers {}
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        }
     };
 
     PreProposeInfo::ModuleMayPropose {

--- a/contracts/proposal/dao-proposal-multiple/src/testing/tests.rs
+++ b/contracts/proposal/dao-proposal-multiple/src/testing/tests.rs
@@ -9,6 +9,7 @@ use cw_utils::Duration;
 use dao_interface::state::ProposalModule;
 use dao_interface::state::{Admin, ModuleInstantiateInfo};
 use dao_voting::multiple_choice::MultipleChoiceAutoVote;
+use dao_voting::pre_propose::PreProposeSubmissionPolicy;
 use dao_voting::veto::{VetoConfig, VetoError};
 use dao_voting::{
     deposit::{
@@ -96,12 +97,19 @@ pub fn get_pre_propose_info(
     open_proposal_submission: bool,
 ) -> PreProposeInfo {
     let pre_propose_contract = app.store_code(pre_propose_multiple_contract());
+
+    let submission_policy = if open_proposal_submission {
+        PreProposeSubmissionPolicy::Anyone {}
+    } else {
+        PreProposeSubmissionPolicy::DaoMembers {}
+    };
+
     PreProposeInfo::ModuleMayPropose {
         info: ModuleInstantiateInfo {
             code_id: pre_propose_contract,
             msg: to_json_binary(&cppm::InstantiateMsg {
                 deposit_info,
-                open_proposal_submission,
+                submission_policy,
                 extension: Empty::default(),
             })
             .unwrap(),

--- a/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
+++ b/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-single",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -82,15 +82,11 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "object",
-                "required": [
-                  "addr"
-                ],
+                "required": ["addr"],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -104,9 +100,7 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": [
-              "core_module"
-            ],
+            "required": ["core_module"],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -123,10 +117,7 @@
       },
       "Coin": {
         "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
+        "required": ["amount", "denom"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -145,9 +136,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -160,9 +149,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -177,12 +164,7 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": [
-          "code_id",
-          "funds",
-          "label",
-          "msg"
-        ],
+        "required": ["code_id", "funds", "label", "msg"],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -229,9 +211,7 @@
           {
             "description": "The majority of voters must vote yes for the proposal to pass.",
             "type": "object",
-            "required": [
-              "majority"
-            ],
+            "required": ["majority"],
             "properties": {
               "majority": {
                 "type": "object",
@@ -243,9 +223,7 @@
           {
             "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
             "type": "object",
-            "required": [
-              "percent"
-            ],
+            "required": ["percent"],
             "properties": {
               "percent": {
                 "$ref": "#/definitions/Decimal"
@@ -260,9 +238,7 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": [
-              "anyone_may_propose"
-            ],
+            "required": ["anyone_may_propose"],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -274,15 +250,11 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": [
-              "module_may_propose"
-            ],
+            "required": ["module_may_propose"],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": [
-                  "info"
-                ],
+                "required": ["info"],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -301,15 +273,11 @@
           {
             "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
             "type": "object",
-            "required": [
-              "absolute_percentage"
-            ],
+            "required": ["absolute_percentage"],
             "properties": {
               "absolute_percentage": {
                 "type": "object",
-                "required": [
-                  "percentage"
-                ],
+                "required": ["percentage"],
                 "properties": {
                   "percentage": {
                     "$ref": "#/definitions/PercentageThreshold"
@@ -323,16 +291,11 @@
           {
             "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
             "type": "object",
-            "required": [
-              "threshold_quorum"
-            ],
+            "required": ["threshold_quorum"],
             "properties": {
               "threshold_quorum": {
                 "type": "object",
-                "required": [
-                  "quorum",
-                  "threshold"
-                ],
+                "required": ["quorum", "threshold"],
                 "properties": {
                   "quorum": {
                     "$ref": "#/definitions/PercentageThreshold"
@@ -349,15 +312,11 @@
           {
             "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
             "type": "object",
-            "required": [
-              "absolute_count"
-            ],
+            "required": ["absolute_count"],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": [
-                  "threshold"
-                ],
+                "required": ["threshold"],
                 "properties": {
                   "threshold": {
                     "$ref": "#/definitions/Uint128"
@@ -415,9 +374,7 @@
       {
         "description": "Creates a proposal in the module.",
         "type": "object",
-        "required": [
-          "propose"
-        ],
+        "required": ["propose"],
         "properties": {
           "propose": {
             "$ref": "#/definitions/SingleChoiceProposeMsg"
@@ -428,16 +385,11 @@
       {
         "description": "Votes on a proposal. Voting power is determined by the DAO's voting power module.",
         "type": "object",
-        "required": [
-          "vote"
-        ],
+        "required": ["vote"],
         "properties": {
           "vote": {
             "type": "object",
-            "required": [
-              "proposal_id",
-              "vote"
-            ],
+            "required": ["proposal_id", "vote"],
             "properties": {
               "proposal_id": {
                 "description": "The ID of the proposal to vote on.",
@@ -447,10 +399,7 @@
               },
               "rationale": {
                 "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               },
               "vote": {
                 "description": "The senders position on the proposal.",
@@ -469,15 +418,11 @@
       {
         "description": "Updates the sender's rationale for their vote on the specified proposal. Errors if no vote vote has been cast.",
         "type": "object",
-        "required": [
-          "update_rationale"
-        ],
+        "required": ["update_rationale"],
         "properties": {
           "update_rationale": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -485,10 +430,7 @@
                 "minimum": 0.0
               },
               "rationale": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -499,15 +441,11 @@
       {
         "description": "Causes the messages associated with a passed proposal to be executed by the DAO.",
         "type": "object",
-        "required": [
-          "execute"
-        ],
+        "required": ["execute"],
         "properties": {
           "execute": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "proposal_id": {
                 "description": "The ID of the proposal to execute.",
@@ -524,15 +462,11 @@
       {
         "description": "Callable only if veto is configured",
         "type": "object",
-        "required": [
-          "veto"
-        ],
+        "required": ["veto"],
         "properties": {
           "veto": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "proposal_id": {
                 "description": "The ID of the proposal to veto.",
@@ -549,15 +483,11 @@
       {
         "description": "Closes a proposal that has failed (either not passed or timed out). If applicable this will cause the proposal deposit associated wth said proposal to be returned.",
         "type": "object",
-        "required": [
-          "close"
-        ],
+        "required": ["close"],
         "properties": {
           "close": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "proposal_id": {
                 "description": "The ID of the proposal to close.",
@@ -574,9 +504,7 @@
       {
         "description": "Updates the governance module's config.",
         "type": "object",
-        "required": [
-          "update_config"
-        ],
+        "required": ["update_config"],
         "properties": {
           "update_config": {
             "type": "object",
@@ -652,15 +580,11 @@
       {
         "description": "Update's the proposal creation policy used for this module. Only the DAO may call this method.",
         "type": "object",
-        "required": [
-          "update_pre_propose_info"
-        ],
+        "required": ["update_pre_propose_info"],
         "properties": {
           "update_pre_propose_info": {
             "type": "object",
-            "required": [
-              "info"
-            ],
+            "required": ["info"],
             "properties": {
               "info": {
                 "$ref": "#/definitions/PreProposeInfo"
@@ -674,15 +598,11 @@
       {
         "description": "Adds an address as a consumer of proposal hooks. Consumers of proposal hooks have hook messages executed on them whenever the status of a proposal changes or a proposal is created. If a consumer contract errors when handling a hook message it will be removed from the list of consumers.",
         "type": "object",
-        "required": [
-          "add_proposal_hook"
-        ],
+        "required": ["add_proposal_hook"],
         "properties": {
           "add_proposal_hook": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -696,15 +616,11 @@
       {
         "description": "Removes a consumer of proposal hooks.",
         "type": "object",
-        "required": [
-          "remove_proposal_hook"
-        ],
+        "required": ["remove_proposal_hook"],
         "properties": {
           "remove_proposal_hook": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -718,15 +634,11 @@
       {
         "description": "Adds an address as a consumer of vote hooks. Consumers of vote hooks have hook messages executed on them whenever the a vote is cast. If a consumer contract errors when handling a hook message it will be removed from the list of consumers.",
         "type": "object",
-        "required": [
-          "add_vote_hook"
-        ],
+        "required": ["add_vote_hook"],
         "properties": {
           "add_vote_hook": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -740,15 +652,11 @@
       {
         "description": "Removed a consumer of vote hooks.",
         "type": "object",
-        "required": [
-          "remove_vote_hook"
-        ],
+        "required": ["remove_vote_hook"],
         "properties": {
           "remove_vote_hook": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -767,15 +675,11 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "object",
-                "required": [
-                  "addr"
-                ],
+                "required": ["addr"],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -789,9 +693,7 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": [
-              "core_module"
-            ],
+            "required": ["core_module"],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -808,16 +710,11 @@
           {
             "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "send"
-            ],
+            "required": ["send"],
             "properties": {
               "send": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "to_address"
-                ],
+                "required": ["amount", "to_address"],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -836,15 +733,11 @@
           {
             "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
             "type": "object",
-            "required": [
-              "burn"
-            ],
+            "required": ["burn"],
             "properties": {
               "burn": {
                 "type": "object",
-                "required": [
-                  "amount"
-                ],
+                "required": ["amount"],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -865,10 +758,7 @@
       },
       "Coin": {
         "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
+        "required": ["amount", "denom"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -882,9 +772,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "bank"
-            ],
+            "required": ["bank"],
             "properties": {
               "bank": {
                 "$ref": "#/definitions/BankMsg"
@@ -894,9 +782,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "custom"
-            ],
+            "required": ["custom"],
             "properties": {
               "custom": {
                 "$ref": "#/definitions/Empty"
@@ -906,9 +792,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "staking"
-            ],
+            "required": ["staking"],
             "properties": {
               "staking": {
                 "$ref": "#/definitions/StakingMsg"
@@ -918,9 +802,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "distribution"
-            ],
+            "required": ["distribution"],
             "properties": {
               "distribution": {
                 "$ref": "#/definitions/DistributionMsg"
@@ -931,16 +813,11 @@
           {
             "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
             "type": "object",
-            "required": [
-              "stargate"
-            ],
+            "required": ["stargate"],
             "properties": {
               "stargate": {
                 "type": "object",
-                "required": [
-                  "type_url",
-                  "value"
-                ],
+                "required": ["type_url", "value"],
                 "properties": {
                   "type_url": {
                     "type": "string"
@@ -955,9 +832,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "ibc"
-            ],
+            "required": ["ibc"],
             "properties": {
               "ibc": {
                 "$ref": "#/definitions/IbcMsg"
@@ -967,9 +842,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "wasm"
-            ],
+            "required": ["wasm"],
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmMsg"
@@ -979,9 +852,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "gov"
-            ],
+            "required": ["gov"],
             "properties": {
               "gov": {
                 "$ref": "#/definitions/GovMsg"
@@ -1001,15 +872,11 @@
           {
             "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "set_withdraw_address"
-            ],
+            "required": ["set_withdraw_address"],
             "properties": {
               "set_withdraw_address": {
                 "type": "object",
-                "required": [
-                  "address"
-                ],
+                "required": ["address"],
                 "properties": {
                   "address": {
                     "description": "The `withdraw_address`",
@@ -1023,15 +890,11 @@
           {
             "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "withdraw_delegator_reward"
-            ],
+            "required": ["withdraw_delegator_reward"],
             "properties": {
               "withdraw_delegator_reward": {
                 "type": "object",
-                "required": [
-                  "validator"
-                ],
+                "required": ["validator"],
                 "properties": {
                   "validator": {
                     "description": "The `validator_address`",
@@ -1049,9 +912,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -1064,9 +925,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -1088,16 +947,11 @@
           {
             "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
             "type": "object",
-            "required": [
-              "vote"
-            ],
+            "required": ["vote"],
             "properties": {
               "vote": {
                 "type": "object",
-                "required": [
-                  "proposal_id",
-                  "vote"
-                ],
+                "required": ["proposal_id", "vote"],
                 "properties": {
                   "proposal_id": {
                     "type": "integer",
@@ -1125,18 +979,11 @@
           {
             "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
             "type": "object",
-            "required": [
-              "transfer"
-            ],
+            "required": ["transfer"],
             "properties": {
               "transfer": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "channel_id",
-                  "timeout",
-                  "to_address"
-                ],
+                "required": ["amount", "channel_id", "timeout", "to_address"],
                 "properties": {
                   "amount": {
                     "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -1170,17 +1017,11 @@
           {
             "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
             "type": "object",
-            "required": [
-              "send_packet"
-            ],
+            "required": ["send_packet"],
             "properties": {
               "send_packet": {
                 "type": "object",
-                "required": [
-                  "channel_id",
-                  "data",
-                  "timeout"
-                ],
+                "required": ["channel_id", "data", "timeout"],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -1204,15 +1045,11 @@
           {
             "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
             "type": "object",
-            "required": [
-              "close_channel"
-            ],
+            "required": ["close_channel"],
             "properties": {
               "close_channel": {
                 "type": "object",
-                "required": [
-                  "channel_id"
-                ],
+                "required": ["channel_id"],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -1253,10 +1090,7 @@
       "IbcTimeoutBlock": {
         "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
         "type": "object",
-        "required": [
-          "height",
-          "revision"
-        ],
+        "required": ["height", "revision"],
         "properties": {
           "height": {
             "description": "block height after which the packet times out. the height within the given revision",
@@ -1275,12 +1109,7 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": [
-          "code_id",
-          "funds",
-          "label",
-          "msg"
-        ],
+        "required": ["code_id", "funds", "label", "msg"],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -1327,9 +1156,7 @@
           {
             "description": "The majority of voters must vote yes for the proposal to pass.",
             "type": "object",
-            "required": [
-              "majority"
-            ],
+            "required": ["majority"],
             "properties": {
               "majority": {
                 "type": "object",
@@ -1341,9 +1168,7 @@
           {
             "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
             "type": "object",
-            "required": [
-              "percent"
-            ],
+            "required": ["percent"],
             "properties": {
               "percent": {
                 "$ref": "#/definitions/Decimal"
@@ -1358,9 +1183,7 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": [
-              "anyone_may_propose"
-            ],
+            "required": ["anyone_may_propose"],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -1372,15 +1195,11 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": [
-              "module_may_propose"
-            ],
+            "required": ["module_may_propose"],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": [
-                  "info"
-                ],
+                "required": ["info"],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -1395,16 +1214,11 @@
       },
       "SingleChoiceAutoVote": {
         "type": "object",
-        "required": [
-          "vote"
-        ],
+        "required": ["vote"],
         "properties": {
           "rationale": {
             "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "vote": {
             "description": "The proposer's position on the proposal.",
@@ -1420,11 +1234,7 @@
       "SingleChoiceProposeMsg": {
         "description": "The contents of a message to create a proposal in the single choice proposal module.\n\nWe break this type out of `ExecuteMsg` because we want pre-propose modules that interact with this contract to be able to get type checking on their propose messages.\n\nWe move this type to this package so that pre-propose modules can import it without importing dao-proposal-single with the library feature which (as it is not additive) cause the execute exports to not be included in wasm builds.",
         "type": "object",
-        "required": [
-          "description",
-          "msgs",
-          "title"
-        ],
+        "required": ["description", "msgs", "title"],
         "properties": {
           "description": {
             "description": "A description of the proposal.",
@@ -1439,10 +1249,7 @@
           },
           "proposer": {
             "description": "The address creating the proposal. If no pre-propose module is attached to this module this must always be None as the proposer is the sender of the propose message. If a pre-propose module is attached, this must be Some and will set the proposer of the proposal it creates.",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "title": {
             "description": "The title of the proposal.",
@@ -1468,16 +1275,11 @@
           {
             "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "delegate"
-            ],
+            "required": ["delegate"],
             "properties": {
               "delegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "validator"
-                ],
+                "required": ["amount", "validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1493,16 +1295,11 @@
           {
             "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "undelegate"
-            ],
+            "required": ["undelegate"],
             "properties": {
               "undelegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "validator"
-                ],
+                "required": ["amount", "validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1518,17 +1315,11 @@
           {
             "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "redelegate"
-            ],
+            "required": ["redelegate"],
             "properties": {
               "redelegate": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "dst_validator",
-                  "src_validator"
-                ],
+                "required": ["amount", "dst_validator", "src_validator"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1552,15 +1343,11 @@
           {
             "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
             "type": "object",
-            "required": [
-              "absolute_percentage"
-            ],
+            "required": ["absolute_percentage"],
             "properties": {
               "absolute_percentage": {
                 "type": "object",
-                "required": [
-                  "percentage"
-                ],
+                "required": ["percentage"],
                 "properties": {
                   "percentage": {
                     "$ref": "#/definitions/PercentageThreshold"
@@ -1574,16 +1361,11 @@
           {
             "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
             "type": "object",
-            "required": [
-              "threshold_quorum"
-            ],
+            "required": ["threshold_quorum"],
             "properties": {
               "threshold_quorum": {
                 "type": "object",
-                "required": [
-                  "quorum",
-                  "threshold"
-                ],
+                "required": ["quorum", "threshold"],
                 "properties": {
                   "quorum": {
                     "$ref": "#/definitions/PercentageThreshold"
@@ -1600,15 +1382,11 @@
           {
             "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
             "type": "object",
-            "required": [
-              "absolute_count"
-            ],
+            "required": ["absolute_count"],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": [
-                  "threshold"
-                ],
+                "required": ["threshold"],
                 "properties": {
                   "threshold": {
                     "$ref": "#/definitions/Uint128"
@@ -1674,34 +1452,23 @@
           {
             "description": "Marks support for the proposal.",
             "type": "string",
-            "enum": [
-              "yes"
-            ]
+            "enum": ["yes"]
           },
           {
             "description": "Marks opposition to the proposal.",
             "type": "string",
-            "enum": [
-              "no"
-            ]
+            "enum": ["no"]
           },
           {
             "description": "Marks participation but does not count towards the ratio of support / opposed.",
             "type": "string",
-            "enum": [
-              "abstain"
-            ]
+            "enum": ["abstain"]
           }
         ]
       },
       "VoteOption": {
         "type": "string",
-        "enum": [
-          "yes",
-          "no",
-          "abstain",
-          "no_with_veto"
-        ]
+        "enum": ["yes", "no", "abstain", "no_with_veto"]
       },
       "WasmMsg": {
         "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
@@ -1709,17 +1476,11 @@
           {
             "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "execute"
-            ],
+            "required": ["execute"],
             "properties": {
               "execute": {
                 "type": "object",
-                "required": [
-                  "contract_addr",
-                  "funds",
-                  "msg"
-                ],
+                "required": ["contract_addr", "funds", "msg"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1746,24 +1507,14 @@
           {
             "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "instantiate"
-            ],
+            "required": ["instantiate"],
             "properties": {
               "instantiate": {
                 "type": "object",
-                "required": [
-                  "code_id",
-                  "funds",
-                  "label",
-                  "msg"
-                ],
+                "required": ["code_id", "funds", "label", "msg"],
                 "properties": {
                   "admin": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
+                    "type": ["string", "null"]
                   },
                   "code_id": {
                     "type": "integer",
@@ -1796,17 +1547,11 @@
           {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": [
-              "migrate"
-            ],
+            "required": ["migrate"],
             "properties": {
               "migrate": {
                 "type": "object",
-                "required": [
-                  "contract_addr",
-                  "msg",
-                  "new_code_id"
-                ],
+                "required": ["contract_addr", "msg", "new_code_id"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1833,16 +1578,11 @@
           {
             "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": [
-              "update_admin"
-            ],
+            "required": ["update_admin"],
             "properties": {
               "update_admin": {
                 "type": "object",
-                "required": [
-                  "admin",
-                  "contract_addr"
-                ],
+                "required": ["admin", "contract_addr"],
                 "properties": {
                   "admin": {
                     "type": "string"
@@ -1858,15 +1598,11 @@
           {
             "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": [
-              "clear_admin"
-            ],
+            "required": ["clear_admin"],
             "properties": {
               "clear_admin": {
                 "type": "object",
-                "required": [
-                  "contract_addr"
-                ],
+                "required": ["contract_addr"],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1887,9 +1623,7 @@
       {
         "description": "Gets the proposal module's config.",
         "type": "object",
-        "required": [
-          "config"
-        ],
+        "required": ["config"],
         "properties": {
           "config": {
             "type": "object",
@@ -1901,15 +1635,11 @@
       {
         "description": "Gets information about a proposal.",
         "type": "object",
-        "required": [
-          "proposal"
-        ],
+        "required": ["proposal"],
         "properties": {
           "proposal": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -1925,28 +1655,20 @@
       {
         "description": "Lists all the proposals that have been cast in this module.",
         "type": "object",
-        "required": [
-          "list_proposals"
-        ],
+        "required": ["list_proposals"],
         "properties": {
           "list_proposals": {
             "type": "object",
             "properties": {
               "limit": {
                 "description": "The maximum number of proposals to return as part of this query. If no limit is set a max of 30 proposals will be returned.",
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               },
               "start_after": {
                 "description": "The proposal ID to start listing proposals after. For example, if this is set to 2 proposals with IDs 3 and higher will be returned.",
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -1959,28 +1681,20 @@
       {
         "description": "Lists all of the proposals that have been cast in this module in decending order of proposal ID.",
         "type": "object",
-        "required": [
-          "reverse_proposals"
-        ],
+        "required": ["reverse_proposals"],
         "properties": {
           "reverse_proposals": {
             "type": "object",
             "properties": {
               "limit": {
                 "description": "The maximum number of proposals to return as part of this query. If no limit is set a max of 30 proposals will be returned.",
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               },
               "start_before": {
                 "description": "The proposal ID to start listing proposals before. For example, if this is set to 6 proposals with IDs 5 and lower will be returned.",
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -1993,16 +1707,11 @@
       {
         "description": "Returns a voters position on a propsal.",
         "type": "object",
-        "required": [
-          "get_vote"
-        ],
+        "required": ["get_vote"],
         "properties": {
           "get_vote": {
             "type": "object",
-            "required": [
-              "proposal_id",
-              "voter"
-            ],
+            "required": ["proposal_id", "voter"],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -2021,22 +1730,15 @@
       {
         "description": "Lists all of the votes that have been cast on a proposal.",
         "type": "object",
-        "required": [
-          "list_votes"
-        ],
+        "required": ["list_votes"],
         "properties": {
           "list_votes": {
             "type": "object",
-            "required": [
-              "proposal_id"
-            ],
+            "required": ["proposal_id"],
             "properties": {
               "limit": {
                 "description": "The maximum number of votes to return in response to this query. If no limit is specified a max of 30 are returned.",
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               },
@@ -2048,10 +1750,7 @@
               },
               "start_after": {
                 "description": "The voter to start listing votes after. Ordering is done alphabetically.",
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -2062,9 +1761,7 @@
       {
         "description": "Returns the number of proposals that have been created in this module.",
         "type": "object",
-        "required": [
-          "proposal_count"
-        ],
+        "required": ["proposal_count"],
         "properties": {
           "proposal_count": {
             "type": "object",
@@ -2076,9 +1773,7 @@
       {
         "description": "Gets the current proposal creation policy for this module.",
         "type": "object",
-        "required": [
-          "proposal_creation_policy"
-        ],
+        "required": ["proposal_creation_policy"],
         "properties": {
           "proposal_creation_policy": {
             "type": "object",
@@ -2090,9 +1785,7 @@
       {
         "description": "Lists all of the consumers of proposal hooks for this module.",
         "type": "object",
-        "required": [
-          "proposal_hooks"
-        ],
+        "required": ["proposal_hooks"],
         "properties": {
           "proposal_hooks": {
             "type": "object",
@@ -2104,9 +1797,7 @@
       {
         "description": "Lists all of the consumers of vote hooks for this module.",
         "type": "object",
-        "required": [
-          "vote_hooks"
-        ],
+        "required": ["vote_hooks"],
         "properties": {
           "vote_hooks": {
             "type": "object",
@@ -2118,9 +1809,7 @@
       {
         "description": "Returns the address of the DAO this module belongs to",
         "type": "object",
-        "required": [
-          "dao"
-        ],
+        "required": ["dao"],
         "properties": {
           "dao": {
             "type": "object",
@@ -2132,9 +1821,7 @@
       {
         "description": "Returns contract version info",
         "type": "object",
-        "required": [
-          "info"
-        ],
+        "required": ["info"],
         "properties": {
           "info": {
             "type": "object",
@@ -2146,9 +1833,7 @@
       {
         "description": "Returns the proposal ID that will be assigned to the next proposal created.",
         "type": "object",
-        "required": [
-          "next_proposal_id"
-        ],
+        "required": ["next_proposal_id"],
         "properties": {
           "next_proposal_id": {
             "type": "object",
@@ -2165,9 +1850,7 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "from_v1"
-        ],
+        "required": ["from_v1"],
         "properties": {
           "from_v1": {
             "type": "object",
@@ -2207,9 +1890,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "from_compatible"
-        ],
+        "required": ["from_compatible"],
         "properties": {
           "from_compatible": {
             "type": "object",
@@ -2226,15 +1907,11 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "object",
-                "required": [
-                  "addr"
-                ],
+                "required": ["addr"],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -2248,9 +1925,7 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": [
-              "core_module"
-            ],
+            "required": ["core_module"],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -2267,10 +1942,7 @@
       },
       "Coin": {
         "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
+        "required": ["amount", "denom"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -2285,9 +1957,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -2300,9 +1970,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -2317,12 +1985,7 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": [
-          "code_id",
-          "funds",
-          "label",
-          "msg"
-        ],
+        "required": ["code_id", "funds", "label", "msg"],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -2368,9 +2031,7 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": [
-              "anyone_may_propose"
-            ],
+            "required": ["anyone_may_propose"],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -2382,15 +2043,11 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": [
-              "module_may_propose"
-            ],
+            "required": ["module_may_propose"],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": [
-                  "info"
-                ],
+                "required": ["info"],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -2531,9 +2188,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "height"
-              ],
+              "required": ["height"],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -2546,9 +2201,7 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": [
-                "time"
-              ],
+              "required": ["time"],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -2566,9 +2219,7 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "majority"
-              ],
+              "required": ["majority"],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -2580,9 +2231,7 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "percent"
-              ],
+              "required": ["percent"],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -2598,15 +2247,11 @@
             {
               "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
               "type": "object",
-              "required": [
-                "absolute_percentage"
-              ],
+              "required": ["absolute_percentage"],
               "properties": {
                 "absolute_percentage": {
                   "type": "object",
-                  "required": [
-                    "percentage"
-                  ],
+                  "required": ["percentage"],
                   "properties": {
                     "percentage": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -2620,16 +2265,11 @@
             {
               "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
               "type": "object",
-              "required": [
-                "threshold_quorum"
-              ],
+              "required": ["threshold_quorum"],
               "properties": {
                 "threshold_quorum": {
                   "type": "object",
-                  "required": [
-                    "quorum",
-                    "threshold"
-                  ],
+                  "required": ["quorum", "threshold"],
                   "properties": {
                     "quorum": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -2646,15 +2286,11 @@
             {
               "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
               "type": "object",
-              "required": [
-                "absolute_count"
-              ],
+              "required": ["absolute_count"],
               "properties": {
                 "absolute_count": {
                   "type": "object",
-                  "required": [
-                    "threshold"
-                  ],
+                  "required": ["threshold"],
                   "properties": {
                     "threshold": {
                       "$ref": "#/definitions/Uint128"
@@ -2744,34 +2380,24 @@
             {
               "description": "Marks support for the proposal.",
               "type": "string",
-              "enum": [
-                "yes"
-              ]
+              "enum": ["yes"]
             },
             {
               "description": "Marks opposition to the proposal.",
               "type": "string",
-              "enum": [
-                "no"
-              ]
+              "enum": ["no"]
             },
             {
               "description": "Marks participation but does not count towards the ratio of support / opposed.",
               "type": "string",
-              "enum": [
-                "abstain"
-              ]
+              "enum": ["abstain"]
             }
           ]
         },
         "VoteInfo": {
           "description": "Information about a vote that was cast.",
           "type": "object",
-          "required": [
-            "power",
-            "vote",
-            "voter"
-          ],
+          "required": ["power", "vote", "voter"],
           "properties": {
             "power": {
               "description": "The voting power behind the vote.",
@@ -2783,10 +2409,7 @@
             },
             "rationale": {
               "description": "Address-specified rationale for the vote.",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "vote": {
               "description": "Position on the vote.",
@@ -2813,9 +2436,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": [
-        "info"
-      ],
+      "required": ["info"],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -2825,10 +2446,7 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": [
-            "contract",
-            "version"
-          ],
+          "required": ["contract", "version"],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -2848,9 +2466,7 @@
       "title": "ProposalListResponse",
       "description": "A list of proposals returned by `ListProposals` and `ReverseProposals`.",
       "type": "object",
-      "required": [
-        "proposals"
-      ],
+      "required": ["proposals"],
       "properties": {
         "proposals": {
           "type": "array",
@@ -2871,16 +2487,11 @@
             {
               "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "send"
-              ],
+              "required": ["send"],
               "properties": {
                 "send": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "to_address"
-                  ],
+                  "required": ["amount", "to_address"],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -2899,15 +2510,11 @@
             {
               "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
               "type": "object",
-              "required": [
-                "burn"
-              ],
+              "required": ["burn"],
               "properties": {
                 "burn": {
                   "type": "object",
-                  "required": [
-                    "amount"
-                  ],
+                  "required": ["amount"],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -2928,10 +2535,7 @@
         },
         "Coin": {
           "type": "object",
-          "required": [
-            "amount",
-            "denom"
-          ],
+          "required": ["amount", "denom"],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -2945,9 +2549,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "bank"
-              ],
+              "required": ["bank"],
               "properties": {
                 "bank": {
                   "$ref": "#/definitions/BankMsg"
@@ -2957,9 +2559,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "custom"
-              ],
+              "required": ["custom"],
               "properties": {
                 "custom": {
                   "$ref": "#/definitions/Empty"
@@ -2969,9 +2569,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "staking"
-              ],
+              "required": ["staking"],
               "properties": {
                 "staking": {
                   "$ref": "#/definitions/StakingMsg"
@@ -2981,9 +2579,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "distribution"
-              ],
+              "required": ["distribution"],
               "properties": {
                 "distribution": {
                   "$ref": "#/definitions/DistributionMsg"
@@ -2994,16 +2590,11 @@
             {
               "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
               "type": "object",
-              "required": [
-                "stargate"
-              ],
+              "required": ["stargate"],
               "properties": {
                 "stargate": {
                   "type": "object",
-                  "required": [
-                    "type_url",
-                    "value"
-                  ],
+                  "required": ["type_url", "value"],
                   "properties": {
                     "type_url": {
                       "type": "string"
@@ -3018,9 +2609,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "ibc"
-              ],
+              "required": ["ibc"],
               "properties": {
                 "ibc": {
                   "$ref": "#/definitions/IbcMsg"
@@ -3030,9 +2619,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "wasm"
-              ],
+              "required": ["wasm"],
               "properties": {
                 "wasm": {
                   "$ref": "#/definitions/WasmMsg"
@@ -3042,9 +2629,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "gov"
-              ],
+              "required": ["gov"],
               "properties": {
                 "gov": {
                   "$ref": "#/definitions/GovMsg"
@@ -3064,15 +2649,11 @@
             {
               "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "set_withdraw_address"
-              ],
+              "required": ["set_withdraw_address"],
               "properties": {
                 "set_withdraw_address": {
                   "type": "object",
-                  "required": [
-                    "address"
-                  ],
+                  "required": ["address"],
                   "properties": {
                     "address": {
                       "description": "The `withdraw_address`",
@@ -3086,15 +2667,11 @@
             {
               "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "withdraw_delegator_reward"
-              ],
+              "required": ["withdraw_delegator_reward"],
               "properties": {
                 "withdraw_delegator_reward": {
                   "type": "object",
-                  "required": [
-                    "validator"
-                  ],
+                  "required": ["validator"],
                   "properties": {
                     "validator": {
                       "description": "The `validator_address`",
@@ -3112,9 +2689,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "height"
-              ],
+              "required": ["height"],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -3127,9 +2702,7 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": [
-                "time"
-              ],
+              "required": ["time"],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -3151,9 +2724,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -3166,9 +2737,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -3179,9 +2748,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -3198,16 +2765,11 @@
             {
               "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
               "type": "object",
-              "required": [
-                "vote"
-              ],
+              "required": ["vote"],
               "properties": {
                 "vote": {
                   "type": "object",
-                  "required": [
-                    "proposal_id",
-                    "vote"
-                  ],
+                  "required": ["proposal_id", "vote"],
                   "properties": {
                     "proposal_id": {
                       "type": "integer",
@@ -3235,18 +2797,11 @@
             {
               "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
               "type": "object",
-              "required": [
-                "transfer"
-              ],
+              "required": ["transfer"],
               "properties": {
                 "transfer": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "channel_id",
-                    "timeout",
-                    "to_address"
-                  ],
+                  "required": ["amount", "channel_id", "timeout", "to_address"],
                   "properties": {
                     "amount": {
                       "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -3280,17 +2835,11 @@
             {
               "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
               "type": "object",
-              "required": [
-                "send_packet"
-              ],
+              "required": ["send_packet"],
               "properties": {
                 "send_packet": {
                   "type": "object",
-                  "required": [
-                    "channel_id",
-                    "data",
-                    "timeout"
-                  ],
+                  "required": ["channel_id", "data", "timeout"],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -3314,15 +2863,11 @@
             {
               "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
               "type": "object",
-              "required": [
-                "close_channel"
-              ],
+              "required": ["close_channel"],
               "properties": {
                 "close_channel": {
                   "type": "object",
-                  "required": [
-                    "channel_id"
-                  ],
+                  "required": ["channel_id"],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -3363,10 +2908,7 @@
         "IbcTimeoutBlock": {
           "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
           "type": "object",
-          "required": [
-            "height",
-            "revision"
-          ],
+          "required": ["height", "revision"],
           "properties": {
             "height": {
               "description": "block height after which the packet times out. the height within the given revision",
@@ -3388,9 +2930,7 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "majority"
-              ],
+              "required": ["majority"],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -3402,9 +2942,7 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "percent"
-              ],
+              "required": ["percent"],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -3417,10 +2955,7 @@
         "ProposalResponse": {
           "description": "Information about a proposal returned by proposal queries.",
           "type": "object",
-          "required": [
-            "id",
-            "proposal"
-          ],
+          "required": ["id", "proposal"],
           "properties": {
             "id": {
               "description": "The ID of the proposal being returned.",
@@ -3554,16 +3089,11 @@
             {
               "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "delegate"
-              ],
+              "required": ["delegate"],
               "properties": {
                 "delegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "validator"
-                  ],
+                  "required": ["amount", "validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -3579,16 +3109,11 @@
             {
               "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "undelegate"
-              ],
+              "required": ["undelegate"],
               "properties": {
                 "undelegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "validator"
-                  ],
+                  "required": ["amount", "validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -3604,17 +3129,11 @@
             {
               "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "redelegate"
-              ],
+              "required": ["redelegate"],
               "properties": {
                 "redelegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "dst_validator",
-                    "src_validator"
-                  ],
+                  "required": ["amount", "dst_validator", "src_validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -3637,57 +3156,41 @@
             {
               "description": "The proposal is open for voting.",
               "type": "string",
-              "enum": [
-                "open"
-              ]
+              "enum": ["open"]
             },
             {
               "description": "The proposal has been rejected.",
               "type": "string",
-              "enum": [
-                "rejected"
-              ]
+              "enum": ["rejected"]
             },
             {
               "description": "The proposal has been passed but has not been executed.",
               "type": "string",
-              "enum": [
-                "passed"
-              ]
+              "enum": ["passed"]
             },
             {
               "description": "The proposal has been passed and executed.",
               "type": "string",
-              "enum": [
-                "executed"
-              ]
+              "enum": ["executed"]
             },
             {
               "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
               "type": "string",
-              "enum": [
-                "closed"
-              ]
+              "enum": ["closed"]
             },
             {
               "description": "The proposal's execution failed.",
               "type": "string",
-              "enum": [
-                "execution_failed"
-              ]
+              "enum": ["execution_failed"]
             },
             {
               "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
               "type": "object",
-              "required": [
-                "veto_timelock"
-              ],
+              "required": ["veto_timelock"],
               "properties": {
                 "veto_timelock": {
                   "type": "object",
-                  "required": [
-                    "expiration"
-                  ],
+                  "required": ["expiration"],
                   "properties": {
                     "expiration": {
                       "$ref": "#/definitions/Expiration"
@@ -3701,9 +3204,7 @@
             {
               "description": "The proposal has been vetoed.",
               "type": "string",
-              "enum": [
-                "vetoed"
-              ]
+              "enum": ["vetoed"]
             }
           ]
         },
@@ -3713,15 +3214,11 @@
             {
               "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
               "type": "object",
-              "required": [
-                "absolute_percentage"
-              ],
+              "required": ["absolute_percentage"],
               "properties": {
                 "absolute_percentage": {
                   "type": "object",
-                  "required": [
-                    "percentage"
-                  ],
+                  "required": ["percentage"],
                   "properties": {
                     "percentage": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -3735,16 +3232,11 @@
             {
               "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
               "type": "object",
-              "required": [
-                "threshold_quorum"
-              ],
+              "required": ["threshold_quorum"],
               "properties": {
                 "threshold_quorum": {
                   "type": "object",
-                  "required": [
-                    "quorum",
-                    "threshold"
-                  ],
+                  "required": ["quorum", "threshold"],
                   "properties": {
                     "quorum": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -3761,15 +3253,11 @@
             {
               "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
               "type": "object",
-              "required": [
-                "absolute_count"
-              ],
+              "required": ["absolute_count"],
               "properties": {
                 "absolute_count": {
                   "type": "object",
-                  "required": [
-                    "threshold"
-                  ],
+                  "required": ["threshold"],
                   "properties": {
                     "threshold": {
                       "$ref": "#/definitions/Uint128"
@@ -3832,20 +3320,11 @@
         },
         "VoteOption": {
           "type": "string",
-          "enum": [
-            "yes",
-            "no",
-            "abstain",
-            "no_with_veto"
-          ]
+          "enum": ["yes", "no", "abstain", "no_with_veto"]
         },
         "Votes": {
           "type": "object",
-          "required": [
-            "abstain",
-            "no",
-            "yes"
-          ],
+          "required": ["abstain", "no", "yes"],
           "properties": {
             "abstain": {
               "$ref": "#/definitions/Uint128"
@@ -3865,17 +3344,11 @@
             {
               "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "execute"
-              ],
+              "required": ["execute"],
               "properties": {
                 "execute": {
                   "type": "object",
-                  "required": [
-                    "contract_addr",
-                    "funds",
-                    "msg"
-                  ],
+                  "required": ["contract_addr", "funds", "msg"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -3902,24 +3375,14 @@
             {
               "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "instantiate"
-              ],
+              "required": ["instantiate"],
               "properties": {
                 "instantiate": {
                   "type": "object",
-                  "required": [
-                    "code_id",
-                    "funds",
-                    "label",
-                    "msg"
-                  ],
+                  "required": ["code_id", "funds", "label", "msg"],
                   "properties": {
                     "admin": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": ["string", "null"]
                     },
                     "code_id": {
                       "type": "integer",
@@ -3952,17 +3415,11 @@
             {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "migrate"
-              ],
+              "required": ["migrate"],
               "properties": {
                 "migrate": {
                   "type": "object",
-                  "required": [
-                    "contract_addr",
-                    "msg",
-                    "new_code_id"
-                  ],
+                  "required": ["contract_addr", "msg", "new_code_id"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -3989,16 +3446,11 @@
             {
               "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": [
-                "update_admin"
-              ],
+              "required": ["update_admin"],
               "properties": {
                 "update_admin": {
                   "type": "object",
-                  "required": [
-                    "admin",
-                    "contract_addr"
-                  ],
+                  "required": ["admin", "contract_addr"],
                   "properties": {
                     "admin": {
                       "type": "string"
@@ -4014,15 +3466,11 @@
             {
               "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": [
-                "clear_admin"
-              ],
+              "required": ["clear_admin"],
               "properties": {
                 "clear_admin": {
                   "type": "object",
-                  "required": [
-                    "contract_addr"
-                  ],
+                  "required": ["contract_addr"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -4041,9 +3489,7 @@
       "title": "VoteListResponse",
       "description": "Information about the votes for a proposal.",
       "type": "object",
-      "required": [
-        "votes"
-      ],
+      "required": ["votes"],
       "properties": {
         "votes": {
           "type": "array",
@@ -4067,34 +3513,24 @@
             {
               "description": "Marks support for the proposal.",
               "type": "string",
-              "enum": [
-                "yes"
-              ]
+              "enum": ["yes"]
             },
             {
               "description": "Marks opposition to the proposal.",
               "type": "string",
-              "enum": [
-                "no"
-              ]
+              "enum": ["no"]
             },
             {
               "description": "Marks participation but does not count towards the ratio of support / opposed.",
               "type": "string",
-              "enum": [
-                "abstain"
-              ]
+              "enum": ["abstain"]
             }
           ]
         },
         "VoteInfo": {
           "description": "Information about a vote that was cast.",
           "type": "object",
-          "required": [
-            "power",
-            "vote",
-            "voter"
-          ],
+          "required": ["power", "vote", "voter"],
           "properties": {
             "power": {
               "description": "The voting power behind the vote.",
@@ -4106,10 +3542,7 @@
             },
             "rationale": {
               "description": "Address-specified rationale for the vote.",
-              "type": [
-                "string",
-                "null"
-              ]
+              "type": ["string", "null"]
             },
             "vote": {
               "description": "Position on the vote.",
@@ -4144,10 +3577,7 @@
       "title": "ProposalResponse",
       "description": "Information about a proposal returned by proposal queries.",
       "type": "object",
-      "required": [
-        "id",
-        "proposal"
-      ],
+      "required": ["id", "proposal"],
       "properties": {
         "id": {
           "description": "The ID of the proposal being returned.",
@@ -4171,16 +3601,11 @@
             {
               "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "send"
-              ],
+              "required": ["send"],
               "properties": {
                 "send": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "to_address"
-                  ],
+                  "required": ["amount", "to_address"],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -4199,15 +3624,11 @@
             {
               "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
               "type": "object",
-              "required": [
-                "burn"
-              ],
+              "required": ["burn"],
               "properties": {
                 "burn": {
                   "type": "object",
-                  "required": [
-                    "amount"
-                  ],
+                  "required": ["amount"],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -4228,10 +3649,7 @@
         },
         "Coin": {
           "type": "object",
-          "required": [
-            "amount",
-            "denom"
-          ],
+          "required": ["amount", "denom"],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -4245,9 +3663,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "bank"
-              ],
+              "required": ["bank"],
               "properties": {
                 "bank": {
                   "$ref": "#/definitions/BankMsg"
@@ -4257,9 +3673,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "custom"
-              ],
+              "required": ["custom"],
               "properties": {
                 "custom": {
                   "$ref": "#/definitions/Empty"
@@ -4269,9 +3683,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "staking"
-              ],
+              "required": ["staking"],
               "properties": {
                 "staking": {
                   "$ref": "#/definitions/StakingMsg"
@@ -4281,9 +3693,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "distribution"
-              ],
+              "required": ["distribution"],
               "properties": {
                 "distribution": {
                   "$ref": "#/definitions/DistributionMsg"
@@ -4294,16 +3704,11 @@
             {
               "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
               "type": "object",
-              "required": [
-                "stargate"
-              ],
+              "required": ["stargate"],
               "properties": {
                 "stargate": {
                   "type": "object",
-                  "required": [
-                    "type_url",
-                    "value"
-                  ],
+                  "required": ["type_url", "value"],
                   "properties": {
                     "type_url": {
                       "type": "string"
@@ -4318,9 +3723,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "ibc"
-              ],
+              "required": ["ibc"],
               "properties": {
                 "ibc": {
                   "$ref": "#/definitions/IbcMsg"
@@ -4330,9 +3733,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "wasm"
-              ],
+              "required": ["wasm"],
               "properties": {
                 "wasm": {
                   "$ref": "#/definitions/WasmMsg"
@@ -4342,9 +3743,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "gov"
-              ],
+              "required": ["gov"],
               "properties": {
                 "gov": {
                   "$ref": "#/definitions/GovMsg"
@@ -4364,15 +3763,11 @@
             {
               "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "set_withdraw_address"
-              ],
+              "required": ["set_withdraw_address"],
               "properties": {
                 "set_withdraw_address": {
                   "type": "object",
-                  "required": [
-                    "address"
-                  ],
+                  "required": ["address"],
                   "properties": {
                     "address": {
                       "description": "The `withdraw_address`",
@@ -4386,15 +3781,11 @@
             {
               "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "withdraw_delegator_reward"
-              ],
+              "required": ["withdraw_delegator_reward"],
               "properties": {
                 "withdraw_delegator_reward": {
                   "type": "object",
-                  "required": [
-                    "validator"
-                  ],
+                  "required": ["validator"],
                   "properties": {
                     "validator": {
                       "description": "The `validator_address`",
@@ -4412,9 +3803,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "height"
-              ],
+              "required": ["height"],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -4427,9 +3816,7 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": [
-                "time"
-              ],
+              "required": ["time"],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -4451,9 +3838,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -4466,9 +3851,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -4479,9 +3862,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -4498,16 +3879,11 @@
             {
               "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
               "type": "object",
-              "required": [
-                "vote"
-              ],
+              "required": ["vote"],
               "properties": {
                 "vote": {
                   "type": "object",
-                  "required": [
-                    "proposal_id",
-                    "vote"
-                  ],
+                  "required": ["proposal_id", "vote"],
                   "properties": {
                     "proposal_id": {
                       "type": "integer",
@@ -4535,18 +3911,11 @@
             {
               "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
               "type": "object",
-              "required": [
-                "transfer"
-              ],
+              "required": ["transfer"],
               "properties": {
                 "transfer": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "channel_id",
-                    "timeout",
-                    "to_address"
-                  ],
+                  "required": ["amount", "channel_id", "timeout", "to_address"],
                   "properties": {
                     "amount": {
                       "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -4580,17 +3949,11 @@
             {
               "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
               "type": "object",
-              "required": [
-                "send_packet"
-              ],
+              "required": ["send_packet"],
               "properties": {
                 "send_packet": {
                   "type": "object",
-                  "required": [
-                    "channel_id",
-                    "data",
-                    "timeout"
-                  ],
+                  "required": ["channel_id", "data", "timeout"],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -4614,15 +3977,11 @@
             {
               "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
               "type": "object",
-              "required": [
-                "close_channel"
-              ],
+              "required": ["close_channel"],
               "properties": {
                 "close_channel": {
                   "type": "object",
-                  "required": [
-                    "channel_id"
-                  ],
+                  "required": ["channel_id"],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -4663,10 +4022,7 @@
         "IbcTimeoutBlock": {
           "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
           "type": "object",
-          "required": [
-            "height",
-            "revision"
-          ],
+          "required": ["height", "revision"],
           "properties": {
             "height": {
               "description": "block height after which the packet times out. the height within the given revision",
@@ -4688,9 +4044,7 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "majority"
-              ],
+              "required": ["majority"],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -4702,9 +4056,7 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "percent"
-              ],
+              "required": ["percent"],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -4834,16 +4186,11 @@
             {
               "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "delegate"
-              ],
+              "required": ["delegate"],
               "properties": {
                 "delegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "validator"
-                  ],
+                  "required": ["amount", "validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -4859,16 +4206,11 @@
             {
               "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "undelegate"
-              ],
+              "required": ["undelegate"],
               "properties": {
                 "undelegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "validator"
-                  ],
+                  "required": ["amount", "validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -4884,17 +4226,11 @@
             {
               "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "redelegate"
-              ],
+              "required": ["redelegate"],
               "properties": {
                 "redelegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "dst_validator",
-                    "src_validator"
-                  ],
+                  "required": ["amount", "dst_validator", "src_validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -4917,57 +4253,41 @@
             {
               "description": "The proposal is open for voting.",
               "type": "string",
-              "enum": [
-                "open"
-              ]
+              "enum": ["open"]
             },
             {
               "description": "The proposal has been rejected.",
               "type": "string",
-              "enum": [
-                "rejected"
-              ]
+              "enum": ["rejected"]
             },
             {
               "description": "The proposal has been passed but has not been executed.",
               "type": "string",
-              "enum": [
-                "passed"
-              ]
+              "enum": ["passed"]
             },
             {
               "description": "The proposal has been passed and executed.",
               "type": "string",
-              "enum": [
-                "executed"
-              ]
+              "enum": ["executed"]
             },
             {
               "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
               "type": "string",
-              "enum": [
-                "closed"
-              ]
+              "enum": ["closed"]
             },
             {
               "description": "The proposal's execution failed.",
               "type": "string",
-              "enum": [
-                "execution_failed"
-              ]
+              "enum": ["execution_failed"]
             },
             {
               "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
               "type": "object",
-              "required": [
-                "veto_timelock"
-              ],
+              "required": ["veto_timelock"],
               "properties": {
                 "veto_timelock": {
                   "type": "object",
-                  "required": [
-                    "expiration"
-                  ],
+                  "required": ["expiration"],
                   "properties": {
                     "expiration": {
                       "$ref": "#/definitions/Expiration"
@@ -4981,9 +4301,7 @@
             {
               "description": "The proposal has been vetoed.",
               "type": "string",
-              "enum": [
-                "vetoed"
-              ]
+              "enum": ["vetoed"]
             }
           ]
         },
@@ -4993,15 +4311,11 @@
             {
               "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
               "type": "object",
-              "required": [
-                "absolute_percentage"
-              ],
+              "required": ["absolute_percentage"],
               "properties": {
                 "absolute_percentage": {
                   "type": "object",
-                  "required": [
-                    "percentage"
-                  ],
+                  "required": ["percentage"],
                   "properties": {
                     "percentage": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -5015,16 +4329,11 @@
             {
               "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
               "type": "object",
-              "required": [
-                "threshold_quorum"
-              ],
+              "required": ["threshold_quorum"],
               "properties": {
                 "threshold_quorum": {
                   "type": "object",
-                  "required": [
-                    "quorum",
-                    "threshold"
-                  ],
+                  "required": ["quorum", "threshold"],
                   "properties": {
                     "quorum": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -5041,15 +4350,11 @@
             {
               "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
               "type": "object",
-              "required": [
-                "absolute_count"
-              ],
+              "required": ["absolute_count"],
               "properties": {
                 "absolute_count": {
                   "type": "object",
-                  "required": [
-                    "threshold"
-                  ],
+                  "required": ["threshold"],
                   "properties": {
                     "threshold": {
                       "$ref": "#/definitions/Uint128"
@@ -5112,20 +4417,11 @@
         },
         "VoteOption": {
           "type": "string",
-          "enum": [
-            "yes",
-            "no",
-            "abstain",
-            "no_with_veto"
-          ]
+          "enum": ["yes", "no", "abstain", "no_with_veto"]
         },
         "Votes": {
           "type": "object",
-          "required": [
-            "abstain",
-            "no",
-            "yes"
-          ],
+          "required": ["abstain", "no", "yes"],
           "properties": {
             "abstain": {
               "$ref": "#/definitions/Uint128"
@@ -5145,17 +4441,11 @@
             {
               "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "execute"
-              ],
+              "required": ["execute"],
               "properties": {
                 "execute": {
                   "type": "object",
-                  "required": [
-                    "contract_addr",
-                    "funds",
-                    "msg"
-                  ],
+                  "required": ["contract_addr", "funds", "msg"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -5182,24 +4472,14 @@
             {
               "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "instantiate"
-              ],
+              "required": ["instantiate"],
               "properties": {
                 "instantiate": {
                   "type": "object",
-                  "required": [
-                    "code_id",
-                    "funds",
-                    "label",
-                    "msg"
-                  ],
+                  "required": ["code_id", "funds", "label", "msg"],
                   "properties": {
                     "admin": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": ["string", "null"]
                     },
                     "code_id": {
                       "type": "integer",
@@ -5232,17 +4512,11 @@
             {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "migrate"
-              ],
+              "required": ["migrate"],
               "properties": {
                 "migrate": {
                   "type": "object",
-                  "required": [
-                    "contract_addr",
-                    "msg",
-                    "new_code_id"
-                  ],
+                  "required": ["contract_addr", "msg", "new_code_id"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -5269,16 +4543,11 @@
             {
               "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": [
-                "update_admin"
-              ],
+              "required": ["update_admin"],
               "properties": {
                 "update_admin": {
                   "type": "object",
-                  "required": [
-                    "admin",
-                    "contract_addr"
-                  ],
+                  "required": ["admin", "contract_addr"],
                   "properties": {
                     "admin": {
                       "type": "string"
@@ -5294,15 +4563,11 @@
             {
               "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": [
-                "clear_admin"
-              ],
+              "required": ["clear_admin"],
               "properties": {
                 "clear_admin": {
                   "type": "object",
-                  "required": [
-                    "contract_addr"
-                  ],
+                  "required": ["contract_addr"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -5331,9 +4596,7 @@
         {
           "description": "Anyone may create a proposal, free of charge.",
           "type": "object",
-          "required": [
-            "anyone"
-          ],
+          "required": ["anyone"],
           "properties": {
             "anyone": {
               "type": "object",
@@ -5345,15 +4608,11 @@
         {
           "description": "Only ADDR may create proposals. It is expected that ADDR is a pre-propose module, though we only require that it is a valid address.",
           "type": "object",
-          "required": [
-            "module"
-          ],
+          "required": ["module"],
           "properties": {
             "module": {
               "type": "object",
-              "required": [
-                "addr"
-              ],
+              "required": ["addr"],
               "properties": {
                 "addr": {
                   "$ref": "#/definitions/Addr"
@@ -5376,9 +4635,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": [
-        "hooks"
-      ],
+      "required": ["hooks"],
       "properties": {
         "hooks": {
           "type": "array",
@@ -5394,9 +4651,7 @@
       "title": "ProposalListResponse",
       "description": "A list of proposals returned by `ListProposals` and `ReverseProposals`.",
       "type": "object",
-      "required": [
-        "proposals"
-      ],
+      "required": ["proposals"],
       "properties": {
         "proposals": {
           "type": "array",
@@ -5417,16 +4672,11 @@
             {
               "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "send"
-              ],
+              "required": ["send"],
               "properties": {
                 "send": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "to_address"
-                  ],
+                  "required": ["amount", "to_address"],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -5445,15 +4695,11 @@
             {
               "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
               "type": "object",
-              "required": [
-                "burn"
-              ],
+              "required": ["burn"],
               "properties": {
                 "burn": {
                   "type": "object",
-                  "required": [
-                    "amount"
-                  ],
+                  "required": ["amount"],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -5474,10 +4720,7 @@
         },
         "Coin": {
           "type": "object",
-          "required": [
-            "amount",
-            "denom"
-          ],
+          "required": ["amount", "denom"],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -5491,9 +4734,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "bank"
-              ],
+              "required": ["bank"],
               "properties": {
                 "bank": {
                   "$ref": "#/definitions/BankMsg"
@@ -5503,9 +4744,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "custom"
-              ],
+              "required": ["custom"],
               "properties": {
                 "custom": {
                   "$ref": "#/definitions/Empty"
@@ -5515,9 +4754,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "staking"
-              ],
+              "required": ["staking"],
               "properties": {
                 "staking": {
                   "$ref": "#/definitions/StakingMsg"
@@ -5527,9 +4764,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "distribution"
-              ],
+              "required": ["distribution"],
               "properties": {
                 "distribution": {
                   "$ref": "#/definitions/DistributionMsg"
@@ -5540,16 +4775,11 @@
             {
               "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
               "type": "object",
-              "required": [
-                "stargate"
-              ],
+              "required": ["stargate"],
               "properties": {
                 "stargate": {
                   "type": "object",
-                  "required": [
-                    "type_url",
-                    "value"
-                  ],
+                  "required": ["type_url", "value"],
                   "properties": {
                     "type_url": {
                       "type": "string"
@@ -5564,9 +4794,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "ibc"
-              ],
+              "required": ["ibc"],
               "properties": {
                 "ibc": {
                   "$ref": "#/definitions/IbcMsg"
@@ -5576,9 +4804,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "wasm"
-              ],
+              "required": ["wasm"],
               "properties": {
                 "wasm": {
                   "$ref": "#/definitions/WasmMsg"
@@ -5588,9 +4814,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "gov"
-              ],
+              "required": ["gov"],
               "properties": {
                 "gov": {
                   "$ref": "#/definitions/GovMsg"
@@ -5610,15 +4834,11 @@
             {
               "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "set_withdraw_address"
-              ],
+              "required": ["set_withdraw_address"],
               "properties": {
                 "set_withdraw_address": {
                   "type": "object",
-                  "required": [
-                    "address"
-                  ],
+                  "required": ["address"],
                   "properties": {
                     "address": {
                       "description": "The `withdraw_address`",
@@ -5632,15 +4852,11 @@
             {
               "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "withdraw_delegator_reward"
-              ],
+              "required": ["withdraw_delegator_reward"],
               "properties": {
                 "withdraw_delegator_reward": {
                   "type": "object",
-                  "required": [
-                    "validator"
-                  ],
+                  "required": ["validator"],
                   "properties": {
                     "validator": {
                       "description": "The `validator_address`",
@@ -5658,9 +4874,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "height"
-              ],
+              "required": ["height"],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -5673,9 +4887,7 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": [
-                "time"
-              ],
+              "required": ["time"],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -5697,9 +4909,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -5712,9 +4922,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -5725,9 +4933,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -5744,16 +4950,11 @@
             {
               "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
               "type": "object",
-              "required": [
-                "vote"
-              ],
+              "required": ["vote"],
               "properties": {
                 "vote": {
                   "type": "object",
-                  "required": [
-                    "proposal_id",
-                    "vote"
-                  ],
+                  "required": ["proposal_id", "vote"],
                   "properties": {
                     "proposal_id": {
                       "type": "integer",
@@ -5781,18 +4982,11 @@
             {
               "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
               "type": "object",
-              "required": [
-                "transfer"
-              ],
+              "required": ["transfer"],
               "properties": {
                 "transfer": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "channel_id",
-                    "timeout",
-                    "to_address"
-                  ],
+                  "required": ["amount", "channel_id", "timeout", "to_address"],
                   "properties": {
                     "amount": {
                       "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -5826,17 +5020,11 @@
             {
               "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
               "type": "object",
-              "required": [
-                "send_packet"
-              ],
+              "required": ["send_packet"],
               "properties": {
                 "send_packet": {
                   "type": "object",
-                  "required": [
-                    "channel_id",
-                    "data",
-                    "timeout"
-                  ],
+                  "required": ["channel_id", "data", "timeout"],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -5860,15 +5048,11 @@
             {
               "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
               "type": "object",
-              "required": [
-                "close_channel"
-              ],
+              "required": ["close_channel"],
               "properties": {
                 "close_channel": {
                   "type": "object",
-                  "required": [
-                    "channel_id"
-                  ],
+                  "required": ["channel_id"],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -5909,10 +5093,7 @@
         "IbcTimeoutBlock": {
           "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
           "type": "object",
-          "required": [
-            "height",
-            "revision"
-          ],
+          "required": ["height", "revision"],
           "properties": {
             "height": {
               "description": "block height after which the packet times out. the height within the given revision",
@@ -5934,9 +5115,7 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "majority"
-              ],
+              "required": ["majority"],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -5948,9 +5127,7 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": [
-                "percent"
-              ],
+              "required": ["percent"],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -5963,10 +5140,7 @@
         "ProposalResponse": {
           "description": "Information about a proposal returned by proposal queries.",
           "type": "object",
-          "required": [
-            "id",
-            "proposal"
-          ],
+          "required": ["id", "proposal"],
           "properties": {
             "id": {
               "description": "The ID of the proposal being returned.",
@@ -6100,16 +5274,11 @@
             {
               "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "delegate"
-              ],
+              "required": ["delegate"],
               "properties": {
                 "delegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "validator"
-                  ],
+                  "required": ["amount", "validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -6125,16 +5294,11 @@
             {
               "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "undelegate"
-              ],
+              "required": ["undelegate"],
               "properties": {
                 "undelegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "validator"
-                  ],
+                  "required": ["amount", "validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -6150,17 +5314,11 @@
             {
               "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "redelegate"
-              ],
+              "required": ["redelegate"],
               "properties": {
                 "redelegate": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "dst_validator",
-                    "src_validator"
-                  ],
+                  "required": ["amount", "dst_validator", "src_validator"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -6183,57 +5341,41 @@
             {
               "description": "The proposal is open for voting.",
               "type": "string",
-              "enum": [
-                "open"
-              ]
+              "enum": ["open"]
             },
             {
               "description": "The proposal has been rejected.",
               "type": "string",
-              "enum": [
-                "rejected"
-              ]
+              "enum": ["rejected"]
             },
             {
               "description": "The proposal has been passed but has not been executed.",
               "type": "string",
-              "enum": [
-                "passed"
-              ]
+              "enum": ["passed"]
             },
             {
               "description": "The proposal has been passed and executed.",
               "type": "string",
-              "enum": [
-                "executed"
-              ]
+              "enum": ["executed"]
             },
             {
               "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
               "type": "string",
-              "enum": [
-                "closed"
-              ]
+              "enum": ["closed"]
             },
             {
               "description": "The proposal's execution failed.",
               "type": "string",
-              "enum": [
-                "execution_failed"
-              ]
+              "enum": ["execution_failed"]
             },
             {
               "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
               "type": "object",
-              "required": [
-                "veto_timelock"
-              ],
+              "required": ["veto_timelock"],
               "properties": {
                 "veto_timelock": {
                   "type": "object",
-                  "required": [
-                    "expiration"
-                  ],
+                  "required": ["expiration"],
                   "properties": {
                     "expiration": {
                       "$ref": "#/definitions/Expiration"
@@ -6247,9 +5389,7 @@
             {
               "description": "The proposal has been vetoed.",
               "type": "string",
-              "enum": [
-                "vetoed"
-              ]
+              "enum": ["vetoed"]
             }
           ]
         },
@@ -6259,15 +5399,11 @@
             {
               "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
               "type": "object",
-              "required": [
-                "absolute_percentage"
-              ],
+              "required": ["absolute_percentage"],
               "properties": {
                 "absolute_percentage": {
                   "type": "object",
-                  "required": [
-                    "percentage"
-                  ],
+                  "required": ["percentage"],
                   "properties": {
                     "percentage": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -6281,16 +5417,11 @@
             {
               "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
               "type": "object",
-              "required": [
-                "threshold_quorum"
-              ],
+              "required": ["threshold_quorum"],
               "properties": {
                 "threshold_quorum": {
                   "type": "object",
-                  "required": [
-                    "quorum",
-                    "threshold"
-                  ],
+                  "required": ["quorum", "threshold"],
                   "properties": {
                     "quorum": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -6307,15 +5438,11 @@
             {
               "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
               "type": "object",
-              "required": [
-                "absolute_count"
-              ],
+              "required": ["absolute_count"],
               "properties": {
                 "absolute_count": {
                   "type": "object",
-                  "required": [
-                    "threshold"
-                  ],
+                  "required": ["threshold"],
                   "properties": {
                     "threshold": {
                       "$ref": "#/definitions/Uint128"
@@ -6378,20 +5505,11 @@
         },
         "VoteOption": {
           "type": "string",
-          "enum": [
-            "yes",
-            "no",
-            "abstain",
-            "no_with_veto"
-          ]
+          "enum": ["yes", "no", "abstain", "no_with_veto"]
         },
         "Votes": {
           "type": "object",
-          "required": [
-            "abstain",
-            "no",
-            "yes"
-          ],
+          "required": ["abstain", "no", "yes"],
           "properties": {
             "abstain": {
               "$ref": "#/definitions/Uint128"
@@ -6411,17 +5529,11 @@
             {
               "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "execute"
-              ],
+              "required": ["execute"],
               "properties": {
                 "execute": {
                   "type": "object",
-                  "required": [
-                    "contract_addr",
-                    "funds",
-                    "msg"
-                  ],
+                  "required": ["contract_addr", "funds", "msg"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -6448,24 +5560,14 @@
             {
               "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "instantiate"
-              ],
+              "required": ["instantiate"],
               "properties": {
                 "instantiate": {
                   "type": "object",
-                  "required": [
-                    "code_id",
-                    "funds",
-                    "label",
-                    "msg"
-                  ],
+                  "required": ["code_id", "funds", "label", "msg"],
                   "properties": {
                     "admin": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                      "type": ["string", "null"]
                     },
                     "code_id": {
                       "type": "integer",
@@ -6498,17 +5600,11 @@
             {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": [
-                "migrate"
-              ],
+              "required": ["migrate"],
               "properties": {
                 "migrate": {
                   "type": "object",
-                  "required": [
-                    "contract_addr",
-                    "msg",
-                    "new_code_id"
-                  ],
+                  "required": ["contract_addr", "msg", "new_code_id"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -6535,16 +5631,11 @@
             {
               "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": [
-                "update_admin"
-              ],
+              "required": ["update_admin"],
               "properties": {
                 "update_admin": {
                   "type": "object",
-                  "required": [
-                    "admin",
-                    "contract_addr"
-                  ],
+                  "required": ["admin", "contract_addr"],
                   "properties": {
                     "admin": {
                       "type": "string"
@@ -6560,15 +5651,11 @@
             {
               "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": [
-                "clear_admin"
-              ],
+              "required": ["clear_admin"],
               "properties": {
                 "clear_admin": {
                   "type": "object",
-                  "required": [
-                    "contract_addr"
-                  ],
+                  "required": ["contract_addr"],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -6586,9 +5673,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": [
-        "hooks"
-      ],
+      "required": ["hooks"],
       "properties": {
         "hooks": {
           "type": "array",

--- a/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
+++ b/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
@@ -5326,6 +5326,7 @@
     "proposal_creation_policy": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ProposalCreationPolicy",
+      "description": "The policy configured in a proposal module that determines whether or not a pre-propose module is in use. If so, only the module can create new proposals. Otherwise, there is no restriction on proposal creation.",
       "oneOf": [
         {
           "description": "Anyone may create a proposal, free of charge.",

--- a/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
+++ b/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
@@ -82,11 +82,15 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "object",
-                "required": ["addr"],
+                "required": [
+                  "addr"
+                ],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -100,7 +104,9 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": ["core_module"],
+            "required": [
+              "core_module"
+            ],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -117,7 +123,10 @@
       },
       "Coin": {
         "type": "object",
-        "required": ["amount", "denom"],
+        "required": [
+          "amount",
+          "denom"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -136,7 +145,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -149,7 +160,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -164,7 +177,12 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": ["code_id", "funds", "label", "msg"],
+        "required": [
+          "code_id",
+          "funds",
+          "label",
+          "msg"
+        ],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -211,7 +229,9 @@
           {
             "description": "The majority of voters must vote yes for the proposal to pass.",
             "type": "object",
-            "required": ["majority"],
+            "required": [
+              "majority"
+            ],
             "properties": {
               "majority": {
                 "type": "object",
@@ -223,7 +243,9 @@
           {
             "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
             "type": "object",
-            "required": ["percent"],
+            "required": [
+              "percent"
+            ],
             "properties": {
               "percent": {
                 "$ref": "#/definitions/Decimal"
@@ -238,7 +260,9 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": ["anyone_may_propose"],
+            "required": [
+              "anyone_may_propose"
+            ],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -250,11 +274,15 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": ["module_may_propose"],
+            "required": [
+              "module_may_propose"
+            ],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": ["info"],
+                "required": [
+                  "info"
+                ],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -273,11 +301,15 @@
           {
             "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
             "type": "object",
-            "required": ["absolute_percentage"],
+            "required": [
+              "absolute_percentage"
+            ],
             "properties": {
               "absolute_percentage": {
                 "type": "object",
-                "required": ["percentage"],
+                "required": [
+                  "percentage"
+                ],
                 "properties": {
                   "percentage": {
                     "$ref": "#/definitions/PercentageThreshold"
@@ -291,11 +323,16 @@
           {
             "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
             "type": "object",
-            "required": ["threshold_quorum"],
+            "required": [
+              "threshold_quorum"
+            ],
             "properties": {
               "threshold_quorum": {
                 "type": "object",
-                "required": ["quorum", "threshold"],
+                "required": [
+                  "quorum",
+                  "threshold"
+                ],
                 "properties": {
                   "quorum": {
                     "$ref": "#/definitions/PercentageThreshold"
@@ -312,11 +349,15 @@
           {
             "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
             "type": "object",
-            "required": ["absolute_count"],
+            "required": [
+              "absolute_count"
+            ],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": ["threshold"],
+                "required": [
+                  "threshold"
+                ],
                 "properties": {
                   "threshold": {
                     "$ref": "#/definitions/Uint128"
@@ -374,7 +415,9 @@
       {
         "description": "Creates a proposal in the module.",
         "type": "object",
-        "required": ["propose"],
+        "required": [
+          "propose"
+        ],
         "properties": {
           "propose": {
             "$ref": "#/definitions/SingleChoiceProposeMsg"
@@ -385,11 +428,16 @@
       {
         "description": "Votes on a proposal. Voting power is determined by the DAO's voting power module.",
         "type": "object",
-        "required": ["vote"],
+        "required": [
+          "vote"
+        ],
         "properties": {
           "vote": {
             "type": "object",
-            "required": ["proposal_id", "vote"],
+            "required": [
+              "proposal_id",
+              "vote"
+            ],
             "properties": {
               "proposal_id": {
                 "description": "The ID of the proposal to vote on.",
@@ -399,7 +447,10 @@
               },
               "rationale": {
                 "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "vote": {
                 "description": "The senders position on the proposal.",
@@ -418,11 +469,15 @@
       {
         "description": "Updates the sender's rationale for their vote on the specified proposal. Errors if no vote vote has been cast.",
         "type": "object",
-        "required": ["update_rationale"],
+        "required": [
+          "update_rationale"
+        ],
         "properties": {
           "update_rationale": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -430,7 +485,10 @@
                 "minimum": 0.0
               },
               "rationale": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -441,11 +499,15 @@
       {
         "description": "Causes the messages associated with a passed proposal to be executed by the DAO.",
         "type": "object",
-        "required": ["execute"],
+        "required": [
+          "execute"
+        ],
         "properties": {
           "execute": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "proposal_id": {
                 "description": "The ID of the proposal to execute.",
@@ -462,11 +524,15 @@
       {
         "description": "Callable only if veto is configured",
         "type": "object",
-        "required": ["veto"],
+        "required": [
+          "veto"
+        ],
         "properties": {
           "veto": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "proposal_id": {
                 "description": "The ID of the proposal to veto.",
@@ -483,11 +549,15 @@
       {
         "description": "Closes a proposal that has failed (either not passed or timed out). If applicable this will cause the proposal deposit associated wth said proposal to be returned.",
         "type": "object",
-        "required": ["close"],
+        "required": [
+          "close"
+        ],
         "properties": {
           "close": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "proposal_id": {
                 "description": "The ID of the proposal to close.",
@@ -504,7 +574,9 @@
       {
         "description": "Updates the governance module's config.",
         "type": "object",
-        "required": ["update_config"],
+        "required": [
+          "update_config"
+        ],
         "properties": {
           "update_config": {
             "type": "object",
@@ -580,11 +652,15 @@
       {
         "description": "Update's the proposal creation policy used for this module. Only the DAO may call this method.",
         "type": "object",
-        "required": ["update_pre_propose_info"],
+        "required": [
+          "update_pre_propose_info"
+        ],
         "properties": {
           "update_pre_propose_info": {
             "type": "object",
-            "required": ["info"],
+            "required": [
+              "info"
+            ],
             "properties": {
               "info": {
                 "$ref": "#/definitions/PreProposeInfo"
@@ -598,11 +674,15 @@
       {
         "description": "Adds an address as a consumer of proposal hooks. Consumers of proposal hooks have hook messages executed on them whenever the status of a proposal changes or a proposal is created. If a consumer contract errors when handling a hook message it will be removed from the list of consumers.",
         "type": "object",
-        "required": ["add_proposal_hook"],
+        "required": [
+          "add_proposal_hook"
+        ],
         "properties": {
           "add_proposal_hook": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -616,11 +696,15 @@
       {
         "description": "Removes a consumer of proposal hooks.",
         "type": "object",
-        "required": ["remove_proposal_hook"],
+        "required": [
+          "remove_proposal_hook"
+        ],
         "properties": {
           "remove_proposal_hook": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -634,11 +718,15 @@
       {
         "description": "Adds an address as a consumer of vote hooks. Consumers of vote hooks have hook messages executed on them whenever the a vote is cast. If a consumer contract errors when handling a hook message it will be removed from the list of consumers.",
         "type": "object",
-        "required": ["add_vote_hook"],
+        "required": [
+          "add_vote_hook"
+        ],
         "properties": {
           "add_vote_hook": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -652,11 +740,15 @@
       {
         "description": "Removed a consumer of vote hooks.",
         "type": "object",
-        "required": ["remove_vote_hook"],
+        "required": [
+          "remove_vote_hook"
+        ],
         "properties": {
           "remove_vote_hook": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -675,11 +767,15 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "object",
-                "required": ["addr"],
+                "required": [
+                  "addr"
+                ],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -693,7 +789,9 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": ["core_module"],
+            "required": [
+              "core_module"
+            ],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -710,11 +808,16 @@
           {
             "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["send"],
+            "required": [
+              "send"
+            ],
             "properties": {
               "send": {
                 "type": "object",
-                "required": ["amount", "to_address"],
+                "required": [
+                  "amount",
+                  "to_address"
+                ],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -733,11 +836,15 @@
           {
             "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
             "type": "object",
-            "required": ["burn"],
+            "required": [
+              "burn"
+            ],
             "properties": {
               "burn": {
                 "type": "object",
-                "required": ["amount"],
+                "required": [
+                  "amount"
+                ],
                 "properties": {
                   "amount": {
                     "type": "array",
@@ -758,7 +865,10 @@
       },
       "Coin": {
         "type": "object",
-        "required": ["amount", "denom"],
+        "required": [
+          "amount",
+          "denom"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -772,7 +882,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["bank"],
+            "required": [
+              "bank"
+            ],
             "properties": {
               "bank": {
                 "$ref": "#/definitions/BankMsg"
@@ -782,7 +894,9 @@
           },
           {
             "type": "object",
-            "required": ["custom"],
+            "required": [
+              "custom"
+            ],
             "properties": {
               "custom": {
                 "$ref": "#/definitions/Empty"
@@ -792,7 +906,9 @@
           },
           {
             "type": "object",
-            "required": ["staking"],
+            "required": [
+              "staking"
+            ],
             "properties": {
               "staking": {
                 "$ref": "#/definitions/StakingMsg"
@@ -802,7 +918,9 @@
           },
           {
             "type": "object",
-            "required": ["distribution"],
+            "required": [
+              "distribution"
+            ],
             "properties": {
               "distribution": {
                 "$ref": "#/definitions/DistributionMsg"
@@ -813,11 +931,16 @@
           {
             "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
             "type": "object",
-            "required": ["stargate"],
+            "required": [
+              "stargate"
+            ],
             "properties": {
               "stargate": {
                 "type": "object",
-                "required": ["type_url", "value"],
+                "required": [
+                  "type_url",
+                  "value"
+                ],
                 "properties": {
                   "type_url": {
                     "type": "string"
@@ -832,7 +955,9 @@
           },
           {
             "type": "object",
-            "required": ["ibc"],
+            "required": [
+              "ibc"
+            ],
             "properties": {
               "ibc": {
                 "$ref": "#/definitions/IbcMsg"
@@ -842,7 +967,9 @@
           },
           {
             "type": "object",
-            "required": ["wasm"],
+            "required": [
+              "wasm"
+            ],
             "properties": {
               "wasm": {
                 "$ref": "#/definitions/WasmMsg"
@@ -852,7 +979,9 @@
           },
           {
             "type": "object",
-            "required": ["gov"],
+            "required": [
+              "gov"
+            ],
             "properties": {
               "gov": {
                 "$ref": "#/definitions/GovMsg"
@@ -872,11 +1001,15 @@
           {
             "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["set_withdraw_address"],
+            "required": [
+              "set_withdraw_address"
+            ],
             "properties": {
               "set_withdraw_address": {
                 "type": "object",
-                "required": ["address"],
+                "required": [
+                  "address"
+                ],
                 "properties": {
                   "address": {
                     "description": "The `withdraw_address`",
@@ -890,11 +1023,15 @@
           {
             "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["withdraw_delegator_reward"],
+            "required": [
+              "withdraw_delegator_reward"
+            ],
             "properties": {
               "withdraw_delegator_reward": {
                 "type": "object",
-                "required": ["validator"],
+                "required": [
+                  "validator"
+                ],
                 "properties": {
                   "validator": {
                     "description": "The `validator_address`",
@@ -912,7 +1049,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -925,7 +1064,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -947,11 +1088,16 @@
           {
             "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
             "type": "object",
-            "required": ["vote"],
+            "required": [
+              "vote"
+            ],
             "properties": {
               "vote": {
                 "type": "object",
-                "required": ["proposal_id", "vote"],
+                "required": [
+                  "proposal_id",
+                  "vote"
+                ],
                 "properties": {
                   "proposal_id": {
                     "type": "integer",
@@ -979,11 +1125,18 @@
           {
             "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
             "type": "object",
-            "required": ["transfer"],
+            "required": [
+              "transfer"
+            ],
             "properties": {
               "transfer": {
                 "type": "object",
-                "required": ["amount", "channel_id", "timeout", "to_address"],
+                "required": [
+                  "amount",
+                  "channel_id",
+                  "timeout",
+                  "to_address"
+                ],
                 "properties": {
                   "amount": {
                     "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -1017,11 +1170,17 @@
           {
             "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
             "type": "object",
-            "required": ["send_packet"],
+            "required": [
+              "send_packet"
+            ],
             "properties": {
               "send_packet": {
                 "type": "object",
-                "required": ["channel_id", "data", "timeout"],
+                "required": [
+                  "channel_id",
+                  "data",
+                  "timeout"
+                ],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -1045,11 +1204,15 @@
           {
             "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
             "type": "object",
-            "required": ["close_channel"],
+            "required": [
+              "close_channel"
+            ],
             "properties": {
               "close_channel": {
                 "type": "object",
-                "required": ["channel_id"],
+                "required": [
+                  "channel_id"
+                ],
                 "properties": {
                   "channel_id": {
                     "type": "string"
@@ -1090,7 +1253,10 @@
       "IbcTimeoutBlock": {
         "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
         "type": "object",
-        "required": ["height", "revision"],
+        "required": [
+          "height",
+          "revision"
+        ],
         "properties": {
           "height": {
             "description": "block height after which the packet times out. the height within the given revision",
@@ -1109,7 +1275,12 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": ["code_id", "funds", "label", "msg"],
+        "required": [
+          "code_id",
+          "funds",
+          "label",
+          "msg"
+        ],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -1156,7 +1327,9 @@
           {
             "description": "The majority of voters must vote yes for the proposal to pass.",
             "type": "object",
-            "required": ["majority"],
+            "required": [
+              "majority"
+            ],
             "properties": {
               "majority": {
                 "type": "object",
@@ -1168,7 +1341,9 @@
           {
             "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
             "type": "object",
-            "required": ["percent"],
+            "required": [
+              "percent"
+            ],
             "properties": {
               "percent": {
                 "$ref": "#/definitions/Decimal"
@@ -1183,7 +1358,9 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": ["anyone_may_propose"],
+            "required": [
+              "anyone_may_propose"
+            ],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -1195,11 +1372,15 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": ["module_may_propose"],
+            "required": [
+              "module_may_propose"
+            ],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": ["info"],
+                "required": [
+                  "info"
+                ],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -1214,11 +1395,16 @@
       },
       "SingleChoiceAutoVote": {
         "type": "object",
-        "required": ["vote"],
+        "required": [
+          "vote"
+        ],
         "properties": {
           "rationale": {
             "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "vote": {
             "description": "The proposer's position on the proposal.",
@@ -1234,7 +1420,11 @@
       "SingleChoiceProposeMsg": {
         "description": "The contents of a message to create a proposal in the single choice proposal module.\n\nWe break this type out of `ExecuteMsg` because we want pre-propose modules that interact with this contract to be able to get type checking on their propose messages.\n\nWe move this type to this package so that pre-propose modules can import it without importing dao-proposal-single with the library feature which (as it is not additive) cause the execute exports to not be included in wasm builds.",
         "type": "object",
-        "required": ["description", "msgs", "title"],
+        "required": [
+          "description",
+          "msgs",
+          "title"
+        ],
         "properties": {
           "description": {
             "description": "A description of the proposal.",
@@ -1249,7 +1439,10 @@
           },
           "proposer": {
             "description": "The address creating the proposal. If no pre-propose module is attached to this module this must always be None as the proposer is the sender of the propose message. If a pre-propose module is attached, this must be Some and will set the proposer of the proposal it creates.",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "title": {
             "description": "The title of the proposal.",
@@ -1275,11 +1468,16 @@
           {
             "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["delegate"],
+            "required": [
+              "delegate"
+            ],
             "properties": {
               "delegate": {
                 "type": "object",
-                "required": ["amount", "validator"],
+                "required": [
+                  "amount",
+                  "validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1295,11 +1493,16 @@
           {
             "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["undelegate"],
+            "required": [
+              "undelegate"
+            ],
             "properties": {
               "undelegate": {
                 "type": "object",
-                "required": ["amount", "validator"],
+                "required": [
+                  "amount",
+                  "validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1315,11 +1518,17 @@
           {
             "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["redelegate"],
+            "required": [
+              "redelegate"
+            ],
             "properties": {
               "redelegate": {
                 "type": "object",
-                "required": ["amount", "dst_validator", "src_validator"],
+                "required": [
+                  "amount",
+                  "dst_validator",
+                  "src_validator"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Coin"
@@ -1343,11 +1552,15 @@
           {
             "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
             "type": "object",
-            "required": ["absolute_percentage"],
+            "required": [
+              "absolute_percentage"
+            ],
             "properties": {
               "absolute_percentage": {
                 "type": "object",
-                "required": ["percentage"],
+                "required": [
+                  "percentage"
+                ],
                 "properties": {
                   "percentage": {
                     "$ref": "#/definitions/PercentageThreshold"
@@ -1361,11 +1574,16 @@
           {
             "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
             "type": "object",
-            "required": ["threshold_quorum"],
+            "required": [
+              "threshold_quorum"
+            ],
             "properties": {
               "threshold_quorum": {
                 "type": "object",
-                "required": ["quorum", "threshold"],
+                "required": [
+                  "quorum",
+                  "threshold"
+                ],
                 "properties": {
                   "quorum": {
                     "$ref": "#/definitions/PercentageThreshold"
@@ -1382,11 +1600,15 @@
           {
             "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
             "type": "object",
-            "required": ["absolute_count"],
+            "required": [
+              "absolute_count"
+            ],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": ["threshold"],
+                "required": [
+                  "threshold"
+                ],
                 "properties": {
                   "threshold": {
                     "$ref": "#/definitions/Uint128"
@@ -1452,23 +1674,34 @@
           {
             "description": "Marks support for the proposal.",
             "type": "string",
-            "enum": ["yes"]
+            "enum": [
+              "yes"
+            ]
           },
           {
             "description": "Marks opposition to the proposal.",
             "type": "string",
-            "enum": ["no"]
+            "enum": [
+              "no"
+            ]
           },
           {
             "description": "Marks participation but does not count towards the ratio of support / opposed.",
             "type": "string",
-            "enum": ["abstain"]
+            "enum": [
+              "abstain"
+            ]
           }
         ]
       },
       "VoteOption": {
         "type": "string",
-        "enum": ["yes", "no", "abstain", "no_with_veto"]
+        "enum": [
+          "yes",
+          "no",
+          "abstain",
+          "no_with_veto"
+        ]
       },
       "WasmMsg": {
         "description": "The message types of the wasm module.\n\nSee https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto",
@@ -1476,11 +1709,17 @@
           {
             "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["execute"],
+            "required": [
+              "execute"
+            ],
             "properties": {
               "execute": {
                 "type": "object",
-                "required": ["contract_addr", "funds", "msg"],
+                "required": [
+                  "contract_addr",
+                  "funds",
+                  "msg"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1507,14 +1746,24 @@
           {
             "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["instantiate"],
+            "required": [
+              "instantiate"
+            ],
             "properties": {
               "instantiate": {
                 "type": "object",
-                "required": ["code_id", "funds", "label", "msg"],
+                "required": [
+                  "code_id",
+                  "funds",
+                  "label",
+                  "msg"
+                ],
                 "properties": {
                   "admin": {
-                    "type": ["string", "null"]
+                    "type": [
+                      "string",
+                      "null"
+                    ]
                   },
                   "code_id": {
                     "type": "integer",
@@ -1547,11 +1796,17 @@
           {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
-            "required": ["migrate"],
+            "required": [
+              "migrate"
+            ],
             "properties": {
               "migrate": {
                 "type": "object",
-                "required": ["contract_addr", "msg", "new_code_id"],
+                "required": [
+                  "contract_addr",
+                  "msg",
+                  "new_code_id"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1578,11 +1833,16 @@
           {
             "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": ["update_admin"],
+            "required": [
+              "update_admin"
+            ],
             "properties": {
               "update_admin": {
                 "type": "object",
-                "required": ["admin", "contract_addr"],
+                "required": [
+                  "admin",
+                  "contract_addr"
+                ],
                 "properties": {
                   "admin": {
                     "type": "string"
@@ -1598,11 +1858,15 @@
           {
             "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
             "type": "object",
-            "required": ["clear_admin"],
+            "required": [
+              "clear_admin"
+            ],
             "properties": {
               "clear_admin": {
                 "type": "object",
-                "required": ["contract_addr"],
+                "required": [
+                  "contract_addr"
+                ],
                 "properties": {
                   "contract_addr": {
                     "type": "string"
@@ -1623,7 +1887,9 @@
       {
         "description": "Gets the proposal module's config.",
         "type": "object",
-        "required": ["config"],
+        "required": [
+          "config"
+        ],
         "properties": {
           "config": {
             "type": "object",
@@ -1635,11 +1901,15 @@
       {
         "description": "Gets information about a proposal.",
         "type": "object",
-        "required": ["proposal"],
+        "required": [
+          "proposal"
+        ],
         "properties": {
           "proposal": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -1655,20 +1925,28 @@
       {
         "description": "Lists all the proposals that have been cast in this module.",
         "type": "object",
-        "required": ["list_proposals"],
+        "required": [
+          "list_proposals"
+        ],
         "properties": {
           "list_proposals": {
             "type": "object",
             "properties": {
               "limit": {
                 "description": "The maximum number of proposals to return as part of this query. If no limit is set a max of 30 proposals will be returned.",
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               },
               "start_after": {
                 "description": "The proposal ID to start listing proposals after. For example, if this is set to 2 proposals with IDs 3 and higher will be returned.",
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -1681,20 +1959,28 @@
       {
         "description": "Lists all of the proposals that have been cast in this module in decending order of proposal ID.",
         "type": "object",
-        "required": ["reverse_proposals"],
+        "required": [
+          "reverse_proposals"
+        ],
         "properties": {
           "reverse_proposals": {
             "type": "object",
             "properties": {
               "limit": {
                 "description": "The maximum number of proposals to return as part of this query. If no limit is set a max of 30 proposals will be returned.",
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               },
               "start_before": {
                 "description": "The proposal ID to start listing proposals before. For example, if this is set to 6 proposals with IDs 5 and lower will be returned.",
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -1707,11 +1993,16 @@
       {
         "description": "Returns a voters position on a propsal.",
         "type": "object",
-        "required": ["get_vote"],
+        "required": [
+          "get_vote"
+        ],
         "properties": {
           "get_vote": {
             "type": "object",
-            "required": ["proposal_id", "voter"],
+            "required": [
+              "proposal_id",
+              "voter"
+            ],
             "properties": {
               "proposal_id": {
                 "type": "integer",
@@ -1730,15 +2021,22 @@
       {
         "description": "Lists all of the votes that have been cast on a proposal.",
         "type": "object",
-        "required": ["list_votes"],
+        "required": [
+          "list_votes"
+        ],
         "properties": {
           "list_votes": {
             "type": "object",
-            "required": ["proposal_id"],
+            "required": [
+              "proposal_id"
+            ],
             "properties": {
               "limit": {
                 "description": "The maximum number of votes to return in response to this query. If no limit is specified a max of 30 are returned.",
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               },
@@ -1750,7 +2048,10 @@
               },
               "start_after": {
                 "description": "The voter to start listing votes after. Ordering is done alphabetically.",
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -1761,7 +2062,9 @@
       {
         "description": "Returns the number of proposals that have been created in this module.",
         "type": "object",
-        "required": ["proposal_count"],
+        "required": [
+          "proposal_count"
+        ],
         "properties": {
           "proposal_count": {
             "type": "object",
@@ -1773,7 +2076,9 @@
       {
         "description": "Gets the current proposal creation policy for this module.",
         "type": "object",
-        "required": ["proposal_creation_policy"],
+        "required": [
+          "proposal_creation_policy"
+        ],
         "properties": {
           "proposal_creation_policy": {
             "type": "object",
@@ -1785,7 +2090,9 @@
       {
         "description": "Lists all of the consumers of proposal hooks for this module.",
         "type": "object",
-        "required": ["proposal_hooks"],
+        "required": [
+          "proposal_hooks"
+        ],
         "properties": {
           "proposal_hooks": {
             "type": "object",
@@ -1797,7 +2104,9 @@
       {
         "description": "Lists all of the consumers of vote hooks for this module.",
         "type": "object",
-        "required": ["vote_hooks"],
+        "required": [
+          "vote_hooks"
+        ],
         "properties": {
           "vote_hooks": {
             "type": "object",
@@ -1809,7 +2118,9 @@
       {
         "description": "Returns the address of the DAO this module belongs to",
         "type": "object",
-        "required": ["dao"],
+        "required": [
+          "dao"
+        ],
         "properties": {
           "dao": {
             "type": "object",
@@ -1821,7 +2132,9 @@
       {
         "description": "Returns contract version info",
         "type": "object",
-        "required": ["info"],
+        "required": [
+          "info"
+        ],
         "properties": {
           "info": {
             "type": "object",
@@ -1833,7 +2146,9 @@
       {
         "description": "Returns the proposal ID that will be assigned to the next proposal created.",
         "type": "object",
-        "required": ["next_proposal_id"],
+        "required": [
+          "next_proposal_id"
+        ],
         "properties": {
           "next_proposal_id": {
             "type": "object",
@@ -1850,7 +2165,9 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["from_v1"],
+        "required": [
+          "from_v1"
+        ],
         "properties": {
           "from_v1": {
             "type": "object",
@@ -1890,7 +2207,9 @@
       },
       {
         "type": "object",
-        "required": ["from_compatible"],
+        "required": [
+          "from_compatible"
+        ],
         "properties": {
           "from_compatible": {
             "type": "object",
@@ -1907,11 +2226,15 @@
           {
             "description": "Set the admin to a specified address.",
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "object",
-                "required": ["addr"],
+                "required": [
+                  "addr"
+                ],
                 "properties": {
                   "addr": {
                     "type": "string"
@@ -1925,7 +2248,9 @@
           {
             "description": "Sets the admin as the core module address.",
             "type": "object",
-            "required": ["core_module"],
+            "required": [
+              "core_module"
+            ],
             "properties": {
               "core_module": {
                 "type": "object",
@@ -1942,7 +2267,10 @@
       },
       "Coin": {
         "type": "object",
-        "required": ["amount", "denom"],
+        "required": [
+          "amount",
+          "denom"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -1957,7 +2285,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -1970,7 +2300,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -1985,7 +2317,12 @@
       "ModuleInstantiateInfo": {
         "description": "Information needed to instantiate a module.",
         "type": "object",
-        "required": ["code_id", "funds", "label", "msg"],
+        "required": [
+          "code_id",
+          "funds",
+          "label",
+          "msg"
+        ],
         "properties": {
           "admin": {
             "description": "CosmWasm level admin of the instantiated contract. See: <https://docs.cosmwasm.com/docs/1.0/smart-contracts/migration>",
@@ -2031,7 +2368,9 @@
           {
             "description": "Anyone may create a proposal free of charge.",
             "type": "object",
-            "required": ["anyone_may_propose"],
+            "required": [
+              "anyone_may_propose"
+            ],
             "properties": {
               "anyone_may_propose": {
                 "type": "object",
@@ -2043,11 +2382,15 @@
           {
             "description": "The module specified in INFO has exclusive rights to proposal creation.",
             "type": "object",
-            "required": ["module_may_propose"],
+            "required": [
+              "module_may_propose"
+            ],
             "properties": {
               "module_may_propose": {
                 "type": "object",
-                "required": ["info"],
+                "required": [
+                  "info"
+                ],
                 "properties": {
                   "info": {
                     "$ref": "#/definitions/ModuleInstantiateInfo"
@@ -2188,7 +2531,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["height"],
+              "required": [
+                "height"
+              ],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -2201,7 +2546,9 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": ["time"],
+              "required": [
+                "time"
+              ],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -2219,7 +2566,9 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["majority"],
+              "required": [
+                "majority"
+              ],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -2231,7 +2580,9 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["percent"],
+              "required": [
+                "percent"
+              ],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -2247,11 +2598,15 @@
             {
               "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
               "type": "object",
-              "required": ["absolute_percentage"],
+              "required": [
+                "absolute_percentage"
+              ],
               "properties": {
                 "absolute_percentage": {
                   "type": "object",
-                  "required": ["percentage"],
+                  "required": [
+                    "percentage"
+                  ],
                   "properties": {
                     "percentage": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -2265,11 +2620,16 @@
             {
               "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
               "type": "object",
-              "required": ["threshold_quorum"],
+              "required": [
+                "threshold_quorum"
+              ],
               "properties": {
                 "threshold_quorum": {
                   "type": "object",
-                  "required": ["quorum", "threshold"],
+                  "required": [
+                    "quorum",
+                    "threshold"
+                  ],
                   "properties": {
                     "quorum": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -2286,11 +2646,15 @@
             {
               "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
               "type": "object",
-              "required": ["absolute_count"],
+              "required": [
+                "absolute_count"
+              ],
               "properties": {
                 "absolute_count": {
                   "type": "object",
-                  "required": ["threshold"],
+                  "required": [
+                    "threshold"
+                  ],
                   "properties": {
                     "threshold": {
                       "$ref": "#/definitions/Uint128"
@@ -2380,24 +2744,34 @@
             {
               "description": "Marks support for the proposal.",
               "type": "string",
-              "enum": ["yes"]
+              "enum": [
+                "yes"
+              ]
             },
             {
               "description": "Marks opposition to the proposal.",
               "type": "string",
-              "enum": ["no"]
+              "enum": [
+                "no"
+              ]
             },
             {
               "description": "Marks participation but does not count towards the ratio of support / opposed.",
               "type": "string",
-              "enum": ["abstain"]
+              "enum": [
+                "abstain"
+              ]
             }
           ]
         },
         "VoteInfo": {
           "description": "Information about a vote that was cast.",
           "type": "object",
-          "required": ["power", "vote", "voter"],
+          "required": [
+            "power",
+            "vote",
+            "voter"
+          ],
           "properties": {
             "power": {
               "description": "The voting power behind the vote.",
@@ -2409,7 +2783,10 @@
             },
             "rationale": {
               "description": "Address-specified rationale for the vote.",
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "vote": {
               "description": "Position on the vote.",
@@ -2436,7 +2813,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": ["info"],
+      "required": [
+        "info"
+      ],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -2446,7 +2825,10 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": ["contract", "version"],
+          "required": [
+            "contract",
+            "version"
+          ],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -2466,7 +2848,9 @@
       "title": "ProposalListResponse",
       "description": "A list of proposals returned by `ListProposals` and `ReverseProposals`.",
       "type": "object",
-      "required": ["proposals"],
+      "required": [
+        "proposals"
+      ],
       "properties": {
         "proposals": {
           "type": "array",
@@ -2487,11 +2871,16 @@
             {
               "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["send"],
+              "required": [
+                "send"
+              ],
               "properties": {
                 "send": {
                   "type": "object",
-                  "required": ["amount", "to_address"],
+                  "required": [
+                    "amount",
+                    "to_address"
+                  ],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -2510,11 +2899,15 @@
             {
               "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
               "type": "object",
-              "required": ["burn"],
+              "required": [
+                "burn"
+              ],
               "properties": {
                 "burn": {
                   "type": "object",
-                  "required": ["amount"],
+                  "required": [
+                    "amount"
+                  ],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -2535,7 +2928,10 @@
         },
         "Coin": {
           "type": "object",
-          "required": ["amount", "denom"],
+          "required": [
+            "amount",
+            "denom"
+          ],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -2549,7 +2945,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["bank"],
+              "required": [
+                "bank"
+              ],
               "properties": {
                 "bank": {
                   "$ref": "#/definitions/BankMsg"
@@ -2559,7 +2957,9 @@
             },
             {
               "type": "object",
-              "required": ["custom"],
+              "required": [
+                "custom"
+              ],
               "properties": {
                 "custom": {
                   "$ref": "#/definitions/Empty"
@@ -2569,7 +2969,9 @@
             },
             {
               "type": "object",
-              "required": ["staking"],
+              "required": [
+                "staking"
+              ],
               "properties": {
                 "staking": {
                   "$ref": "#/definitions/StakingMsg"
@@ -2579,7 +2981,9 @@
             },
             {
               "type": "object",
-              "required": ["distribution"],
+              "required": [
+                "distribution"
+              ],
               "properties": {
                 "distribution": {
                   "$ref": "#/definitions/DistributionMsg"
@@ -2590,11 +2994,16 @@
             {
               "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
               "type": "object",
-              "required": ["stargate"],
+              "required": [
+                "stargate"
+              ],
               "properties": {
                 "stargate": {
                   "type": "object",
-                  "required": ["type_url", "value"],
+                  "required": [
+                    "type_url",
+                    "value"
+                  ],
                   "properties": {
                     "type_url": {
                       "type": "string"
@@ -2609,7 +3018,9 @@
             },
             {
               "type": "object",
-              "required": ["ibc"],
+              "required": [
+                "ibc"
+              ],
               "properties": {
                 "ibc": {
                   "$ref": "#/definitions/IbcMsg"
@@ -2619,7 +3030,9 @@
             },
             {
               "type": "object",
-              "required": ["wasm"],
+              "required": [
+                "wasm"
+              ],
               "properties": {
                 "wasm": {
                   "$ref": "#/definitions/WasmMsg"
@@ -2629,7 +3042,9 @@
             },
             {
               "type": "object",
-              "required": ["gov"],
+              "required": [
+                "gov"
+              ],
               "properties": {
                 "gov": {
                   "$ref": "#/definitions/GovMsg"
@@ -2649,11 +3064,15 @@
             {
               "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["set_withdraw_address"],
+              "required": [
+                "set_withdraw_address"
+              ],
               "properties": {
                 "set_withdraw_address": {
                   "type": "object",
-                  "required": ["address"],
+                  "required": [
+                    "address"
+                  ],
                   "properties": {
                     "address": {
                       "description": "The `withdraw_address`",
@@ -2667,11 +3086,15 @@
             {
               "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["withdraw_delegator_reward"],
+              "required": [
+                "withdraw_delegator_reward"
+              ],
               "properties": {
                 "withdraw_delegator_reward": {
                   "type": "object",
-                  "required": ["validator"],
+                  "required": [
+                    "validator"
+                  ],
                   "properties": {
                     "validator": {
                       "description": "The `validator_address`",
@@ -2689,7 +3112,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["height"],
+              "required": [
+                "height"
+              ],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -2702,7 +3127,9 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": ["time"],
+              "required": [
+                "time"
+              ],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -2724,7 +3151,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -2737,7 +3166,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -2748,7 +3179,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -2765,11 +3198,16 @@
             {
               "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
               "type": "object",
-              "required": ["vote"],
+              "required": [
+                "vote"
+              ],
               "properties": {
                 "vote": {
                   "type": "object",
-                  "required": ["proposal_id", "vote"],
+                  "required": [
+                    "proposal_id",
+                    "vote"
+                  ],
                   "properties": {
                     "proposal_id": {
                       "type": "integer",
@@ -2797,11 +3235,18 @@
             {
               "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
               "type": "object",
-              "required": ["transfer"],
+              "required": [
+                "transfer"
+              ],
               "properties": {
                 "transfer": {
                   "type": "object",
-                  "required": ["amount", "channel_id", "timeout", "to_address"],
+                  "required": [
+                    "amount",
+                    "channel_id",
+                    "timeout",
+                    "to_address"
+                  ],
                   "properties": {
                     "amount": {
                       "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -2835,11 +3280,17 @@
             {
               "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
               "type": "object",
-              "required": ["send_packet"],
+              "required": [
+                "send_packet"
+              ],
               "properties": {
                 "send_packet": {
                   "type": "object",
-                  "required": ["channel_id", "data", "timeout"],
+                  "required": [
+                    "channel_id",
+                    "data",
+                    "timeout"
+                  ],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -2863,11 +3314,15 @@
             {
               "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
               "type": "object",
-              "required": ["close_channel"],
+              "required": [
+                "close_channel"
+              ],
               "properties": {
                 "close_channel": {
                   "type": "object",
-                  "required": ["channel_id"],
+                  "required": [
+                    "channel_id"
+                  ],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -2908,7 +3363,10 @@
         "IbcTimeoutBlock": {
           "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
           "type": "object",
-          "required": ["height", "revision"],
+          "required": [
+            "height",
+            "revision"
+          ],
           "properties": {
             "height": {
               "description": "block height after which the packet times out. the height within the given revision",
@@ -2930,7 +3388,9 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["majority"],
+              "required": [
+                "majority"
+              ],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -2942,7 +3402,9 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["percent"],
+              "required": [
+                "percent"
+              ],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -2955,7 +3417,10 @@
         "ProposalResponse": {
           "description": "Information about a proposal returned by proposal queries.",
           "type": "object",
-          "required": ["id", "proposal"],
+          "required": [
+            "id",
+            "proposal"
+          ],
           "properties": {
             "id": {
               "description": "The ID of the proposal being returned.",
@@ -3089,11 +3554,16 @@
             {
               "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["delegate"],
+              "required": [
+                "delegate"
+              ],
               "properties": {
                 "delegate": {
                   "type": "object",
-                  "required": ["amount", "validator"],
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -3109,11 +3579,16 @@
             {
               "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["undelegate"],
+              "required": [
+                "undelegate"
+              ],
               "properties": {
                 "undelegate": {
                   "type": "object",
-                  "required": ["amount", "validator"],
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -3129,11 +3604,17 @@
             {
               "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["redelegate"],
+              "required": [
+                "redelegate"
+              ],
               "properties": {
                 "redelegate": {
                   "type": "object",
-                  "required": ["amount", "dst_validator", "src_validator"],
+                  "required": [
+                    "amount",
+                    "dst_validator",
+                    "src_validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -3156,41 +3637,57 @@
             {
               "description": "The proposal is open for voting.",
               "type": "string",
-              "enum": ["open"]
+              "enum": [
+                "open"
+              ]
             },
             {
               "description": "The proposal has been rejected.",
               "type": "string",
-              "enum": ["rejected"]
+              "enum": [
+                "rejected"
+              ]
             },
             {
               "description": "The proposal has been passed but has not been executed.",
               "type": "string",
-              "enum": ["passed"]
+              "enum": [
+                "passed"
+              ]
             },
             {
               "description": "The proposal has been passed and executed.",
               "type": "string",
-              "enum": ["executed"]
+              "enum": [
+                "executed"
+              ]
             },
             {
               "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
               "type": "string",
-              "enum": ["closed"]
+              "enum": [
+                "closed"
+              ]
             },
             {
               "description": "The proposal's execution failed.",
               "type": "string",
-              "enum": ["execution_failed"]
+              "enum": [
+                "execution_failed"
+              ]
             },
             {
               "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
               "type": "object",
-              "required": ["veto_timelock"],
+              "required": [
+                "veto_timelock"
+              ],
               "properties": {
                 "veto_timelock": {
                   "type": "object",
-                  "required": ["expiration"],
+                  "required": [
+                    "expiration"
+                  ],
                   "properties": {
                     "expiration": {
                       "$ref": "#/definitions/Expiration"
@@ -3204,7 +3701,9 @@
             {
               "description": "The proposal has been vetoed.",
               "type": "string",
-              "enum": ["vetoed"]
+              "enum": [
+                "vetoed"
+              ]
             }
           ]
         },
@@ -3214,11 +3713,15 @@
             {
               "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
               "type": "object",
-              "required": ["absolute_percentage"],
+              "required": [
+                "absolute_percentage"
+              ],
               "properties": {
                 "absolute_percentage": {
                   "type": "object",
-                  "required": ["percentage"],
+                  "required": [
+                    "percentage"
+                  ],
                   "properties": {
                     "percentage": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -3232,11 +3735,16 @@
             {
               "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
               "type": "object",
-              "required": ["threshold_quorum"],
+              "required": [
+                "threshold_quorum"
+              ],
               "properties": {
                 "threshold_quorum": {
                   "type": "object",
-                  "required": ["quorum", "threshold"],
+                  "required": [
+                    "quorum",
+                    "threshold"
+                  ],
                   "properties": {
                     "quorum": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -3253,11 +3761,15 @@
             {
               "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
               "type": "object",
-              "required": ["absolute_count"],
+              "required": [
+                "absolute_count"
+              ],
               "properties": {
                 "absolute_count": {
                   "type": "object",
-                  "required": ["threshold"],
+                  "required": [
+                    "threshold"
+                  ],
                   "properties": {
                     "threshold": {
                       "$ref": "#/definitions/Uint128"
@@ -3320,11 +3832,20 @@
         },
         "VoteOption": {
           "type": "string",
-          "enum": ["yes", "no", "abstain", "no_with_veto"]
+          "enum": [
+            "yes",
+            "no",
+            "abstain",
+            "no_with_veto"
+          ]
         },
         "Votes": {
           "type": "object",
-          "required": ["abstain", "no", "yes"],
+          "required": [
+            "abstain",
+            "no",
+            "yes"
+          ],
           "properties": {
             "abstain": {
               "$ref": "#/definitions/Uint128"
@@ -3344,11 +3865,17 @@
             {
               "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["execute"],
+              "required": [
+                "execute"
+              ],
               "properties": {
                 "execute": {
                   "type": "object",
-                  "required": ["contract_addr", "funds", "msg"],
+                  "required": [
+                    "contract_addr",
+                    "funds",
+                    "msg"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -3375,14 +3902,24 @@
             {
               "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["instantiate"],
+              "required": [
+                "instantiate"
+              ],
               "properties": {
                 "instantiate": {
                   "type": "object",
-                  "required": ["code_id", "funds", "label", "msg"],
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg"
+                  ],
                   "properties": {
                     "admin": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "code_id": {
                       "type": "integer",
@@ -3415,11 +3952,17 @@
             {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["migrate"],
+              "required": [
+                "migrate"
+              ],
               "properties": {
                 "migrate": {
                   "type": "object",
-                  "required": ["contract_addr", "msg", "new_code_id"],
+                  "required": [
+                    "contract_addr",
+                    "msg",
+                    "new_code_id"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -3446,11 +3989,16 @@
             {
               "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": ["update_admin"],
+              "required": [
+                "update_admin"
+              ],
               "properties": {
                 "update_admin": {
                   "type": "object",
-                  "required": ["admin", "contract_addr"],
+                  "required": [
+                    "admin",
+                    "contract_addr"
+                  ],
                   "properties": {
                     "admin": {
                       "type": "string"
@@ -3466,11 +4014,15 @@
             {
               "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": ["clear_admin"],
+              "required": [
+                "clear_admin"
+              ],
               "properties": {
                 "clear_admin": {
                   "type": "object",
-                  "required": ["contract_addr"],
+                  "required": [
+                    "contract_addr"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -3489,7 +4041,9 @@
       "title": "VoteListResponse",
       "description": "Information about the votes for a proposal.",
       "type": "object",
-      "required": ["votes"],
+      "required": [
+        "votes"
+      ],
       "properties": {
         "votes": {
           "type": "array",
@@ -3513,24 +4067,34 @@
             {
               "description": "Marks support for the proposal.",
               "type": "string",
-              "enum": ["yes"]
+              "enum": [
+                "yes"
+              ]
             },
             {
               "description": "Marks opposition to the proposal.",
               "type": "string",
-              "enum": ["no"]
+              "enum": [
+                "no"
+              ]
             },
             {
               "description": "Marks participation but does not count towards the ratio of support / opposed.",
               "type": "string",
-              "enum": ["abstain"]
+              "enum": [
+                "abstain"
+              ]
             }
           ]
         },
         "VoteInfo": {
           "description": "Information about a vote that was cast.",
           "type": "object",
-          "required": ["power", "vote", "voter"],
+          "required": [
+            "power",
+            "vote",
+            "voter"
+          ],
           "properties": {
             "power": {
               "description": "The voting power behind the vote.",
@@ -3542,7 +4106,10 @@
             },
             "rationale": {
               "description": "Address-specified rationale for the vote.",
-              "type": ["string", "null"]
+              "type": [
+                "string",
+                "null"
+              ]
             },
             "vote": {
               "description": "Position on the vote.",
@@ -3577,7 +4144,10 @@
       "title": "ProposalResponse",
       "description": "Information about a proposal returned by proposal queries.",
       "type": "object",
-      "required": ["id", "proposal"],
+      "required": [
+        "id",
+        "proposal"
+      ],
       "properties": {
         "id": {
           "description": "The ID of the proposal being returned.",
@@ -3601,11 +4171,16 @@
             {
               "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["send"],
+              "required": [
+                "send"
+              ],
               "properties": {
                 "send": {
                   "type": "object",
-                  "required": ["amount", "to_address"],
+                  "required": [
+                    "amount",
+                    "to_address"
+                  ],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -3624,11 +4199,15 @@
             {
               "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
               "type": "object",
-              "required": ["burn"],
+              "required": [
+                "burn"
+              ],
               "properties": {
                 "burn": {
                   "type": "object",
-                  "required": ["amount"],
+                  "required": [
+                    "amount"
+                  ],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -3649,7 +4228,10 @@
         },
         "Coin": {
           "type": "object",
-          "required": ["amount", "denom"],
+          "required": [
+            "amount",
+            "denom"
+          ],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -3663,7 +4245,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["bank"],
+              "required": [
+                "bank"
+              ],
               "properties": {
                 "bank": {
                   "$ref": "#/definitions/BankMsg"
@@ -3673,7 +4257,9 @@
             },
             {
               "type": "object",
-              "required": ["custom"],
+              "required": [
+                "custom"
+              ],
               "properties": {
                 "custom": {
                   "$ref": "#/definitions/Empty"
@@ -3683,7 +4269,9 @@
             },
             {
               "type": "object",
-              "required": ["staking"],
+              "required": [
+                "staking"
+              ],
               "properties": {
                 "staking": {
                   "$ref": "#/definitions/StakingMsg"
@@ -3693,7 +4281,9 @@
             },
             {
               "type": "object",
-              "required": ["distribution"],
+              "required": [
+                "distribution"
+              ],
               "properties": {
                 "distribution": {
                   "$ref": "#/definitions/DistributionMsg"
@@ -3704,11 +4294,16 @@
             {
               "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
               "type": "object",
-              "required": ["stargate"],
+              "required": [
+                "stargate"
+              ],
               "properties": {
                 "stargate": {
                   "type": "object",
-                  "required": ["type_url", "value"],
+                  "required": [
+                    "type_url",
+                    "value"
+                  ],
                   "properties": {
                     "type_url": {
                       "type": "string"
@@ -3723,7 +4318,9 @@
             },
             {
               "type": "object",
-              "required": ["ibc"],
+              "required": [
+                "ibc"
+              ],
               "properties": {
                 "ibc": {
                   "$ref": "#/definitions/IbcMsg"
@@ -3733,7 +4330,9 @@
             },
             {
               "type": "object",
-              "required": ["wasm"],
+              "required": [
+                "wasm"
+              ],
               "properties": {
                 "wasm": {
                   "$ref": "#/definitions/WasmMsg"
@@ -3743,7 +4342,9 @@
             },
             {
               "type": "object",
-              "required": ["gov"],
+              "required": [
+                "gov"
+              ],
               "properties": {
                 "gov": {
                   "$ref": "#/definitions/GovMsg"
@@ -3763,11 +4364,15 @@
             {
               "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["set_withdraw_address"],
+              "required": [
+                "set_withdraw_address"
+              ],
               "properties": {
                 "set_withdraw_address": {
                   "type": "object",
-                  "required": ["address"],
+                  "required": [
+                    "address"
+                  ],
                   "properties": {
                     "address": {
                       "description": "The `withdraw_address`",
@@ -3781,11 +4386,15 @@
             {
               "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["withdraw_delegator_reward"],
+              "required": [
+                "withdraw_delegator_reward"
+              ],
               "properties": {
                 "withdraw_delegator_reward": {
                   "type": "object",
-                  "required": ["validator"],
+                  "required": [
+                    "validator"
+                  ],
                   "properties": {
                     "validator": {
                       "description": "The `validator_address`",
@@ -3803,7 +4412,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["height"],
+              "required": [
+                "height"
+              ],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -3816,7 +4427,9 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": ["time"],
+              "required": [
+                "time"
+              ],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -3838,7 +4451,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -3851,7 +4466,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -3862,7 +4479,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -3879,11 +4498,16 @@
             {
               "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
               "type": "object",
-              "required": ["vote"],
+              "required": [
+                "vote"
+              ],
               "properties": {
                 "vote": {
                   "type": "object",
-                  "required": ["proposal_id", "vote"],
+                  "required": [
+                    "proposal_id",
+                    "vote"
+                  ],
                   "properties": {
                     "proposal_id": {
                       "type": "integer",
@@ -3911,11 +4535,18 @@
             {
               "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
               "type": "object",
-              "required": ["transfer"],
+              "required": [
+                "transfer"
+              ],
               "properties": {
                 "transfer": {
                   "type": "object",
-                  "required": ["amount", "channel_id", "timeout", "to_address"],
+                  "required": [
+                    "amount",
+                    "channel_id",
+                    "timeout",
+                    "to_address"
+                  ],
                   "properties": {
                     "amount": {
                       "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -3949,11 +4580,17 @@
             {
               "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
               "type": "object",
-              "required": ["send_packet"],
+              "required": [
+                "send_packet"
+              ],
               "properties": {
                 "send_packet": {
                   "type": "object",
-                  "required": ["channel_id", "data", "timeout"],
+                  "required": [
+                    "channel_id",
+                    "data",
+                    "timeout"
+                  ],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -3977,11 +4614,15 @@
             {
               "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
               "type": "object",
-              "required": ["close_channel"],
+              "required": [
+                "close_channel"
+              ],
               "properties": {
                 "close_channel": {
                   "type": "object",
-                  "required": ["channel_id"],
+                  "required": [
+                    "channel_id"
+                  ],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -4022,7 +4663,10 @@
         "IbcTimeoutBlock": {
           "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
           "type": "object",
-          "required": ["height", "revision"],
+          "required": [
+            "height",
+            "revision"
+          ],
           "properties": {
             "height": {
               "description": "block height after which the packet times out. the height within the given revision",
@@ -4044,7 +4688,9 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["majority"],
+              "required": [
+                "majority"
+              ],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -4056,7 +4702,9 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["percent"],
+              "required": [
+                "percent"
+              ],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -4186,11 +4834,16 @@
             {
               "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["delegate"],
+              "required": [
+                "delegate"
+              ],
               "properties": {
                 "delegate": {
                   "type": "object",
-                  "required": ["amount", "validator"],
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -4206,11 +4859,16 @@
             {
               "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["undelegate"],
+              "required": [
+                "undelegate"
+              ],
               "properties": {
                 "undelegate": {
                   "type": "object",
-                  "required": ["amount", "validator"],
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -4226,11 +4884,17 @@
             {
               "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["redelegate"],
+              "required": [
+                "redelegate"
+              ],
               "properties": {
                 "redelegate": {
                   "type": "object",
-                  "required": ["amount", "dst_validator", "src_validator"],
+                  "required": [
+                    "amount",
+                    "dst_validator",
+                    "src_validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -4253,41 +4917,57 @@
             {
               "description": "The proposal is open for voting.",
               "type": "string",
-              "enum": ["open"]
+              "enum": [
+                "open"
+              ]
             },
             {
               "description": "The proposal has been rejected.",
               "type": "string",
-              "enum": ["rejected"]
+              "enum": [
+                "rejected"
+              ]
             },
             {
               "description": "The proposal has been passed but has not been executed.",
               "type": "string",
-              "enum": ["passed"]
+              "enum": [
+                "passed"
+              ]
             },
             {
               "description": "The proposal has been passed and executed.",
               "type": "string",
-              "enum": ["executed"]
+              "enum": [
+                "executed"
+              ]
             },
             {
               "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
               "type": "string",
-              "enum": ["closed"]
+              "enum": [
+                "closed"
+              ]
             },
             {
               "description": "The proposal's execution failed.",
               "type": "string",
-              "enum": ["execution_failed"]
+              "enum": [
+                "execution_failed"
+              ]
             },
             {
               "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
               "type": "object",
-              "required": ["veto_timelock"],
+              "required": [
+                "veto_timelock"
+              ],
               "properties": {
                 "veto_timelock": {
                   "type": "object",
-                  "required": ["expiration"],
+                  "required": [
+                    "expiration"
+                  ],
                   "properties": {
                     "expiration": {
                       "$ref": "#/definitions/Expiration"
@@ -4301,7 +4981,9 @@
             {
               "description": "The proposal has been vetoed.",
               "type": "string",
-              "enum": ["vetoed"]
+              "enum": [
+                "vetoed"
+              ]
             }
           ]
         },
@@ -4311,11 +4993,15 @@
             {
               "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
               "type": "object",
-              "required": ["absolute_percentage"],
+              "required": [
+                "absolute_percentage"
+              ],
               "properties": {
                 "absolute_percentage": {
                   "type": "object",
-                  "required": ["percentage"],
+                  "required": [
+                    "percentage"
+                  ],
                   "properties": {
                     "percentage": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -4329,11 +5015,16 @@
             {
               "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
               "type": "object",
-              "required": ["threshold_quorum"],
+              "required": [
+                "threshold_quorum"
+              ],
               "properties": {
                 "threshold_quorum": {
                   "type": "object",
-                  "required": ["quorum", "threshold"],
+                  "required": [
+                    "quorum",
+                    "threshold"
+                  ],
                   "properties": {
                     "quorum": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -4350,11 +5041,15 @@
             {
               "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
               "type": "object",
-              "required": ["absolute_count"],
+              "required": [
+                "absolute_count"
+              ],
               "properties": {
                 "absolute_count": {
                   "type": "object",
-                  "required": ["threshold"],
+                  "required": [
+                    "threshold"
+                  ],
                   "properties": {
                     "threshold": {
                       "$ref": "#/definitions/Uint128"
@@ -4417,11 +5112,20 @@
         },
         "VoteOption": {
           "type": "string",
-          "enum": ["yes", "no", "abstain", "no_with_veto"]
+          "enum": [
+            "yes",
+            "no",
+            "abstain",
+            "no_with_veto"
+          ]
         },
         "Votes": {
           "type": "object",
-          "required": ["abstain", "no", "yes"],
+          "required": [
+            "abstain",
+            "no",
+            "yes"
+          ],
           "properties": {
             "abstain": {
               "$ref": "#/definitions/Uint128"
@@ -4441,11 +5145,17 @@
             {
               "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["execute"],
+              "required": [
+                "execute"
+              ],
               "properties": {
                 "execute": {
                   "type": "object",
-                  "required": ["contract_addr", "funds", "msg"],
+                  "required": [
+                    "contract_addr",
+                    "funds",
+                    "msg"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -4472,14 +5182,24 @@
             {
               "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["instantiate"],
+              "required": [
+                "instantiate"
+              ],
               "properties": {
                 "instantiate": {
                   "type": "object",
-                  "required": ["code_id", "funds", "label", "msg"],
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg"
+                  ],
                   "properties": {
                     "admin": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "code_id": {
                       "type": "integer",
@@ -4512,11 +5232,17 @@
             {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["migrate"],
+              "required": [
+                "migrate"
+              ],
               "properties": {
                 "migrate": {
                   "type": "object",
-                  "required": ["contract_addr", "msg", "new_code_id"],
+                  "required": [
+                    "contract_addr",
+                    "msg",
+                    "new_code_id"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -4543,11 +5269,16 @@
             {
               "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": ["update_admin"],
+              "required": [
+                "update_admin"
+              ],
               "properties": {
                 "update_admin": {
                   "type": "object",
-                  "required": ["admin", "contract_addr"],
+                  "required": [
+                    "admin",
+                    "contract_addr"
+                  ],
                   "properties": {
                     "admin": {
                       "type": "string"
@@ -4563,11 +5294,15 @@
             {
               "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": ["clear_admin"],
+              "required": [
+                "clear_admin"
+              ],
               "properties": {
                 "clear_admin": {
                   "type": "object",
-                  "required": ["contract_addr"],
+                  "required": [
+                    "contract_addr"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -4596,7 +5331,9 @@
         {
           "description": "Anyone may create a proposal, free of charge.",
           "type": "object",
-          "required": ["anyone"],
+          "required": [
+            "anyone"
+          ],
           "properties": {
             "anyone": {
               "type": "object",
@@ -4608,11 +5345,15 @@
         {
           "description": "Only ADDR may create proposals. It is expected that ADDR is a pre-propose module, though we only require that it is a valid address.",
           "type": "object",
-          "required": ["module"],
+          "required": [
+            "module"
+          ],
           "properties": {
             "module": {
               "type": "object",
-              "required": ["addr"],
+              "required": [
+                "addr"
+              ],
               "properties": {
                 "addr": {
                   "$ref": "#/definitions/Addr"
@@ -4635,7 +5376,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": ["hooks"],
+      "required": [
+        "hooks"
+      ],
       "properties": {
         "hooks": {
           "type": "array",
@@ -4651,7 +5394,9 @@
       "title": "ProposalListResponse",
       "description": "A list of proposals returned by `ListProposals` and `ReverseProposals`.",
       "type": "object",
-      "required": ["proposals"],
+      "required": [
+        "proposals"
+      ],
       "properties": {
         "proposals": {
           "type": "array",
@@ -4672,11 +5417,16 @@
             {
               "description": "Sends native tokens from the contract to the given address.\n\nThis is translated to a [MsgSend](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto#L19-L28). `from_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["send"],
+              "required": [
+                "send"
+              ],
               "properties": {
                 "send": {
                   "type": "object",
-                  "required": ["amount", "to_address"],
+                  "required": [
+                    "amount",
+                    "to_address"
+                  ],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -4695,11 +5445,15 @@
             {
               "description": "This will burn the given coins from the contract's account. There is no Cosmos SDK message that performs this, but it can be done by calling the bank keeper. Important if a contract controls significant token supply that must be retired.",
               "type": "object",
-              "required": ["burn"],
+              "required": [
+                "burn"
+              ],
               "properties": {
                 "burn": {
                   "type": "object",
-                  "required": ["amount"],
+                  "required": [
+                    "amount"
+                  ],
                   "properties": {
                     "amount": {
                       "type": "array",
@@ -4720,7 +5474,10 @@
         },
         "Coin": {
           "type": "object",
-          "required": ["amount", "denom"],
+          "required": [
+            "amount",
+            "denom"
+          ],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -4734,7 +5491,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["bank"],
+              "required": [
+                "bank"
+              ],
               "properties": {
                 "bank": {
                   "$ref": "#/definitions/BankMsg"
@@ -4744,7 +5503,9 @@
             },
             {
               "type": "object",
-              "required": ["custom"],
+              "required": [
+                "custom"
+              ],
               "properties": {
                 "custom": {
                   "$ref": "#/definitions/Empty"
@@ -4754,7 +5515,9 @@
             },
             {
               "type": "object",
-              "required": ["staking"],
+              "required": [
+                "staking"
+              ],
               "properties": {
                 "staking": {
                   "$ref": "#/definitions/StakingMsg"
@@ -4764,7 +5527,9 @@
             },
             {
               "type": "object",
-              "required": ["distribution"],
+              "required": [
+                "distribution"
+              ],
               "properties": {
                 "distribution": {
                   "$ref": "#/definitions/DistributionMsg"
@@ -4775,11 +5540,16 @@
             {
               "description": "A Stargate message encoded the same way as a protobuf [Any](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/any.proto). This is the same structure as messages in `TxBody` from [ADR-020](https://github.com/cosmos/cosmos-sdk/blob/master/docs/architecture/adr-020-protobuf-transaction-encoding.md)",
               "type": "object",
-              "required": ["stargate"],
+              "required": [
+                "stargate"
+              ],
               "properties": {
                 "stargate": {
                   "type": "object",
-                  "required": ["type_url", "value"],
+                  "required": [
+                    "type_url",
+                    "value"
+                  ],
                   "properties": {
                     "type_url": {
                       "type": "string"
@@ -4794,7 +5564,9 @@
             },
             {
               "type": "object",
-              "required": ["ibc"],
+              "required": [
+                "ibc"
+              ],
               "properties": {
                 "ibc": {
                   "$ref": "#/definitions/IbcMsg"
@@ -4804,7 +5576,9 @@
             },
             {
               "type": "object",
-              "required": ["wasm"],
+              "required": [
+                "wasm"
+              ],
               "properties": {
                 "wasm": {
                   "$ref": "#/definitions/WasmMsg"
@@ -4814,7 +5588,9 @@
             },
             {
               "type": "object",
-              "required": ["gov"],
+              "required": [
+                "gov"
+              ],
               "properties": {
                 "gov": {
                   "$ref": "#/definitions/GovMsg"
@@ -4834,11 +5610,15 @@
             {
               "description": "This is translated to a [MsgSetWithdrawAddress](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L29-L37). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["set_withdraw_address"],
+              "required": [
+                "set_withdraw_address"
+              ],
               "properties": {
                 "set_withdraw_address": {
                   "type": "object",
-                  "required": ["address"],
+                  "required": [
+                    "address"
+                  ],
                   "properties": {
                     "address": {
                       "description": "The `withdraw_address`",
@@ -4852,11 +5632,15 @@
             {
               "description": "This is translated to a [[MsgWithdrawDelegatorReward](https://github.com/cosmos/cosmos-sdk/blob/v0.42.4/proto/cosmos/distribution/v1beta1/tx.proto#L42-L50). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["withdraw_delegator_reward"],
+              "required": [
+                "withdraw_delegator_reward"
+              ],
               "properties": {
                 "withdraw_delegator_reward": {
                   "type": "object",
-                  "required": ["validator"],
+                  "required": [
+                    "validator"
+                  ],
                   "properties": {
                     "validator": {
                       "description": "The `validator_address`",
@@ -4874,7 +5658,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["height"],
+              "required": [
+                "height"
+              ],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -4887,7 +5673,9 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": ["time"],
+              "required": [
+                "time"
+              ],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -4909,7 +5697,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -4922,7 +5712,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -4933,7 +5725,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -4950,11 +5744,16 @@
             {
               "description": "This maps directly to [MsgVote](https://github.com/cosmos/cosmos-sdk/blob/v0.42.5/proto/cosmos/gov/v1beta1/tx.proto#L46-L56) in the Cosmos SDK with voter set to the contract address.",
               "type": "object",
-              "required": ["vote"],
+              "required": [
+                "vote"
+              ],
               "properties": {
                 "vote": {
                   "type": "object",
-                  "required": ["proposal_id", "vote"],
+                  "required": [
+                    "proposal_id",
+                    "vote"
+                  ],
                   "properties": {
                     "proposal_id": {
                       "type": "integer",
@@ -4982,11 +5781,18 @@
             {
               "description": "Sends bank tokens owned by the contract to the given address on another chain. The channel must already be established between the ibctransfer module on this chain and a matching module on the remote chain. We cannot select the port_id, this is whatever the local chain has bound the ibctransfer module to.",
               "type": "object",
-              "required": ["transfer"],
+              "required": [
+                "transfer"
+              ],
               "properties": {
                 "transfer": {
                   "type": "object",
-                  "required": ["amount", "channel_id", "timeout", "to_address"],
+                  "required": [
+                    "amount",
+                    "channel_id",
+                    "timeout",
+                    "to_address"
+                  ],
                   "properties": {
                     "amount": {
                       "description": "packet data only supports one coin https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/ibc/applications/transfer/v1/transfer.proto#L11-L20",
@@ -5020,11 +5826,17 @@
             {
               "description": "Sends an IBC packet with given data over the existing channel. Data should be encoded in a format defined by the channel version, and the module on the other side should know how to parse this.",
               "type": "object",
-              "required": ["send_packet"],
+              "required": [
+                "send_packet"
+              ],
               "properties": {
                 "send_packet": {
                   "type": "object",
-                  "required": ["channel_id", "data", "timeout"],
+                  "required": [
+                    "channel_id",
+                    "data",
+                    "timeout"
+                  ],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -5048,11 +5860,15 @@
             {
               "description": "This will close an existing channel that is owned by this contract. Port is auto-assigned to the contract's IBC port",
               "type": "object",
-              "required": ["close_channel"],
+              "required": [
+                "close_channel"
+              ],
               "properties": {
                 "close_channel": {
                   "type": "object",
-                  "required": ["channel_id"],
+                  "required": [
+                    "channel_id"
+                  ],
                   "properties": {
                     "channel_id": {
                       "type": "string"
@@ -5093,7 +5909,10 @@
         "IbcTimeoutBlock": {
           "description": "IBCTimeoutHeight Height is a monotonically increasing data type that can be compared against another Height for the purposes of updating and freezing clients. Ordering is (revision_number, timeout_height)",
           "type": "object",
-          "required": ["height", "revision"],
+          "required": [
+            "height",
+            "revision"
+          ],
           "properties": {
             "height": {
               "description": "block height after which the packet times out. the height within the given revision",
@@ -5115,7 +5934,9 @@
             {
               "description": "The majority of voters must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["majority"],
+              "required": [
+                "majority"
+              ],
               "properties": {
                 "majority": {
                   "type": "object",
@@ -5127,7 +5948,9 @@
             {
               "description": "A percentage of voting power >= percent must vote yes for the proposal to pass.",
               "type": "object",
-              "required": ["percent"],
+              "required": [
+                "percent"
+              ],
               "properties": {
                 "percent": {
                   "$ref": "#/definitions/Decimal"
@@ -5140,7 +5963,10 @@
         "ProposalResponse": {
           "description": "Information about a proposal returned by proposal queries.",
           "type": "object",
-          "required": ["id", "proposal"],
+          "required": [
+            "id",
+            "proposal"
+          ],
           "properties": {
             "id": {
               "description": "The ID of the proposal being returned.",
@@ -5274,11 +6100,16 @@
             {
               "description": "This is translated to a [MsgDelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L81-L90). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["delegate"],
+              "required": [
+                "delegate"
+              ],
               "properties": {
                 "delegate": {
                   "type": "object",
-                  "required": ["amount", "validator"],
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -5294,11 +6125,16 @@
             {
               "description": "This is translated to a [MsgUndelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L112-L121). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["undelegate"],
+              "required": [
+                "undelegate"
+              ],
               "properties": {
                 "undelegate": {
                   "type": "object",
-                  "required": ["amount", "validator"],
+                  "required": [
+                    "amount",
+                    "validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -5314,11 +6150,17 @@
             {
               "description": "This is translated to a [MsgBeginRedelegate](https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto#L95-L105). `delegator_address` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["redelegate"],
+              "required": [
+                "redelegate"
+              ],
               "properties": {
                 "redelegate": {
                   "type": "object",
-                  "required": ["amount", "dst_validator", "src_validator"],
+                  "required": [
+                    "amount",
+                    "dst_validator",
+                    "src_validator"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Coin"
@@ -5341,41 +6183,57 @@
             {
               "description": "The proposal is open for voting.",
               "type": "string",
-              "enum": ["open"]
+              "enum": [
+                "open"
+              ]
             },
             {
               "description": "The proposal has been rejected.",
               "type": "string",
-              "enum": ["rejected"]
+              "enum": [
+                "rejected"
+              ]
             },
             {
               "description": "The proposal has been passed but has not been executed.",
               "type": "string",
-              "enum": ["passed"]
+              "enum": [
+                "passed"
+              ]
             },
             {
               "description": "The proposal has been passed and executed.",
               "type": "string",
-              "enum": ["executed"]
+              "enum": [
+                "executed"
+              ]
             },
             {
               "description": "The proposal has failed or expired and has been closed. A proposal deposit refund has been issued if applicable.",
               "type": "string",
-              "enum": ["closed"]
+              "enum": [
+                "closed"
+              ]
             },
             {
               "description": "The proposal's execution failed.",
               "type": "string",
-              "enum": ["execution_failed"]
+              "enum": [
+                "execution_failed"
+              ]
             },
             {
               "description": "The proposal is timelocked. Only the configured vetoer can execute or veto until the timelock expires.",
               "type": "object",
-              "required": ["veto_timelock"],
+              "required": [
+                "veto_timelock"
+              ],
               "properties": {
                 "veto_timelock": {
                   "type": "object",
-                  "required": ["expiration"],
+                  "required": [
+                    "expiration"
+                  ],
                   "properties": {
                     "expiration": {
                       "$ref": "#/definitions/Expiration"
@@ -5389,7 +6247,9 @@
             {
               "description": "The proposal has been vetoed.",
               "type": "string",
-              "enum": ["vetoed"]
+              "enum": [
+                "vetoed"
+              ]
             }
           ]
         },
@@ -5399,11 +6259,15 @@
             {
               "description": "Declares a percentage of the total weight that must cast Yes votes in order for a proposal to pass.  See `ThresholdResponse::AbsolutePercentage` in the cw3 spec for details.",
               "type": "object",
-              "required": ["absolute_percentage"],
+              "required": [
+                "absolute_percentage"
+              ],
               "properties": {
                 "absolute_percentage": {
                   "type": "object",
-                  "required": ["percentage"],
+                  "required": [
+                    "percentage"
+                  ],
                   "properties": {
                     "percentage": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -5417,11 +6281,16 @@
             {
               "description": "Declares a `quorum` of the total votes that must participate in the election in order for the vote to be considered at all. See `ThresholdResponse::ThresholdQuorum` in the cw3 spec for details.",
               "type": "object",
-              "required": ["threshold_quorum"],
+              "required": [
+                "threshold_quorum"
+              ],
               "properties": {
                 "threshold_quorum": {
                   "type": "object",
-                  "required": ["quorum", "threshold"],
+                  "required": [
+                    "quorum",
+                    "threshold"
+                  ],
                   "properties": {
                     "quorum": {
                       "$ref": "#/definitions/PercentageThreshold"
@@ -5438,11 +6307,15 @@
             {
               "description": "An absolute number of votes needed for something to cross the threshold. Useful for multisig style voting.",
               "type": "object",
-              "required": ["absolute_count"],
+              "required": [
+                "absolute_count"
+              ],
               "properties": {
                 "absolute_count": {
                   "type": "object",
-                  "required": ["threshold"],
+                  "required": [
+                    "threshold"
+                  ],
                   "properties": {
                     "threshold": {
                       "$ref": "#/definitions/Uint128"
@@ -5505,11 +6378,20 @@
         },
         "VoteOption": {
           "type": "string",
-          "enum": ["yes", "no", "abstain", "no_with_veto"]
+          "enum": [
+            "yes",
+            "no",
+            "abstain",
+            "no_with_veto"
+          ]
         },
         "Votes": {
           "type": "object",
-          "required": ["abstain", "no", "yes"],
+          "required": [
+            "abstain",
+            "no",
+            "yes"
+          ],
           "properties": {
             "abstain": {
               "$ref": "#/definitions/Uint128"
@@ -5529,11 +6411,17 @@
             {
               "description": "Dispatches a call to another contract at a known address (with known ABI).\n\nThis is translated to a [MsgExecuteContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L68-L78). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["execute"],
+              "required": [
+                "execute"
+              ],
               "properties": {
                 "execute": {
                   "type": "object",
-                  "required": ["contract_addr", "funds", "msg"],
+                  "required": [
+                    "contract_addr",
+                    "funds",
+                    "msg"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -5560,14 +6448,24 @@
             {
               "description": "Instantiates a new contracts from previously uploaded Wasm code.\n\nThe contract address is non-predictable. But it is guaranteed that when emitting the same Instantiate message multiple times, multiple instances on different addresses will be generated. See also Instantiate2.\n\nThis is translated to a [MsgInstantiateContract](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L53-L71). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["instantiate"],
+              "required": [
+                "instantiate"
+              ],
               "properties": {
                 "instantiate": {
                   "type": "object",
-                  "required": ["code_id", "funds", "label", "msg"],
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg"
+                  ],
                   "properties": {
                     "admin": {
-                      "type": ["string", "null"]
+                      "type": [
+                        "string",
+                        "null"
+                      ]
                     },
                     "code_id": {
                       "type": "integer",
@@ -5600,11 +6498,17 @@
             {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
-              "required": ["migrate"],
+              "required": [
+                "migrate"
+              ],
               "properties": {
                 "migrate": {
                   "type": "object",
-                  "required": ["contract_addr", "msg", "new_code_id"],
+                  "required": [
+                    "contract_addr",
+                    "msg",
+                    "new_code_id"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -5631,11 +6535,16 @@
             {
               "description": "Sets a new admin (for migrate) on the given contract. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": ["update_admin"],
+              "required": [
+                "update_admin"
+              ],
               "properties": {
                 "update_admin": {
                   "type": "object",
-                  "required": ["admin", "contract_addr"],
+                  "required": [
+                    "admin",
+                    "contract_addr"
+                  ],
                   "properties": {
                     "admin": {
                       "type": "string"
@@ -5651,11 +6560,15 @@
             {
               "description": "Clears the admin on the given contract, so no more migration possible. Fails if this contract is not currently admin of the target contract.",
               "type": "object",
-              "required": ["clear_admin"],
+              "required": [
+                "clear_admin"
+              ],
               "properties": {
                 "clear_admin": {
                   "type": "object",
-                  "required": ["contract_addr"],
+                  "required": [
+                    "contract_addr"
+                  ],
                   "properties": {
                     "contract_addr": {
                       "type": "string"
@@ -5673,7 +6586,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": ["hooks"],
+      "required": [
+        "hooks"
+      ],
       "properties": {
         "hooks": {
           "type": "array",

--- a/contracts/proposal/dao-proposal-single/src/testing/instantiate.rs
+++ b/contracts/proposal/dao-proposal-single/src/testing/instantiate.rs
@@ -33,9 +33,13 @@ pub(crate) fn get_pre_propose_info(
         app.store_code(crate::testing::contracts::pre_propose_single_contract());
 
     let submission_policy = if open_proposal_submission {
-        PreProposeSubmissionPolicy::Anyone {}
+        PreProposeSubmissionPolicy::Anyone { denylist: None }
     } else {
-        PreProposeSubmissionPolicy::DaoMembers {}
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: None,
+            denylist: None,
+        }
     };
 
     PreProposeInfo::ModuleMayPropose {

--- a/contracts/proposal/dao-proposal-single/src/testing/instantiate.rs
+++ b/contracts/proposal/dao-proposal-single/src/testing/instantiate.rs
@@ -8,7 +8,7 @@ use dao_pre_propose_single as cppbps;
 
 use dao_voting::{
     deposit::{DepositRefundPolicy, UncheckedDepositInfo, VotingModuleTokenType},
-    pre_propose::PreProposeInfo,
+    pre_propose::{PreProposeInfo, PreProposeSubmissionPolicy},
     threshold::{ActiveThreshold, PercentageThreshold, Threshold::ThresholdQuorum},
 };
 use dao_voting_cw4::msg::GroupContract;
@@ -31,12 +31,19 @@ pub(crate) fn get_pre_propose_info(
 ) -> PreProposeInfo {
     let pre_propose_contract =
         app.store_code(crate::testing::contracts::pre_propose_single_contract());
+
+    let submission_policy = if open_proposal_submission {
+        PreProposeSubmissionPolicy::Anyone {}
+    } else {
+        PreProposeSubmissionPolicy::DaoMembers {}
+    };
+
     PreProposeInfo::ModuleMayPropose {
         info: ModuleInstantiateInfo {
             code_id: pre_propose_contract,
             msg: to_json_binary(&cppbps::InstantiateMsg {
                 deposit_info,
-                open_proposal_submission,
+                submission_policy,
                 extension: Empty::default(),
             })
             .unwrap(),

--- a/contracts/proposal/dao-proposal-single/src/testing/tests.rs
+++ b/contracts/proposal/dao-proposal-single/src/testing/tests.rs
@@ -19,7 +19,7 @@ use dao_interface::{
 use dao_testing::{ShouldExecute, TestSingleChoiceVote};
 use dao_voting::{
     deposit::{CheckedDepositInfo, UncheckedDepositInfo, VotingModuleTokenType},
-    pre_propose::{PreProposeInfo, ProposalCreationPolicy},
+    pre_propose::{PreProposeInfo, PreProposeSubmissionPolicy, ProposalCreationPolicy},
     proposal::{SingleChoiceProposeMsg as ProposeMsg, MAX_PROPOSAL_SIZE},
     reply::{
         failed_pre_propose_module_hook_id, mask_proposal_execution_proposal_id,
@@ -3955,7 +3955,7 @@ fn test_update_pre_propose_module() {
                                 amount: Uint128::new(1),
                                 refund_policy: dao_voting::deposit::DepositRefundPolicy::OnlyPassed,
                             }),
-                            open_proposal_submission: false,
+                            submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
                             extension: Empty::default(),
                         })
                         .unwrap(),
@@ -4006,7 +4006,7 @@ fn test_update_pre_propose_module() {
                 amount: Uint128::new(1),
                 refund_policy: dao_voting::deposit::DepositRefundPolicy::OnlyPassed,
             }),
-            open_proposal_submission: false,
+            submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
         }
     );
 

--- a/contracts/proposal/dao-proposal-single/src/testing/tests.rs
+++ b/contracts/proposal/dao-proposal-single/src/testing/tests.rs
@@ -3955,7 +3955,11 @@ fn test_update_pre_propose_module() {
                                 amount: Uint128::new(1),
                                 refund_policy: dao_voting::deposit::DepositRefundPolicy::OnlyPassed,
                             }),
-                            submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
+                            submission_policy: PreProposeSubmissionPolicy::Specific {
+                                dao_members: true,
+                                allowlist: None,
+                                denylist: None,
+                            },
                             extension: Empty::default(),
                         })
                         .unwrap(),
@@ -4006,7 +4010,11 @@ fn test_update_pre_propose_module() {
                 amount: Uint128::new(1),
                 refund_policy: dao_voting::deposit::DepositRefundPolicy::OnlyPassed,
             }),
-            submission_policy: PreProposeSubmissionPolicy::DaoMembers {},
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: None,
+                denylist: None
+            },
         }
     );
 

--- a/contracts/staking/cw20-stake-external-rewards/schema/cw20-stake-external-rewards.json
+++ b/contracts/staking/cw20-stake-external-rewards/schema/cw20-stake-external-rewards.json
@@ -1,22 +1,15 @@
 {
   "contract_name": "cw20-stake-external-rewards",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "reward_duration",
-      "reward_token",
-      "staking_contract"
-    ],
+    "required": ["reward_duration", "reward_token", "staking_contract"],
     "properties": {
       "owner": {
-        "type": [
-          "string",
-          "null"
-        ]
+        "type": ["string", "null"]
       },
       "reward_duration": {
         "type": "integer",
@@ -40,9 +33,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "native"
-            ],
+            "required": ["native"],
             "properties": {
               "native": {
                 "type": "string"
@@ -52,9 +43,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "cw20"
-            ],
+            "required": ["cw20"],
             "properties": {
               "cw20": {
                 "$ref": "#/definitions/Addr"
@@ -72,9 +61,7 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "stake_change_hook"
-        ],
+        "required": ["stake_change_hook"],
         "properties": {
           "stake_change_hook": {
             "$ref": "#/definitions/StakeChangedHookMsg"
@@ -84,9 +71,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "claim"
-        ],
+        "required": ["claim"],
         "properties": {
           "claim": {
             "type": "object",
@@ -97,9 +82,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "receive"
-        ],
+        "required": ["receive"],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -109,9 +92,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "fund"
-        ],
+        "required": ["fund"],
         "properties": {
           "fund": {
             "type": "object",
@@ -122,15 +103,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "update_reward_duration"
-        ],
+        "required": ["update_reward_duration"],
         "properties": {
           "update_reward_duration": {
             "type": "object",
-            "required": [
-              "new_duration"
-            ],
+            "required": ["new_duration"],
             "properties": {
               "new_duration": {
                 "type": "integer",
@@ -146,9 +123,7 @@
       {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": [
-          "update_ownership"
-        ],
+        "required": ["update_ownership"],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -164,15 +139,11 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": [
-              "transfer_ownership"
-            ],
+            "required": ["transfer_ownership"],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": [
-                  "new_owner"
-                ],
+                "required": ["new_owner"],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -196,16 +167,12 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": [
-              "accept_ownership"
-            ]
+            "enum": ["accept_ownership"]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": [
-              "renounce_ownership"
-            ]
+            "enum": ["renounce_ownership"]
           }
         ]
       },
@@ -220,11 +187,7 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": [
-          "amount",
-          "msg",
-          "sender"
-        ],
+        "required": ["amount", "msg", "sender"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -244,9 +207,7 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": [
-              "at_height"
-            ],
+            "required": ["at_height"],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -259,9 +220,7 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": [
-              "at_time"
-            ],
+            "required": ["at_time"],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -272,9 +231,7 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": [
-              "never"
-            ],
+            "required": ["never"],
             "properties": {
               "never": {
                 "type": "object",
@@ -290,16 +247,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "stake"
-            ],
+            "required": ["stake"],
             "properties": {
               "stake": {
                 "type": "object",
-                "required": [
-                  "addr",
-                  "amount"
-                ],
+                "required": ["addr", "amount"],
                 "properties": {
                   "addr": {
                     "$ref": "#/definitions/Addr"
@@ -315,16 +267,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "unstake"
-            ],
+            "required": ["unstake"],
             "properties": {
               "unstake": {
                 "type": "object",
-                "required": [
-                  "addr",
-                  "amount"
-                ],
+                "required": ["addr", "amount"],
                 "properties": {
                   "addr": {
                     "$ref": "#/definitions/Addr"
@@ -364,9 +311,7 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "info"
-        ],
+        "required": ["info"],
         "properties": {
           "info": {
             "type": "object",
@@ -377,15 +322,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "get_pending_rewards"
-        ],
+        "required": ["get_pending_rewards"],
         "properties": {
           "get_pending_rewards": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -398,9 +339,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "ownership"
-        ],
+        "required": ["ownership"],
         "properties": {
           "ownership": {
             "type": "object",
@@ -418,9 +357,7 @@
       {
         "description": "Migrates from version 0.2.6 to 2.0.0. The significant changes being the addition of a two-step ownership transfer using `cw_ownable` and the removal of the manager. Migrating will automatically remove the current manager.",
         "type": "object",
-        "required": [
-          "from_v1"
-        ],
+        "required": ["from_v1"],
         "properties": {
           "from_v1": {
             "type": "object",
@@ -437,12 +374,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "PendingRewardsResponse",
       "type": "object",
-      "required": [
-        "address",
-        "denom",
-        "last_update_block",
-        "pending_rewards"
-      ],
+      "required": ["address", "denom", "last_update_block", "pending_rewards"],
       "properties": {
         "address": {
           "type": "string"
@@ -469,9 +401,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "native"
-              ],
+              "required": ["native"],
               "properties": {
                 "native": {
                   "type": "string"
@@ -481,9 +411,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "cw20"
-              ],
+              "required": ["cw20"],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -503,10 +431,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": [
-        "config",
-        "reward"
-      ],
+      "required": ["config", "reward"],
       "properties": {
         "config": {
           "$ref": "#/definitions/Config"
@@ -523,10 +448,7 @@
         },
         "Config": {
           "type": "object",
-          "required": [
-            "reward_token",
-            "staking_contract"
-          ],
+          "required": ["reward_token", "staking_contract"],
           "properties": {
             "reward_token": {
               "$ref": "#/definitions/Denom"
@@ -541,9 +463,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "native"
-              ],
+              "required": ["native"],
               "properties": {
                 "native": {
                   "type": "string"
@@ -553,9 +473,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "cw20"
-              ],
+              "required": ["cw20"],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -567,11 +485,7 @@
         },
         "RewardConfig": {
           "type": "object",
-          "required": [
-            "period_finish",
-            "reward_duration",
-            "reward_rate"
-          ],
+          "required": ["period_finish", "reward_duration", "reward_rate"],
           "properties": {
             "period_finish": {
               "type": "integer",
@@ -647,9 +561,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -662,9 +574,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -675,9 +585,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",

--- a/contracts/staking/cw20-stake-external-rewards/schema/cw20-stake-external-rewards.json
+++ b/contracts/staking/cw20-stake-external-rewards/schema/cw20-stake-external-rewards.json
@@ -6,10 +6,17 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["reward_duration", "reward_token", "staking_contract"],
+    "required": [
+      "reward_duration",
+      "reward_token",
+      "staking_contract"
+    ],
     "properties": {
       "owner": {
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "reward_duration": {
         "type": "integer",
@@ -33,7 +40,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["native"],
+            "required": [
+              "native"
+            ],
             "properties": {
               "native": {
                 "type": "string"
@@ -43,7 +52,9 @@
           },
           {
             "type": "object",
-            "required": ["cw20"],
+            "required": [
+              "cw20"
+            ],
             "properties": {
               "cw20": {
                 "$ref": "#/definitions/Addr"
@@ -61,7 +72,9 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["stake_change_hook"],
+        "required": [
+          "stake_change_hook"
+        ],
         "properties": {
           "stake_change_hook": {
             "$ref": "#/definitions/StakeChangedHookMsg"
@@ -71,7 +84,9 @@
       },
       {
         "type": "object",
-        "required": ["claim"],
+        "required": [
+          "claim"
+        ],
         "properties": {
           "claim": {
             "type": "object",
@@ -82,7 +97,9 @@
       },
       {
         "type": "object",
-        "required": ["receive"],
+        "required": [
+          "receive"
+        ],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -92,7 +109,9 @@
       },
       {
         "type": "object",
-        "required": ["fund"],
+        "required": [
+          "fund"
+        ],
         "properties": {
           "fund": {
             "type": "object",
@@ -103,11 +122,15 @@
       },
       {
         "type": "object",
-        "required": ["update_reward_duration"],
+        "required": [
+          "update_reward_duration"
+        ],
         "properties": {
           "update_reward_duration": {
             "type": "object",
-            "required": ["new_duration"],
+            "required": [
+              "new_duration"
+            ],
             "properties": {
               "new_duration": {
                 "type": "integer",
@@ -123,7 +146,9 @@
       {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": ["update_ownership"],
+        "required": [
+          "update_ownership"
+        ],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -139,11 +164,15 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": ["transfer_ownership"],
+            "required": [
+              "transfer_ownership"
+            ],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": ["new_owner"],
+                "required": [
+                  "new_owner"
+                ],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -167,12 +196,16 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": ["accept_ownership"]
+            "enum": [
+              "accept_ownership"
+            ]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": ["renounce_ownership"]
+            "enum": [
+              "renounce_ownership"
+            ]
           }
         ]
       },
@@ -187,7 +220,11 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": ["amount", "msg", "sender"],
+        "required": [
+          "amount",
+          "msg",
+          "sender"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -207,7 +244,9 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": ["at_height"],
+            "required": [
+              "at_height"
+            ],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -220,7 +259,9 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": ["at_time"],
+            "required": [
+              "at_time"
+            ],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -231,7 +272,9 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": ["never"],
+            "required": [
+              "never"
+            ],
             "properties": {
               "never": {
                 "type": "object",
@@ -247,11 +290,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["stake"],
+            "required": [
+              "stake"
+            ],
             "properties": {
               "stake": {
                 "type": "object",
-                "required": ["addr", "amount"],
+                "required": [
+                  "addr",
+                  "amount"
+                ],
                 "properties": {
                   "addr": {
                     "$ref": "#/definitions/Addr"
@@ -267,11 +315,16 @@
           },
           {
             "type": "object",
-            "required": ["unstake"],
+            "required": [
+              "unstake"
+            ],
             "properties": {
               "unstake": {
                 "type": "object",
-                "required": ["addr", "amount"],
+                "required": [
+                  "addr",
+                  "amount"
+                ],
                 "properties": {
                   "addr": {
                     "$ref": "#/definitions/Addr"
@@ -311,7 +364,9 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["info"],
+        "required": [
+          "info"
+        ],
         "properties": {
           "info": {
             "type": "object",
@@ -322,11 +377,15 @@
       },
       {
         "type": "object",
-        "required": ["get_pending_rewards"],
+        "required": [
+          "get_pending_rewards"
+        ],
         "properties": {
           "get_pending_rewards": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -339,7 +398,9 @@
       },
       {
         "type": "object",
-        "required": ["ownership"],
+        "required": [
+          "ownership"
+        ],
         "properties": {
           "ownership": {
             "type": "object",
@@ -357,7 +418,9 @@
       {
         "description": "Migrates from version 0.2.6 to 2.0.0. The significant changes being the addition of a two-step ownership transfer using `cw_ownable` and the removal of the manager. Migrating will automatically remove the current manager.",
         "type": "object",
-        "required": ["from_v1"],
+        "required": [
+          "from_v1"
+        ],
         "properties": {
           "from_v1": {
             "type": "object",
@@ -374,7 +437,12 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "PendingRewardsResponse",
       "type": "object",
-      "required": ["address", "denom", "last_update_block", "pending_rewards"],
+      "required": [
+        "address",
+        "denom",
+        "last_update_block",
+        "pending_rewards"
+      ],
       "properties": {
         "address": {
           "type": "string"
@@ -401,7 +469,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["native"],
+              "required": [
+                "native"
+              ],
               "properties": {
                 "native": {
                   "type": "string"
@@ -411,7 +481,9 @@
             },
             {
               "type": "object",
-              "required": ["cw20"],
+              "required": [
+                "cw20"
+              ],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -431,7 +503,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": ["config", "reward"],
+      "required": [
+        "config",
+        "reward"
+      ],
       "properties": {
         "config": {
           "$ref": "#/definitions/Config"
@@ -448,7 +523,10 @@
         },
         "Config": {
           "type": "object",
-          "required": ["reward_token", "staking_contract"],
+          "required": [
+            "reward_token",
+            "staking_contract"
+          ],
           "properties": {
             "reward_token": {
               "$ref": "#/definitions/Denom"
@@ -463,7 +541,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["native"],
+              "required": [
+                "native"
+              ],
               "properties": {
                 "native": {
                   "type": "string"
@@ -473,7 +553,9 @@
             },
             {
               "type": "object",
-              "required": ["cw20"],
+              "required": [
+                "cw20"
+              ],
               "properties": {
                 "cw20": {
                   "$ref": "#/definitions/Addr"
@@ -485,7 +567,11 @@
         },
         "RewardConfig": {
           "type": "object",
-          "required": ["period_finish", "reward_duration", "reward_rate"],
+          "required": [
+            "period_finish",
+            "reward_duration",
+            "reward_rate"
+          ],
           "properties": {
             "period_finish": {
               "type": "integer",
@@ -561,7 +647,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -574,7 +662,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -585,7 +675,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",

--- a/contracts/staking/cw20-stake-reward-distributor/schema/cw20-stake-reward-distributor.json
+++ b/contracts/staking/cw20-stake-reward-distributor/schema/cw20-stake-reward-distributor.json
@@ -1,17 +1,12 @@
 {
   "contract_name": "cw20-stake-reward-distributor",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "owner",
-      "reward_rate",
-      "reward_token",
-      "staking_addr"
-    ],
+    "required": ["owner", "reward_rate", "reward_token", "staking_addr"],
     "properties": {
       "owner": {
         "type": "string"
@@ -40,17 +35,11 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "update_config"
-        ],
+        "required": ["update_config"],
         "properties": {
           "update_config": {
             "type": "object",
-            "required": [
-              "reward_rate",
-              "reward_token",
-              "staking_addr"
-            ],
+            "required": ["reward_rate", "reward_token", "staking_addr"],
             "properties": {
               "reward_rate": {
                 "$ref": "#/definitions/Uint128"
@@ -69,9 +58,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "distribute"
-        ],
+        "required": ["distribute"],
         "properties": {
           "distribute": {
             "type": "object",
@@ -82,9 +69,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "withdraw"
-        ],
+        "required": ["withdraw"],
         "properties": {
           "withdraw": {
             "type": "object",
@@ -96,9 +81,7 @@
       {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": [
-          "update_ownership"
-        ],
+        "required": ["update_ownership"],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -114,15 +97,11 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": [
-              "transfer_ownership"
-            ],
+            "required": ["transfer_ownership"],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": [
-                  "new_owner"
-                ],
+                "required": ["new_owner"],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -146,16 +125,12 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": [
-              "accept_ownership"
-            ]
+            "enum": ["accept_ownership"]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": [
-              "renounce_ownership"
-            ]
+            "enum": ["renounce_ownership"]
           }
         ]
       },
@@ -165,9 +140,7 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": [
-              "at_height"
-            ],
+            "required": ["at_height"],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -180,9 +153,7 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": [
-              "at_time"
-            ],
+            "required": ["at_time"],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -193,9 +164,7 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": [
-              "never"
-            ],
+            "required": ["never"],
             "properties": {
               "never": {
                 "type": "object",
@@ -230,9 +199,7 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "info"
-        ],
+        "required": ["info"],
         "properties": {
           "info": {
             "type": "object",
@@ -243,9 +210,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "ownership"
-        ],
+        "required": ["ownership"],
         "properties": {
           "ownership": {
             "type": "object",
@@ -263,9 +228,7 @@
       {
         "description": "Updates the contract from v1 -> v2. Version two implements a two step ownership transfer.",
         "type": "object",
-        "required": [
-          "from_v1"
-        ],
+        "required": ["from_v1"],
         "properties": {
           "from_v1": {
             "type": "object",
@@ -282,11 +245,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": [
-        "balance",
-        "config",
-        "last_payment_block"
-      ],
+      "required": ["balance", "config", "last_payment_block"],
       "properties": {
         "balance": {
           "$ref": "#/definitions/Uint128"
@@ -308,11 +267,7 @@
         },
         "Config": {
           "type": "object",
-          "required": [
-            "reward_rate",
-            "reward_token",
-            "staking_addr"
-          ],
+          "required": ["reward_rate", "reward_token", "staking_addr"],
           "properties": {
             "reward_rate": {
               "$ref": "#/definitions/Uint128"
@@ -384,9 +339,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -399,9 +352,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -412,9 +363,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",

--- a/contracts/staking/cw20-stake-reward-distributor/schema/cw20-stake-reward-distributor.json
+++ b/contracts/staking/cw20-stake-reward-distributor/schema/cw20-stake-reward-distributor.json
@@ -6,7 +6,12 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["owner", "reward_rate", "reward_token", "staking_addr"],
+    "required": [
+      "owner",
+      "reward_rate",
+      "reward_token",
+      "staking_addr"
+    ],
     "properties": {
       "owner": {
         "type": "string"
@@ -35,11 +40,17 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["update_config"],
+        "required": [
+          "update_config"
+        ],
         "properties": {
           "update_config": {
             "type": "object",
-            "required": ["reward_rate", "reward_token", "staking_addr"],
+            "required": [
+              "reward_rate",
+              "reward_token",
+              "staking_addr"
+            ],
             "properties": {
               "reward_rate": {
                 "$ref": "#/definitions/Uint128"
@@ -58,7 +69,9 @@
       },
       {
         "type": "object",
-        "required": ["distribute"],
+        "required": [
+          "distribute"
+        ],
         "properties": {
           "distribute": {
             "type": "object",
@@ -69,7 +82,9 @@
       },
       {
         "type": "object",
-        "required": ["withdraw"],
+        "required": [
+          "withdraw"
+        ],
         "properties": {
           "withdraw": {
             "type": "object",
@@ -81,7 +96,9 @@
       {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": ["update_ownership"],
+        "required": [
+          "update_ownership"
+        ],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -97,11 +114,15 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": ["transfer_ownership"],
+            "required": [
+              "transfer_ownership"
+            ],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": ["new_owner"],
+                "required": [
+                  "new_owner"
+                ],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -125,12 +146,16 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": ["accept_ownership"]
+            "enum": [
+              "accept_ownership"
+            ]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": ["renounce_ownership"]
+            "enum": [
+              "renounce_ownership"
+            ]
           }
         ]
       },
@@ -140,7 +165,9 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": ["at_height"],
+            "required": [
+              "at_height"
+            ],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -153,7 +180,9 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": ["at_time"],
+            "required": [
+              "at_time"
+            ],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -164,7 +193,9 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": ["never"],
+            "required": [
+              "never"
+            ],
             "properties": {
               "never": {
                 "type": "object",
@@ -199,7 +230,9 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["info"],
+        "required": [
+          "info"
+        ],
         "properties": {
           "info": {
             "type": "object",
@@ -210,7 +243,9 @@
       },
       {
         "type": "object",
-        "required": ["ownership"],
+        "required": [
+          "ownership"
+        ],
         "properties": {
           "ownership": {
             "type": "object",
@@ -228,7 +263,9 @@
       {
         "description": "Updates the contract from v1 -> v2. Version two implements a two step ownership transfer.",
         "type": "object",
-        "required": ["from_v1"],
+        "required": [
+          "from_v1"
+        ],
         "properties": {
           "from_v1": {
             "type": "object",
@@ -245,7 +282,11 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": ["balance", "config", "last_payment_block"],
+      "required": [
+        "balance",
+        "config",
+        "last_payment_block"
+      ],
       "properties": {
         "balance": {
           "$ref": "#/definitions/Uint128"
@@ -267,7 +308,11 @@
         },
         "Config": {
           "type": "object",
-          "required": ["reward_rate", "reward_token", "staking_addr"],
+          "required": [
+            "reward_rate",
+            "reward_token",
+            "staking_addr"
+          ],
           "properties": {
             "reward_rate": {
               "$ref": "#/definitions/Uint128"
@@ -339,7 +384,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -352,7 +399,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -363,7 +412,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",

--- a/contracts/staking/cw20-stake/schema/cw20-stake.json
+++ b/contracts/staking/cw20-stake/schema/cw20-stake.json
@@ -6,10 +6,15 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["token_address"],
+    "required": [
+      "token_address"
+    ],
     "properties": {
       "owner": {
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "token_address": {
         "type": "string"
@@ -32,7 +37,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -45,7 +52,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -65,7 +74,9 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["receive"],
+        "required": [
+          "receive"
+        ],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -75,11 +86,15 @@
       },
       {
         "type": "object",
-        "required": ["unstake"],
+        "required": [
+          "unstake"
+        ],
         "properties": {
           "unstake": {
             "type": "object",
-            "required": ["amount"],
+            "required": [
+              "amount"
+            ],
             "properties": {
               "amount": {
                 "$ref": "#/definitions/Uint128"
@@ -92,7 +107,9 @@
       },
       {
         "type": "object",
-        "required": ["claim"],
+        "required": [
+          "claim"
+        ],
         "properties": {
           "claim": {
             "type": "object",
@@ -103,7 +120,9 @@
       },
       {
         "type": "object",
-        "required": ["update_config"],
+        "required": [
+          "update_config"
+        ],
         "properties": {
           "update_config": {
             "type": "object",
@@ -126,11 +145,15 @@
       },
       {
         "type": "object",
-        "required": ["add_hook"],
+        "required": [
+          "add_hook"
+        ],
         "properties": {
           "add_hook": {
             "type": "object",
-            "required": ["addr"],
+            "required": [
+              "addr"
+            ],
             "properties": {
               "addr": {
                 "type": "string"
@@ -143,11 +166,15 @@
       },
       {
         "type": "object",
-        "required": ["remove_hook"],
+        "required": [
+          "remove_hook"
+        ],
         "properties": {
           "remove_hook": {
             "type": "object",
-            "required": ["addr"],
+            "required": [
+              "addr"
+            ],
             "properties": {
               "addr": {
                 "type": "string"
@@ -161,7 +188,9 @@
       {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": ["update_ownership"],
+        "required": [
+          "update_ownership"
+        ],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -177,11 +206,15 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": ["transfer_ownership"],
+            "required": [
+              "transfer_ownership"
+            ],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": ["new_owner"],
+                "required": [
+                  "new_owner"
+                ],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -205,12 +238,16 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": ["accept_ownership"]
+            "enum": [
+              "accept_ownership"
+            ]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": ["renounce_ownership"]
+            "enum": [
+              "renounce_ownership"
+            ]
           }
         ]
       },
@@ -221,7 +258,11 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": ["amount", "msg", "sender"],
+        "required": [
+          "amount",
+          "msg",
+          "sender"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -240,7 +281,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -253,7 +296,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -271,7 +316,9 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": ["at_height"],
+            "required": [
+              "at_height"
+            ],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -284,7 +331,9 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": ["at_time"],
+            "required": [
+              "at_time"
+            ],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -295,7 +344,9 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": ["never"],
+            "required": [
+              "never"
+            ],
             "properties": {
               "never": {
                 "type": "object",
@@ -330,17 +381,24 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["staked_balance_at_height"],
+        "required": [
+          "staked_balance_at_height"
+        ],
         "properties": {
           "staked_balance_at_height": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
               },
               "height": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -352,13 +410,18 @@
       },
       {
         "type": "object",
-        "required": ["total_staked_at_height"],
+        "required": [
+          "total_staked_at_height"
+        ],
         "properties": {
           "total_staked_at_height": {
             "type": "object",
             "properties": {
               "height": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -370,11 +433,15 @@
       },
       {
         "type": "object",
-        "required": ["staked_value"],
+        "required": [
+          "staked_value"
+        ],
         "properties": {
           "staked_value": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -387,7 +454,9 @@
       },
       {
         "type": "object",
-        "required": ["total_value"],
+        "required": [
+          "total_value"
+        ],
         "properties": {
           "total_value": {
             "type": "object",
@@ -398,7 +467,9 @@
       },
       {
         "type": "object",
-        "required": ["get_config"],
+        "required": [
+          "get_config"
+        ],
         "properties": {
           "get_config": {
             "type": "object",
@@ -409,11 +480,15 @@
       },
       {
         "type": "object",
-        "required": ["claims"],
+        "required": [
+          "claims"
+        ],
         "properties": {
           "claims": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -426,7 +501,9 @@
       },
       {
         "type": "object",
-        "required": ["get_hooks"],
+        "required": [
+          "get_hooks"
+        ],
         "properties": {
           "get_hooks": {
             "type": "object",
@@ -437,18 +514,26 @@
       },
       {
         "type": "object",
-        "required": ["list_stakers"],
+        "required": [
+          "list_stakers"
+        ],
         "properties": {
           "list_stakers": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -458,7 +543,9 @@
       },
       {
         "type": "object",
-        "required": ["ownership"],
+        "required": [
+          "ownership"
+        ],
         "properties": {
           "ownership": {
             "type": "object",
@@ -476,7 +563,9 @@
       {
         "description": "Migrates the contract from version one to version two. This will remove the contract's current manager, and require a nomination -> acceptance flow for future ownership transfers.",
         "type": "object",
-        "required": ["from_v1"],
+        "required": [
+          "from_v1"
+        ],
         "properties": {
           "from_v1": {
             "type": "object",
@@ -493,7 +582,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ClaimsResponse",
       "type": "object",
-      "required": ["claims"],
+      "required": [
+        "claims"
+      ],
       "properties": {
         "claims": {
           "type": "array",
@@ -506,7 +597,10 @@
       "definitions": {
         "Claim": {
           "type": "object",
-          "required": ["amount", "release_at"],
+          "required": [
+            "amount",
+            "release_at"
+          ],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -523,7 +617,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -536,7 +632,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -547,7 +645,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -580,7 +680,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Config",
       "type": "object",
-      "required": ["token_address"],
+      "required": [
+        "token_address"
+      ],
       "properties": {
         "token_address": {
           "$ref": "#/definitions/Addr"
@@ -607,7 +709,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["height"],
+              "required": [
+                "height"
+              ],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -620,7 +724,9 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": ["time"],
+              "required": [
+                "time"
+              ],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -638,7 +744,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "GetHooksResponse",
       "type": "object",
-      "required": ["hooks"],
+      "required": [
+        "hooks"
+      ],
       "properties": {
         "hooks": {
           "type": "array",
@@ -653,7 +761,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ListStakersResponse",
       "type": "object",
-      "required": ["stakers"],
+      "required": [
+        "stakers"
+      ],
       "properties": {
         "stakers": {
           "type": "array",
@@ -666,7 +776,10 @@
       "definitions": {
         "StakerBalanceResponse": {
           "type": "object",
-          "required": ["address", "balance"],
+          "required": [
+            "address",
+            "balance"
+          ],
           "properties": {
             "address": {
               "type": "string"
@@ -735,7 +848,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -748,7 +863,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -759,7 +876,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -788,7 +907,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "StakedBalanceAtHeightResponse",
       "type": "object",
-      "required": ["balance", "height"],
+      "required": [
+        "balance",
+        "height"
+      ],
       "properties": {
         "balance": {
           "$ref": "#/definitions/Uint128"
@@ -811,7 +933,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "StakedValueResponse",
       "type": "object",
-      "required": ["value"],
+      "required": [
+        "value"
+      ],
       "properties": {
         "value": {
           "$ref": "#/definitions/Uint128"
@@ -829,7 +953,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalStakedAtHeightResponse",
       "type": "object",
-      "required": ["height", "total"],
+      "required": [
+        "height",
+        "total"
+      ],
       "properties": {
         "height": {
           "type": "integer",
@@ -852,7 +979,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalValueResponse",
       "type": "object",
-      "required": ["total"],
+      "required": [
+        "total"
+      ],
       "properties": {
         "total": {
           "$ref": "#/definitions/Uint128"

--- a/contracts/staking/cw20-stake/schema/cw20-stake.json
+++ b/contracts/staking/cw20-stake/schema/cw20-stake.json
@@ -1,20 +1,15 @@
 {
   "contract_name": "cw20-stake",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "token_address"
-    ],
+    "required": ["token_address"],
     "properties": {
       "owner": {
-        "type": [
-          "string",
-          "null"
-        ]
+        "type": ["string", "null"]
       },
       "token_address": {
         "type": "string"
@@ -37,9 +32,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -52,9 +45,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -74,9 +65,7 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "receive"
-        ],
+        "required": ["receive"],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -86,15 +75,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "unstake"
-        ],
+        "required": ["unstake"],
         "properties": {
           "unstake": {
             "type": "object",
-            "required": [
-              "amount"
-            ],
+            "required": ["amount"],
             "properties": {
               "amount": {
                 "$ref": "#/definitions/Uint128"
@@ -107,9 +92,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "claim"
-        ],
+        "required": ["claim"],
         "properties": {
           "claim": {
             "type": "object",
@@ -120,9 +103,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "update_config"
-        ],
+        "required": ["update_config"],
         "properties": {
           "update_config": {
             "type": "object",
@@ -145,15 +126,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "add_hook"
-        ],
+        "required": ["add_hook"],
         "properties": {
           "add_hook": {
             "type": "object",
-            "required": [
-              "addr"
-            ],
+            "required": ["addr"],
             "properties": {
               "addr": {
                 "type": "string"
@@ -166,15 +143,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "remove_hook"
-        ],
+        "required": ["remove_hook"],
         "properties": {
           "remove_hook": {
             "type": "object",
-            "required": [
-              "addr"
-            ],
+            "required": ["addr"],
             "properties": {
               "addr": {
                 "type": "string"
@@ -188,9 +161,7 @@
       {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": [
-          "update_ownership"
-        ],
+        "required": ["update_ownership"],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -206,15 +177,11 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": [
-              "transfer_ownership"
-            ],
+            "required": ["transfer_ownership"],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": [
-                  "new_owner"
-                ],
+                "required": ["new_owner"],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -238,16 +205,12 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": [
-              "accept_ownership"
-            ]
+            "enum": ["accept_ownership"]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": [
-              "renounce_ownership"
-            ]
+            "enum": ["renounce_ownership"]
           }
         ]
       },
@@ -258,11 +221,7 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": [
-          "amount",
-          "msg",
-          "sender"
-        ],
+        "required": ["amount", "msg", "sender"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -281,9 +240,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -296,9 +253,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -316,9 +271,7 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": [
-              "at_height"
-            ],
+            "required": ["at_height"],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -331,9 +284,7 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": [
-              "at_time"
-            ],
+            "required": ["at_time"],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -344,9 +295,7 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": [
-              "never"
-            ],
+            "required": ["never"],
             "properties": {
               "never": {
                 "type": "object",
@@ -381,24 +330,17 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "staked_balance_at_height"
-        ],
+        "required": ["staked_balance_at_height"],
         "properties": {
           "staked_balance_at_height": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
               },
               "height": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -410,18 +352,13 @@
       },
       {
         "type": "object",
-        "required": [
-          "total_staked_at_height"
-        ],
+        "required": ["total_staked_at_height"],
         "properties": {
           "total_staked_at_height": {
             "type": "object",
             "properties": {
               "height": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -433,15 +370,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "staked_value"
-        ],
+        "required": ["staked_value"],
         "properties": {
           "staked_value": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -454,9 +387,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "total_value"
-        ],
+        "required": ["total_value"],
         "properties": {
           "total_value": {
             "type": "object",
@@ -467,9 +398,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "get_config"
-        ],
+        "required": ["get_config"],
         "properties": {
           "get_config": {
             "type": "object",
@@ -480,15 +409,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "claims"
-        ],
+        "required": ["claims"],
         "properties": {
           "claims": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -501,9 +426,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "get_hooks"
-        ],
+        "required": ["get_hooks"],
         "properties": {
           "get_hooks": {
             "type": "object",
@@ -514,26 +437,18 @@
       },
       {
         "type": "object",
-        "required": [
-          "list_stakers"
-        ],
+        "required": ["list_stakers"],
         "properties": {
           "list_stakers": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -543,9 +458,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "ownership"
-        ],
+        "required": ["ownership"],
         "properties": {
           "ownership": {
             "type": "object",
@@ -563,9 +476,7 @@
       {
         "description": "Migrates the contract from version one to version two. This will remove the contract's current manager, and require a nomination -> acceptance flow for future ownership transfers.",
         "type": "object",
-        "required": [
-          "from_v1"
-        ],
+        "required": ["from_v1"],
         "properties": {
           "from_v1": {
             "type": "object",
@@ -582,9 +493,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ClaimsResponse",
       "type": "object",
-      "required": [
-        "claims"
-      ],
+      "required": ["claims"],
       "properties": {
         "claims": {
           "type": "array",
@@ -597,10 +506,7 @@
       "definitions": {
         "Claim": {
           "type": "object",
-          "required": [
-            "amount",
-            "release_at"
-          ],
+          "required": ["amount", "release_at"],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -617,9 +523,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -632,9 +536,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -645,9 +547,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -680,9 +580,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Config",
       "type": "object",
-      "required": [
-        "token_address"
-      ],
+      "required": ["token_address"],
       "properties": {
         "token_address": {
           "$ref": "#/definitions/Addr"
@@ -709,9 +607,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "height"
-              ],
+              "required": ["height"],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -724,9 +620,7 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": [
-                "time"
-              ],
+              "required": ["time"],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -744,9 +638,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "GetHooksResponse",
       "type": "object",
-      "required": [
-        "hooks"
-      ],
+      "required": ["hooks"],
       "properties": {
         "hooks": {
           "type": "array",
@@ -761,9 +653,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ListStakersResponse",
       "type": "object",
-      "required": [
-        "stakers"
-      ],
+      "required": ["stakers"],
       "properties": {
         "stakers": {
           "type": "array",
@@ -776,10 +666,7 @@
       "definitions": {
         "StakerBalanceResponse": {
           "type": "object",
-          "required": [
-            "address",
-            "balance"
-          ],
+          "required": ["address", "balance"],
           "properties": {
             "address": {
               "type": "string"
@@ -848,9 +735,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -863,9 +748,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -876,9 +759,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -907,10 +788,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "StakedBalanceAtHeightResponse",
       "type": "object",
-      "required": [
-        "balance",
-        "height"
-      ],
+      "required": ["balance", "height"],
       "properties": {
         "balance": {
           "$ref": "#/definitions/Uint128"
@@ -933,9 +811,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "StakedValueResponse",
       "type": "object",
-      "required": [
-        "value"
-      ],
+      "required": ["value"],
       "properties": {
         "value": {
           "$ref": "#/definitions/Uint128"
@@ -953,10 +829,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalStakedAtHeightResponse",
       "type": "object",
-      "required": [
-        "height",
-        "total"
-      ],
+      "required": ["height", "total"],
       "properties": {
         "height": {
           "type": "integer",
@@ -979,9 +852,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalValueResponse",
       "type": "object",
-      "required": [
-        "total"
-      ],
+      "required": ["total"],
       "properties": {
         "total": {
           "$ref": "#/definitions/Uint128"

--- a/contracts/voting/dao-voting-cw20-staked/schema/dao-voting-cw20-staked.json
+++ b/contracts/voting/dao-voting-cw20-staked/schema/dao-voting-cw20-staked.json
@@ -6,7 +6,9 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["token_info"],
+    "required": [
+      "token_info"
+    ],
     "properties": {
       "active_threshold": {
         "description": "The number or percentage of tokens that must be staked for the DAO to be active",
@@ -31,11 +33,15 @@
           {
             "description": "The absolute number of tokens that must be staked for the module to be active.",
             "type": "object",
-            "required": ["absolute_count"],
+            "required": [
+              "absolute_count"
+            ],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": ["count"],
+                "required": [
+                  "count"
+                ],
                 "properties": {
                   "count": {
                     "$ref": "#/definitions/Uint128"
@@ -49,11 +55,15 @@
           {
             "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
             "type": "object",
-            "required": ["percentage"],
+            "required": [
+              "percentage"
+            ],
             "properties": {
               "percentage": {
                 "type": "object",
-                "required": ["percent"],
+                "required": [
+                  "percent"
+                ],
                 "properties": {
                   "percent": {
                     "$ref": "#/definitions/Decimal"
@@ -72,7 +82,10 @@
       },
       "Cw20Coin": {
         "type": "object",
-        "required": ["address", "amount"],
+        "required": [
+          "address",
+          "amount"
+        ],
         "properties": {
           "address": {
             "type": "string"
@@ -92,7 +105,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -105,7 +120,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -123,7 +140,9 @@
           {
             "description": "Store the Logo as an SVG file. The content must conform to the spec at https://en.wikipedia.org/wiki/Scalable_Vector_Graphics (The contract should do some light-weight sanity-check validation)",
             "type": "object",
-            "required": ["svg"],
+            "required": [
+              "svg"
+            ],
             "properties": {
               "svg": {
                 "$ref": "#/definitions/Binary"
@@ -134,7 +153,9 @@
           {
             "description": "Store the Logo as a PNG file. This will likely only support up to 64x64 or so within the 5KB limit.",
             "type": "object",
-            "required": ["png"],
+            "required": [
+              "png"
+            ],
             "properties": {
               "png": {
                 "$ref": "#/definitions/Binary"
@@ -148,7 +169,10 @@
         "type": "object",
         "properties": {
           "description": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "logo": {
             "anyOf": [
@@ -161,10 +185,16 @@
             ]
           },
           "marketing": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "project": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "additionalProperties": false
@@ -175,7 +205,9 @@
           {
             "description": "A reference to an externally hosted logo. Must be a valid HTTP or HTTPS URL.",
             "type": "object",
-            "required": ["url"],
+            "required": [
+              "url"
+            ],
             "properties": {
               "url": {
                 "type": "string"
@@ -186,7 +218,9 @@
           {
             "description": "Logo content stored on the blockchain. Enforce maximum size of 5KB on all variants",
             "type": "object",
-            "required": ["embedded"],
+            "required": [
+              "embedded"
+            ],
             "properties": {
               "embedded": {
                 "$ref": "#/definitions/EmbeddedLogo"
@@ -201,11 +235,15 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["existing"],
+            "required": [
+              "existing"
+            ],
             "properties": {
               "existing": {
                 "type": "object",
-                "required": ["staking_contract_address"],
+                "required": [
+                  "staking_contract_address"
+                ],
                 "properties": {
                   "staking_contract_address": {
                     "description": "Address of an already instantiated staking contract.",
@@ -219,11 +257,15 @@
           },
           {
             "type": "object",
-            "required": ["new"],
+            "required": [
+              "new"
+            ],
             "properties": {
               "new": {
                 "type": "object",
-                "required": ["staking_code_id"],
+                "required": [
+                  "staking_code_id"
+                ],
                 "properties": {
                   "staking_code_id": {
                     "description": "Code ID for staking contract to instantiate.",
@@ -254,11 +296,16 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["existing"],
+            "required": [
+              "existing"
+            ],
             "properties": {
               "existing": {
                 "type": "object",
-                "required": ["address", "staking_contract"],
+                "required": [
+                  "address",
+                  "staking_contract"
+                ],
                 "properties": {
                   "address": {
                     "description": "Address of an already instantiated cw20 token contract.",
@@ -280,7 +327,9 @@
           },
           {
             "type": "object",
-            "required": ["new"],
+            "required": [
+              "new"
+            ],
             "properties": {
               "new": {
                 "type": "object",
@@ -377,7 +426,9 @@
       {
         "description": "Sets the active threshold to a new value. Only the instantiator this contract (a DAO most likely) may call this method.",
         "type": "object",
-        "required": ["update_active_threshold"],
+        "required": [
+          "update_active_threshold"
+        ],
         "properties": {
           "update_active_threshold": {
             "type": "object",
@@ -406,11 +457,15 @@
           {
             "description": "The absolute number of tokens that must be staked for the module to be active.",
             "type": "object",
-            "required": ["absolute_count"],
+            "required": [
+              "absolute_count"
+            ],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": ["count"],
+                "required": [
+                  "count"
+                ],
                 "properties": {
                   "count": {
                     "$ref": "#/definitions/Uint128"
@@ -424,11 +479,15 @@
           {
             "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
             "type": "object",
-            "required": ["percentage"],
+            "required": [
+              "percentage"
+            ],
             "properties": {
               "percentage": {
                 "type": "object",
-                "required": ["percent"],
+                "required": [
+                  "percent"
+                ],
                 "properties": {
                   "percent": {
                     "$ref": "#/definitions/Decimal"
@@ -458,7 +517,9 @@
       {
         "description": "Gets the address of the cw20-stake contract this voting module is wrapping.",
         "type": "object",
-        "required": ["staking_contract"],
+        "required": [
+          "staking_contract"
+        ],
         "properties": {
           "staking_contract": {
             "type": "object",
@@ -469,7 +530,9 @@
       },
       {
         "type": "object",
-        "required": ["active_threshold"],
+        "required": [
+          "active_threshold"
+        ],
         "properties": {
           "active_threshold": {
             "type": "object",
@@ -481,17 +544,24 @@
       {
         "description": "Returns the voting power for an address at a given height.",
         "type": "object",
-        "required": ["voting_power_at_height"],
+        "required": [
+          "voting_power_at_height"
+        ],
         "properties": {
           "voting_power_at_height": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
               },
               "height": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -504,13 +574,18 @@
       {
         "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
-        "required": ["total_power_at_height"],
+        "required": [
+          "total_power_at_height"
+        ],
         "properties": {
           "total_power_at_height": {
             "type": "object",
             "properties": {
               "height": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -523,7 +598,9 @@
       {
         "description": "Returns the address of the DAO this module belongs to.",
         "type": "object",
-        "required": ["dao"],
+        "required": [
+          "dao"
+        ],
         "properties": {
           "dao": {
             "type": "object",
@@ -535,7 +612,9 @@
       {
         "description": "Returns contract version info.",
         "type": "object",
-        "required": ["info"],
+        "required": [
+          "info"
+        ],
         "properties": {
           "info": {
             "type": "object",
@@ -546,7 +625,9 @@
       },
       {
         "type": "object",
-        "required": ["token_contract"],
+        "required": [
+          "token_contract"
+        ],
         "properties": {
           "token_contract": {
             "type": "object",
@@ -557,7 +638,9 @@
       },
       {
         "type": "object",
-        "required": ["is_active"],
+        "required": [
+          "is_active"
+        ],
         "properties": {
           "is_active": {
             "type": "object",
@@ -600,11 +683,15 @@
             {
               "description": "The absolute number of tokens that must be staked for the module to be active.",
               "type": "object",
-              "required": ["absolute_count"],
+              "required": [
+                "absolute_count"
+              ],
               "properties": {
                 "absolute_count": {
                   "type": "object",
-                  "required": ["count"],
+                  "required": [
+                    "count"
+                  ],
                   "properties": {
                     "count": {
                       "$ref": "#/definitions/Uint128"
@@ -618,11 +705,15 @@
             {
               "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
               "type": "object",
-              "required": ["percentage"],
+              "required": [
+                "percentage"
+              ],
               "properties": {
                 "percentage": {
                   "type": "object",
-                  "required": ["percent"],
+                  "required": [
+                    "percent"
+                  ],
                   "properties": {
                     "percent": {
                       "$ref": "#/definitions/Decimal"
@@ -655,7 +746,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": ["info"],
+      "required": [
+        "info"
+      ],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -665,7 +758,10 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": ["contract", "version"],
+          "required": [
+            "contract",
+            "version"
+          ],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -701,7 +797,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalPowerAtHeightResponse",
       "type": "object",
-      "required": ["height", "power"],
+      "required": [
+        "height",
+        "power"
+      ],
       "properties": {
         "height": {
           "type": "integer",
@@ -724,7 +823,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VotingPowerAtHeightResponse",
       "type": "object",
-      "required": ["height", "power"],
+      "required": [
+        "height",
+        "power"
+      ],
       "properties": {
         "height": {
           "type": "integer",

--- a/contracts/voting/dao-voting-cw20-staked/schema/dao-voting-cw20-staked.json
+++ b/contracts/voting/dao-voting-cw20-staked/schema/dao-voting-cw20-staked.json
@@ -1,14 +1,12 @@
 {
   "contract_name": "dao-voting-cw20-staked",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "token_info"
-    ],
+    "required": ["token_info"],
     "properties": {
       "active_threshold": {
         "description": "The number or percentage of tokens that must be staked for the DAO to be active",
@@ -33,15 +31,11 @@
           {
             "description": "The absolute number of tokens that must be staked for the module to be active.",
             "type": "object",
-            "required": [
-              "absolute_count"
-            ],
+            "required": ["absolute_count"],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": [
-                  "count"
-                ],
+                "required": ["count"],
                 "properties": {
                   "count": {
                     "$ref": "#/definitions/Uint128"
@@ -55,15 +49,11 @@
           {
             "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
             "type": "object",
-            "required": [
-              "percentage"
-            ],
+            "required": ["percentage"],
             "properties": {
               "percentage": {
                 "type": "object",
-                "required": [
-                  "percent"
-                ],
+                "required": ["percent"],
                 "properties": {
                   "percent": {
                     "$ref": "#/definitions/Decimal"
@@ -82,10 +72,7 @@
       },
       "Cw20Coin": {
         "type": "object",
-        "required": [
-          "address",
-          "amount"
-        ],
+        "required": ["address", "amount"],
         "properties": {
           "address": {
             "type": "string"
@@ -105,9 +92,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -120,9 +105,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -140,9 +123,7 @@
           {
             "description": "Store the Logo as an SVG file. The content must conform to the spec at https://en.wikipedia.org/wiki/Scalable_Vector_Graphics (The contract should do some light-weight sanity-check validation)",
             "type": "object",
-            "required": [
-              "svg"
-            ],
+            "required": ["svg"],
             "properties": {
               "svg": {
                 "$ref": "#/definitions/Binary"
@@ -153,9 +134,7 @@
           {
             "description": "Store the Logo as a PNG file. This will likely only support up to 64x64 or so within the 5KB limit.",
             "type": "object",
-            "required": [
-              "png"
-            ],
+            "required": ["png"],
             "properties": {
               "png": {
                 "$ref": "#/definitions/Binary"
@@ -169,10 +148,7 @@
         "type": "object",
         "properties": {
           "description": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "logo": {
             "anyOf": [
@@ -185,16 +161,10 @@
             ]
           },
           "marketing": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "project": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           }
         },
         "additionalProperties": false
@@ -205,9 +175,7 @@
           {
             "description": "A reference to an externally hosted logo. Must be a valid HTTP or HTTPS URL.",
             "type": "object",
-            "required": [
-              "url"
-            ],
+            "required": ["url"],
             "properties": {
               "url": {
                 "type": "string"
@@ -218,9 +186,7 @@
           {
             "description": "Logo content stored on the blockchain. Enforce maximum size of 5KB on all variants",
             "type": "object",
-            "required": [
-              "embedded"
-            ],
+            "required": ["embedded"],
             "properties": {
               "embedded": {
                 "$ref": "#/definitions/EmbeddedLogo"
@@ -235,15 +201,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "existing"
-            ],
+            "required": ["existing"],
             "properties": {
               "existing": {
                 "type": "object",
-                "required": [
-                  "staking_contract_address"
-                ],
+                "required": ["staking_contract_address"],
                 "properties": {
                   "staking_contract_address": {
                     "description": "Address of an already instantiated staking contract.",
@@ -257,15 +219,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "new"
-            ],
+            "required": ["new"],
             "properties": {
               "new": {
                 "type": "object",
-                "required": [
-                  "staking_code_id"
-                ],
+                "required": ["staking_code_id"],
                 "properties": {
                   "staking_code_id": {
                     "description": "Code ID for staking contract to instantiate.",
@@ -296,16 +254,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "existing"
-            ],
+            "required": ["existing"],
             "properties": {
               "existing": {
                 "type": "object",
-                "required": [
-                  "address",
-                  "staking_contract"
-                ],
+                "required": ["address", "staking_contract"],
                 "properties": {
                   "address": {
                     "description": "Address of an already instantiated cw20 token contract.",
@@ -327,9 +280,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "new"
-            ],
+            "required": ["new"],
             "properties": {
               "new": {
                 "type": "object",
@@ -426,9 +377,7 @@
       {
         "description": "Sets the active threshold to a new value. Only the instantiator this contract (a DAO most likely) may call this method.",
         "type": "object",
-        "required": [
-          "update_active_threshold"
-        ],
+        "required": ["update_active_threshold"],
         "properties": {
           "update_active_threshold": {
             "type": "object",
@@ -457,15 +406,11 @@
           {
             "description": "The absolute number of tokens that must be staked for the module to be active.",
             "type": "object",
-            "required": [
-              "absolute_count"
-            ],
+            "required": ["absolute_count"],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": [
-                  "count"
-                ],
+                "required": ["count"],
                 "properties": {
                   "count": {
                     "$ref": "#/definitions/Uint128"
@@ -479,15 +424,11 @@
           {
             "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
             "type": "object",
-            "required": [
-              "percentage"
-            ],
+            "required": ["percentage"],
             "properties": {
               "percentage": {
                 "type": "object",
-                "required": [
-                  "percent"
-                ],
+                "required": ["percent"],
                 "properties": {
                   "percent": {
                     "$ref": "#/definitions/Decimal"
@@ -517,9 +458,7 @@
       {
         "description": "Gets the address of the cw20-stake contract this voting module is wrapping.",
         "type": "object",
-        "required": [
-          "staking_contract"
-        ],
+        "required": ["staking_contract"],
         "properties": {
           "staking_contract": {
             "type": "object",
@@ -530,9 +469,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "active_threshold"
-        ],
+        "required": ["active_threshold"],
         "properties": {
           "active_threshold": {
             "type": "object",
@@ -544,24 +481,17 @@
       {
         "description": "Returns the voting power for an address at a given height.",
         "type": "object",
-        "required": [
-          "voting_power_at_height"
-        ],
+        "required": ["voting_power_at_height"],
         "properties": {
           "voting_power_at_height": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
               },
               "height": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -574,18 +504,13 @@
       {
         "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
-        "required": [
-          "total_power_at_height"
-        ],
+        "required": ["total_power_at_height"],
         "properties": {
           "total_power_at_height": {
             "type": "object",
             "properties": {
               "height": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -598,9 +523,7 @@
       {
         "description": "Returns the address of the DAO this module belongs to.",
         "type": "object",
-        "required": [
-          "dao"
-        ],
+        "required": ["dao"],
         "properties": {
           "dao": {
             "type": "object",
@@ -612,9 +535,7 @@
       {
         "description": "Returns contract version info.",
         "type": "object",
-        "required": [
-          "info"
-        ],
+        "required": ["info"],
         "properties": {
           "info": {
             "type": "object",
@@ -625,9 +546,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "token_contract"
-        ],
+        "required": ["token_contract"],
         "properties": {
           "token_contract": {
             "type": "object",
@@ -638,9 +557,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "is_active"
-        ],
+        "required": ["is_active"],
         "properties": {
           "is_active": {
             "type": "object",
@@ -683,15 +600,11 @@
             {
               "description": "The absolute number of tokens that must be staked for the module to be active.",
               "type": "object",
-              "required": [
-                "absolute_count"
-              ],
+              "required": ["absolute_count"],
               "properties": {
                 "absolute_count": {
                   "type": "object",
-                  "required": [
-                    "count"
-                  ],
+                  "required": ["count"],
                   "properties": {
                     "count": {
                       "$ref": "#/definitions/Uint128"
@@ -705,15 +618,11 @@
             {
               "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
               "type": "object",
-              "required": [
-                "percentage"
-              ],
+              "required": ["percentage"],
               "properties": {
                 "percentage": {
                   "type": "object",
-                  "required": [
-                    "percent"
-                  ],
+                  "required": ["percent"],
                   "properties": {
                     "percent": {
                       "$ref": "#/definitions/Decimal"
@@ -746,9 +655,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": [
-        "info"
-      ],
+      "required": ["info"],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -758,10 +665,7 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": [
-            "contract",
-            "version"
-          ],
+          "required": ["contract", "version"],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -797,10 +701,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalPowerAtHeightResponse",
       "type": "object",
-      "required": [
-        "height",
-        "power"
-      ],
+      "required": ["height", "power"],
       "properties": {
         "height": {
           "type": "integer",
@@ -823,10 +724,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VotingPowerAtHeightResponse",
       "type": "object",
-      "required": [
-        "height",
-        "power"
-      ],
+      "required": ["height", "power"],
       "properties": {
         "height": {
           "type": "integer",

--- a/contracts/voting/dao-voting-cw4/schema/dao-voting-cw4.json
+++ b/contracts/voting/dao-voting-cw4/schema/dao-voting-cw4.json
@@ -1,14 +1,12 @@
 {
   "contract_name": "dao-voting-cw4",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "group_contract"
-    ],
+    "required": ["group_contract"],
     "properties": {
       "group_contract": {
         "$ref": "#/definitions/GroupContract"
@@ -20,15 +18,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "existing"
-            ],
+            "required": ["existing"],
             "properties": {
               "existing": {
                 "type": "object",
-                "required": [
-                  "address"
-                ],
+                "required": ["address"],
                 "properties": {
                   "address": {
                     "type": "string"
@@ -41,16 +35,11 @@
           },
           {
             "type": "object",
-            "required": [
-              "new"
-            ],
+            "required": ["new"],
             "properties": {
               "new": {
                 "type": "object",
-                "required": [
-                  "cw4_group_code_id",
-                  "initial_members"
-                ],
+                "required": ["cw4_group_code_id", "initial_members"],
                 "properties": {
                   "cw4_group_code_id": {
                     "type": "integer",
@@ -74,10 +63,7 @@
       "Member": {
         "description": "A group member has a weight associated with them. This may all be equal, or may have meaning in the app that makes use of the group (eg. voting power)",
         "type": "object",
-        "required": [
-          "addr",
-          "weight"
-        ],
+        "required": ["addr", "weight"],
         "properties": {
           "addr": {
             "type": "string"
@@ -104,9 +90,7 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "group_contract"
-        ],
+        "required": ["group_contract"],
         "properties": {
           "group_contract": {
             "type": "object",
@@ -118,24 +102,17 @@
       {
         "description": "Returns the voting power for an address at a given height.",
         "type": "object",
-        "required": [
-          "voting_power_at_height"
-        ],
+        "required": ["voting_power_at_height"],
         "properties": {
           "voting_power_at_height": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
               },
               "height": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -148,18 +125,13 @@
       {
         "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
-        "required": [
-          "total_power_at_height"
-        ],
+        "required": ["total_power_at_height"],
         "properties": {
           "total_power_at_height": {
             "type": "object",
             "properties": {
               "height": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -172,9 +144,7 @@
       {
         "description": "Returns the address of the DAO this module belongs to.",
         "type": "object",
-        "required": [
-          "dao"
-        ],
+        "required": ["dao"],
         "properties": {
           "dao": {
             "type": "object",
@@ -186,9 +156,7 @@
       {
         "description": "Returns contract version info.",
         "type": "object",
-        "required": [
-          "info"
-        ],
+        "required": ["info"],
         "properties": {
           "info": {
             "type": "object",
@@ -223,9 +191,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": [
-        "info"
-      ],
+      "required": ["info"],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -235,10 +201,7 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": [
-            "contract",
-            "version"
-          ],
+          "required": ["contract", "version"],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -257,10 +220,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalPowerAtHeightResponse",
       "type": "object",
-      "required": [
-        "height",
-        "power"
-      ],
+      "required": ["height", "power"],
       "properties": {
         "height": {
           "type": "integer",
@@ -283,10 +243,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VotingPowerAtHeightResponse",
       "type": "object",
-      "required": [
-        "height",
-        "power"
-      ],
+      "required": ["height", "power"],
       "properties": {
         "height": {
           "type": "integer",

--- a/contracts/voting/dao-voting-cw4/schema/dao-voting-cw4.json
+++ b/contracts/voting/dao-voting-cw4/schema/dao-voting-cw4.json
@@ -6,7 +6,9 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["group_contract"],
+    "required": [
+      "group_contract"
+    ],
     "properties": {
       "group_contract": {
         "$ref": "#/definitions/GroupContract"
@@ -18,11 +20,15 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["existing"],
+            "required": [
+              "existing"
+            ],
             "properties": {
               "existing": {
                 "type": "object",
-                "required": ["address"],
+                "required": [
+                  "address"
+                ],
                 "properties": {
                   "address": {
                     "type": "string"
@@ -35,11 +41,16 @@
           },
           {
             "type": "object",
-            "required": ["new"],
+            "required": [
+              "new"
+            ],
             "properties": {
               "new": {
                 "type": "object",
-                "required": ["cw4_group_code_id", "initial_members"],
+                "required": [
+                  "cw4_group_code_id",
+                  "initial_members"
+                ],
                 "properties": {
                   "cw4_group_code_id": {
                     "type": "integer",
@@ -63,7 +74,10 @@
       "Member": {
         "description": "A group member has a weight associated with them. This may all be equal, or may have meaning in the app that makes use of the group (eg. voting power)",
         "type": "object",
-        "required": ["addr", "weight"],
+        "required": [
+          "addr",
+          "weight"
+        ],
         "properties": {
           "addr": {
             "type": "string"
@@ -90,7 +104,9 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["group_contract"],
+        "required": [
+          "group_contract"
+        ],
         "properties": {
           "group_contract": {
             "type": "object",
@@ -102,17 +118,24 @@
       {
         "description": "Returns the voting power for an address at a given height.",
         "type": "object",
-        "required": ["voting_power_at_height"],
+        "required": [
+          "voting_power_at_height"
+        ],
         "properties": {
           "voting_power_at_height": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
               },
               "height": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -125,13 +148,18 @@
       {
         "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
-        "required": ["total_power_at_height"],
+        "required": [
+          "total_power_at_height"
+        ],
         "properties": {
           "total_power_at_height": {
             "type": "object",
             "properties": {
               "height": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -144,7 +172,9 @@
       {
         "description": "Returns the address of the DAO this module belongs to.",
         "type": "object",
-        "required": ["dao"],
+        "required": [
+          "dao"
+        ],
         "properties": {
           "dao": {
             "type": "object",
@@ -156,7 +186,9 @@
       {
         "description": "Returns contract version info.",
         "type": "object",
-        "required": ["info"],
+        "required": [
+          "info"
+        ],
         "properties": {
           "info": {
             "type": "object",
@@ -191,7 +223,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": ["info"],
+      "required": [
+        "info"
+      ],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -201,7 +235,10 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": ["contract", "version"],
+          "required": [
+            "contract",
+            "version"
+          ],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -220,7 +257,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalPowerAtHeightResponse",
       "type": "object",
-      "required": ["height", "power"],
+      "required": [
+        "height",
+        "power"
+      ],
       "properties": {
         "height": {
           "type": "integer",
@@ -243,7 +283,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VotingPowerAtHeightResponse",
       "type": "object",
-      "required": ["height", "power"],
+      "required": [
+        "height",
+        "power"
+      ],
       "properties": {
         "height": {
           "type": "integer",

--- a/contracts/voting/dao-voting-cw721-roles/schema/dao-voting-cw721-roles.json
+++ b/contracts/voting/dao-voting-cw721-roles/schema/dao-voting-cw721-roles.json
@@ -6,7 +6,9 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["nft_contract"],
+    "required": [
+      "nft_contract"
+    ],
     "properties": {
       "nft_contract": {
         "description": "Info about the associated NFT contract",
@@ -21,11 +23,16 @@
     "definitions": {
       "MetadataExt": {
         "type": "object",
-        "required": ["weight"],
+        "required": [
+          "weight"
+        ],
         "properties": {
           "role": {
             "description": "Optional on-chain role for this member, can be used by other contracts to enforce permissions",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "weight": {
             "description": "The voting weight of this role",
@@ -40,11 +47,15 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["existing"],
+            "required": [
+              "existing"
+            ],
             "properties": {
               "existing": {
                 "type": "object",
-                "required": ["address"],
+                "required": [
+                  "address"
+                ],
                 "properties": {
                   "address": {
                     "description": "Address of an already instantiated cw721-weighted-roles token contract.",
@@ -58,7 +69,9 @@
           },
           {
             "type": "object",
-            "required": ["new"],
+            "required": [
+              "new"
+            ],
             "properties": {
               "new": {
                 "type": "object",
@@ -105,7 +118,11 @@
       },
       "NftMintMsg": {
         "type": "object",
-        "required": ["extension", "owner", "token_id"],
+        "required": [
+          "extension",
+          "owner",
+          "token_id"
+        ],
         "properties": {
           "extension": {
             "description": "Any custom extension used by this contract",
@@ -125,7 +142,10 @@
           },
           "token_uri": {
             "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "additionalProperties": false
@@ -144,7 +164,9 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["config"],
+        "required": [
+          "config"
+        ],
         "properties": {
           "config": {
             "type": "object",
@@ -156,17 +178,24 @@
       {
         "description": "Returns the voting power for an address at a given height.",
         "type": "object",
-        "required": ["voting_power_at_height"],
+        "required": [
+          "voting_power_at_height"
+        ],
         "properties": {
           "voting_power_at_height": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
               },
               "height": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -179,13 +208,18 @@
       {
         "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
-        "required": ["total_power_at_height"],
+        "required": [
+          "total_power_at_height"
+        ],
         "properties": {
           "total_power_at_height": {
             "type": "object",
             "properties": {
               "height": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -198,7 +232,9 @@
       {
         "description": "Returns the address of the DAO this module belongs to.",
         "type": "object",
-        "required": ["dao"],
+        "required": [
+          "dao"
+        ],
         "properties": {
           "dao": {
             "type": "object",
@@ -210,7 +246,9 @@
       {
         "description": "Returns contract version info.",
         "type": "object",
-        "required": ["info"],
+        "required": [
+          "info"
+        ],
         "properties": {
           "info": {
             "type": "object",
@@ -228,7 +266,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Config",
       "type": "object",
-      "required": ["nft_address"],
+      "required": [
+        "nft_address"
+      ],
       "properties": {
         "nft_address": {
           "$ref": "#/definitions/Addr"
@@ -252,7 +292,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": ["info"],
+      "required": [
+        "info"
+      ],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -262,7 +304,10 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": ["contract", "version"],
+          "required": [
+            "contract",
+            "version"
+          ],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -281,7 +326,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalPowerAtHeightResponse",
       "type": "object",
-      "required": ["height", "power"],
+      "required": [
+        "height",
+        "power"
+      ],
       "properties": {
         "height": {
           "type": "integer",
@@ -304,7 +352,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VotingPowerAtHeightResponse",
       "type": "object",
-      "required": ["height", "power"],
+      "required": [
+        "height",
+        "power"
+      ],
       "properties": {
         "height": {
           "type": "integer",

--- a/contracts/voting/dao-voting-cw721-roles/schema/dao-voting-cw721-roles.json
+++ b/contracts/voting/dao-voting-cw721-roles/schema/dao-voting-cw721-roles.json
@@ -1,14 +1,12 @@
 {
   "contract_name": "dao-voting-cw721-roles",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "nft_contract"
-    ],
+    "required": ["nft_contract"],
     "properties": {
       "nft_contract": {
         "description": "Info about the associated NFT contract",
@@ -23,16 +21,11 @@
     "definitions": {
       "MetadataExt": {
         "type": "object",
-        "required": [
-          "weight"
-        ],
+        "required": ["weight"],
         "properties": {
           "role": {
             "description": "Optional on-chain role for this member, can be used by other contracts to enforce permissions",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "weight": {
             "description": "The voting weight of this role",
@@ -47,15 +40,11 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "existing"
-            ],
+            "required": ["existing"],
             "properties": {
               "existing": {
                 "type": "object",
-                "required": [
-                  "address"
-                ],
+                "required": ["address"],
                 "properties": {
                   "address": {
                     "description": "Address of an already instantiated cw721-weighted-roles token contract.",
@@ -69,9 +58,7 @@
           },
           {
             "type": "object",
-            "required": [
-              "new"
-            ],
+            "required": ["new"],
             "properties": {
               "new": {
                 "type": "object",
@@ -118,11 +105,7 @@
       },
       "NftMintMsg": {
         "type": "object",
-        "required": [
-          "extension",
-          "owner",
-          "token_id"
-        ],
+        "required": ["extension", "owner", "token_id"],
         "properties": {
           "extension": {
             "description": "Any custom extension used by this contract",
@@ -142,10 +125,7 @@
           },
           "token_uri": {
             "description": "Universal resource identifier for this NFT Should point to a JSON file that conforms to the ERC721 Metadata JSON Schema",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           }
         },
         "additionalProperties": false
@@ -164,9 +144,7 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "config"
-        ],
+        "required": ["config"],
         "properties": {
           "config": {
             "type": "object",
@@ -178,24 +156,17 @@
       {
         "description": "Returns the voting power for an address at a given height.",
         "type": "object",
-        "required": [
-          "voting_power_at_height"
-        ],
+        "required": ["voting_power_at_height"],
         "properties": {
           "voting_power_at_height": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
               },
               "height": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -208,18 +179,13 @@
       {
         "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
-        "required": [
-          "total_power_at_height"
-        ],
+        "required": ["total_power_at_height"],
         "properties": {
           "total_power_at_height": {
             "type": "object",
             "properties": {
               "height": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -232,9 +198,7 @@
       {
         "description": "Returns the address of the DAO this module belongs to.",
         "type": "object",
-        "required": [
-          "dao"
-        ],
+        "required": ["dao"],
         "properties": {
           "dao": {
             "type": "object",
@@ -246,9 +210,7 @@
       {
         "description": "Returns contract version info.",
         "type": "object",
-        "required": [
-          "info"
-        ],
+        "required": ["info"],
         "properties": {
           "info": {
             "type": "object",
@@ -266,9 +228,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Config",
       "type": "object",
-      "required": [
-        "nft_address"
-      ],
+      "required": ["nft_address"],
       "properties": {
         "nft_address": {
           "$ref": "#/definitions/Addr"
@@ -292,9 +252,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": [
-        "info"
-      ],
+      "required": ["info"],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -304,10 +262,7 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": [
-            "contract",
-            "version"
-          ],
+          "required": ["contract", "version"],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -326,10 +281,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalPowerAtHeightResponse",
       "type": "object",
-      "required": [
-        "height",
-        "power"
-      ],
+      "required": ["height", "power"],
       "properties": {
         "height": {
           "type": "integer",
@@ -352,10 +304,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VotingPowerAtHeightResponse",
       "type": "object",
-      "required": [
-        "height",
-        "power"
-      ],
+      "required": ["height", "power"],
       "properties": {
         "height": {
           "type": "integer",

--- a/contracts/voting/dao-voting-cw721-staked/schema/dao-voting-cw721-staked.json
+++ b/contracts/voting/dao-voting-cw721-staked/schema/dao-voting-cw721-staked.json
@@ -1,14 +1,12 @@
 {
   "contract_name": "dao-voting-cw721-staked",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "nft_contract"
-    ],
+    "required": ["nft_contract"],
     "properties": {
       "active_threshold": {
         "description": "The number or percentage of tokens that must be staked for the DAO to be active",
@@ -49,15 +47,11 @@
           {
             "description": "The absolute number of tokens that must be staked for the module to be active.",
             "type": "object",
-            "required": [
-              "absolute_count"
-            ],
+            "required": ["absolute_count"],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": [
-                  "count"
-                ],
+                "required": ["count"],
                 "properties": {
                   "count": {
                     "$ref": "#/definitions/Uint128"
@@ -71,15 +65,11 @@
           {
             "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
             "type": "object",
-            "required": [
-              "percentage"
-            ],
+            "required": ["percentage"],
             "properties": {
               "percentage": {
                 "type": "object",
-                "required": [
-                  "percent"
-                ],
+                "required": ["percent"],
                 "properties": {
                   "percent": {
                     "$ref": "#/definitions/Decimal"
@@ -105,9 +95,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -120,9 +108,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -139,15 +125,11 @@
           {
             "description": "Uses an existing cw721 or sg721 token contract.",
             "type": "object",
-            "required": [
-              "existing"
-            ],
+            "required": ["existing"],
             "properties": {
               "existing": {
                 "type": "object",
-                "required": [
-                  "address"
-                ],
+                "required": ["address"],
                 "properties": {
                   "address": {
                     "description": "Address of an already instantiated cw721 or sg721 token contract.",
@@ -162,18 +144,11 @@
           {
             "description": "Creates a new NFT collection used for staking and governance.",
             "type": "object",
-            "required": [
-              "new"
-            ],
+            "required": ["new"],
             "properties": {
               "new": {
                 "type": "object",
-                "required": [
-                  "code_id",
-                  "initial_nfts",
-                  "label",
-                  "msg"
-                ],
+                "required": ["code_id", "initial_nfts", "label", "msg"],
                 "properties": {
                   "code_id": {
                     "description": "Code ID for cw721 token contract.",
@@ -204,9 +179,7 @@
           {
             "description": "Uses a factory contract that must return the address of the NFT contract. The binary must serialize to a `WasmMsg::Execute` message. Validation happens in the factory contract itself, so be sure to use a trusted factory contract.",
             "type": "object",
-            "required": [
-              "factory"
-            ],
+            "required": ["factory"],
             "properties": {
               "factory": {
                 "$ref": "#/definitions/Binary"
@@ -229,9 +202,7 @@
       {
         "description": "Used to stake NFTs. To stake a NFT send a cw721 send message to this contract with the NFT you would like to stake. The `msg` field is ignored.",
         "type": "object",
-        "required": [
-          "receive_nft"
-        ],
+        "required": ["receive_nft"],
         "properties": {
           "receive_nft": {
             "$ref": "#/definitions/Cw721ReceiveMsg"
@@ -242,15 +213,11 @@
       {
         "description": "Unstakes the specified token_ids on behalf of the sender. token_ids must have unique values and have non-zero length.",
         "type": "object",
-        "required": [
-          "unstake"
-        ],
+        "required": ["unstake"],
         "properties": {
           "unstake": {
             "type": "object",
-            "required": [
-              "token_ids"
-            ],
+            "required": ["token_ids"],
             "properties": {
               "token_ids": {
                 "type": "array",
@@ -267,9 +234,7 @@
       {
         "description": "Claim NFTs that have been unstaked for the specified duration.",
         "type": "object",
-        "required": [
-          "claim_nfts"
-        ],
+        "required": ["claim_nfts"],
         "properties": {
           "claim_nfts": {
             "type": "object",
@@ -281,9 +246,7 @@
       {
         "description": "Updates the contract configuration, namely unstaking duration. Only callable by the DAO that initialized this voting contract.",
         "type": "object",
-        "required": [
-          "update_config"
-        ],
+        "required": ["update_config"],
         "properties": {
           "update_config": {
             "type": "object",
@@ -307,15 +270,11 @@
       {
         "description": "Adds a hook which is called on staking / unstaking events. Only callable by the DAO that initialized this voting contract.",
         "type": "object",
-        "required": [
-          "add_hook"
-        ],
+        "required": ["add_hook"],
         "properties": {
           "add_hook": {
             "type": "object",
-            "required": [
-              "addr"
-            ],
+            "required": ["addr"],
             "properties": {
               "addr": {
                 "type": "string"
@@ -329,15 +288,11 @@
       {
         "description": "Removes a hook which is called on staking / unstaking events. Only callable by the DAO that initialized this voting contract.",
         "type": "object",
-        "required": [
-          "remove_hook"
-        ],
+        "required": ["remove_hook"],
         "properties": {
           "remove_hook": {
             "type": "object",
-            "required": [
-              "addr"
-            ],
+            "required": ["addr"],
             "properties": {
               "addr": {
                 "type": "string"
@@ -351,9 +306,7 @@
       {
         "description": "Sets the active threshold to a new value. Only callable by the DAO that initialized this voting contract.",
         "type": "object",
-        "required": [
-          "update_active_threshold"
-        ],
+        "required": ["update_active_threshold"],
         "properties": {
           "update_active_threshold": {
             "type": "object",
@@ -382,15 +335,11 @@
           {
             "description": "The absolute number of tokens that must be staked for the module to be active.",
             "type": "object",
-            "required": [
-              "absolute_count"
-            ],
+            "required": ["absolute_count"],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": [
-                  "count"
-                ],
+                "required": ["count"],
                 "properties": {
                   "count": {
                     "$ref": "#/definitions/Uint128"
@@ -404,15 +353,11 @@
           {
             "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
             "type": "object",
-            "required": [
-              "percentage"
-            ],
+            "required": ["percentage"],
             "properties": {
               "percentage": {
                 "type": "object",
-                "required": [
-                  "percent"
-                ],
+                "required": ["percent"],
                 "properties": {
                   "percent": {
                     "$ref": "#/definitions/Decimal"
@@ -432,11 +377,7 @@
       "Cw721ReceiveMsg": {
         "description": "Cw721ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": [
-          "msg",
-          "sender",
-          "token_id"
-        ],
+        "required": ["msg", "sender", "token_id"],
         "properties": {
           "msg": {
             "$ref": "#/definitions/Binary"
@@ -459,9 +400,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -474,9 +413,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -500,9 +437,7 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "config"
-        ],
+        "required": ["config"],
         "properties": {
           "config": {
             "type": "object",
@@ -513,15 +448,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "nft_claims"
-        ],
+        "required": ["nft_claims"],
         "properties": {
           "nft_claims": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -534,9 +465,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "hooks"
-        ],
+        "required": ["hooks"],
         "properties": {
           "hooks": {
             "type": "object",
@@ -547,32 +476,22 @@
       },
       {
         "type": "object",
-        "required": [
-          "staked_nfts"
-        ],
+        "required": ["staked_nfts"],
         "properties": {
           "staked_nfts": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
               },
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -582,9 +501,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "active_threshold"
-        ],
+        "required": ["active_threshold"],
         "properties": {
           "active_threshold": {
             "type": "object",
@@ -595,9 +512,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "is_active"
-        ],
+        "required": ["is_active"],
         "properties": {
           "is_active": {
             "type": "object",
@@ -609,24 +524,17 @@
       {
         "description": "Returns the voting power for an address at a given height.",
         "type": "object",
-        "required": [
-          "voting_power_at_height"
-        ],
+        "required": ["voting_power_at_height"],
         "properties": {
           "voting_power_at_height": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
               },
               "height": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -639,18 +547,13 @@
       {
         "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
-        "required": [
-          "total_power_at_height"
-        ],
+        "required": ["total_power_at_height"],
         "properties": {
           "total_power_at_height": {
             "type": "object",
             "properties": {
               "height": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -663,9 +566,7 @@
       {
         "description": "Returns the address of the DAO this module belongs to.",
         "type": "object",
-        "required": [
-          "dao"
-        ],
+        "required": ["dao"],
         "properties": {
           "dao": {
             "type": "object",
@@ -677,9 +578,7 @@
       {
         "description": "Returns contract version info.",
         "type": "object",
-        "required": [
-          "info"
-        ],
+        "required": ["info"],
         "properties": {
           "info": {
             "type": "object",
@@ -717,15 +616,11 @@
             {
               "description": "The absolute number of tokens that must be staked for the module to be active.",
               "type": "object",
-              "required": [
-                "absolute_count"
-              ],
+              "required": ["absolute_count"],
               "properties": {
                 "absolute_count": {
                   "type": "object",
-                  "required": [
-                    "count"
-                  ],
+                  "required": ["count"],
                   "properties": {
                     "count": {
                       "$ref": "#/definitions/Uint128"
@@ -739,15 +634,11 @@
             {
               "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
               "type": "object",
-              "required": [
-                "percentage"
-              ],
+              "required": ["percentage"],
               "properties": {
                 "percentage": {
                   "type": "object",
-                  "required": [
-                    "percent"
-                  ],
+                  "required": ["percent"],
                   "properties": {
                     "percent": {
                       "$ref": "#/definitions/Decimal"
@@ -774,9 +665,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Config",
       "type": "object",
-      "required": [
-        "nft_address"
-      ],
+      "required": ["nft_address"],
       "properties": {
         "nft_address": {
           "$ref": "#/definitions/Addr"
@@ -803,9 +692,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "height"
-              ],
+              "required": ["height"],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -818,9 +705,7 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": [
-                "time"
-              ],
+              "required": ["time"],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -844,9 +729,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": [
-        "hooks"
-      ],
+      "required": ["hooks"],
       "properties": {
         "hooks": {
           "type": "array",
@@ -861,9 +744,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": [
-        "info"
-      ],
+      "required": ["info"],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -873,10 +754,7 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": [
-            "contract",
-            "version"
-          ],
+          "required": ["contract", "version"],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -900,9 +778,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "NftClaimsResponse",
       "type": "object",
-      "required": [
-        "nft_claims"
-      ],
+      "required": ["nft_claims"],
       "properties": {
         "nft_claims": {
           "type": "array",
@@ -919,9 +795,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -934,9 +808,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -947,9 +819,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -962,10 +832,7 @@
         },
         "NftClaim": {
           "type": "object",
-          "required": [
-            "release_at",
-            "token_id"
-          ],
+          "required": ["release_at", "token_id"],
           "properties": {
             "release_at": {
               "$ref": "#/definitions/Expiration"
@@ -1002,10 +869,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalPowerAtHeightResponse",
       "type": "object",
-      "required": [
-        "height",
-        "power"
-      ],
+      "required": ["height", "power"],
       "properties": {
         "height": {
           "type": "integer",
@@ -1028,10 +892,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VotingPowerAtHeightResponse",
       "type": "object",
-      "required": [
-        "height",
-        "power"
-      ],
+      "required": ["height", "power"],
       "properties": {
         "height": {
           "type": "integer",

--- a/contracts/voting/dao-voting-cw721-staked/schema/dao-voting-cw721-staked.json
+++ b/contracts/voting/dao-voting-cw721-staked/schema/dao-voting-cw721-staked.json
@@ -6,7 +6,9 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["nft_contract"],
+    "required": [
+      "nft_contract"
+    ],
     "properties": {
       "active_threshold": {
         "description": "The number or percentage of tokens that must be staked for the DAO to be active",
@@ -47,11 +49,15 @@
           {
             "description": "The absolute number of tokens that must be staked for the module to be active.",
             "type": "object",
-            "required": ["absolute_count"],
+            "required": [
+              "absolute_count"
+            ],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": ["count"],
+                "required": [
+                  "count"
+                ],
                 "properties": {
                   "count": {
                     "$ref": "#/definitions/Uint128"
@@ -65,11 +71,15 @@
           {
             "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
             "type": "object",
-            "required": ["percentage"],
+            "required": [
+              "percentage"
+            ],
             "properties": {
               "percentage": {
                 "type": "object",
-                "required": ["percent"],
+                "required": [
+                  "percent"
+                ],
                 "properties": {
                   "percent": {
                     "$ref": "#/definitions/Decimal"
@@ -95,7 +105,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -108,7 +120,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -125,11 +139,15 @@
           {
             "description": "Uses an existing cw721 or sg721 token contract.",
             "type": "object",
-            "required": ["existing"],
+            "required": [
+              "existing"
+            ],
             "properties": {
               "existing": {
                 "type": "object",
-                "required": ["address"],
+                "required": [
+                  "address"
+                ],
                 "properties": {
                   "address": {
                     "description": "Address of an already instantiated cw721 or sg721 token contract.",
@@ -144,11 +162,18 @@
           {
             "description": "Creates a new NFT collection used for staking and governance.",
             "type": "object",
-            "required": ["new"],
+            "required": [
+              "new"
+            ],
             "properties": {
               "new": {
                 "type": "object",
-                "required": ["code_id", "initial_nfts", "label", "msg"],
+                "required": [
+                  "code_id",
+                  "initial_nfts",
+                  "label",
+                  "msg"
+                ],
                 "properties": {
                   "code_id": {
                     "description": "Code ID for cw721 token contract.",
@@ -179,7 +204,9 @@
           {
             "description": "Uses a factory contract that must return the address of the NFT contract. The binary must serialize to a `WasmMsg::Execute` message. Validation happens in the factory contract itself, so be sure to use a trusted factory contract.",
             "type": "object",
-            "required": ["factory"],
+            "required": [
+              "factory"
+            ],
             "properties": {
               "factory": {
                 "$ref": "#/definitions/Binary"
@@ -202,7 +229,9 @@
       {
         "description": "Used to stake NFTs. To stake a NFT send a cw721 send message to this contract with the NFT you would like to stake. The `msg` field is ignored.",
         "type": "object",
-        "required": ["receive_nft"],
+        "required": [
+          "receive_nft"
+        ],
         "properties": {
           "receive_nft": {
             "$ref": "#/definitions/Cw721ReceiveMsg"
@@ -213,11 +242,15 @@
       {
         "description": "Unstakes the specified token_ids on behalf of the sender. token_ids must have unique values and have non-zero length.",
         "type": "object",
-        "required": ["unstake"],
+        "required": [
+          "unstake"
+        ],
         "properties": {
           "unstake": {
             "type": "object",
-            "required": ["token_ids"],
+            "required": [
+              "token_ids"
+            ],
             "properties": {
               "token_ids": {
                 "type": "array",
@@ -234,7 +267,9 @@
       {
         "description": "Claim NFTs that have been unstaked for the specified duration.",
         "type": "object",
-        "required": ["claim_nfts"],
+        "required": [
+          "claim_nfts"
+        ],
         "properties": {
           "claim_nfts": {
             "type": "object",
@@ -246,7 +281,9 @@
       {
         "description": "Updates the contract configuration, namely unstaking duration. Only callable by the DAO that initialized this voting contract.",
         "type": "object",
-        "required": ["update_config"],
+        "required": [
+          "update_config"
+        ],
         "properties": {
           "update_config": {
             "type": "object",
@@ -270,11 +307,15 @@
       {
         "description": "Adds a hook which is called on staking / unstaking events. Only callable by the DAO that initialized this voting contract.",
         "type": "object",
-        "required": ["add_hook"],
+        "required": [
+          "add_hook"
+        ],
         "properties": {
           "add_hook": {
             "type": "object",
-            "required": ["addr"],
+            "required": [
+              "addr"
+            ],
             "properties": {
               "addr": {
                 "type": "string"
@@ -288,11 +329,15 @@
       {
         "description": "Removes a hook which is called on staking / unstaking events. Only callable by the DAO that initialized this voting contract.",
         "type": "object",
-        "required": ["remove_hook"],
+        "required": [
+          "remove_hook"
+        ],
         "properties": {
           "remove_hook": {
             "type": "object",
-            "required": ["addr"],
+            "required": [
+              "addr"
+            ],
             "properties": {
               "addr": {
                 "type": "string"
@@ -306,7 +351,9 @@
       {
         "description": "Sets the active threshold to a new value. Only callable by the DAO that initialized this voting contract.",
         "type": "object",
-        "required": ["update_active_threshold"],
+        "required": [
+          "update_active_threshold"
+        ],
         "properties": {
           "update_active_threshold": {
             "type": "object",
@@ -335,11 +382,15 @@
           {
             "description": "The absolute number of tokens that must be staked for the module to be active.",
             "type": "object",
-            "required": ["absolute_count"],
+            "required": [
+              "absolute_count"
+            ],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": ["count"],
+                "required": [
+                  "count"
+                ],
                 "properties": {
                   "count": {
                     "$ref": "#/definitions/Uint128"
@@ -353,11 +404,15 @@
           {
             "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
             "type": "object",
-            "required": ["percentage"],
+            "required": [
+              "percentage"
+            ],
             "properties": {
               "percentage": {
                 "type": "object",
-                "required": ["percent"],
+                "required": [
+                  "percent"
+                ],
                 "properties": {
                   "percent": {
                     "$ref": "#/definitions/Decimal"
@@ -377,7 +432,11 @@
       "Cw721ReceiveMsg": {
         "description": "Cw721ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": ["msg", "sender", "token_id"],
+        "required": [
+          "msg",
+          "sender",
+          "token_id"
+        ],
         "properties": {
           "msg": {
             "$ref": "#/definitions/Binary"
@@ -400,7 +459,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -413,7 +474,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -437,7 +500,9 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["config"],
+        "required": [
+          "config"
+        ],
         "properties": {
           "config": {
             "type": "object",
@@ -448,11 +513,15 @@
       },
       {
         "type": "object",
-        "required": ["nft_claims"],
+        "required": [
+          "nft_claims"
+        ],
         "properties": {
           "nft_claims": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -465,7 +534,9 @@
       },
       {
         "type": "object",
-        "required": ["hooks"],
+        "required": [
+          "hooks"
+        ],
         "properties": {
           "hooks": {
             "type": "object",
@@ -476,22 +547,32 @@
       },
       {
         "type": "object",
-        "required": ["staked_nfts"],
+        "required": [
+          "staked_nfts"
+        ],
         "properties": {
           "staked_nfts": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
               },
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -501,7 +582,9 @@
       },
       {
         "type": "object",
-        "required": ["active_threshold"],
+        "required": [
+          "active_threshold"
+        ],
         "properties": {
           "active_threshold": {
             "type": "object",
@@ -512,7 +595,9 @@
       },
       {
         "type": "object",
-        "required": ["is_active"],
+        "required": [
+          "is_active"
+        ],
         "properties": {
           "is_active": {
             "type": "object",
@@ -524,17 +609,24 @@
       {
         "description": "Returns the voting power for an address at a given height.",
         "type": "object",
-        "required": ["voting_power_at_height"],
+        "required": [
+          "voting_power_at_height"
+        ],
         "properties": {
           "voting_power_at_height": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
               },
               "height": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -547,13 +639,18 @@
       {
         "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
-        "required": ["total_power_at_height"],
+        "required": [
+          "total_power_at_height"
+        ],
         "properties": {
           "total_power_at_height": {
             "type": "object",
             "properties": {
               "height": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -566,7 +663,9 @@
       {
         "description": "Returns the address of the DAO this module belongs to.",
         "type": "object",
-        "required": ["dao"],
+        "required": [
+          "dao"
+        ],
         "properties": {
           "dao": {
             "type": "object",
@@ -578,7 +677,9 @@
       {
         "description": "Returns contract version info.",
         "type": "object",
-        "required": ["info"],
+        "required": [
+          "info"
+        ],
         "properties": {
           "info": {
             "type": "object",
@@ -616,11 +717,15 @@
             {
               "description": "The absolute number of tokens that must be staked for the module to be active.",
               "type": "object",
-              "required": ["absolute_count"],
+              "required": [
+                "absolute_count"
+              ],
               "properties": {
                 "absolute_count": {
                   "type": "object",
-                  "required": ["count"],
+                  "required": [
+                    "count"
+                  ],
                   "properties": {
                     "count": {
                       "$ref": "#/definitions/Uint128"
@@ -634,11 +739,15 @@
             {
               "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
               "type": "object",
-              "required": ["percentage"],
+              "required": [
+                "percentage"
+              ],
               "properties": {
                 "percentage": {
                   "type": "object",
-                  "required": ["percent"],
+                  "required": [
+                    "percent"
+                  ],
                   "properties": {
                     "percent": {
                       "$ref": "#/definitions/Decimal"
@@ -665,7 +774,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "Config",
       "type": "object",
-      "required": ["nft_address"],
+      "required": [
+        "nft_address"
+      ],
       "properties": {
         "nft_address": {
           "$ref": "#/definitions/Addr"
@@ -692,7 +803,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["height"],
+              "required": [
+                "height"
+              ],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -705,7 +818,9 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": ["time"],
+              "required": [
+                "time"
+              ],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -729,7 +844,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "HooksResponse",
       "type": "object",
-      "required": ["hooks"],
+      "required": [
+        "hooks"
+      ],
       "properties": {
         "hooks": {
           "type": "array",
@@ -744,7 +861,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": ["info"],
+      "required": [
+        "info"
+      ],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -754,7 +873,10 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": ["contract", "version"],
+          "required": [
+            "contract",
+            "version"
+          ],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -778,7 +900,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "NftClaimsResponse",
       "type": "object",
-      "required": ["nft_claims"],
+      "required": [
+        "nft_claims"
+      ],
       "properties": {
         "nft_claims": {
           "type": "array",
@@ -795,7 +919,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -808,7 +934,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -819,7 +947,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -832,7 +962,10 @@
         },
         "NftClaim": {
           "type": "object",
-          "required": ["release_at", "token_id"],
+          "required": [
+            "release_at",
+            "token_id"
+          ],
           "properties": {
             "release_at": {
               "$ref": "#/definitions/Expiration"
@@ -869,7 +1002,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalPowerAtHeightResponse",
       "type": "object",
-      "required": ["height", "power"],
+      "required": [
+        "height",
+        "power"
+      ],
       "properties": {
         "height": {
           "type": "integer",
@@ -892,7 +1028,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VotingPowerAtHeightResponse",
       "type": "object",
-      "required": ["height", "power"],
+      "required": [
+        "height",
+        "power"
+      ],
       "properties": {
         "height": {
           "type": "integer",

--- a/contracts/voting/dao-voting-token-staked/schema/dao-voting-token-staked.json
+++ b/contracts/voting/dao-voting-token-staked/schema/dao-voting-token-staked.json
@@ -6,7 +6,9 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["token_info"],
+    "required": [
+      "token_info"
+    ],
     "properties": {
       "active_threshold": {
         "description": "The number or percentage of tokens that must be staked for the DAO to be active",
@@ -47,11 +49,15 @@
           {
             "description": "The absolute number of tokens that must be staked for the module to be active.",
             "type": "object",
-            "required": ["absolute_count"],
+            "required": [
+              "absolute_count"
+            ],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": ["count"],
+                "required": [
+                  "count"
+                ],
                 "properties": {
                   "count": {
                     "$ref": "#/definitions/Uint128"
@@ -65,11 +71,15 @@
           {
             "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
             "type": "object",
-            "required": ["percentage"],
+            "required": [
+              "percentage"
+            ],
             "properties": {
               "percentage": {
                 "type": "object",
-                "required": ["percent"],
+                "required": [
+                  "percent"
+                ],
                 "properties": {
                   "percent": {
                     "$ref": "#/definitions/Decimal"
@@ -93,7 +103,11 @@
       "DenomUnit": {
         "description": "DenomUnit represents a struct that describes a given denomination unit of the basic token.",
         "type": "object",
-        "required": ["aliases", "denom", "exponent"],
+        "required": [
+          "aliases",
+          "denom",
+          "exponent"
+        ],
         "properties": {
           "aliases": {
             "description": "aliases is a list of string aliases for the given denom",
@@ -119,7 +133,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -132,7 +148,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -146,7 +164,10 @@
       },
       "InitialBalance": {
         "type": "object",
-        "required": ["address", "amount"],
+        "required": [
+          "address",
+          "amount"
+        ],
         "properties": {
           "address": {
             "type": "string"
@@ -159,11 +180,19 @@
       },
       "NewDenomMetadata": {
         "type": "object",
-        "required": ["description", "display", "name", "symbol"],
+        "required": [
+          "description",
+          "display",
+          "name",
+          "symbol"
+        ],
         "properties": {
           "additional_denom_units": {
             "description": "Used define additional units of the token (e.g. \"tiger\") These must have an exponent larger than 0.",
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "$ref": "#/definitions/DenomUnit"
             }
@@ -189,7 +218,11 @@
       },
       "NewTokenInfo": {
         "type": "object",
-        "required": ["initial_balances", "subdenom", "token_issuer_code_id"],
+        "required": [
+          "initial_balances",
+          "subdenom",
+          "token_issuer_code_id"
+        ],
         "properties": {
           "initial_balances": {
             "description": "The initial balances to set for the token, cannot be empty.",
@@ -238,11 +271,15 @@
           {
             "description": "Uses an existing Token Factory token and creates a new issuer contract. Full setup, such as transferring ownership or setting up MsgSetBeforeSendHook, must be done manually.",
             "type": "object",
-            "required": ["existing"],
+            "required": [
+              "existing"
+            ],
             "properties": {
               "existing": {
                 "type": "object",
-                "required": ["denom"],
+                "required": [
+                  "denom"
+                ],
                 "properties": {
                   "denom": {
                     "description": "Token factory denom",
@@ -257,7 +294,9 @@
           {
             "description": "Creates a new Token Factory token via the issue contract with the DAO automatically setup as admin and owner.",
             "type": "object",
-            "required": ["new"],
+            "required": [
+              "new"
+            ],
             "properties": {
               "new": {
                 "$ref": "#/definitions/NewTokenInfo"
@@ -268,7 +307,9 @@
           {
             "description": "Uses a factory contract that must return the denom, optionally a Token Contract address. The binary must serialize to a `WasmMsg::Execute` message. Validation happens in the factory contract itself, so be sure to use a trusted factory contract.",
             "type": "object",
-            "required": ["factory"],
+            "required": [
+              "factory"
+            ],
             "properties": {
               "factory": {
                 "$ref": "#/definitions/Binary"
@@ -291,7 +332,9 @@
       {
         "description": "Stakes tokens with the contract to get voting power in the DAO",
         "type": "object",
-        "required": ["stake"],
+        "required": [
+          "stake"
+        ],
         "properties": {
           "stake": {
             "type": "object",
@@ -303,11 +346,15 @@
       {
         "description": "Unstakes tokens so that they begin unbonding",
         "type": "object",
-        "required": ["unstake"],
+        "required": [
+          "unstake"
+        ],
         "properties": {
           "unstake": {
             "type": "object",
-            "required": ["amount"],
+            "required": [
+              "amount"
+            ],
             "properties": {
               "amount": {
                 "$ref": "#/definitions/Uint128"
@@ -321,7 +368,9 @@
       {
         "description": "Updates the contract configuration",
         "type": "object",
-        "required": ["update_config"],
+        "required": [
+          "update_config"
+        ],
         "properties": {
           "update_config": {
             "type": "object",
@@ -345,7 +394,9 @@
       {
         "description": "Claims unstaked tokens that have completed the unbonding period",
         "type": "object",
-        "required": ["claim"],
+        "required": [
+          "claim"
+        ],
         "properties": {
           "claim": {
             "type": "object",
@@ -357,7 +408,9 @@
       {
         "description": "Sets the active threshold to a new value. Only the instantiator of this contract (a DAO most likely) may call this method.",
         "type": "object",
-        "required": ["update_active_threshold"],
+        "required": [
+          "update_active_threshold"
+        ],
         "properties": {
           "update_active_threshold": {
             "type": "object",
@@ -381,11 +434,15 @@
       {
         "description": "Adds a hook that fires on staking / unstaking",
         "type": "object",
-        "required": ["add_hook"],
+        "required": [
+          "add_hook"
+        ],
         "properties": {
           "add_hook": {
             "type": "object",
-            "required": ["addr"],
+            "required": [
+              "addr"
+            ],
             "properties": {
               "addr": {
                 "type": "string"
@@ -399,11 +456,15 @@
       {
         "description": "Removes a hook that fires on staking / unstaking",
         "type": "object",
-        "required": ["remove_hook"],
+        "required": [
+          "remove_hook"
+        ],
         "properties": {
           "remove_hook": {
             "type": "object",
-            "required": ["addr"],
+            "required": [
+              "addr"
+            ],
             "properties": {
               "addr": {
                 "type": "string"
@@ -422,11 +483,15 @@
           {
             "description": "The absolute number of tokens that must be staked for the module to be active.",
             "type": "object",
-            "required": ["absolute_count"],
+            "required": [
+              "absolute_count"
+            ],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": ["count"],
+                "required": [
+                  "count"
+                ],
                 "properties": {
                   "count": {
                     "$ref": "#/definitions/Uint128"
@@ -440,11 +505,15 @@
           {
             "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
             "type": "object",
-            "required": ["percentage"],
+            "required": [
+              "percentage"
+            ],
             "properties": {
               "percentage": {
                 "type": "object",
-                "required": ["percent"],
+                "required": [
+                  "percent"
+                ],
                 "properties": {
                   "percent": {
                     "$ref": "#/definitions/Decimal"
@@ -466,7 +535,9 @@
         "oneOf": [
           {
             "type": "object",
-            "required": ["height"],
+            "required": [
+              "height"
+            ],
             "properties": {
               "height": {
                 "type": "integer",
@@ -479,7 +550,9 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": ["time"],
+            "required": [
+              "time"
+            ],
             "properties": {
               "time": {
                 "type": "integer",
@@ -503,7 +576,9 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["get_config"],
+        "required": [
+          "get_config"
+        ],
         "properties": {
           "get_config": {
             "type": "object",
@@ -514,11 +589,15 @@
       },
       {
         "type": "object",
-        "required": ["claims"],
+        "required": [
+          "claims"
+        ],
         "properties": {
           "claims": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
@@ -531,18 +610,26 @@
       },
       {
         "type": "object",
-        "required": ["list_stakers"],
+        "required": [
+          "list_stakers"
+        ],
         "properties": {
           "list_stakers": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -552,7 +639,9 @@
       },
       {
         "type": "object",
-        "required": ["active_threshold"],
+        "required": [
+          "active_threshold"
+        ],
         "properties": {
           "active_threshold": {
             "type": "object",
@@ -563,7 +652,9 @@
       },
       {
         "type": "object",
-        "required": ["get_hooks"],
+        "required": [
+          "get_hooks"
+        ],
         "properties": {
           "get_hooks": {
             "type": "object",
@@ -574,7 +665,9 @@
       },
       {
         "type": "object",
-        "required": ["token_contract"],
+        "required": [
+          "token_contract"
+        ],
         "properties": {
           "token_contract": {
             "type": "object",
@@ -585,7 +678,9 @@
       },
       {
         "type": "object",
-        "required": ["denom"],
+        "required": [
+          "denom"
+        ],
         "properties": {
           "denom": {
             "type": "object",
@@ -596,7 +691,9 @@
       },
       {
         "type": "object",
-        "required": ["is_active"],
+        "required": [
+          "is_active"
+        ],
         "properties": {
           "is_active": {
             "type": "object",
@@ -608,17 +705,24 @@
       {
         "description": "Returns the voting power for an address at a given height.",
         "type": "object",
-        "required": ["voting_power_at_height"],
+        "required": [
+          "voting_power_at_height"
+        ],
         "properties": {
           "voting_power_at_height": {
             "type": "object",
-            "required": ["address"],
+            "required": [
+              "address"
+            ],
             "properties": {
               "address": {
                 "type": "string"
               },
               "height": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -631,13 +735,18 @@
       {
         "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
-        "required": ["total_power_at_height"],
+        "required": [
+          "total_power_at_height"
+        ],
         "properties": {
           "total_power_at_height": {
             "type": "object",
             "properties": {
               "height": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -650,7 +759,9 @@
       {
         "description": "Returns the address of the DAO this module belongs to.",
         "type": "object",
-        "required": ["dao"],
+        "required": [
+          "dao"
+        ],
         "properties": {
           "dao": {
             "type": "object",
@@ -662,7 +773,9 @@
       {
         "description": "Returns contract version info.",
         "type": "object",
-        "required": ["info"],
+        "required": [
+          "info"
+        ],
         "properties": {
           "info": {
             "type": "object",
@@ -705,11 +818,15 @@
             {
               "description": "The absolute number of tokens that must be staked for the module to be active.",
               "type": "object",
-              "required": ["absolute_count"],
+              "required": [
+                "absolute_count"
+              ],
               "properties": {
                 "absolute_count": {
                   "type": "object",
-                  "required": ["count"],
+                  "required": [
+                    "count"
+                  ],
                   "properties": {
                     "count": {
                       "$ref": "#/definitions/Uint128"
@@ -723,11 +840,15 @@
             {
               "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
               "type": "object",
-              "required": ["percentage"],
+              "required": [
+                "percentage"
+              ],
               "properties": {
                 "percentage": {
                   "type": "object",
-                  "required": ["percent"],
+                  "required": [
+                    "percent"
+                  ],
                   "properties": {
                     "percent": {
                       "$ref": "#/definitions/Decimal"
@@ -754,7 +875,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ClaimsResponse",
       "type": "object",
-      "required": ["claims"],
+      "required": [
+        "claims"
+      ],
       "properties": {
         "claims": {
           "type": "array",
@@ -767,7 +890,10 @@
       "definitions": {
         "Claim": {
           "type": "object",
-          "required": ["amount", "release_at"],
+          "required": [
+            "amount",
+            "release_at"
+          ],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -784,7 +910,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -797,7 +925,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -808,7 +938,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",
@@ -847,7 +979,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "DenomResponse",
       "type": "object",
-      "required": ["denom"],
+      "required": [
+        "denom"
+      ],
       "properties": {
         "denom": {
           "type": "string"
@@ -878,7 +1012,9 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["height"],
+              "required": [
+                "height"
+              ],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -891,7 +1027,9 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": ["time"],
+              "required": [
+                "time"
+              ],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -909,7 +1047,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "GetHooksResponse",
       "type": "object",
-      "required": ["hooks"],
+      "required": [
+        "hooks"
+      ],
       "properties": {
         "hooks": {
           "type": "array",
@@ -924,7 +1064,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": ["info"],
+      "required": [
+        "info"
+      ],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -934,7 +1076,10 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": ["contract", "version"],
+          "required": [
+            "contract",
+            "version"
+          ],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -958,7 +1103,9 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ListStakersResponse",
       "type": "object",
-      "required": ["stakers"],
+      "required": [
+        "stakers"
+      ],
       "properties": {
         "stakers": {
           "type": "array",
@@ -971,7 +1118,10 @@
       "definitions": {
         "StakerBalanceResponse": {
           "type": "object",
-          "required": ["address", "balance"],
+          "required": [
+            "address",
+            "balance"
+          ],
           "properties": {
             "address": {
               "type": "string"
@@ -1010,7 +1160,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalPowerAtHeightResponse",
       "type": "object",
-      "required": ["height", "power"],
+      "required": [
+        "height",
+        "power"
+      ],
       "properties": {
         "height": {
           "type": "integer",
@@ -1033,7 +1186,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VotingPowerAtHeightResponse",
       "type": "object",
-      "required": ["height", "power"],
+      "required": [
+        "height",
+        "power"
+      ],
       "properties": {
         "height": {
           "type": "integer",

--- a/contracts/voting/dao-voting-token-staked/schema/dao-voting-token-staked.json
+++ b/contracts/voting/dao-voting-token-staked/schema/dao-voting-token-staked.json
@@ -1,14 +1,12 @@
 {
   "contract_name": "dao-voting-token-staked",
-  "contract_version": "2.4.2",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "token_info"
-    ],
+    "required": ["token_info"],
     "properties": {
       "active_threshold": {
         "description": "The number or percentage of tokens that must be staked for the DAO to be active",
@@ -49,15 +47,11 @@
           {
             "description": "The absolute number of tokens that must be staked for the module to be active.",
             "type": "object",
-            "required": [
-              "absolute_count"
-            ],
+            "required": ["absolute_count"],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": [
-                  "count"
-                ],
+                "required": ["count"],
                 "properties": {
                   "count": {
                     "$ref": "#/definitions/Uint128"
@@ -71,15 +65,11 @@
           {
             "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
             "type": "object",
-            "required": [
-              "percentage"
-            ],
+            "required": ["percentage"],
             "properties": {
               "percentage": {
                 "type": "object",
-                "required": [
-                  "percent"
-                ],
+                "required": ["percent"],
                 "properties": {
                   "percent": {
                     "$ref": "#/definitions/Decimal"
@@ -103,11 +93,7 @@
       "DenomUnit": {
         "description": "DenomUnit represents a struct that describes a given denomination unit of the basic token.",
         "type": "object",
-        "required": [
-          "aliases",
-          "denom",
-          "exponent"
-        ],
+        "required": ["aliases", "denom", "exponent"],
         "properties": {
           "aliases": {
             "description": "aliases is a list of string aliases for the given denom",
@@ -133,9 +119,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -148,9 +132,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -164,10 +146,7 @@
       },
       "InitialBalance": {
         "type": "object",
-        "required": [
-          "address",
-          "amount"
-        ],
+        "required": ["address", "amount"],
         "properties": {
           "address": {
             "type": "string"
@@ -180,19 +159,11 @@
       },
       "NewDenomMetadata": {
         "type": "object",
-        "required": [
-          "description",
-          "display",
-          "name",
-          "symbol"
-        ],
+        "required": ["description", "display", "name", "symbol"],
         "properties": {
           "additional_denom_units": {
             "description": "Used define additional units of the token (e.g. \"tiger\") These must have an exponent larger than 0.",
-            "type": [
-              "array",
-              "null"
-            ],
+            "type": ["array", "null"],
             "items": {
               "$ref": "#/definitions/DenomUnit"
             }
@@ -218,11 +189,7 @@
       },
       "NewTokenInfo": {
         "type": "object",
-        "required": [
-          "initial_balances",
-          "subdenom",
-          "token_issuer_code_id"
-        ],
+        "required": ["initial_balances", "subdenom", "token_issuer_code_id"],
         "properties": {
           "initial_balances": {
             "description": "The initial balances to set for the token, cannot be empty.",
@@ -271,15 +238,11 @@
           {
             "description": "Uses an existing Token Factory token and creates a new issuer contract. Full setup, such as transferring ownership or setting up MsgSetBeforeSendHook, must be done manually.",
             "type": "object",
-            "required": [
-              "existing"
-            ],
+            "required": ["existing"],
             "properties": {
               "existing": {
                 "type": "object",
-                "required": [
-                  "denom"
-                ],
+                "required": ["denom"],
                 "properties": {
                   "denom": {
                     "description": "Token factory denom",
@@ -294,9 +257,7 @@
           {
             "description": "Creates a new Token Factory token via the issue contract with the DAO automatically setup as admin and owner.",
             "type": "object",
-            "required": [
-              "new"
-            ],
+            "required": ["new"],
             "properties": {
               "new": {
                 "$ref": "#/definitions/NewTokenInfo"
@@ -307,9 +268,7 @@
           {
             "description": "Uses a factory contract that must return the denom, optionally a Token Contract address. The binary must serialize to a `WasmMsg::Execute` message. Validation happens in the factory contract itself, so be sure to use a trusted factory contract.",
             "type": "object",
-            "required": [
-              "factory"
-            ],
+            "required": ["factory"],
             "properties": {
               "factory": {
                 "$ref": "#/definitions/Binary"
@@ -332,9 +291,7 @@
       {
         "description": "Stakes tokens with the contract to get voting power in the DAO",
         "type": "object",
-        "required": [
-          "stake"
-        ],
+        "required": ["stake"],
         "properties": {
           "stake": {
             "type": "object",
@@ -346,15 +303,11 @@
       {
         "description": "Unstakes tokens so that they begin unbonding",
         "type": "object",
-        "required": [
-          "unstake"
-        ],
+        "required": ["unstake"],
         "properties": {
           "unstake": {
             "type": "object",
-            "required": [
-              "amount"
-            ],
+            "required": ["amount"],
             "properties": {
               "amount": {
                 "$ref": "#/definitions/Uint128"
@@ -368,9 +321,7 @@
       {
         "description": "Updates the contract configuration",
         "type": "object",
-        "required": [
-          "update_config"
-        ],
+        "required": ["update_config"],
         "properties": {
           "update_config": {
             "type": "object",
@@ -394,9 +345,7 @@
       {
         "description": "Claims unstaked tokens that have completed the unbonding period",
         "type": "object",
-        "required": [
-          "claim"
-        ],
+        "required": ["claim"],
         "properties": {
           "claim": {
             "type": "object",
@@ -408,9 +357,7 @@
       {
         "description": "Sets the active threshold to a new value. Only the instantiator of this contract (a DAO most likely) may call this method.",
         "type": "object",
-        "required": [
-          "update_active_threshold"
-        ],
+        "required": ["update_active_threshold"],
         "properties": {
           "update_active_threshold": {
             "type": "object",
@@ -434,15 +381,11 @@
       {
         "description": "Adds a hook that fires on staking / unstaking",
         "type": "object",
-        "required": [
-          "add_hook"
-        ],
+        "required": ["add_hook"],
         "properties": {
           "add_hook": {
             "type": "object",
-            "required": [
-              "addr"
-            ],
+            "required": ["addr"],
             "properties": {
               "addr": {
                 "type": "string"
@@ -456,15 +399,11 @@
       {
         "description": "Removes a hook that fires on staking / unstaking",
         "type": "object",
-        "required": [
-          "remove_hook"
-        ],
+        "required": ["remove_hook"],
         "properties": {
           "remove_hook": {
             "type": "object",
-            "required": [
-              "addr"
-            ],
+            "required": ["addr"],
             "properties": {
               "addr": {
                 "type": "string"
@@ -483,15 +422,11 @@
           {
             "description": "The absolute number of tokens that must be staked for the module to be active.",
             "type": "object",
-            "required": [
-              "absolute_count"
-            ],
+            "required": ["absolute_count"],
             "properties": {
               "absolute_count": {
                 "type": "object",
-                "required": [
-                  "count"
-                ],
+                "required": ["count"],
                 "properties": {
                   "count": {
                     "$ref": "#/definitions/Uint128"
@@ -505,15 +440,11 @@
           {
             "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
             "type": "object",
-            "required": [
-              "percentage"
-            ],
+            "required": ["percentage"],
             "properties": {
               "percentage": {
                 "type": "object",
-                "required": [
-                  "percent"
-                ],
+                "required": ["percent"],
                 "properties": {
                   "percent": {
                     "$ref": "#/definitions/Decimal"
@@ -535,9 +466,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "height"
-            ],
+            "required": ["height"],
             "properties": {
               "height": {
                 "type": "integer",
@@ -550,9 +479,7 @@
           {
             "description": "Time in seconds",
             "type": "object",
-            "required": [
-              "time"
-            ],
+            "required": ["time"],
             "properties": {
               "time": {
                 "type": "integer",
@@ -576,9 +503,7 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "get_config"
-        ],
+        "required": ["get_config"],
         "properties": {
           "get_config": {
             "type": "object",
@@ -589,15 +514,11 @@
       },
       {
         "type": "object",
-        "required": [
-          "claims"
-        ],
+        "required": ["claims"],
         "properties": {
           "claims": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
@@ -610,26 +531,18 @@
       },
       {
         "type": "object",
-        "required": [
-          "list_stakers"
-        ],
+        "required": ["list_stakers"],
         "properties": {
           "list_stakers": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -639,9 +552,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "active_threshold"
-        ],
+        "required": ["active_threshold"],
         "properties": {
           "active_threshold": {
             "type": "object",
@@ -652,9 +563,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "get_hooks"
-        ],
+        "required": ["get_hooks"],
         "properties": {
           "get_hooks": {
             "type": "object",
@@ -665,9 +574,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "token_contract"
-        ],
+        "required": ["token_contract"],
         "properties": {
           "token_contract": {
             "type": "object",
@@ -678,9 +585,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "denom"
-        ],
+        "required": ["denom"],
         "properties": {
           "denom": {
             "type": "object",
@@ -691,9 +596,7 @@
       },
       {
         "type": "object",
-        "required": [
-          "is_active"
-        ],
+        "required": ["is_active"],
         "properties": {
           "is_active": {
             "type": "object",
@@ -705,24 +608,17 @@
       {
         "description": "Returns the voting power for an address at a given height.",
         "type": "object",
-        "required": [
-          "voting_power_at_height"
-        ],
+        "required": ["voting_power_at_height"],
         "properties": {
           "voting_power_at_height": {
             "type": "object",
-            "required": [
-              "address"
-            ],
+            "required": ["address"],
             "properties": {
               "address": {
                 "type": "string"
               },
               "height": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -735,18 +631,13 @@
       {
         "description": "Returns the total voting power at a given block heigh.",
         "type": "object",
-        "required": [
-          "total_power_at_height"
-        ],
+        "required": ["total_power_at_height"],
         "properties": {
           "total_power_at_height": {
             "type": "object",
             "properties": {
               "height": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -759,9 +650,7 @@
       {
         "description": "Returns the address of the DAO this module belongs to.",
         "type": "object",
-        "required": [
-          "dao"
-        ],
+        "required": ["dao"],
         "properties": {
           "dao": {
             "type": "object",
@@ -773,9 +662,7 @@
       {
         "description": "Returns contract version info.",
         "type": "object",
-        "required": [
-          "info"
-        ],
+        "required": ["info"],
         "properties": {
           "info": {
             "type": "object",
@@ -818,15 +705,11 @@
             {
               "description": "The absolute number of tokens that must be staked for the module to be active.",
               "type": "object",
-              "required": [
-                "absolute_count"
-              ],
+              "required": ["absolute_count"],
               "properties": {
                 "absolute_count": {
                   "type": "object",
-                  "required": [
-                    "count"
-                  ],
+                  "required": ["count"],
                   "properties": {
                     "count": {
                       "$ref": "#/definitions/Uint128"
@@ -840,15 +723,11 @@
             {
               "description": "The percentage of tokens that must be staked for the module to be active. Computed as `staked / total_supply`.",
               "type": "object",
-              "required": [
-                "percentage"
-              ],
+              "required": ["percentage"],
               "properties": {
                 "percentage": {
                   "type": "object",
-                  "required": [
-                    "percent"
-                  ],
+                  "required": ["percent"],
                   "properties": {
                     "percent": {
                       "$ref": "#/definitions/Decimal"
@@ -875,9 +754,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ClaimsResponse",
       "type": "object",
-      "required": [
-        "claims"
-      ],
+      "required": ["claims"],
       "properties": {
         "claims": {
           "type": "array",
@@ -890,10 +767,7 @@
       "definitions": {
         "Claim": {
           "type": "object",
-          "required": [
-            "amount",
-            "release_at"
-          ],
+          "required": ["amount", "release_at"],
           "properties": {
             "amount": {
               "$ref": "#/definitions/Uint128"
@@ -910,9 +784,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -925,9 +797,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -938,9 +808,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",
@@ -979,9 +847,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "DenomResponse",
       "type": "object",
-      "required": [
-        "denom"
-      ],
+      "required": ["denom"],
       "properties": {
         "denom": {
           "type": "string"
@@ -1012,9 +878,7 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "height"
-              ],
+              "required": ["height"],
               "properties": {
                 "height": {
                   "type": "integer",
@@ -1027,9 +891,7 @@
             {
               "description": "Time in seconds",
               "type": "object",
-              "required": [
-                "time"
-              ],
+              "required": ["time"],
               "properties": {
                 "time": {
                   "type": "integer",
@@ -1047,9 +909,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "GetHooksResponse",
       "type": "object",
-      "required": [
-        "hooks"
-      ],
+      "required": ["hooks"],
       "properties": {
         "hooks": {
           "type": "array",
@@ -1064,9 +924,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "InfoResponse",
       "type": "object",
-      "required": [
-        "info"
-      ],
+      "required": ["info"],
       "properties": {
         "info": {
           "$ref": "#/definitions/ContractVersion"
@@ -1076,10 +934,7 @@
       "definitions": {
         "ContractVersion": {
           "type": "object",
-          "required": [
-            "contract",
-            "version"
-          ],
+          "required": ["contract", "version"],
           "properties": {
             "contract": {
               "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
@@ -1103,9 +958,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ListStakersResponse",
       "type": "object",
-      "required": [
-        "stakers"
-      ],
+      "required": ["stakers"],
       "properties": {
         "stakers": {
           "type": "array",
@@ -1118,10 +971,7 @@
       "definitions": {
         "StakerBalanceResponse": {
           "type": "object",
-          "required": [
-            "address",
-            "balance"
-          ],
+          "required": ["address", "balance"],
           "properties": {
             "address": {
               "type": "string"
@@ -1160,10 +1010,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "TotalPowerAtHeightResponse",
       "type": "object",
-      "required": [
-        "height",
-        "power"
-      ],
+      "required": ["height", "power"],
       "properties": {
         "height": {
           "type": "integer",
@@ -1186,10 +1033,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "VotingPowerAtHeightResponse",
       "type": "object",
-      "required": [
-        "height",
-        "power"
-      ],
+      "required": ["height", "power"],
       "properties": {
         "height": {
           "type": "integer",

--- a/packages/dao-pre-propose-base/src/error.rs
+++ b/packages/dao-pre-propose-base/src/error.rs
@@ -26,16 +26,13 @@ pub enum PreProposeError {
     ParseReplyError(#[from] ParseReplyError),
 
     #[error(transparent)]
-    PreProposeSubmissionPolicyError(#[from] PreProposeSubmissionPolicyError),
+    SubmissionPolicy(#[from] PreProposeSubmissionPolicyError),
 
     #[error("Message sender is not proposal module")]
     NotModule {},
 
     #[error("Message sender is not dao")]
     NotDao {},
-
-    #[error("You must be a member of this DAO (have voting power) to create a proposal")]
-    NotMember {},
 
     #[error("No denomination for withdrawal. specify a denomination to withdraw")]
     NoWithdrawalDenom {},

--- a/packages/dao-pre-propose-base/src/error.rs
+++ b/packages/dao-pre-propose-base/src/error.rs
@@ -4,7 +4,9 @@ use cw_utils::ParseReplyError;
 use thiserror::Error;
 
 use cw_hooks::HookError;
-use dao_voting::{deposit::DepositError, status::Status};
+use dao_voting::{
+    deposit::DepositError, pre_propose::PreProposeSubmissionPolicyError, status::Status,
+};
 
 #[derive(Error, Debug, PartialEq)]
 pub enum PreProposeError {
@@ -22,6 +24,9 @@ pub enum PreProposeError {
 
     #[error(transparent)]
     ParseReplyError(#[from] ParseReplyError),
+
+    #[error(transparent)]
+    PreProposeSubmissionPolicyError(#[from] PreProposeSubmissionPolicyError),
 
     #[error("Message sender is not proposal module")]
     NotModule {},

--- a/packages/dao-pre-propose-base/src/error.rs
+++ b/packages/dao-pre-propose-base/src/error.rs
@@ -51,4 +51,7 @@ pub enum PreProposeError {
 
     #[error("An unknown reply ID was received.")]
     UnknownReplyID {},
+
+    #[error("Unsupported")]
+    Unsupported {},
 }

--- a/packages/dao-pre-propose-base/src/execute.rs
+++ b/packages/dao-pre-propose-base/src/execute.rs
@@ -358,14 +358,14 @@ where
                     },
                 )?;
                 if voting_power.power.is_zero() {
-                    return Err(PreProposeError::PreProposeSubmissionPolicyError(
+                    return Err(PreProposeError::SubmissionPolicy(
                         PreProposeSubmissionPolicyError::UnauthorizedDaoMembers {},
                     ));
                 }
             }
             PreProposeSubmissionPolicy::Allowlist { addresses } => {
                 if !addresses.contains(&who) {
-                    return Err(PreProposeError::PreProposeSubmissionPolicyError(
+                    return Err(PreProposeError::SubmissionPolicy(
                         PreProposeSubmissionPolicyError::UnauthorizedAllowlist {},
                     ));
                 }

--- a/packages/dao-pre-propose-base/src/msg.rs
+++ b/packages/dao-pre-propose-base/src/msg.rs
@@ -125,6 +125,9 @@ where
     /// PROPOSAL_ID.
     #[returns(DepositInfoResponse)]
     DepositInfo { proposal_id: u64 },
+    /// Returns whether or not the address can submit proposals.
+    #[returns(bool)]
+    CanPropose { address: String },
     /// Returns list of proposal submitted hooks.
     #[returns(cw_hooks::HooksResponse)]
     ProposalSubmittedHooks {},

--- a/packages/dao-pre-propose-base/src/msg.rs
+++ b/packages/dao-pre-propose-base/src/msg.rs
@@ -30,7 +30,6 @@ pub enum ExecuteMsg<ProposalMessage, ExecuteExt> {
     /// updated. Only the DAO may execute this message.
     UpdateConfig {
         deposit_info: Option<UncheckedDepositInfo>,
-        // TODO(pre-propose-submission-policy): allow optional updates like timewave
         submission_policy: PreProposeSubmissionPolicy,
     },
 

--- a/packages/dao-pre-propose-base/src/msg.rs
+++ b/packages/dao-pre-propose-base/src/msg.rs
@@ -29,8 +29,25 @@ pub enum ExecuteMsg<ProposalMessage, ExecuteExt> {
     /// will only apply to proposals created after the config is
     /// updated. Only the DAO may execute this message.
     UpdateConfig {
+        /// If None, will remove the deposit. Backwards compatible.
         deposit_info: Option<UncheckedDepositInfo>,
-        submission_policy: PreProposeSubmissionPolicy,
+        /// If None, will leave the submission policy in the config as-is.
+        submission_policy: Option<PreProposeSubmissionPolicy>,
+    },
+
+    /// Perform more granular submission policy updates to allow for atomic
+    /// operations that don't override others.
+    UpdateSubmissionPolicy {
+        /// Optionally add to the denylist. Works for any submission policy.
+        denylist_add: Option<Vec<String>>,
+        /// Optionally remove from denylist. Works for any submission policy.
+        denylist_remove: Option<Vec<String>>,
+        /// If using specific policy, optionally update the `dao_members` flag.
+        set_dao_members: Option<bool>,
+        /// If using specific policy, optionally add to the allowlist.
+        allowlist_add: Option<Vec<String>>,
+        /// If using specific policy, optionally remove from the allowlist.
+        allowlist_remove: Option<Vec<String>>,
     },
 
     /// Withdraws funds inside of this contract to the message

--- a/packages/dao-pre-propose-base/src/msg.rs
+++ b/packages/dao-pre-propose-base/src/msg.rs
@@ -2,6 +2,7 @@ use cosmwasm_schema::{cw_serde, schemars::JsonSchema, QueryResponses};
 use cw_denom::UncheckedDenom;
 use dao_voting::{
     deposit::{CheckedDepositInfo, UncheckedDepositInfo},
+    pre_propose::PreProposeSubmissionPolicy,
     status::Status,
 };
 
@@ -10,10 +11,8 @@ pub struct InstantiateMsg<InstantiateExt> {
     /// Information about the deposit requirements for this
     /// module. None if no deposit.
     pub deposit_info: Option<UncheckedDepositInfo>,
-    /// If false, only members (addresses with voting power) may create
-    /// proposals in the DAO. Otherwise, any address may create a
-    /// proposal so long as they pay the deposit.
-    pub open_proposal_submission: bool,
+    /// The policy dictating who is allowed to submit proposals.
+    pub submission_policy: PreProposeSubmissionPolicy,
     /// Extension for instantiation. The default implementation will
     /// do nothing with this data.
     pub extension: InstantiateExt,
@@ -31,7 +30,8 @@ pub enum ExecuteMsg<ProposalMessage, ExecuteExt> {
     /// updated. Only the DAO may execute this message.
     UpdateConfig {
         deposit_info: Option<UncheckedDepositInfo>,
-        open_proposal_submission: bool,
+        // TODO(pre-propose-submission-policy): allow optional updates like timewave
+        submission_policy: PreProposeSubmissionPolicy,
     },
 
     /// Withdraws funds inside of this contract to the message

--- a/packages/dao-pre-propose-base/src/state.rs
+++ b/packages/dao-pre-propose-base/src/state.rs
@@ -5,17 +5,15 @@ use cosmwasm_std::Addr;
 use cw_hooks::Hooks;
 use cw_storage_plus::{Item, Map};
 
-use dao_voting::deposit::CheckedDepositInfo;
+use dao_voting::{deposit::CheckedDepositInfo, pre_propose::PreProposeSubmissionPolicy};
 
 #[cw_serde]
 pub struct Config {
     /// Information about the deposit required to create a
     /// proposal. If `None`, no deposit is required.
     pub deposit_info: Option<CheckedDepositInfo>,
-    /// If false, only members (addresses with voting power) may create
-    /// proposals in the DAO. Otherwise, any address may create a
-    /// proposal so long as they pay the deposit.
-    pub open_proposal_submission: bool,
+    /// The policy dictating who is allowed to submit proposals.
+    pub submission_policy: PreProposeSubmissionPolicy,
 }
 
 pub struct PreProposeContract<InstantiateExt, ExecuteExt, QueryExt, ProposalMessage> {

--- a/packages/dao-pre-propose-base/src/tests.rs
+++ b/packages/dao-pre-propose-base/src/tests.rs
@@ -87,7 +87,7 @@ fn test_proposal_submitted_hooks() {
             &mut deps.storage,
             &Config {
                 deposit_info: None,
-                submission_policy: PreProposeSubmissionPolicy::Anyone {},
+                submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
             },
         )
         .unwrap();

--- a/packages/dao-pre-propose-base/src/tests.rs
+++ b/packages/dao-pre-propose-base/src/tests.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{
     to_json_binary, Addr, Binary, ContractResult, Empty, Response, SubMsg, WasmMsg,
 };
 use cw_hooks::HooksResponse;
-use dao_voting::status::Status;
+use dao_voting::{pre_propose::PreProposeSubmissionPolicy, status::Status};
 
 use crate::{
     error::PreProposeError,
@@ -87,7 +87,7 @@ fn test_proposal_submitted_hooks() {
             &mut deps.storage,
             &Config {
                 deposit_info: None,
-                open_proposal_submission: true,
+                submission_policy: PreProposeSubmissionPolicy::Anyone {},
             },
         )
         .unwrap();

--- a/packages/dao-voting/src/pre_propose.rs
+++ b/packages/dao-voting/src/pre_propose.rs
@@ -63,7 +63,7 @@ impl PreProposeInfo {
 }
 
 // TODO(pre-propose-submission-policy):
-// - add tests for the allowlist
+// - add tests for the allowlist and dao_members flags under the anyone denylist test
 
 /// The policy configured in a pre-propose module that determines who can submit
 /// proposals. This is the preferred way to restrict proposal creation (as
@@ -97,6 +97,9 @@ pub enum PreProposeSubmissionPolicyError {
 
     #[error("You are not allowed to submit proposals")]
     Unauthorized {},
+
+    #[error("The current proposal submission policy (Anyone) only supports a denylist. Change the policy to Specific in order to configure more granular permissions.")]
+    AnyoneInvalidUpdateFields {},
 }
 
 impl PreProposeSubmissionPolicy {

--- a/packages/dao-voting/src/pre_propose.rs
+++ b/packages/dao-voting/src/pre_propose.rs
@@ -63,7 +63,6 @@ impl PreProposeInfo {
 }
 
 // TODO(pre-propose-submission-policy):
-// - add executions that add/remove individual addresses to/from the allowlist
 // - add tests for the allowlist
 
 /// The policy configured in a pre-propose module that determines who can submit
@@ -75,16 +74,16 @@ pub enum PreProposeSubmissionPolicy {
     /// Anyone may create proposals, except for those in the denylist.
     Anyone {
         /// Addresses that may not create proposals.
-        denylist: Option<Vec<Addr>>,
+        denylist: Option<Vec<String>>,
     },
     /// Specific people may create proposals.
     Specific {
         /// Whether or not DAO members may create proposals.
         dao_members: bool,
         /// Addresses that may create proposals.
-        allowlist: Option<Vec<Addr>>,
+        allowlist: Option<Vec<String>>,
         /// Addresses that may not create proposals, overriding other settings.
-        denylist: Option<Vec<Addr>>,
+        denylist: Option<Vec<String>>,
     },
 }
 

--- a/packages/dao-voting/src/pre_propose.rs
+++ b/packages/dao-voting/src/pre_propose.rs
@@ -62,9 +62,6 @@ impl PreProposeInfo {
     }
 }
 
-// TODO(pre-propose-submission-policy):
-// - add tests for the allowlist and dao_members flags under the anyone denylist test
-
 /// The policy configured in a pre-propose module that determines who can submit
 /// proposals. This is the preferred way to restrict proposal creation (as
 /// opposed to the ProposalCreationPolicy above) since pre-propose modules


### PR DESCRIPTION
Resolves #841 

This makes it possible to specify exactly who can create proposals, by allowing the pre-propose modules to configure:
- whether or not DAO members can submit proposals
- an allowlist
- a denylist that overrides the other two settings

It also bumps the contract versions to v2.5.0