### PR TITLE
[audit] 1. Rewards are lost if the distribution is funded after the expiry

### DIFF
--- a/contracts/external/cw-tokenfactory-issuer/tests/mod.rs
+++ b/contracts/external/cw-tokenfactory-issuer/tests/mod.rs
@@ -1,7 +1,3 @@
-// Ignore integration tests for code coverage since there will be problems with dynamic linking libosmosistesttube
-// and also, tarpaulin will not be able read coverage out of wasm binary anyway
-#![cfg(not(tarpaulin))]
-
 #[cfg(feature = "test-tube")]
 mod cases;
 #[cfg(feature = "test-tube")]

--- a/contracts/external/dao-migrator/README.md
+++ b/contracts/external/dao-migrator/README.md
@@ -5,7 +5,7 @@
 
 Here is the [discussion](https://github.com/DA0-DA0/dao-contracts/discussions/607).
 
-A migrator module for a DAO DAO DAO which handles migration for DAO modules 
+A migrator module for a DAO DAO DAO which handles migration for DAO modules
 and test it went successfully.
 
 DAO core migration is handled by a proposal, which adds this module and do
@@ -14,6 +14,7 @@ If custom module is found, this TX fails and migration is cancelled, custom
 module requires a custom migration to be done by the DAO.
 
 # General idea
+
 1. Proposal is made to migrate DAO core to V2, which also adds this module to the DAO.
 2. On init of this contract, a callback is fired to do the migration.
 3. Then we check to make sure the DAO doesn't have custom modules.
@@ -23,9 +24,10 @@ module requires a custom migration to be done by the DAO.
 7. In any case where 1 migration fails, we fail the whole TX.
 
 # Important notes
-* custom modules cannot reliably be migrated by this contract, 
-because of that we fail the process to avoid any unwanted results.
 
-* If any module migration fails we fail the whole thing, 
-this is to make sure that we either have a fully working V2,
-or we do nothing and make sure the DAO is operational at any time.
+- custom modules cannot reliably be migrated by this contract,
+  because of that we fail the process to avoid any unwanted results.
+
+- If any module migration fails we fail the whole thing,
+  this is to make sure that we either have a fully working V2,
+  or we do nothing and make sure the DAO is operational at any time.

--- a/contracts/proposal/dao-proposal-condorcet/src/testing/suite.rs
+++ b/contracts/proposal/dao-proposal-condorcet/src/testing/suite.rs
@@ -146,7 +146,7 @@ impl SuiteBuilder {
         if let Some(candidates) = self.with_proposal {
             suite
                 .propose(
-                    &suite.sender(),
+                    suite.sender(),
                     (0..candidates)
                         .map(|_| vec![unimportant_message()])
                         .collect(),

--- a/contracts/voting/dao-voting-token-staked/src/tests/test_tube/mod.rs
+++ b/contracts/voting/dao-voting-token-staked/src/tests/test_tube/mod.rs
@@ -1,6 +1,2 @@
-// Ignore integration tests for code coverage since there will be problems with dynamic linking libosmosistesttube
-// and also, tarpaulin will not be able read coverage out of wasm binary anyway
-#![cfg(not(tarpaulin))]
-
 mod integration_tests;
 mod test_env;

--- a/packages/dao-testing/src/test_tube/mod.rs
+++ b/packages/dao-testing/src/test_tube/mod.rs
@@ -1,7 +1,3 @@
-// Ignore integration tests for code coverage since there will be problems with dynamic linking libosmosistesttube
-// and also, tarpaulin will not be able read coverage out of wasm binary anyway
-#![cfg(not(tarpaulin))]
-
 // Integrationg tests using an actual chain binary, requires
 // the "test-tube" feature to be enabled
 // cargo test --features test-tube


### PR DESCRIPTION
From Oak:

> In contracts/distribution/dao-rewards-distributor/src/contract.rs:303, the execute_fund function restarts the distribution if it is not continuous and already expired at the current block. This is problematic because the rewards that accrued from the last updated timestamp (active_epoch.last_updated_total_earned_puvp) to the ending timestamp (active_epoch.ends_at) will be lost.
Consequently, stakers will not receive the rewards for the staking period, causing a loss of rewards.

This fix ensures rewards are calculated and stored before restarting the distribution so they are not lost.