### PR TITLE
Support instantiate2 in `cw-admin-factory`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,7 @@ dependencies = [
 name = "cw-admin-factory"
 version = "2.5.0"
 dependencies = [
+ "bech32",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-admin-factory",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,13 +692,20 @@ version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-admin-factory",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20-base 1.1.2",
+ "cw4 1.1.2",
  "dao-dao-core",
  "dao-interface",
+ "dao-proposal-single",
+ "dao-testing",
+ "dao-voting 2.5.0",
+ "dao-voting-cw4",
+ "osmosis-test-tube",
  "thiserror",
 ]
 
@@ -2013,6 +2020,7 @@ version = "2.5.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
+ "cw-admin-factory",
  "cw-core",
  "cw-hooks",
  "cw-multi-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ overflow-checks = true
 [workspace.dependencies]
 anyhow = { version = "1.0" }
 assert_matches = "1.5"
+bech32 = "0.9.1"
 cosm-orc = { version = "4.0" }
 cosm-tome = "0.2"
 cosmos-sdk-proto = "0.19"

--- a/contracts/external/cw-admin-factory/Cargo.toml
+++ b/contracts/external/cw-admin-factory/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name ="cw-admin-factory"
+name = "cw-admin-factory"
 authors = ["Jake Hartnell", "blue-note", "ekez <ekez@withoutdoing.com>"]
 description = "A CosmWasm factory contract for instantiating a contract as its own admin."
 edition = { workspace = true }
@@ -17,7 +17,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = { workspace = true }
+cosmwasm-std = { workspace = true, features = ["cosmwasm_1_2"] }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }

--- a/contracts/external/cw-admin-factory/Cargo.toml
+++ b/contracts/external/cw-admin-factory/Cargo.toml
@@ -30,6 +30,7 @@ thiserror = { workspace = true }
 cw-utils = { workspace = true }
 
 [dev-dependencies]
+bech32 = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw-admin-factory = { workspace = true }
 cw-multi-test = { workspace = true }

--- a/contracts/external/cw-admin-factory/Cargo.toml
+++ b/contracts/external/cw-admin-factory/Cargo.toml
@@ -15,6 +15,11 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query exports
 library = []
+# use test tube feature to enable test-tube integration tests, for example
+# cargo test --features "test-tube"
+test-tube = []
+# when writing tests you may wish to enable test-tube as a default feature
+# default = ["test-tube"]
 
 [dependencies]
 cosmwasm-std = { workspace = true, features = ["cosmwasm_1_2"] }
@@ -26,7 +31,14 @@ cw-utils = { workspace = true }
 
 [dev-dependencies]
 cosmwasm-schema = { workspace = true }
+cw-admin-factory = { workspace = true }
 cw-multi-test = { workspace = true }
+cw20-base = { workspace = true, features = ["library"] }
+cw4 = { workspace = true }
 dao-dao-core = { workspace = true, features = ["library"] }
 dao-interface = { workspace = true }
-cw20-base = { workspace = true, features = ["library"] }
+dao-proposal-single = { workspace = true }
+dao-testing = { workspace = true }
+dao-voting = { workspace = true }
+dao-voting-cw4 = { workspace = true }
+osmosis-test-tube = { workspace = true }

--- a/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
+++ b/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
@@ -22,7 +22,7 @@
     "title": "ExecuteMsg",
     "oneOf": [
       {
-        "description": "Instantiates the target contract with the provided instantiate message and code id and updates the contract's admin to be itself.",
+        "description": "Instantiates the target contract with the provided instantiate message, code ID, and label and updates the contract's admin to be itself.",
         "type": "object",
         "required": [
           "instantiate_contract_with_self_admin"
@@ -46,6 +46,49 @@
               },
               "label": {
                 "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Instantiates the target contract with the provided instantiate message, code ID, label, and salt, via instantiate2 to give a predictable address, and updates the contract's admin to be itself.",
+        "type": "object",
+        "required": [
+          "instantiate2_contract_with_self_admin"
+        ],
+        "properties": {
+          "instantiate2_contract_with_self_admin": {
+            "type": "object",
+            "required": [
+              "code_id",
+              "instantiate_msg",
+              "label",
+              "salt"
+            ],
+            "properties": {
+              "code_id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "expect": {
+                "description": "Optionally specify the expected address and fail if it doesn't match the instantiated contract. This makes it easy for a consumer to validate that they are using the correct address elsewhere.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "instantiate_msg": {
+                "$ref": "#/definitions/Binary"
+              },
+              "label": {
+                "type": "string"
+              },
+              "salt": {
+                "$ref": "#/definitions/Binary"
               }
             },
             "additionalProperties": false

--- a/contracts/external/cw-admin-factory/src/contract.rs
+++ b/contracts/external/cw-admin-factory/src/contract.rs
@@ -121,7 +121,7 @@ pub fn instantiate2_contract(
         salt,
     };
 
-    let msg = SubMsg::reply_on_success(instantiate, INSTANTIATE_CONTRACT_REPLY_ID);
+    let msg = SubMsg::reply_on_success(instantiate, INSTANTIATE2_CONTRACT_REPLY_ID);
     Ok(Response::default()
         .add_attribute("action", "instantiate2_contract_with_self_admin")
         .add_submessage(msg))

--- a/contracts/external/cw-admin-factory/src/contract.rs
+++ b/contracts/external/cw-admin-factory/src/contract.rs
@@ -10,11 +10,13 @@ use cw_utils::parse_reply_instantiate_data;
 
 use crate::error::ContractError;
 use crate::msg::{AdminResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
-use crate::state::ADMIN;
+use crate::state::{ADMIN, EXPECT};
 
 pub(crate) const CONTRACT_NAME: &str = "crates.io:cw-admin-factory";
 pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub const INSTANTIATE_CONTRACT_REPLY_ID: u64 = 0;
+pub const INSTANTIATE2_CONTRACT_REPLY_ID: u64 = 2;
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
@@ -46,6 +48,13 @@ pub fn execute(
             code_id,
             label,
         } => instantiate_contract(deps, env, info, msg, code_id, label),
+        ExecuteMsg::Instantiate2ContractWithSelfAdmin {
+            instantiate_msg: msg,
+            code_id,
+            label,
+            salt,
+            expect,
+        } => instantiate2_contract(deps, env, info, msg, code_id, label, salt, expect),
     }
 }
 
@@ -75,7 +84,46 @@ pub fn instantiate_contract(
 
     let msg = SubMsg::reply_on_success(instantiate, INSTANTIATE_CONTRACT_REPLY_ID);
     Ok(Response::default()
-        .add_attribute("action", "instantiate_cw_core")
+        .add_attribute("action", "instantiate_contract_with_self_admin")
+        .add_submessage(msg))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn instantiate2_contract(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    instantiate_msg: Binary,
+    code_id: u64,
+    label: String,
+    salt: Binary,
+    expect: Option<String>,
+) -> Result<Response, ContractError> {
+    // If admin set, require the sender to be the admin.
+    if let Some(admin) = ADMIN.load(deps.storage)? {
+        if admin != info.sender {
+            return Err(ContractError::Unauthorized {});
+        }
+    }
+
+    if let Some(expect) = expect {
+        let expect = deps.api.addr_validate(&expect)?;
+        EXPECT.save(deps.storage, &expect)?;
+    }
+
+    // Instantiate the specified contract with factory as the admin.
+    let instantiate = WasmMsg::Instantiate2 {
+        admin: Some(env.contract.address.to_string()),
+        code_id,
+        msg: instantiate_msg,
+        funds: info.funds,
+        label,
+        salt,
+    };
+
+    let msg = SubMsg::reply_on_success(instantiate, INSTANTIATE_CONTRACT_REPLY_ID);
+    Ok(Response::default()
+        .add_attribute("action", "instantiate2_contract_with_self_admin")
         .add_submessage(msg))
 }
 
@@ -90,10 +138,26 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
-    match msg.id {
-        INSTANTIATE_CONTRACT_REPLY_ID => {
+    let msg_id = msg.id;
+    match msg_id {
+        INSTANTIATE_CONTRACT_REPLY_ID | INSTANTIATE2_CONTRACT_REPLY_ID => {
             let res = parse_reply_instantiate_data(msg)?;
             let contract_addr = deps.api.addr_validate(&res.contract_address)?;
+
+            if msg_id == INSTANTIATE2_CONTRACT_REPLY_ID {
+                // If saved an expected address, verify it matches and clear it.
+                let expect = EXPECT.may_load(deps.storage)?;
+                if let Some(expect) = expect {
+                    EXPECT.remove(deps.storage);
+                    if contract_addr != expect {
+                        return Err(ContractError::UnexpectedContractAddress {
+                            expected: expect.to_string(),
+                            actual: contract_addr.to_string(),
+                        });
+                    }
+                }
+            }
+
             // Make the contract its own admin.
             let msg = WasmMsg::UpdateAdmin {
                 contract_addr: contract_addr.to_string(),

--- a/contracts/external/cw-admin-factory/src/error.rs
+++ b/contracts/external/cw-admin-factory/src/error.rs
@@ -15,4 +15,7 @@ pub enum ContractError {
 
     #[error("An unknown reply ID was received.")]
     UnknownReplyID {},
+
+    #[error("Expected contract address {expected} but instantiated {actual}.")]
+    UnexpectedContractAddress { expected: String, actual: String },
 }

--- a/contracts/external/cw-admin-factory/src/integration_tests.rs
+++ b/contracts/external/cw-admin-factory/src/integration_tests.rs
@@ -215,18 +215,17 @@ fn test_set_self_admin_instantiate2() {
                 code_id: dao_dao_core_id,
                 label: "third".to_string(),
                 salt: salt.clone(),
-                expect: Some("wrong".to_string()),
+                expect: Some(cw_admin_factory.contract_addr.clone()),
             },
             &[],
             &accounts[0],
         )
         .unwrap_err();
-
     assert_eq!(
         err,
         RunnerError::ExecuteError {
             msg: ContractError::UnexpectedContractAddress {
-                expected: "wrong".to_string(),
+                expected: cw_admin_factory.contract_addr.clone(),
                 actual: actual_addr.to_string(),
             }
             .to_string()
@@ -244,5 +243,5 @@ fn addr_canonicalize(prefix: &str, input: &str) -> CanonicalAddr {
 
 fn addr_humanize(prefix: &str, canonical: &CanonicalAddr) -> Addr {
     let encoded = encode(prefix, canonical.as_slice().to_base32(), Variant::Bech32).unwrap();
-    return Addr::unchecked(encoded);
+    Addr::unchecked(encoded)
 }

--- a/contracts/external/cw-admin-factory/src/integration_tests.rs
+++ b/contracts/external/cw-admin-factory/src/integration_tests.rs
@@ -1,0 +1,214 @@
+use cosmwasm_std::{
+    instantiate2_address, testing::mock_dependencies, to_json_binary, Api, Binary, Coin, Decimal,
+};
+use cw_utils::Duration;
+use dao_interface::state::{Admin, ModuleInstantiateInfo};
+use dao_testing::test_tube::{
+    cw4_group::Cw4Group, cw_admin_factory::CwAdminFactory, dao_dao_core::DaoCore,
+    dao_proposal_single::DaoProposalSingle, dao_voting_cw4::DaoVotingCw4,
+};
+use dao_voting::{
+    pre_propose::PreProposeInfo,
+    threshold::{PercentageThreshold, Threshold},
+};
+use osmosis_test_tube::{
+    osmosis_std::types::cosmwasm::wasm::v1::{
+        QueryCodeRequest, QueryCodeResponse, QueryContractInfoRequest, QueryContractInfoResponse,
+    },
+    Account, OsmosisTestApp, Runner, RunnerError,
+};
+
+use cw_admin_factory::msg::ExecuteMsg;
+
+use crate::ContractError;
+
+#[test]
+fn test_set_self_admin_instantiate2() {
+    let app = OsmosisTestApp::new();
+    let accounts = app
+        .init_accounts(&[Coin::new(1000000000000000u128, "uosmo")], 10)
+        .unwrap();
+
+    let cw_admin_factory = CwAdminFactory::new(&app, None, &accounts[0], &[]).unwrap();
+    let dao_dao_core_id = DaoCore::upload(&app, &accounts[0]).unwrap();
+    let cw4_group_id = Cw4Group::upload(&app, &accounts[0]).unwrap();
+    let dao_voting_cw4_id = DaoVotingCw4::upload(&app, &accounts[0]).unwrap();
+    let proposal_single_id = DaoProposalSingle::upload(&app, &accounts[0]).unwrap();
+
+    // Get DAO core checksum
+    let dao_core_checksum = app
+        .query::<QueryCodeRequest, QueryCodeResponse>(
+            "/cosmwasm.wasm.v1.Query/Code",
+            &QueryCodeRequest {
+                code_id: dao_dao_core_id,
+            },
+        )
+        .unwrap()
+        .code_info
+        .unwrap()
+        .data_hash;
+
+    let msg = dao_interface::msg::InstantiateMsg {
+        dao_uri: None,
+        admin: None,
+        name: "DAO DAO".to_string(),
+        description: "A DAO that makes DAO tooling".to_string(),
+        image_url: None,
+        automatically_add_cw20s: false,
+        automatically_add_cw721s: false,
+        voting_module_instantiate_info: ModuleInstantiateInfo {
+            code_id: dao_voting_cw4_id,
+            msg: to_json_binary(&dao_voting_cw4::msg::InstantiateMsg {
+                group_contract: dao_voting_cw4::msg::GroupContract::New {
+                    cw4_group_code_id: cw4_group_id,
+                    initial_members: vec![cw4::Member {
+                        addr: accounts[0].address(),
+                        weight: 1,
+                    }],
+                },
+            })
+            .unwrap(),
+            admin: Some(Admin::CoreModule {}),
+            funds: vec![],
+            label: "DAO DAO Voting Module".to_string(),
+        },
+        proposal_modules_instantiate_info: vec![ModuleInstantiateInfo {
+            code_id: proposal_single_id,
+            msg: to_json_binary(&dao_proposal_single::msg::InstantiateMsg {
+                min_voting_period: None,
+                threshold: Threshold::ThresholdQuorum {
+                    threshold: PercentageThreshold::Majority {},
+                    quorum: PercentageThreshold::Percent(Decimal::percent(35)),
+                },
+                max_voting_period: Duration::Time(432000),
+                allow_revoting: false,
+                only_members_execute: true,
+                close_proposal_on_execution_failure: false,
+                pre_propose_info: PreProposeInfo::AnyoneMayPropose {},
+                veto: None,
+            })
+            .unwrap(),
+            admin: Some(Admin::CoreModule {}),
+            funds: vec![],
+            label: "DAO DAO Proposal Module".to_string(),
+        }],
+        initial_items: None,
+    };
+
+    let salt = Binary::from("salt".as_bytes());
+    let res = cw_admin_factory
+        .execute(
+            &ExecuteMsg::Instantiate2ContractWithSelfAdmin {
+                instantiate_msg: to_json_binary(&msg).unwrap(),
+                code_id: dao_dao_core_id,
+                label: "first".to_string(),
+                salt: salt.clone(),
+                expect: None,
+            },
+            &[],
+            &accounts[0],
+        )
+        .unwrap();
+    let instantiate_event = &res.events[2];
+    assert_eq!(instantiate_event.ty, "instantiate");
+    let core_addr = instantiate_event.attributes[0].value.clone();
+
+    // Check that admin of core address is itself
+    let core_admin = app
+        .query::<QueryContractInfoRequest, QueryContractInfoResponse>(
+            "/cosmwasm.wasm.v1.Query/ContractInfo",
+            &QueryContractInfoRequest {
+                address: core_addr.clone(),
+            },
+        )
+        .unwrap()
+        .contract_info
+        .unwrap()
+        .admin;
+    assert_eq!(core_admin, core_addr.clone());
+
+    let deps = mock_dependencies();
+
+    // Check that the address matches the predicted address
+    let canonical_factory = deps
+        .api
+        .addr_canonicalize(&cw_admin_factory.contract_addr)
+        .unwrap();
+    let expected_addr =
+        instantiate2_address(&dao_core_checksum, &canonical_factory, salt.as_slice()).unwrap();
+    let canonical_core = deps.api.addr_canonicalize(&core_addr).unwrap();
+    assert_eq!(canonical_core, expected_addr);
+
+    // Check that it succeeds when expect matches.
+    let salt = Binary::from("salt_two".as_bytes());
+    let expected_addr = deps
+        .api
+        .addr_humanize(
+            &instantiate2_address(&dao_core_checksum, &canonical_factory, salt.as_slice()).unwrap(),
+        )
+        .unwrap();
+    let res = cw_admin_factory
+        .execute(
+            &ExecuteMsg::Instantiate2ContractWithSelfAdmin {
+                instantiate_msg: to_json_binary(&msg).unwrap(),
+                code_id: dao_dao_core_id,
+                label: "second".to_string(),
+                salt: salt.clone(),
+                expect: Some(expected_addr.to_string()),
+            },
+            &[],
+            &accounts[0],
+        )
+        .unwrap();
+    let instantiate_event = &res.events[2];
+    assert_eq!(instantiate_event.ty, "instantiate");
+    let core_addr = instantiate_event.attributes[0].value.clone();
+    assert_eq!(core_addr, expected_addr);
+
+    // Check that admin of core address is itself
+    let core_admin = app
+        .query::<QueryContractInfoRequest, QueryContractInfoResponse>(
+            "/cosmwasm.wasm.v1.Query/ContractInfo",
+            &QueryContractInfoRequest {
+                address: core_addr.clone(),
+            },
+        )
+        .unwrap()
+        .contract_info
+        .unwrap()
+        .admin;
+    assert_eq!(core_admin, core_addr.clone());
+
+    // Check that it fails when expect does not match.
+    let salt = Binary::from("salt_mismatch".as_bytes());
+    let actual_addr = deps
+        .api
+        .addr_humanize(
+            &instantiate2_address(&dao_core_checksum, &canonical_factory, salt.as_slice()).unwrap(),
+        )
+        .unwrap();
+    let err = cw_admin_factory
+        .execute(
+            &ExecuteMsg::Instantiate2ContractWithSelfAdmin {
+                instantiate_msg: to_json_binary(&msg).unwrap(),
+                code_id: dao_dao_core_id,
+                label: "third".to_string(),
+                salt: salt.clone(),
+                expect: Some("wrong".to_string()),
+            },
+            &[],
+            &accounts[0],
+        )
+        .unwrap_err();
+
+    assert_eq!(
+        err,
+        RunnerError::ExecuteError {
+            msg: ContractError::UnexpectedContractAddress {
+                expected: "wrong".to_string(),
+                actual: actual_addr.to_string(),
+            }
+            .to_string()
+        },
+    );
+}

--- a/contracts/external/cw-admin-factory/src/integration_tests.rs
+++ b/contracts/external/cw-admin-factory/src/integration_tests.rs
@@ -1,6 +1,5 @@
 use cosmwasm_std::{
-    instantiate2_address, testing::mock_dependencies, to_json_binary, Addr, Api, Binary, Coin,
-    Decimal,
+    instantiate2_address, testing::mock_dependencies, to_json_binary, Api, Binary, Coin, Decimal,
 };
 use cw_utils::Duration;
 use dao_interface::state::{Admin, ModuleInstantiateInfo};
@@ -139,7 +138,7 @@ fn test_set_self_admin_instantiate2() {
         .contract_info
         .unwrap()
         .admin;
-    assert_eq!(core_admin, core_addr.to_string());
+    assert_eq!(&core_admin, core_addr);
 
     let deps = mock_dependencies();
 
@@ -148,10 +147,13 @@ fn test_set_self_admin_instantiate2() {
         .api
         .addr_canonicalize(&cw_admin_factory.contract_addr)
         .unwrap();
-    let expected_addr =
-        instantiate2_address(&dao_core_checksum, &canonical_factory, salt.as_slice()).unwrap();
-    let canonical_core = deps.api.addr_canonicalize(core_addr).unwrap();
-    assert_eq!(canonical_core, expected_addr);
+    let expected_addr = deps
+        .api
+        .addr_humanize(
+            &instantiate2_address(&dao_core_checksum, &canonical_factory, salt.as_slice()).unwrap(),
+        )
+        .unwrap();
+    assert_eq!(core_addr, expected_addr.as_str());
 
     // Check that it succeeds when expect matches.
     let salt = Binary::from("salt_two".as_bytes());
@@ -189,7 +191,7 @@ fn test_set_self_admin_instantiate2() {
         .find(|a| a.key == "_contract_address")
         .unwrap()
         .value;
-    assert_eq!(Addr::unchecked(core_addr), expected_addr);
+    assert_eq!(core_addr, expected_addr.as_str());
 
     // Check that admin of core address is itself
     let core_admin = app
@@ -203,7 +205,7 @@ fn test_set_self_admin_instantiate2() {
         .contract_info
         .unwrap()
         .admin;
-    assert_eq!(core_admin, core_addr.clone());
+    assert_eq!(&core_admin, core_addr);
 
     // Check that it fails when expect does not match.
     let salt = Binary::from("salt_mismatch".as_bytes());

--- a/contracts/external/cw-admin-factory/src/integration_tests.rs
+++ b/contracts/external/cw-admin-factory/src/integration_tests.rs
@@ -224,11 +224,13 @@ fn test_set_self_admin_instantiate2() {
     assert_eq!(
         err,
         RunnerError::ExecuteError {
-            msg: ContractError::UnexpectedContractAddress {
-                expected: cw_admin_factory.contract_addr.clone(),
-                actual: actual_addr.to_string(),
-            }
-            .to_string()
+            msg: format!(
+                "failed to execute message; message index: 0: dispatch: submessages: reply: {}: execute wasm contract failed",
+                ContractError::UnexpectedContractAddress {
+                    expected: cw_admin_factory.contract_addr.clone(),
+                    actual: actual_addr.to_string(),
+                }
+            )
         },
     );
 }

--- a/contracts/external/cw-admin-factory/src/lib.rs
+++ b/contracts/external/cw-admin-factory/src/lib.rs
@@ -8,4 +8,11 @@ pub mod state;
 #[cfg(test)]
 mod tests;
 
+// Integrationg tests using an actual chain binary, requires
+// the "test-tube" feature to be enabled
+// cargo test --features test-tube
+#[cfg(test)]
+#[cfg(feature = "test-tube")]
+mod integration_tests;
+
 pub use crate::error::ContractError;

--- a/contracts/external/cw-admin-factory/src/msg.rs
+++ b/contracts/external/cw-admin-factory/src/msg.rs
@@ -10,12 +10,25 @@ pub struct InstantiateMsg {
 
 #[cw_serde]
 pub enum ExecuteMsg {
-    /// Instantiates the target contract with the provided instantiate message and code id and
-    /// updates the contract's admin to be itself.
+    /// Instantiates the target contract with the provided instantiate message,
+    /// code ID, and label and updates the contract's admin to be itself.
     InstantiateContractWithSelfAdmin {
         instantiate_msg: Binary,
         code_id: u64,
         label: String,
+    },
+    /// Instantiates the target contract with the provided instantiate message,
+    /// code ID, label, and salt, via instantiate2 to give a predictable
+    /// address, and updates the contract's admin to be itself.
+    Instantiate2ContractWithSelfAdmin {
+        instantiate_msg: Binary,
+        code_id: u64,
+        label: String,
+        salt: Binary,
+        /// Optionally specify the expected address and fail if it doesn't match
+        /// the instantiated contract. This makes it easy for a consumer to
+        /// validate that they are using the correct address elsewhere.
+        expect: Option<String>,
     },
 }
 

--- a/contracts/external/cw-admin-factory/src/state.rs
+++ b/contracts/external/cw-admin-factory/src/state.rs
@@ -3,3 +3,6 @@ use cw_storage_plus::Item;
 
 /// The account allowed to execute the contract. If None, anyone is allowed.
 pub const ADMIN: Item<Option<Addr>> = Item::new("admin");
+
+/// The expected instantiate2 address to validate in the reply.
+pub const EXPECT: Item<Addr> = Item::new("expect");

--- a/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
@@ -720,6 +720,10 @@
           }
         ]
       },
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
       "DepositRefundPolicy": {
         "oneOf": [
           {
@@ -997,6 +1001,36 @@
                         "$ref": "#/definitions/VoteOption"
                       }
                     ]
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "This maps directly to [MsgVoteWeighted](https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/proto/cosmos/gov/v1beta1/tx.proto#L66-L78) in the Cosmos SDK with voter set to the contract address.",
+            "type": "object",
+            "required": [
+              "vote_weighted"
+            ],
+            "properties": {
+              "vote_weighted": {
+                "type": "object",
+                "required": [
+                  "options",
+                  "proposal_id"
+                ],
+                "properties": {
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/WeightedVoteOption"
+                    }
+                  },
+                  "proposal_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
                   }
                 }
               }
@@ -1676,6 +1710,60 @@
             "additionalProperties": false
           },
           {
+            "description": "Instantiates a new contracts from previously uploaded Wasm code using a predictable address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].\n\nThis is translated to a [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96). `sender` is automatically filled with the current contract's address. `fix_msg` is automatically set to false.",
+            "type": "object",
+            "required": [
+              "instantiate2"
+            ],
+            "properties": {
+              "instantiate2": {
+                "type": "object",
+                "required": [
+                  "code_id",
+                  "funds",
+                  "label",
+                  "msg",
+                  "salt"
+                ],
+                "properties": {
+                  "admin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "code_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "funds": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Coin"
+                    }
+                  },
+                  "label": {
+                    "description": "A human-readable label for the contract.\n\nValid values should: - not be empty - not be bigger than 128 bytes (or some chain-specific limit) - not start / end with whitespace",
+                    "type": "string"
+                  },
+                  "msg": {
+                    "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/Binary"
+                      }
+                    ]
+                  },
+                  "salt": {
+                    "$ref": "#/definitions/Binary"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
             "required": [
@@ -1759,6 +1847,21 @@
             "additionalProperties": false
           }
         ]
+      },
+      "WeightedVoteOption": {
+        "type": "object",
+        "required": [
+          "option",
+          "weight"
+        ],
+        "properties": {
+          "option": {
+            "$ref": "#/definitions/VoteOption"
+          },
+          "weight": {
+            "$ref": "#/definitions/Decimal"
+          }
+        }
       }
     }
   },

--- a/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
@@ -712,6 +712,10 @@
           }
         ]
       },
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
       "DepositRefundPolicy": {
         "oneOf": [
           {
@@ -915,6 +919,36 @@
                         "$ref": "#/definitions/VoteOption"
                       }
                     ]
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "This maps directly to [MsgVoteWeighted](https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/proto/cosmos/gov/v1beta1/tx.proto#L66-L78) in the Cosmos SDK with voter set to the contract address.",
+            "type": "object",
+            "required": [
+              "vote_weighted"
+            ],
+            "properties": {
+              "vote_weighted": {
+                "type": "object",
+                "required": [
+                  "options",
+                  "proposal_id"
+                ],
+                "properties": {
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/WeightedVoteOption"
+                    }
+                  },
+                  "proposal_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
                   }
                 }
               }
@@ -1621,6 +1655,60 @@
             "additionalProperties": false
           },
           {
+            "description": "Instantiates a new contracts from previously uploaded Wasm code using a predictable address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].\n\nThis is translated to a [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96). `sender` is automatically filled with the current contract's address. `fix_msg` is automatically set to false.",
+            "type": "object",
+            "required": [
+              "instantiate2"
+            ],
+            "properties": {
+              "instantiate2": {
+                "type": "object",
+                "required": [
+                  "code_id",
+                  "funds",
+                  "label",
+                  "msg",
+                  "salt"
+                ],
+                "properties": {
+                  "admin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "code_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "funds": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Coin"
+                    }
+                  },
+                  "label": {
+                    "description": "A human-readable label for the contract.\n\nValid values should: - not be empty - not be bigger than 128 bytes (or some chain-specific limit) - not start / end with whitespace",
+                    "type": "string"
+                  },
+                  "msg": {
+                    "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/Binary"
+                      }
+                    ]
+                  },
+                  "salt": {
+                    "$ref": "#/definitions/Binary"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
             "required": [
@@ -1704,6 +1792,21 @@
             "additionalProperties": false
           }
         ]
+      },
+      "WeightedVoteOption": {
+        "type": "object",
+        "required": [
+          "option",
+          "weight"
+        ],
+        "properties": {
+          "option": {
+            "$ref": "#/definitions/VoteOption"
+          },
+          "weight": {
+            "$ref": "#/definitions/Decimal"
+          }
+        }
       }
     }
   },

--- a/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
+++ b/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
@@ -712,6 +712,10 @@
           }
         ]
       },
+      "Decimal": {
+        "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+        "type": "string"
+      },
       "DepositRefundPolicy": {
         "oneOf": [
           {
@@ -915,6 +919,36 @@
                         "$ref": "#/definitions/VoteOption"
                       }
                     ]
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "description": "This maps directly to [MsgVoteWeighted](https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/proto/cosmos/gov/v1beta1/tx.proto#L66-L78) in the Cosmos SDK with voter set to the contract address.",
+            "type": "object",
+            "required": [
+              "vote_weighted"
+            ],
+            "properties": {
+              "vote_weighted": {
+                "type": "object",
+                "required": [
+                  "options",
+                  "proposal_id"
+                ],
+                "properties": {
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/WeightedVoteOption"
+                    }
+                  },
+                  "proposal_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
                   }
                 }
               }
@@ -1595,6 +1629,60 @@
             "additionalProperties": false
           },
           {
+            "description": "Instantiates a new contracts from previously uploaded Wasm code using a predictable address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].\n\nThis is translated to a [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96). `sender` is automatically filled with the current contract's address. `fix_msg` is automatically set to false.",
+            "type": "object",
+            "required": [
+              "instantiate2"
+            ],
+            "properties": {
+              "instantiate2": {
+                "type": "object",
+                "required": [
+                  "code_id",
+                  "funds",
+                  "label",
+                  "msg",
+                  "salt"
+                ],
+                "properties": {
+                  "admin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "code_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "funds": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Coin"
+                    }
+                  },
+                  "label": {
+                    "description": "A human-readable label for the contract.\n\nValid values should: - not be empty - not be bigger than 128 bytes (or some chain-specific limit) - not start / end with whitespace",
+                    "type": "string"
+                  },
+                  "msg": {
+                    "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/Binary"
+                      }
+                    ]
+                  },
+                  "salt": {
+                    "$ref": "#/definitions/Binary"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
             "required": [
@@ -1678,6 +1766,21 @@
             "additionalProperties": false
           }
         ]
+      },
+      "WeightedVoteOption": {
+        "type": "object",
+        "required": [
+          "option",
+          "weight"
+        ],
+        "properties": {
+          "option": {
+            "$ref": "#/definitions/VoteOption"
+          },
+          "weight": {
+            "$ref": "#/definitions/Decimal"
+          }
+        }
       }
     }
   },

--- a/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
+++ b/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
@@ -555,6 +555,36 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "description": "This maps directly to [MsgVoteWeighted](https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/proto/cosmos/gov/v1beta1/tx.proto#L66-L78) in the Cosmos SDK with voter set to the contract address.",
+            "type": "object",
+            "required": [
+              "vote_weighted"
+            ],
+            "properties": {
+              "vote_weighted": {
+                "type": "object",
+                "required": [
+                  "options",
+                  "proposal_id"
+                ],
+                "properties": {
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/WeightedVoteOption"
+                    }
+                  },
+                  "proposal_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },
@@ -973,6 +1003,60 @@
             "additionalProperties": false
           },
           {
+            "description": "Instantiates a new contracts from previously uploaded Wasm code using a predictable address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].\n\nThis is translated to a [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96). `sender` is automatically filled with the current contract's address. `fix_msg` is automatically set to false.",
+            "type": "object",
+            "required": [
+              "instantiate2"
+            ],
+            "properties": {
+              "instantiate2": {
+                "type": "object",
+                "required": [
+                  "code_id",
+                  "funds",
+                  "label",
+                  "msg",
+                  "salt"
+                ],
+                "properties": {
+                  "admin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "code_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "funds": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Coin"
+                    }
+                  },
+                  "label": {
+                    "description": "A human-readable label for the contract.\n\nValid values should: - not be empty - not be bigger than 128 bytes (or some chain-specific limit) - not start / end with whitespace",
+                    "type": "string"
+                  },
+                  "msg": {
+                    "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/Binary"
+                      }
+                    ]
+                  },
+                  "salt": {
+                    "$ref": "#/definitions/Binary"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
             "required": [
@@ -1056,6 +1140,21 @@
             "additionalProperties": false
           }
         ]
+      },
+      "WeightedVoteOption": {
+        "type": "object",
+        "required": [
+          "option",
+          "weight"
+        ],
+        "properties": {
+          "option": {
+            "$ref": "#/definitions/VoteOption"
+          },
+          "weight": {
+            "$ref": "#/definitions/Decimal"
+          }
+        }
       }
     }
   },
@@ -1696,6 +1795,36 @@
                 }
               },
               "additionalProperties": false
+            },
+            {
+              "description": "This maps directly to [MsgVoteWeighted](https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/proto/cosmos/gov/v1beta1/tx.proto#L66-L78) in the Cosmos SDK with voter set to the contract address.",
+              "type": "object",
+              "required": [
+                "vote_weighted"
+              ],
+              "properties": {
+                "vote_weighted": {
+                  "type": "object",
+                  "required": [
+                    "options",
+                    "proposal_id"
+                  ],
+                  "properties": {
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/WeightedVoteOption"
+                      }
+                    },
+                    "proposal_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
             }
           ]
         },
@@ -2267,6 +2396,60 @@
               "additionalProperties": false
             },
             {
+              "description": "Instantiates a new contracts from previously uploaded Wasm code using a predictable address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].\n\nThis is translated to a [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96). `sender` is automatically filled with the current contract's address. `fix_msg` is automatically set to false.",
+              "type": "object",
+              "required": [
+                "instantiate2"
+              ],
+              "properties": {
+                "instantiate2": {
+                  "type": "object",
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg",
+                    "salt"
+                  ],
+                  "properties": {
+                    "admin": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "code_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "funds": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    },
+                    "label": {
+                      "description": "A human-readable label for the contract.\n\nValid values should: - not be empty - not be bigger than 128 bytes (or some chain-specific limit) - not start / end with whitespace",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Binary"
+                        }
+                      ]
+                    },
+                    "salt": {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
               "required": [
@@ -2350,6 +2533,21 @@
               "additionalProperties": false
             }
           ]
+        },
+        "WeightedVoteOption": {
+          "type": "object",
+          "required": [
+            "option",
+            "weight"
+          ],
+          "properties": {
+            "option": {
+              "$ref": "#/definitions/VoteOption"
+            },
+            "weight": {
+              "$ref": "#/definitions/Decimal"
+            }
+          }
         },
         "Winner": {
           "oneOf": [

--- a/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
+++ b/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
@@ -1063,6 +1063,36 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "description": "This maps directly to [MsgVoteWeighted](https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/proto/cosmos/gov/v1beta1/tx.proto#L66-L78) in the Cosmos SDK with voter set to the contract address.",
+            "type": "object",
+            "required": [
+              "vote_weighted"
+            ],
+            "properties": {
+              "vote_weighted": {
+                "type": "object",
+                "required": [
+                  "options",
+                  "proposal_id"
+                ],
+                "properties": {
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/WeightedVoteOption"
+                    }
+                  },
+                  "proposal_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },
@@ -1723,6 +1753,60 @@
             "additionalProperties": false
           },
           {
+            "description": "Instantiates a new contracts from previously uploaded Wasm code using a predictable address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].\n\nThis is translated to a [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96). `sender` is automatically filled with the current contract's address. `fix_msg` is automatically set to false.",
+            "type": "object",
+            "required": [
+              "instantiate2"
+            ],
+            "properties": {
+              "instantiate2": {
+                "type": "object",
+                "required": [
+                  "code_id",
+                  "funds",
+                  "label",
+                  "msg",
+                  "salt"
+                ],
+                "properties": {
+                  "admin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "code_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "funds": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Coin"
+                    }
+                  },
+                  "label": {
+                    "description": "A human-readable label for the contract.\n\nValid values should: - not be empty - not be bigger than 128 bytes (or some chain-specific limit) - not start / end with whitespace",
+                    "type": "string"
+                  },
+                  "msg": {
+                    "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/Binary"
+                      }
+                    ]
+                  },
+                  "salt": {
+                    "$ref": "#/definitions/Binary"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
             "required": [
@@ -1806,6 +1890,21 @@
             "additionalProperties": false
           }
         ]
+      },
+      "WeightedVoteOption": {
+        "type": "object",
+        "required": [
+          "option",
+          "weight"
+        ],
+        "properties": {
+          "option": {
+            "$ref": "#/definitions/VoteOption"
+          },
+          "weight": {
+            "$ref": "#/definitions/Decimal"
+          }
+        }
       }
     }
   },
@@ -3120,6 +3219,36 @@
                 }
               },
               "additionalProperties": false
+            },
+            {
+              "description": "This maps directly to [MsgVoteWeighted](https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/proto/cosmos/gov/v1beta1/tx.proto#L66-L78) in the Cosmos SDK with voter set to the contract address.",
+              "type": "object",
+              "required": [
+                "vote_weighted"
+              ],
+              "properties": {
+                "vote_weighted": {
+                  "type": "object",
+                  "required": [
+                    "options",
+                    "proposal_id"
+                  ],
+                  "properties": {
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/WeightedVoteOption"
+                      }
+                    },
+                    "proposal_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
             }
           ]
         },
@@ -3807,6 +3936,60 @@
               "additionalProperties": false
             },
             {
+              "description": "Instantiates a new contracts from previously uploaded Wasm code using a predictable address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].\n\nThis is translated to a [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96). `sender` is automatically filled with the current contract's address. `fix_msg` is automatically set to false.",
+              "type": "object",
+              "required": [
+                "instantiate2"
+              ],
+              "properties": {
+                "instantiate2": {
+                  "type": "object",
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg",
+                    "salt"
+                  ],
+                  "properties": {
+                    "admin": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "code_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "funds": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    },
+                    "label": {
+                      "description": "A human-readable label for the contract.\n\nValid values should: - not be empty - not be bigger than 128 bytes (or some chain-specific limit) - not start / end with whitespace",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Binary"
+                        }
+                      ]
+                    },
+                    "salt": {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
               "required": [
@@ -3890,6 +4073,21 @@
               "additionalProperties": false
             }
           ]
+        },
+        "WeightedVoteOption": {
+          "type": "object",
+          "required": [
+            "option",
+            "weight"
+          ],
+          "properties": {
+            "option": {
+              "$ref": "#/definitions/VoteOption"
+            },
+            "weight": {
+              "$ref": "#/definitions/Decimal"
+            }
+          }
         }
       }
     },
@@ -4409,6 +4607,36 @@
                 }
               },
               "additionalProperties": false
+            },
+            {
+              "description": "This maps directly to [MsgVoteWeighted](https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/proto/cosmos/gov/v1beta1/tx.proto#L66-L78) in the Cosmos SDK with voter set to the contract address.",
+              "type": "object",
+              "required": [
+                "vote_weighted"
+              ],
+              "properties": {
+                "vote_weighted": {
+                  "type": "object",
+                  "required": [
+                    "options",
+                    "proposal_id"
+                  ],
+                  "properties": {
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/WeightedVoteOption"
+                      }
+                    },
+                    "proposal_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
             }
           ]
         },
@@ -5077,6 +5305,60 @@
               "additionalProperties": false
             },
             {
+              "description": "Instantiates a new contracts from previously uploaded Wasm code using a predictable address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].\n\nThis is translated to a [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96). `sender` is automatically filled with the current contract's address. `fix_msg` is automatically set to false.",
+              "type": "object",
+              "required": [
+                "instantiate2"
+              ],
+              "properties": {
+                "instantiate2": {
+                  "type": "object",
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg",
+                    "salt"
+                  ],
+                  "properties": {
+                    "admin": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "code_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "funds": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    },
+                    "label": {
+                      "description": "A human-readable label for the contract.\n\nValid values should: - not be empty - not be bigger than 128 bytes (or some chain-specific limit) - not start / end with whitespace",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Binary"
+                        }
+                      ]
+                    },
+                    "salt": {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
               "required": [
@@ -5160,6 +5442,21 @@
               "additionalProperties": false
             }
           ]
+        },
+        "WeightedVoteOption": {
+          "type": "object",
+          "required": [
+            "option",
+            "weight"
+          ],
+          "properties": {
+            "option": {
+              "$ref": "#/definitions/VoteOption"
+            },
+            "weight": {
+              "$ref": "#/definitions/Decimal"
+            }
+          }
         }
       }
     },
@@ -5651,6 +5948,36 @@
                           "$ref": "#/definitions/VoteOption"
                         }
                       ]
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This maps directly to [MsgVoteWeighted](https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/proto/cosmos/gov/v1beta1/tx.proto#L66-L78) in the Cosmos SDK with voter set to the contract address.",
+              "type": "object",
+              "required": [
+                "vote_weighted"
+              ],
+              "properties": {
+                "vote_weighted": {
+                  "type": "object",
+                  "required": [
+                    "options",
+                    "proposal_id"
+                  ],
+                  "properties": {
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/WeightedVoteOption"
+                      }
+                    },
+                    "proposal_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
                     }
                   }
                 }
@@ -6343,6 +6670,60 @@
               "additionalProperties": false
             },
             {
+              "description": "Instantiates a new contracts from previously uploaded Wasm code using a predictable address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].\n\nThis is translated to a [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96). `sender` is automatically filled with the current contract's address. `fix_msg` is automatically set to false.",
+              "type": "object",
+              "required": [
+                "instantiate2"
+              ],
+              "properties": {
+                "instantiate2": {
+                  "type": "object",
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg",
+                    "salt"
+                  ],
+                  "properties": {
+                    "admin": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "code_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "funds": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    },
+                    "label": {
+                      "description": "A human-readable label for the contract.\n\nValid values should: - not be empty - not be bigger than 128 bytes (or some chain-specific limit) - not start / end with whitespace",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Binary"
+                        }
+                      ]
+                    },
+                    "salt": {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
               "required": [
@@ -6426,6 +6807,21 @@
               "additionalProperties": false
             }
           ]
+        },
+        "WeightedVoteOption": {
+          "type": "object",
+          "required": [
+            "option",
+            "weight"
+          ],
+          "properties": {
+            "option": {
+              "$ref": "#/definitions/VoteOption"
+            },
+            "weight": {
+              "$ref": "#/definitions/Decimal"
+            }
+          }
         }
       }
     },

--- a/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
+++ b/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
@@ -1116,6 +1116,36 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "description": "This maps directly to [MsgVoteWeighted](https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/proto/cosmos/gov/v1beta1/tx.proto#L66-L78) in the Cosmos SDK with voter set to the contract address.",
+            "type": "object",
+            "required": [
+              "vote_weighted"
+            ],
+            "properties": {
+              "vote_weighted": {
+                "type": "object",
+                "required": [
+                  "options",
+                  "proposal_id"
+                ],
+                "properties": {
+                  "options": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/WeightedVoteOption"
+                    }
+                  },
+                  "proposal_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },
@@ -1794,6 +1824,60 @@
             "additionalProperties": false
           },
           {
+            "description": "Instantiates a new contracts from previously uploaded Wasm code using a predictable address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].\n\nThis is translated to a [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96). `sender` is automatically filled with the current contract's address. `fix_msg` is automatically set to false.",
+            "type": "object",
+            "required": [
+              "instantiate2"
+            ],
+            "properties": {
+              "instantiate2": {
+                "type": "object",
+                "required": [
+                  "code_id",
+                  "funds",
+                  "label",
+                  "msg",
+                  "salt"
+                ],
+                "properties": {
+                  "admin": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "code_id": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "funds": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/definitions/Coin"
+                    }
+                  },
+                  "label": {
+                    "description": "A human-readable label for the contract.\n\nValid values should: - not be empty - not be bigger than 128 bytes (or some chain-specific limit) - not start / end with whitespace",
+                    "type": "string"
+                  },
+                  "msg": {
+                    "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/Binary"
+                      }
+                    ]
+                  },
+                  "salt": {
+                    "$ref": "#/definitions/Binary"
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          {
             "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
             "type": "object",
             "required": [
@@ -1877,6 +1961,21 @@
             "additionalProperties": false
           }
         ]
+      },
+      "WeightedVoteOption": {
+        "type": "object",
+        "required": [
+          "option",
+          "weight"
+        ],
+        "properties": {
+          "option": {
+            "$ref": "#/definitions/VoteOption"
+          },
+          "weight": {
+            "$ref": "#/definitions/Decimal"
+          }
+        }
       }
     }
   },
@@ -3226,6 +3325,36 @@
                 }
               },
               "additionalProperties": false
+            },
+            {
+              "description": "This maps directly to [MsgVoteWeighted](https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/proto/cosmos/gov/v1beta1/tx.proto#L66-L78) in the Cosmos SDK with voter set to the contract address.",
+              "type": "object",
+              "required": [
+                "vote_weighted"
+              ],
+              "properties": {
+                "vote_weighted": {
+                  "type": "object",
+                  "required": [
+                    "options",
+                    "proposal_id"
+                  ],
+                  "properties": {
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/WeightedVoteOption"
+                      }
+                    },
+                    "proposal_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
             }
           ]
         },
@@ -3950,6 +4079,60 @@
               "additionalProperties": false
             },
             {
+              "description": "Instantiates a new contracts from previously uploaded Wasm code using a predictable address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].\n\nThis is translated to a [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96). `sender` is automatically filled with the current contract's address. `fix_msg` is automatically set to false.",
+              "type": "object",
+              "required": [
+                "instantiate2"
+              ],
+              "properties": {
+                "instantiate2": {
+                  "type": "object",
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg",
+                    "salt"
+                  ],
+                  "properties": {
+                    "admin": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "code_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "funds": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    },
+                    "label": {
+                      "description": "A human-readable label for the contract.\n\nValid values should: - not be empty - not be bigger than 128 bytes (or some chain-specific limit) - not start / end with whitespace",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Binary"
+                        }
+                      ]
+                    },
+                    "salt": {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
               "required": [
@@ -4033,6 +4216,21 @@
               "additionalProperties": false
             }
           ]
+        },
+        "WeightedVoteOption": {
+          "type": "object",
+          "required": [
+            "option",
+            "weight"
+          ],
+          "properties": {
+            "option": {
+              "$ref": "#/definitions/VoteOption"
+            },
+            "weight": {
+              "$ref": "#/definitions/Decimal"
+            }
+          }
         }
       }
     },
@@ -4526,6 +4724,36 @@
                 }
               },
               "additionalProperties": false
+            },
+            {
+              "description": "This maps directly to [MsgVoteWeighted](https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/proto/cosmos/gov/v1beta1/tx.proto#L66-L78) in the Cosmos SDK with voter set to the contract address.",
+              "type": "object",
+              "required": [
+                "vote_weighted"
+              ],
+              "properties": {
+                "vote_weighted": {
+                  "type": "object",
+                  "required": [
+                    "options",
+                    "proposal_id"
+                  ],
+                  "properties": {
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/WeightedVoteOption"
+                      }
+                    },
+                    "proposal_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
             }
           ]
         },
@@ -5230,6 +5458,60 @@
               "additionalProperties": false
             },
             {
+              "description": "Instantiates a new contracts from previously uploaded Wasm code using a predictable address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].\n\nThis is translated to a [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96). `sender` is automatically filled with the current contract's address. `fix_msg` is automatically set to false.",
+              "type": "object",
+              "required": [
+                "instantiate2"
+              ],
+              "properties": {
+                "instantiate2": {
+                  "type": "object",
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg",
+                    "salt"
+                  ],
+                  "properties": {
+                    "admin": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "code_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "funds": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    },
+                    "label": {
+                      "description": "A human-readable label for the contract.\n\nValid values should: - not be empty - not be bigger than 128 bytes (or some chain-specific limit) - not start / end with whitespace",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Binary"
+                        }
+                      ]
+                    },
+                    "salt": {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
               "required": [
@@ -5313,6 +5595,21 @@
               "additionalProperties": false
             }
           ]
+        },
+        "WeightedVoteOption": {
+          "type": "object",
+          "required": [
+            "option",
+            "weight"
+          ],
+          "properties": {
+            "option": {
+              "$ref": "#/definitions/VoteOption"
+            },
+            "weight": {
+              "$ref": "#/definitions/Decimal"
+            }
+          }
         }
       }
     },
@@ -5767,6 +6064,36 @@
                           "$ref": "#/definitions/VoteOption"
                         }
                       ]
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "This maps directly to [MsgVoteWeighted](https://github.com/cosmos/cosmos-sdk/blob/v0.45.8/proto/cosmos/gov/v1beta1/tx.proto#L66-L78) in the Cosmos SDK with voter set to the contract address.",
+              "type": "object",
+              "required": [
+                "vote_weighted"
+              ],
+              "properties": {
+                "vote_weighted": {
+                  "type": "object",
+                  "required": [
+                    "options",
+                    "proposal_id"
+                  ],
+                  "properties": {
+                    "options": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/WeightedVoteOption"
+                      }
+                    },
+                    "proposal_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
                     }
                   }
                 }
@@ -6496,6 +6823,60 @@
               "additionalProperties": false
             },
             {
+              "description": "Instantiates a new contracts from previously uploaded Wasm code using a predictable address derivation algorithm implemented in [`cosmwasm_std::instantiate2_address`].\n\nThis is translated to a [MsgInstantiateContract2](https://github.com/CosmWasm/wasmd/blob/v0.29.2/proto/cosmwasm/wasm/v1/tx.proto#L73-L96). `sender` is automatically filled with the current contract's address. `fix_msg` is automatically set to false.",
+              "type": "object",
+              "required": [
+                "instantiate2"
+              ],
+              "properties": {
+                "instantiate2": {
+                  "type": "object",
+                  "required": [
+                    "code_id",
+                    "funds",
+                    "label",
+                    "msg",
+                    "salt"
+                  ],
+                  "properties": {
+                    "admin": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "code_id": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "funds": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Coin"
+                      }
+                    },
+                    "label": {
+                      "description": "A human-readable label for the contract.\n\nValid values should: - not be empty - not be bigger than 128 bytes (or some chain-specific limit) - not start / end with whitespace",
+                      "type": "string"
+                    },
+                    "msg": {
+                      "description": "msg is the JSON-encoded InstantiateMsg struct (as raw Binary)",
+                      "allOf": [
+                        {
+                          "$ref": "#/definitions/Binary"
+                        }
+                      ]
+                    },
+                    "salt": {
+                      "$ref": "#/definitions/Binary"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
               "description": "Migrates a given contracts to use new wasm code. Passes a MigrateMsg to allow us to customize behavior.\n\nOnly the contract admin (as defined in wasmd), if any, is able to make this call.\n\nThis is translated to a [MsgMigrateContract](https://github.com/CosmWasm/wasmd/blob/v0.14.0/x/wasm/internal/types/tx.proto#L86-L96). `sender` is automatically filled with the current contract's address.",
               "type": "object",
               "required": [
@@ -6579,6 +6960,21 @@
               "additionalProperties": false
             }
           ]
+        },
+        "WeightedVoteOption": {
+          "type": "object",
+          "required": [
+            "option",
+            "weight"
+          ],
+          "properties": {
+            "option": {
+              "$ref": "#/definitions/VoteOption"
+            },
+            "weight": {
+              "$ref": "#/definitions/Decimal"
+            }
+          }
         }
       }
     },

--- a/packages/dao-testing/Cargo.toml
+++ b/packages/dao-testing/Cargo.toml
@@ -34,6 +34,7 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
+cw-admin-factory = { workspace = true }
 cw-core-v1 = { workspace = true, features = ["library"] }
 cw-hooks = { workspace = true }
 cw-proposal-single-v1 = { workspace = true }

--- a/packages/dao-testing/Cargo.toml
+++ b/packages/dao-testing/Cargo.toml
@@ -11,6 +11,8 @@ version = { workspace = true }
 # use test tube feature to enable test-tube integration tests, for example
 # cargo test --features "test-tube"
 test-tube = []
+# when writing tests you may wish to enable test-tube as a default feature
+# default = ["test-tube"]
 
 # This crate depends on multi-test and rand. These are not features in
 # wasm builds of cosmwasm. Despite this crate only being used as a dev

--- a/packages/dao-testing/src/test_tube/cw4_group.rs
+++ b/packages/dao-testing/src/test_tube/cw4_group.rs
@@ -1,0 +1,128 @@
+use cosmwasm_std::Coin;
+use cw4_group::{
+    msg::{ExecuteMsg, InstantiateMsg, QueryMsg},
+    ContractError,
+};
+use osmosis_test_tube::{
+    osmosis_std::types::cosmwasm::wasm::v1::MsgExecuteContractResponse, Account, Module,
+    OsmosisTestApp, RunnerError, RunnerExecuteResult, SigningAccount, Wasm,
+};
+use serde::de::DeserializeOwned;
+use std::fmt::Debug;
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub struct Cw4Group<'a> {
+    pub app: &'a OsmosisTestApp,
+    pub code_id: u64,
+    pub contract_addr: String,
+}
+
+impl<'a> Cw4Group<'a> {
+    pub fn new(
+        app: &'a OsmosisTestApp,
+        instantiate_msg: &InstantiateMsg,
+        signer: &SigningAccount,
+    ) -> Result<Self, RunnerError> {
+        let wasm = Wasm::new(app);
+
+        let code_id = wasm
+            .store_code(&Self::get_wasm_byte_code(), None, signer)?
+            .data
+            .code_id;
+
+        let contract_addr = wasm
+            .instantiate(
+                code_id,
+                &instantiate_msg,
+                Some(&signer.address()),
+                None,
+                &[],
+                signer,
+            )?
+            .data
+            .address;
+
+        Ok(Self {
+            app,
+            code_id,
+            contract_addr,
+        })
+    }
+
+    pub fn new_with_values(
+        app: &'a OsmosisTestApp,
+        code_id: u64,
+        contract_addr: String,
+    ) -> Result<Self, RunnerError> {
+        Ok(Self {
+            app,
+            code_id,
+            contract_addr,
+        })
+    }
+
+    /// uploads contract and returns a code ID
+    pub fn upload(app: &OsmosisTestApp, signer: &SigningAccount) -> Result<u64, RunnerError> {
+        let wasm = Wasm::new(app);
+
+        let code_id = wasm
+            .store_code(&Self::get_wasm_byte_code(), None, signer)?
+            .data
+            .code_id;
+
+        Ok(code_id)
+    }
+
+    // executes
+    pub fn execute(
+        &self,
+        execute_msg: &ExecuteMsg,
+        funds: &[Coin],
+        signer: &SigningAccount,
+    ) -> RunnerExecuteResult<MsgExecuteContractResponse> {
+        let wasm = Wasm::new(self.app);
+        wasm.execute(&self.contract_addr, execute_msg, funds, signer)
+    }
+
+    // queries
+    pub fn query<T>(&self, query_msg: &QueryMsg) -> Result<T, RunnerError>
+    where
+        T: DeserializeOwned,
+    {
+        let wasm = Wasm::new(self.app);
+        wasm.query(&self.contract_addr, query_msg)
+    }
+
+    fn get_wasm_byte_code() -> Vec<u8> {
+        let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let byte_code = std::fs::read(
+            manifest_path
+                .join("..")
+                .join("..")
+                .join("artifacts")
+                .join("cw4_group.wasm"),
+        );
+        match byte_code {
+            Ok(byte_code) => byte_code,
+            // On arm processors, the above path is not found, so we try the following path
+            Err(_) => std::fs::read(
+                manifest_path
+                    .join("..")
+                    .join("..")
+                    .join("artifacts")
+                    .join("cw4_group-aarch64.wasm"),
+            )
+            .unwrap(),
+        }
+    }
+
+    pub fn execute_error(err: ContractError) -> RunnerError {
+        RunnerError::ExecuteError {
+            msg: format!(
+                "failed to execute message; message index: 0: {}: execute wasm contract failed",
+                err
+            ),
+        }
+    }
+}

--- a/packages/dao-testing/src/test_tube/cw_admin_factory.rs
+++ b/packages/dao-testing/src/test_tube/cw_admin_factory.rs
@@ -1,0 +1,128 @@
+use cosmwasm_std::Coin;
+use cw_admin_factory::{
+    msg::{ExecuteMsg, InstantiateMsg, QueryMsg},
+    ContractError,
+};
+use osmosis_test_tube::{
+    osmosis_std::types::cosmwasm::wasm::v1::MsgExecuteContractResponse, Account, Module,
+    OsmosisTestApp, RunnerError, RunnerExecuteResult, SigningAccount, Wasm,
+};
+use serde::de::DeserializeOwned;
+use std::fmt::Debug;
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub struct CwAdminFactory<'a> {
+    pub app: &'a OsmosisTestApp,
+    pub code_id: u64,
+    pub contract_addr: String,
+}
+
+impl<'a> CwAdminFactory<'a> {
+    pub fn new(
+        app: &'a OsmosisTestApp,
+        admin: Option<String>,
+        signer: &SigningAccount,
+        funds: &[Coin],
+    ) -> Result<Self, RunnerError> {
+        let wasm = Wasm::new(app);
+        let code_id = wasm
+            .store_code(&Self::get_wasm_byte_code(), None, signer)?
+            .data
+            .code_id;
+
+        let contract_addr = wasm
+            .instantiate(
+                code_id,
+                &InstantiateMsg { admin },
+                Some(&signer.address()),
+                None,
+                funds,
+                signer,
+            )?
+            .data
+            .address;
+
+        Ok(Self {
+            app,
+            code_id,
+            contract_addr,
+        })
+    }
+
+    pub fn new_with_values(
+        app: &'a OsmosisTestApp,
+        code_id: u64,
+        contract_addr: String,
+    ) -> Result<Self, RunnerError> {
+        Ok(Self {
+            app,
+            code_id,
+            contract_addr,
+        })
+    }
+
+    /// uploads contract and returns a code ID
+    pub fn upload(app: &OsmosisTestApp, signer: &SigningAccount) -> Result<u64, RunnerError> {
+        let wasm = Wasm::new(app);
+
+        let code_id = wasm
+            .store_code(&Self::get_wasm_byte_code(), None, signer)?
+            .data
+            .code_id;
+
+        Ok(code_id)
+    }
+
+    // executes
+    pub fn execute(
+        &self,
+        execute_msg: &ExecuteMsg,
+        funds: &[Coin],
+        signer: &SigningAccount,
+    ) -> RunnerExecuteResult<MsgExecuteContractResponse> {
+        let wasm = Wasm::new(self.app);
+        wasm.execute(&self.contract_addr, execute_msg, funds, signer)
+    }
+
+    // queries
+    pub fn query<T>(&self, query_msg: &QueryMsg) -> Result<T, RunnerError>
+    where
+        T: DeserializeOwned,
+    {
+        let wasm = Wasm::new(self.app);
+        wasm.query(&self.contract_addr, query_msg)
+    }
+
+    fn get_wasm_byte_code() -> Vec<u8> {
+        let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let byte_code = std::fs::read(
+            manifest_path
+                .join("..")
+                .join("..")
+                .join("artifacts")
+                .join("cw_admin_factory.wasm"),
+        );
+        match byte_code {
+            Ok(byte_code) => byte_code,
+            // On arm processors, the above path is not found, so we try the following path
+            Err(_) => std::fs::read(
+                manifest_path
+                    .join("..")
+                    .join("..")
+                    .join("artifacts")
+                    .join("cw_admin_factory-aarch64.wasm"),
+            )
+            .unwrap(),
+        }
+    }
+
+    pub fn execute_error(err: ContractError) -> RunnerError {
+        RunnerError::ExecuteError {
+            msg: format!(
+                "failed to execute message; message index: 0: {}: execute wasm contract failed",
+                err
+            ),
+        }
+    }
+}

--- a/packages/dao-testing/src/test_tube/dao_voting_cw4.rs
+++ b/packages/dao-testing/src/test_tube/dao_voting_cw4.rs
@@ -101,7 +101,7 @@ impl<'a> DaoVotingCw4<'a> {
                 .join("..")
                 .join("..")
                 .join("artifacts")
-                .join("cw_admin_factory.wasm"),
+                .join("dao_voting_cw4.wasm"),
         );
         match byte_code {
             Ok(byte_code) => byte_code,
@@ -111,7 +111,7 @@ impl<'a> DaoVotingCw4<'a> {
                     .join("..")
                     .join("..")
                     .join("artifacts")
-                    .join("cw_admin_factory-aarch64.wasm"),
+                    .join("dao_voting_cw4-aarch64.wasm"),
             )
             .unwrap(),
         }

--- a/packages/dao-testing/src/test_tube/dao_voting_cw4.rs
+++ b/packages/dao-testing/src/test_tube/dao_voting_cw4.rs
@@ -1,0 +1,128 @@
+use cosmwasm_std::Coin;
+use cw_admin_factory::{
+    msg::{ExecuteMsg, InstantiateMsg, QueryMsg},
+    ContractError,
+};
+use osmosis_test_tube::{
+    osmosis_std::types::cosmwasm::wasm::v1::MsgExecuteContractResponse, Account, Module,
+    OsmosisTestApp, RunnerError, RunnerExecuteResult, SigningAccount, Wasm,
+};
+use serde::de::DeserializeOwned;
+use std::fmt::Debug;
+use std::path::PathBuf;
+
+#[derive(Debug)]
+pub struct DaoVotingCw4<'a> {
+    pub app: &'a OsmosisTestApp,
+    pub code_id: u64,
+    pub contract_addr: String,
+}
+
+impl<'a> DaoVotingCw4<'a> {
+    pub fn new(
+        app: &'a OsmosisTestApp,
+        instantiate_msg: &InstantiateMsg,
+        signer: &SigningAccount,
+        funds: &[Coin],
+    ) -> Result<Self, RunnerError> {
+        let wasm = Wasm::new(app);
+        let code_id = wasm
+            .store_code(&Self::get_wasm_byte_code(), None, signer)?
+            .data
+            .code_id;
+
+        let contract_addr = wasm
+            .instantiate(
+                code_id,
+                &instantiate_msg,
+                Some(&signer.address()),
+                None,
+                funds,
+                signer,
+            )?
+            .data
+            .address;
+
+        Ok(Self {
+            app,
+            code_id,
+            contract_addr,
+        })
+    }
+
+    pub fn new_with_values(
+        app: &'a OsmosisTestApp,
+        code_id: u64,
+        contract_addr: String,
+    ) -> Result<Self, RunnerError> {
+        Ok(Self {
+            app,
+            code_id,
+            contract_addr,
+        })
+    }
+
+    /// uploads contract and returns a code ID
+    pub fn upload(app: &OsmosisTestApp, signer: &SigningAccount) -> Result<u64, RunnerError> {
+        let wasm = Wasm::new(app);
+
+        let code_id = wasm
+            .store_code(&Self::get_wasm_byte_code(), None, signer)?
+            .data
+            .code_id;
+
+        Ok(code_id)
+    }
+
+    // executes
+    pub fn execute(
+        &self,
+        execute_msg: &ExecuteMsg,
+        funds: &[Coin],
+        signer: &SigningAccount,
+    ) -> RunnerExecuteResult<MsgExecuteContractResponse> {
+        let wasm = Wasm::new(self.app);
+        wasm.execute(&self.contract_addr, execute_msg, funds, signer)
+    }
+
+    // queries
+    pub fn query<T>(&self, query_msg: &QueryMsg) -> Result<T, RunnerError>
+    where
+        T: DeserializeOwned,
+    {
+        let wasm = Wasm::new(self.app);
+        wasm.query(&self.contract_addr, query_msg)
+    }
+
+    fn get_wasm_byte_code() -> Vec<u8> {
+        let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let byte_code = std::fs::read(
+            manifest_path
+                .join("..")
+                .join("..")
+                .join("artifacts")
+                .join("cw_admin_factory.wasm"),
+        );
+        match byte_code {
+            Ok(byte_code) => byte_code,
+            // On arm processors, the above path is not found, so we try the following path
+            Err(_) => std::fs::read(
+                manifest_path
+                    .join("..")
+                    .join("..")
+                    .join("artifacts")
+                    .join("cw_admin_factory-aarch64.wasm"),
+            )
+            .unwrap(),
+        }
+    }
+
+    pub fn execute_error(err: ContractError) -> RunnerError {
+        RunnerError::ExecuteError {
+            msg: format!(
+                "failed to execute message; message index: 0: {}: execute wasm contract failed",
+                err
+            ),
+        }
+    }
+}

--- a/packages/dao-testing/src/test_tube/mod.rs
+++ b/packages/dao-testing/src/test_tube/mod.rs
@@ -5,8 +5,15 @@
 // Integrationg tests using an actual chain binary, requires
 // the "test-tube" feature to be enabled
 // cargo test --features test-tube
+
+#[cfg(feature = "test-tube")]
+pub mod cw_admin_factory;
+
 #[cfg(feature = "test-tube")]
 pub mod cw_tokenfactory_issuer;
+
+#[cfg(feature = "test-tube")]
+pub mod cw4_group;
 
 #[cfg(feature = "test-tube")]
 pub mod cw721_base;
@@ -19,3 +26,6 @@ pub mod dao_proposal_single;
 
 #[cfg(feature = "test-tube")]
 pub mod dao_test_custom_factory;
+
+#[cfg(feature = "test-tube")]
+pub mod dao_voting_cw4;


### PR DESCRIPTION
Add support for `instantiate2` with `cw-admin-factory` so that we can create DAOs with predictable addresses and set up more features upon DAO creation.