### PR TITLE
[audit] 2. Incorrect reward distribution due to inconsistent voting power queries

### DIFF
--- a/contracts/distribution/dao-rewards-distributor/src/helpers.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/helpers.rs
@@ -10,13 +10,13 @@ use dao_interface::voting::{
 
 use crate::ContractError;
 
-pub fn get_prev_block_total_vp(
+pub fn get_total_voting_power_at_block(
     deps: Deps,
     block: &BlockInfo,
     contract_addr: &Addr,
 ) -> StdResult<Uint128> {
     let msg = VotingQueryMsg::TotalPowerAtHeight {
-        height: Some(block.height.checked_sub(1).unwrap_or_default()),
+        height: Some(block.height),
     };
     let resp: TotalPowerAtHeightResponse = deps.querier.query_wasm_smart(contract_addr, &msg)?;
     Ok(resp.power)

--- a/contracts/distribution/dao-rewards-distributor/src/rewards.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/rewards.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{Addr, BlockInfo, Deps, DepsMut, Env, StdResult, Uint128, Uint
 
 use crate::{
     helpers::{
-        get_prev_block_total_vp, get_voting_power_at_block, scale_factor, DurationExt,
+        get_total_voting_power_at_block, get_voting_power_at_block, scale_factor, DurationExt,
         ExpirationExt,
     },
     state::{DistributionState, EmissionRate, UserRewardState, DISTRIBUTIONS, USER_REWARDS},
@@ -107,10 +107,11 @@ pub fn get_active_total_earned_puvp(
                 return Ok(curr);
             }
 
-            let prev_total_power = get_prev_block_total_vp(deps, block, &distribution.vp_contract)?;
+            let total_power =
+                get_total_voting_power_at_block(deps, block, &distribution.vp_contract)?;
 
             // if no voting power is registered, no one should receive rewards.
-            if prev_total_power.is_zero() {
+            if total_power.is_zero() {
                 Ok(curr)
             } else {
                 // count intervals of the rewards emission that have passed
@@ -128,8 +129,7 @@ pub fn get_active_total_earned_puvp(
 
                 // the new rewards per unit voting power that have been
                 // distributed since the last update
-                let new_rewards_puvp =
-                    new_rewards_distributed.checked_div(prev_total_power.into())?;
+                let new_rewards_puvp = new_rewards_distributed.checked_div(total_power.into())?;
                 Ok(curr.checked_add(new_rewards_puvp)?)
             }
         }

--- a/contracts/distribution/dao-rewards-distributor/src/state.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/state.rs
@@ -9,7 +9,7 @@ use cw_utils::Duration;
 use std::{cmp::min, collections::HashMap};
 
 use crate::{
-    helpers::{get_prev_block_total_vp, scale_factor, DurationExt, ExpirationExt},
+    helpers::{get_total_voting_power_at_block, scale_factor, DurationExt, ExpirationExt},
     rewards::get_active_total_earned_puvp,
     ContractError,
 };
@@ -366,18 +366,18 @@ impl DistributionState {
 
         let curr = self.active_epoch.total_earned_puvp;
 
-        let prev_total_power = get_prev_block_total_vp(deps, block, &self.vp_contract)?;
+        let total_power = get_total_voting_power_at_block(deps, block, &self.vp_contract)?;
 
         // if no voting power is registered, error since rewards can't be
         // distributed.
-        if prev_total_power.is_zero() {
+        if total_power.is_zero() {
             Err(ContractError::NoVotingPowerNoRewards {})
         } else {
             // the new rewards per unit voting power based on the funded amount
             let new_rewards_puvp = Uint256::from(funded_amount_delta)
                 // this can never overflow since funded_amount is a Uint128
                 .checked_mul(scale_factor())?
-                .checked_div(prev_total_power.into())?;
+                .checked_div(total_power.into())?;
 
             self.active_epoch.total_earned_puvp = curr.checked_add(new_rewards_puvp)?;
 


### PR DESCRIPTION
From Oak:

> In contracts/distribution/dao-rewards-distributor/src/rewards.rs:113-136, the get_active_total_earned_puvp function computes the reward index by dividing the accrued rewards with total voting power queried from the previous block height (see contracts/distribution/dao-rewards-distributor/src/helpers.rs:19). This is incorrect because the user reward is computed with voting power queried from the current block height, as seen in contracts/distribution/dao-rewards-distributor/src/helpers.rs:33.
> 
> Consequently, the reward index will be computed using an outdated total voting power, resulting in incorrect reward distribution. An attacker can exploit this issue by staking many tokens one block before claiming the rewards to receive more at the expense of other users.

This fix ensures that the total voting power from the same height as the member's voting powers is used.