### PR TITLE
Add `info` query to pre-propose modules

### DIFF
--- a/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
@@ -1898,6 +1898,20 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns contract version info.",
+        "type": "object",
+        "required": [
+          "info"
+        ],
+        "properties": {
+          "info": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Gets the module's configuration.",
         "type": "object",
         "required": [
@@ -2610,6 +2624,40 @@
         "Uint128": {
           "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
           "type": "string"
+        }
+      }
+    },
+    "info": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "InfoResponse",
+      "type": "object",
+      "required": [
+        "info"
+      ],
+      "properties": {
+        "info": {
+          "$ref": "#/definitions/ContractVersion"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "ContractVersion": {
+          "type": "object",
+          "required": [
+            "contract",
+            "version"
+          ],
+          "properties": {
+            "contract": {
+              "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
+              "type": "string"
+            },
+            "version": {
+              "description": "version is any string that this implementation knows. It may be simple counter \"1\", \"2\". or semantic version on release tags \"v0.7.0\", or some custom feature flag list. the only code that needs to understand the version parsing is code that knows how to migrate from the given contract (and is tied to it's implementation somehow)",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       }
     },

--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
@@ -4,6 +4,7 @@ use cw20::Cw20Coin;
 use cw_denom::UncheckedDenom;
 use cw_multi_test::{App, BankSudo, Contract, ContractWrapper, Executor};
 use cw_utils::Duration;
+use dao_interface::proposal::InfoResponse;
 use dao_interface::state::ProposalModule;
 use dao_interface::state::{Admin, ModuleInstantiateInfo};
 use dao_pre_propose_base::{error::PreProposeError, msg::DepositInfoResponse, state::Config};
@@ -179,6 +180,15 @@ fn setup_default_test(
         get_proposal_module(app, pre_propose.clone())
     );
     assert_eq!(core_addr, get_dao(app, pre_propose.clone()));
+    assert_eq!(
+        InfoResponse {
+            info: ContractVersion {
+                contract: "crates.io:dao-pre-propose-approval-single".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string()
+            }
+        },
+        get_info(app, pre_propose.clone())
+    );
 
     DefaultTestSetup {
         core_addr,
@@ -294,6 +304,12 @@ fn get_config(app: &App, module: Addr) -> Config {
 fn get_dao(app: &App, module: Addr) -> Addr {
     app.wrap()
         .query_wasm_smart(module, &QueryMsg::Dao {})
+        .unwrap()
+}
+
+fn get_info(app: &App, module: Addr) -> InfoResponse {
+    app.wrap()
+        .query_wasm_smart(module, &QueryMsg::Info {})
         .unwrap()
 }
 

--- a/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
+++ b/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
@@ -713,6 +713,20 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns contract version info.",
+        "type": "object",
+        "required": [
+          "info"
+        ],
+        "properties": {
+          "info": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Gets the module's configuration.",
         "type": "object",
         "required": [
@@ -1224,6 +1238,40 @@
         "Uint128": {
           "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
           "type": "string"
+        }
+      }
+    },
+    "info": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "InfoResponse",
+      "type": "object",
+      "required": [
+        "info"
+      ],
+      "properties": {
+        "info": {
+          "$ref": "#/definitions/ContractVersion"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "ContractVersion": {
+          "type": "object",
+          "required": [
+            "contract",
+            "version"
+          ],
+          "properties": {
+            "contract": {
+              "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
+              "type": "string"
+            },
+            "version": {
+              "description": "version is any string that this implementation knows. It may be simple counter \"1\", \"2\". or semantic version on release tags \"v0.7.0\", or some custom feature flag list. the only code that needs to understand the version parsing is code that knows how to migrate from the given contract (and is tied to it's implementation somehow)",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       }
     },

--- a/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
@@ -3,6 +3,7 @@ use cw2::ContractVersion;
 use cw20::Cw20Coin;
 use cw_denom::UncheckedDenom;
 use cw_multi_test::{App, BankSudo, Contract, ContractWrapper, Executor};
+use dao_interface::proposal::InfoResponse;
 use dao_voting::pre_propose::{PreProposeSubmissionPolicy, PreProposeSubmissionPolicyError};
 use dps::query::{ProposalListResponse, ProposalResponse};
 
@@ -300,6 +301,15 @@ fn setup_default_test(
         approver_core_addr,
         get_dao(app, pre_propose_approver.clone())
     );
+    assert_eq!(
+        InfoResponse {
+            info: ContractVersion {
+                contract: "crates.io:dao-pre-propose-approver".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string()
+            }
+        },
+        get_info(app, pre_propose_approver.clone())
+    );
 
     DefaultTestSetup {
         core_addr,
@@ -415,6 +425,12 @@ fn get_config(app: &App, module: Addr) -> Config {
 fn get_dao(app: &App, module: Addr) -> Addr {
     app.wrap()
         .query_wasm_smart(module, &QueryMsg::Dao {})
+        .unwrap()
+}
+
+fn get_info(app: &App, module: Addr) -> InfoResponse {
+    app.wrap()
+        .query_wasm_smart(module, &QueryMsg::Info {})
         .unwrap()
 }
 

--- a/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
@@ -1843,6 +1843,20 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns contract version info.",
+        "type": "object",
+        "required": [
+          "info"
+        ],
+        "properties": {
+          "info": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Gets the module's configuration.",
         "type": "object",
         "required": [
@@ -2295,6 +2309,40 @@
         "Uint128": {
           "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
           "type": "string"
+        }
+      }
+    },
+    "info": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "InfoResponse",
+      "type": "object",
+      "required": [
+        "info"
+      ],
+      "properties": {
+        "info": {
+          "$ref": "#/definitions/ContractVersion"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "ContractVersion": {
+          "type": "object",
+          "required": [
+            "contract",
+            "version"
+          ],
+          "properties": {
+            "contract": {
+              "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
+              "type": "string"
+            },
+            "version": {
+              "description": "version is any string that this implementation knows. It may be simple counter \"1\", \"2\". or semantic version on release tags \"v0.7.0\", or some custom feature flag list. the only code that needs to understand the version parsing is code that knows how to migrate from the given contract (and is tied to it's implementation somehow)",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       }
     },

--- a/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
@@ -5,6 +5,7 @@ use cw20::Cw20Coin;
 use cw_denom::UncheckedDenom;
 use cw_multi_test::{App, BankSudo, Contract, ContractWrapper, Executor};
 use cw_utils::Duration;
+use dao_interface::proposal::InfoResponse;
 use dao_interface::state::ProposalModule;
 use dao_interface::state::{Admin, ModuleInstantiateInfo};
 use dao_pre_propose_base::{error::PreProposeError, msg::DepositInfoResponse, state::Config};
@@ -178,6 +179,15 @@ fn setup_default_test(
         get_proposal_module(app, pre_propose.clone())
     );
     assert_eq!(core_addr, get_dao(app, pre_propose.clone()));
+    assert_eq!(
+        InfoResponse {
+            info: ContractVersion {
+                contract: "crates.io:dao-pre-propose-multiple".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string()
+            }
+        },
+        get_info(app, pre_propose.clone())
+    );
 
     DefaultTestSetup {
         core_addr,
@@ -347,6 +357,12 @@ fn get_config(app: &App, module: Addr) -> Config {
 fn get_dao(app: &App, module: Addr) -> Addr {
     app.wrap()
         .query_wasm_smart(module, &QueryMsg::Dao {})
+        .unwrap()
+}
+
+fn get_info(app: &App, module: Addr) -> InfoResponse {
+    app.wrap()
+        .query_wasm_smart(module, &QueryMsg::Info {})
         .unwrap()
 }
 

--- a/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
+++ b/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
@@ -1817,6 +1817,20 @@
         "additionalProperties": false
       },
       {
+        "description": "Returns contract version info.",
+        "type": "object",
+        "required": [
+          "info"
+        ],
+        "properties": {
+          "info": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Gets the module's configuration.",
         "type": "object",
         "required": [
@@ -2269,6 +2283,40 @@
         "Uint128": {
           "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
           "type": "string"
+        }
+      }
+    },
+    "info": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "InfoResponse",
+      "type": "object",
+      "required": [
+        "info"
+      ],
+      "properties": {
+        "info": {
+          "$ref": "#/definitions/ContractVersion"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "ContractVersion": {
+          "type": "object",
+          "required": [
+            "contract",
+            "version"
+          ],
+          "properties": {
+            "contract": {
+              "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
+              "type": "string"
+            },
+            "version": {
+              "description": "version is any string that this implementation knows. It may be simple counter \"1\", \"2\". or semantic version on release tags \"v0.7.0\", or some custom feature flag list. the only code that needs to understand the version parsing is code that knows how to migrate from the given contract (and is tied to it's implementation somehow)",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
         }
       }
     },

--- a/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
@@ -4,6 +4,7 @@ use cw20::Cw20Coin;
 use cw_denom::UncheckedDenom;
 use cw_multi_test::{App, BankSudo, Contract, ContractWrapper, Executor};
 use cw_utils::Duration;
+use dao_interface::proposal::InfoResponse;
 use dao_interface::state::ProposalModule;
 use dao_interface::state::{Admin, ModuleInstantiateInfo};
 use dao_pre_propose_base::{error::PreProposeError, msg::DepositInfoResponse, state::Config};
@@ -176,6 +177,15 @@ fn setup_default_test(
         get_proposal_module(app, pre_propose.clone())
     );
     assert_eq!(core_addr, get_dao(app, pre_propose.clone()));
+    assert_eq!(
+        InfoResponse {
+            info: ContractVersion {
+                contract: "crates.io:dao-pre-propose-single".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string()
+            }
+        },
+        get_info(app, pre_propose.clone())
+    );
 
     DefaultTestSetup {
         core_addr,
@@ -322,6 +332,12 @@ fn get_config(app: &App, module: Addr) -> Config {
 fn get_dao(app: &App, module: Addr) -> Addr {
     app.wrap()
         .query_wasm_smart(module, &QueryMsg::Dao {})
+        .unwrap()
+}
+
+fn get_info(app: &App, module: Addr) -> InfoResponse {
+    app.wrap()
+        .query_wasm_smart(module, &QueryMsg::Info {})
         .unwrap()
 }
 

--- a/packages/dao-pre-propose-base/src/execute.rs
+++ b/packages/dao-pre-propose-base/src/execute.rs
@@ -567,6 +567,9 @@ where
                 to_json_binary(&self.proposal_module.load(deps.storage)?)
             }
             QueryMsg::Dao {} => to_json_binary(&self.dao.load(deps.storage)?),
+            QueryMsg::Info {} => to_json_binary(&dao_interface::proposal::InfoResponse {
+                info: cw2::get_contract_version(deps.storage)?,
+            }),
             QueryMsg::Config {} => to_json_binary(&self.config.load(deps.storage)?),
             QueryMsg::DepositInfo { proposal_id } => {
                 let (deposit_info, proposer) = self.deposits.load(deps.storage, proposal_id)?;

--- a/packages/dao-pre-propose-base/src/msg.rs
+++ b/packages/dao-pre-propose-base/src/msg.rs
@@ -1,5 +1,6 @@
 use cosmwasm_schema::{cw_serde, schemars::JsonSchema, QueryResponses};
 use cw_denom::UncheckedDenom;
+use dao_interface::proposal::InfoResponse;
 use dao_voting::{
     deposit::{CheckedDepositInfo, UncheckedDepositInfo},
     pre_propose::PreProposeSubmissionPolicy,
@@ -118,6 +119,9 @@ where
     /// with. Returns `Addr`.
     #[returns(cosmwasm_std::Addr)]
     Dao {},
+    /// Returns contract version info.
+    #[returns(InfoResponse)]
+    Info {},
     /// Gets the module's configuration.
     #[returns(crate::state::Config)]
     Config {},


### PR DESCRIPTION
Add the `info` query that the rest of the contracts support to the pre-propose modules.