### PR TITLE
[audit] 10. Suboptimal usage of optional vectors & 12. Code deduplication

### DIFF
--- a/ci/bootstrap-env/src/main.rs
+++ b/ci/bootstrap-env/src/main.rs
@@ -102,8 +102,8 @@ fn main() -> Result<()> {
                             }),
                             submission_policy: PreProposeSubmissionPolicy::Specific {
                                 dao_members: true,
-                                allowlist: None,
-                                denylist: None,
+                                allowlist: vec![],
+                                denylist: vec![],
                             },
                             extension: Empty::default(),
                         })

--- a/ci/integration-tests/src/helpers/helper.rs
+++ b/ci/integration-tests/src/helpers/helper.rs
@@ -86,8 +86,8 @@ pub fn create_dao(
                             }),
                             submission_policy: PreProposeSubmissionPolicy::Specific {
                                 dao_members: true,
-                                allowlist: None,
-                                denylist: None,
+                                allowlist: vec![],
+                                denylist: vec![],
                             },
                             extension: Empty::default(),
                         })

--- a/contracts/external/cw-tokenfactory-issuer/tests/mod.rs
+++ b/contracts/external/cw-tokenfactory-issuer/tests/mod.rs
@@ -1,7 +1,3 @@
-// Ignore integration tests for code coverage since there will be problems with dynamic linking libosmosistesttube
-// and also, tarpaulin will not be able read coverage out of wasm binary anyway
-#![cfg(not(tarpaulin))]
-
 #[cfg(feature = "test-tube")]
 mod cases;
 #[cfg(feature = "test-tube")]

--- a/contracts/external/dao-migrator/README.md
+++ b/contracts/external/dao-migrator/README.md
@@ -5,7 +5,7 @@
 
 Here is the [discussion](https://github.com/DA0-DA0/dao-contracts/discussions/607).
 
-A migrator module for a DAO DAO DAO which handles migration for DAO modules 
+A migrator module for a DAO DAO DAO which handles migration for DAO modules
 and test it went successfully.
 
 DAO core migration is handled by a proposal, which adds this module and do
@@ -14,6 +14,7 @@ If custom module is found, this TX fails and migration is cancelled, custom
 module requires a custom migration to be done by the DAO.
 
 # General idea
+
 1. Proposal is made to migrate DAO core to V2, which also adds this module to the DAO.
 2. On init of this contract, a callback is fired to do the migration.
 3. Then we check to make sure the DAO doesn't have custom modules.
@@ -23,9 +24,10 @@ module requires a custom migration to be done by the DAO.
 7. In any case where 1 migration fails, we fail the whole TX.
 
 # Important notes
-* custom modules cannot reliably be migrated by this contract, 
-because of that we fail the process to avoid any unwanted results.
 
-* If any module migration fails we fail the whole thing, 
-this is to make sure that we either have a fully working V2,
-or we do nothing and make sure the DAO is operational at any time.
+- custom modules cannot reliably be migrated by this contract,
+  because of that we fail the process to avoid any unwanted results.
+
+- If any module migration fails we fail the whole thing,
+  this is to make sure that we either have a fully working V2,
+  or we do nothing and make sure the DAO is operational at any time.

--- a/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
@@ -41,6 +41,10 @@
     },
     "additionalProperties": false,
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "DepositRefundPolicy": {
         "oneOf": [
           {
@@ -139,15 +143,15 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "required": [
+                  "denylist"
+                ],
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -166,17 +170,16 @@
               "specific": {
                 "type": "object",
                 "required": [
-                  "dao_members"
+                  "allowlist",
+                  "dao_members",
+                  "denylist"
                 ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   },
                   "dao_members": {
@@ -185,12 +188,9 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -531,6 +531,10 @@
       }
     ],
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "BankMsg": {
         "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
         "oneOf": [
@@ -1204,15 +1208,15 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "required": [
+                  "denylist"
+                ],
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -1231,17 +1235,16 @@
               "specific": {
                 "type": "object",
                 "required": [
-                  "dao_members"
+                  "allowlist",
+                  "dao_members",
+                  "denylist"
                 ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   },
                   "dao_members": {
@@ -1250,12 +1253,9 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -2328,6 +2328,10 @@
       }
     ],
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "Empty": {
         "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "object"
@@ -2344,15 +2348,15 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "required": [
+                  "denylist"
+                ],
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -2371,17 +2375,16 @@
               "specific": {
                 "type": "object",
                 "required": [
-                  "dao_members"
+                  "allowlist",
+                  "dao_members",
+                  "denylist"
                 ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   },
                   "dao_members": {
@@ -2390,12 +2393,9 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -2553,15 +2553,15 @@
               "properties": {
                 "anyone": {
                   "type": "object",
+                  "required": [
+                    "denylist"
+                  ],
                   "properties": {
                     "denylist": {
                       "description": "Addresses that may not create proposals.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": "array",
                       "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/Addr"
                       }
                     }
                   },
@@ -2580,17 +2580,16 @@
                 "specific": {
                   "type": "object",
                   "required": [
-                    "dao_members"
+                    "allowlist",
+                    "dao_members",
+                    "denylist"
                   ],
                   "properties": {
                     "allowlist": {
                       "description": "Addresses that may create proposals.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": "array",
                       "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/Addr"
                       }
                     },
                     "dao_members": {
@@ -2599,12 +2598,9 @@
                     },
                     "denylist": {
                       "description": "Addresses that may not create proposals, overriding other settings.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": "array",
                       "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/Addr"
                       }
                     }
                   },

--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
@@ -1951,7 +1951,7 @@ fn test_update_submission_policy() {
         Config {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Anyone {
-                denylist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
+                denylist: vec![Addr::unchecked("else"), Addr::unchecked("someone")],
             },
         }
     );
@@ -2128,7 +2128,7 @@ fn test_update_submission_policy() {
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
                 allowlist: vec![],
-                denylist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
+                denylist: vec![Addr::unchecked("else"), Addr::unchecked("someone")],
             },
         }
     );
@@ -2211,7 +2211,7 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
+                allowlist: vec![Addr::unchecked("else"), Addr::unchecked("someone")],
                 denylist: vec![],
             },
         }

--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
@@ -65,12 +65,12 @@ fn get_default_proposal_module_instantiate(
     let pre_propose_id = app.store_code(dao_pre_propose_approval_single_contract());
 
     let submission_policy = if open_proposal_submission {
-        PreProposeSubmissionPolicy::Anyone { denylist: None }
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] }
     } else {
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         }
     };
 
@@ -1393,7 +1393,7 @@ fn test_anyone_denylist() {
         pre_propose.clone(),
         core_addr.as_str(),
         None,
-        PreProposeSubmissionPolicy::Anyone { denylist: None },
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
     );
 
     let rando = "rando";
@@ -1408,7 +1408,7 @@ fn test_anyone_denylist() {
         core_addr.as_str(),
         None,
         PreProposeSubmissionPolicy::Anyone {
-            denylist: Some(vec![rando.to_string()]),
+            denylist: vec![Addr::unchecked(rando)],
         },
     );
 
@@ -1457,8 +1457,8 @@ fn test_specific_allowlist_denylist() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         },
     );
 
@@ -1499,8 +1499,8 @@ fn test_specific_allowlist_denylist() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: Some(vec![rando.to_string()]),
-            denylist: None,
+            allowlist: vec![Addr::unchecked(rando)],
+            denylist: vec![],
         },
     );
 
@@ -1515,8 +1515,8 @@ fn test_specific_allowlist_denylist() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: Some(vec![rando.to_string()]),
-            denylist: Some(vec!["ekez".to_string()]),
+            allowlist: vec![Addr::unchecked(rando)],
+            denylist: vec![Addr::unchecked("ekez")],
         },
     );
 
@@ -1551,8 +1551,8 @@ fn test_specific_allowlist_denylist() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: false,
-            allowlist: Some(vec![rando.to_string()]),
-            denylist: None,
+            allowlist: vec![Addr::unchecked(rando)],
+            denylist: vec![],
         },
     );
 
@@ -1616,8 +1616,8 @@ fn test_instantiate_with_zero_native_deposit() {
                         }),
                         submission_policy: PreProposeSubmissionPolicy::Specific {
                             dao_members: true,
-                            allowlist: None,
-                            denylist: None,
+                            allowlist: vec![],
+                            denylist: vec![],
                         },
                         extension: InstantiateExt {
                             approver: "approver".to_string(),
@@ -1685,8 +1685,8 @@ fn test_instantiate_with_zero_cw20_deposit() {
                         }),
                         submission_policy: PreProposeSubmissionPolicy::Specific {
                             dao_members: true,
-                            allowlist: None,
-                            denylist: None,
+                            allowlist: vec![],
+                            denylist: vec![],
                         },
                         extension: InstantiateExt {
                             approver: "approver".to_string(),
@@ -1737,8 +1737,8 @@ fn test_update_config() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None
+                allowlist: vec![],
+                denylist: vec![]
             }
         }
     );
@@ -1759,7 +1759,7 @@ fn test_update_config() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Never,
         }),
-        PreProposeSubmissionPolicy::Anyone { denylist: None },
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
     );
 
     let config = get_config(&app, pre_propose.clone());
@@ -1771,7 +1771,7 @@ fn test_update_config() {
                 amount: Uint128::new(10),
                 refund_policy: DepositRefundPolicy::Never
             }),
-            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
         }
     );
 
@@ -1826,7 +1826,7 @@ fn test_update_config() {
         pre_propose.clone(),
         proposal_single.as_str(),
         None,
-        PreProposeSubmissionPolicy::Anyone { denylist: None },
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
     );
     assert_eq!(err, PreProposeError::NotDao {});
 
@@ -1838,8 +1838,8 @@ fn test_update_config() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: false,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         },
     );
     assert_eq!(
@@ -1855,8 +1855,8 @@ fn test_update_config() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: false,
-            allowlist: Some(vec!["ekez".to_string()]),
-            denylist: Some(vec!["ekez".to_string()]),
+            allowlist: vec![Addr::unchecked("ekez")],
+            denylist: vec![Addr::unchecked("ekez")],
         },
     );
     assert_eq!(
@@ -1881,7 +1881,7 @@ fn test_update_submission_policy() {
         config,
         Config {
             deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
         }
     );
 
@@ -1925,7 +1925,7 @@ fn test_update_submission_policy() {
         Config {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Anyone {
-                denylist: Some(vec!["ekez".to_string()]),
+                denylist: vec![Addr::unchecked("ekez")],
             },
         }
     );
@@ -1951,7 +1951,7 @@ fn test_update_submission_policy() {
         Config {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Anyone {
-                denylist: Some(vec!["someone".to_string(), "else".to_string()]),
+                denylist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
             },
         }
     );
@@ -1976,7 +1976,7 @@ fn test_update_submission_policy() {
         config,
         Config {
             deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
         }
     );
 
@@ -2056,8 +2056,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: Some(PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None,
+                allowlist: vec![],
+                denylist: vec![],
             }),
         },
         &[],
@@ -2071,8 +2071,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None,
+                allowlist: vec![],
+                denylist: vec![],
             },
         }
     );
@@ -2099,8 +2099,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: Some(vec!["ekez".to_string()]),
+                allowlist: vec![],
+                denylist: vec![Addr::unchecked("ekez")],
             },
         }
     );
@@ -2127,8 +2127,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: Some(vec!["someone".to_string(), "else".to_string()]),
+                allowlist: vec![],
+                denylist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
             },
         }
     );
@@ -2155,8 +2155,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None
+                allowlist: vec![],
+                denylist: vec![]
             },
         }
     );
@@ -2183,8 +2183,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: Some(vec!["ekez".to_string()]),
-                denylist: None,
+                allowlist: vec![Addr::unchecked("ekez")],
+                denylist: vec![],
             },
         }
     );
@@ -2211,8 +2211,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: Some(vec!["someone".to_string(), "else".to_string()]),
-                denylist: None,
+                allowlist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
+                denylist: vec![],
             },
         }
     );
@@ -2239,8 +2239,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None
+                allowlist: vec![],
+                denylist: vec![]
             },
         }
     );
@@ -2289,8 +2289,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: false,
-                allowlist: Some(vec!["ekez".to_string()]),
-                denylist: None
+                allowlist: vec![Addr::unchecked("ekez")],
+                denylist: vec![]
             },
         }
     );
@@ -2363,8 +2363,8 @@ fn test_withdraw() {
         }),
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         },
     );
 
@@ -2414,8 +2414,8 @@ fn test_withdraw() {
         }),
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         },
     );
 
@@ -2792,8 +2792,8 @@ fn test_migrate_from_v241() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None
+                allowlist: vec![],
+                denylist: vec![]
             }
         },
         config
@@ -3087,8 +3087,8 @@ fn test_migrate_from_v241_with_policy_update() {
                     msg: to_json_binary(&MigrateMsg::FromUnderV250 {
                         policy: Some(PreProposeSubmissionPolicy::Specific {
                             dao_members: false,
-                            allowlist: Some(vec!["noob".to_string()]),
-                            denylist: None,
+                            allowlist: vec![Addr::unchecked("noob")],
+                            denylist: vec![],
                         }),
                     })
                     .unwrap(),
@@ -3155,8 +3155,8 @@ fn test_migrate_from_v241_with_policy_update() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: false,
-                allowlist: Some(vec!["noob".to_string()]),
-                denylist: None
+                allowlist: vec![Addr::unchecked("noob")],
+                denylist: vec![]
             }
         },
         config

--- a/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
+++ b/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
@@ -266,6 +266,10 @@
       }
     ],
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "ApproverProposeMessage": {
         "oneOf": [
           {
@@ -451,15 +455,15 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "required": [
+                  "denylist"
+                ],
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -478,17 +482,16 @@
               "specific": {
                 "type": "object",
                 "required": [
-                  "dao_members"
+                  "allowlist",
+                  "dao_members",
+                  "denylist"
                 ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   },
                   "dao_members": {
@@ -497,12 +500,9 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -942,6 +942,10 @@
       }
     ],
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "Empty": {
         "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "object"
@@ -958,15 +962,15 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "required": [
+                  "denylist"
+                ],
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -985,17 +989,16 @@
               "specific": {
                 "type": "object",
                 "required": [
-                  "dao_members"
+                  "allowlist",
+                  "dao_members",
+                  "denylist"
                 ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   },
                   "dao_members": {
@@ -1004,12 +1007,9 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -1167,15 +1167,15 @@
               "properties": {
                 "anyone": {
                   "type": "object",
+                  "required": [
+                    "denylist"
+                  ],
                   "properties": {
                     "denylist": {
                       "description": "Addresses that may not create proposals.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": "array",
                       "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/Addr"
                       }
                     }
                   },
@@ -1194,17 +1194,16 @@
                 "specific": {
                   "type": "object",
                   "required": [
-                    "dao_members"
+                    "allowlist",
+                    "dao_members",
+                    "denylist"
                   ],
                   "properties": {
                     "allowlist": {
                       "description": "Addresses that may create proposals.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": "array",
                       "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/Addr"
                       }
                     },
                     "dao_members": {
@@ -1213,12 +1212,9 @@
                     },
                     "denylist": {
                       "description": "Addresses that may not create proposals, overriding other settings.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": "array",
                       "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/Addr"
                       }
                     }
                   },

--- a/contracts/pre-propose/dao-pre-propose-approver/src/contract.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/contract.rs
@@ -41,8 +41,8 @@ pub fn instantiate(
         deposit_info: None,
         submission_policy: PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         },
         extension: Empty {},
     };

--- a/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/tests.rs
@@ -82,12 +82,12 @@ fn get_proposal_module_approval_single_instantiate(
     let pre_propose_id = app.store_code(cw_pre_propose_base_proposal_single());
 
     let submission_policy = if open_proposal_submission {
-        PreProposeSubmissionPolicy::Anyone { denylist: None }
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] }
     } else {
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         }
     };
 
@@ -1359,8 +1359,8 @@ fn test_update_config() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None
+                allowlist: vec![],
+                denylist: vec![]
             }
         }
     );
@@ -1388,7 +1388,7 @@ fn test_update_config() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Never,
         }),
-        PreProposeSubmissionPolicy::Anyone { denylist: None },
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
     );
 
     let config = get_config(&app, pre_propose.clone());
@@ -1400,7 +1400,7 @@ fn test_update_config() {
                 amount: Uint128::new(10),
                 refund_policy: DepositRefundPolicy::Never
             }),
-            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
         }
     );
 
@@ -1457,7 +1457,7 @@ fn test_update_config() {
         pre_propose.clone(),
         proposal_single.as_str(),
         None,
-        PreProposeSubmissionPolicy::Anyone { denylist: None },
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
     );
     assert_eq!(err, PreProposeError::NotDao {});
 
@@ -1469,8 +1469,8 @@ fn test_update_config() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: false,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         },
     );
     assert_eq!(
@@ -1486,8 +1486,8 @@ fn test_update_config() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: false,
-            allowlist: Some(vec!["ekez".to_string()]),
-            denylist: Some(vec!["ekez".to_string()]),
+            allowlist: vec![Addr::unchecked("ekez")],
+            denylist: vec![Addr::unchecked("ekez")],
         },
     );
     assert_eq!(
@@ -1520,8 +1520,8 @@ fn test_approver_unsupported_update_config() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: false,
-            allowlist: Some(vec!["ekez".to_string()]),
-            denylist: None,
+            allowlist: vec![Addr::unchecked("ekez")],
+            denylist: vec![],
         },
     );
     assert_eq!(err, PreProposeError::Unsupported {});
@@ -1636,8 +1636,8 @@ fn test_withdraw() {
         }),
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         },
     );
 
@@ -1689,8 +1689,8 @@ fn test_withdraw() {
         }),
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         },
     );
 

--- a/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
@@ -41,6 +41,10 @@
     },
     "additionalProperties": false,
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "DepositRefundPolicy": {
         "oneOf": [
           {
@@ -131,15 +135,15 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "required": [
+                  "denylist"
+                ],
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -158,17 +162,16 @@
               "specific": {
                 "type": "object",
                 "required": [
-                  "dao_members"
+                  "allowlist",
+                  "dao_members",
+                  "denylist"
                 ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   },
                   "dao_members": {
@@ -177,12 +180,9 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -523,6 +523,10 @@
       }
     ],
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "BankMsg": {
         "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
         "oneOf": [
@@ -1201,15 +1205,15 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "required": [
+                  "denylist"
+                ],
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -1228,17 +1232,16 @@
               "specific": {
                 "type": "object",
                 "required": [
-                  "dao_members"
+                  "allowlist",
+                  "dao_members",
+                  "denylist"
                 ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   },
                   "dao_members": {
@@ -1247,12 +1250,9 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -2013,6 +2013,10 @@
       }
     ],
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "Empty": {
         "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "object"
@@ -2029,15 +2033,15 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "required": [
+                  "denylist"
+                ],
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -2056,17 +2060,16 @@
               "specific": {
                 "type": "object",
                 "required": [
-                  "dao_members"
+                  "allowlist",
+                  "dao_members",
+                  "denylist"
                 ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   },
                   "dao_members": {
@@ -2075,12 +2078,9 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -2238,15 +2238,15 @@
               "properties": {
                 "anyone": {
                   "type": "object",
+                  "required": [
+                    "denylist"
+                  ],
                   "properties": {
                     "denylist": {
                       "description": "Addresses that may not create proposals.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": "array",
                       "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/Addr"
                       }
                     }
                   },
@@ -2265,17 +2265,16 @@
                 "specific": {
                   "type": "object",
                   "required": [
-                    "dao_members"
+                    "allowlist",
+                    "dao_members",
+                    "denylist"
                   ],
                   "properties": {
                     "allowlist": {
                       "description": "Addresses that may create proposals.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": "array",
                       "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/Addr"
                       }
                     },
                     "dao_members": {
@@ -2284,12 +2283,9 @@
                     },
                     "denylist": {
                       "description": "Addresses that may not create proposals, overriding other settings.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": "array",
                       "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/Addr"
                       }
                     }
                   },

--- a/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
@@ -1712,7 +1712,7 @@ fn test_update_submission_policy() {
         Config {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Anyone {
-                denylist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
+                denylist: vec![Addr::unchecked("else"), Addr::unchecked("someone")],
             },
         }
     );
@@ -1889,7 +1889,7 @@ fn test_update_submission_policy() {
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
                 allowlist: vec![],
-                denylist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
+                denylist: vec![Addr::unchecked("else"), Addr::unchecked("someone")],
             },
         }
     );
@@ -1972,7 +1972,7 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
+                allowlist: vec![Addr::unchecked("else"), Addr::unchecked("someone")],
                 denylist: vec![],
             },
         }

--- a/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-multiple/src/tests.rs
@@ -68,12 +68,12 @@ fn get_default_proposal_module_instantiate(
     let pre_propose_id = app.store_code(dao_pre_propose_multiple_contract());
 
     let submission_policy = if open_proposal_submission {
-        PreProposeSubmissionPolicy::Anyone { denylist: None }
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] }
     } else {
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         }
     };
 
@@ -1067,7 +1067,7 @@ fn test_anyone_denylist() {
         pre_propose.clone(),
         core_addr.as_str(),
         None,
-        PreProposeSubmissionPolicy::Anyone { denylist: None },
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
     );
 
     let rando = "rando";
@@ -1088,7 +1088,7 @@ fn test_anyone_denylist() {
         core_addr.as_str(),
         None,
         PreProposeSubmissionPolicy::Anyone {
-            denylist: Some(vec![rando.to_string()]),
+            denylist: vec![Addr::unchecked(rando)],
         },
     );
 
@@ -1143,8 +1143,8 @@ fn test_specific_allowlist_denylist() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         },
     );
 
@@ -1197,8 +1197,8 @@ fn test_specific_allowlist_denylist() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: Some(vec![rando.to_string()]),
-            denylist: None,
+            allowlist: vec![Addr::unchecked(rando)],
+            denylist: vec![],
         },
     );
 
@@ -1219,8 +1219,8 @@ fn test_specific_allowlist_denylist() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: Some(vec![rando.to_string()]),
-            denylist: Some(vec!["ekez".to_string()]),
+            allowlist: vec![Addr::unchecked(rando)],
+            denylist: vec![Addr::unchecked("ekez")],
         },
     );
 
@@ -1261,8 +1261,8 @@ fn test_specific_allowlist_denylist() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: false,
-            allowlist: Some(vec![rando.to_string()]),
-            denylist: None,
+            allowlist: vec![Addr::unchecked(rando)],
+            denylist: vec![],
         },
     );
 
@@ -1370,8 +1370,8 @@ fn test_instantiate_with_zero_native_deposit() {
                         }),
                         submission_policy: PreProposeSubmissionPolicy::Specific {
                             dao_members: true,
-                            allowlist: None,
-                            denylist: None,
+                            allowlist: vec![],
+                            denylist: vec![],
                         },
                         extension: Empty::default(),
                     })
@@ -1437,8 +1437,8 @@ fn test_instantiate_with_zero_cw20_deposit() {
                         }),
                         submission_policy: PreProposeSubmissionPolicy::Specific {
                             dao_members: true,
-                            allowlist: None,
-                            denylist: None,
+                            allowlist: vec![],
+                            denylist: vec![],
                         },
                         extension: Empty::default(),
                     })
@@ -1487,8 +1487,8 @@ fn test_update_config() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None
+                allowlist: vec![],
+                denylist: vec![]
             }
         }
     );
@@ -1512,7 +1512,7 @@ fn test_update_config() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Never,
         }),
-        PreProposeSubmissionPolicy::Anyone { denylist: None },
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
     );
 
     let config = get_config(&app, pre_propose.clone());
@@ -1524,7 +1524,7 @@ fn test_update_config() {
                 amount: Uint128::new(10),
                 refund_policy: DepositRefundPolicy::Never
             }),
-            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
         }
     );
 
@@ -1587,7 +1587,7 @@ fn test_update_config() {
         pre_propose.clone(),
         proposal_single.as_str(),
         None,
-        PreProposeSubmissionPolicy::Anyone { denylist: None },
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
     );
     assert_eq!(err, PreProposeError::NotDao {});
 
@@ -1599,8 +1599,8 @@ fn test_update_config() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: false,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         },
     );
     assert_eq!(
@@ -1616,8 +1616,8 @@ fn test_update_config() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: false,
-            allowlist: Some(vec!["ekez".to_string()]),
-            denylist: Some(vec!["ekez".to_string()]),
+            allowlist: vec![Addr::unchecked("ekez")],
+            denylist: vec![Addr::unchecked("ekez")],
         },
     );
     assert_eq!(
@@ -1642,7 +1642,7 @@ fn test_update_submission_policy() {
         config,
         Config {
             deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
         }
     );
 
@@ -1686,7 +1686,7 @@ fn test_update_submission_policy() {
         Config {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Anyone {
-                denylist: Some(vec!["ekez".to_string()]),
+                denylist: vec![Addr::unchecked("ekez")],
             },
         }
     );
@@ -1712,7 +1712,7 @@ fn test_update_submission_policy() {
         Config {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Anyone {
-                denylist: Some(vec!["someone".to_string(), "else".to_string()]),
+                denylist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
             },
         }
     );
@@ -1737,7 +1737,7 @@ fn test_update_submission_policy() {
         config,
         Config {
             deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
         }
     );
 
@@ -1817,8 +1817,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: Some(PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None,
+                allowlist: vec![],
+                denylist: vec![],
             }),
         },
         &[],
@@ -1832,8 +1832,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None,
+                allowlist: vec![],
+                denylist: vec![],
             },
         }
     );
@@ -1860,8 +1860,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: Some(vec!["ekez".to_string()]),
+                allowlist: vec![],
+                denylist: vec![Addr::unchecked("ekez")],
             },
         }
     );
@@ -1888,8 +1888,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: Some(vec!["someone".to_string(), "else".to_string()]),
+                allowlist: vec![],
+                denylist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
             },
         }
     );
@@ -1916,8 +1916,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None
+                allowlist: vec![],
+                denylist: vec![]
             },
         }
     );
@@ -1944,8 +1944,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: Some(vec!["ekez".to_string()]),
-                denylist: None,
+                allowlist: vec![Addr::unchecked("ekez")],
+                denylist: vec![],
             },
         }
     );
@@ -1972,8 +1972,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: Some(vec!["someone".to_string(), "else".to_string()]),
-                denylist: None,
+                allowlist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
+                denylist: vec![],
             },
         }
     );
@@ -2000,8 +2000,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None
+                allowlist: vec![],
+                denylist: vec![]
             },
         }
     );
@@ -2050,8 +2050,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: false,
-                allowlist: Some(vec!["ekez".to_string()]),
-                denylist: None
+                allowlist: vec![Addr::unchecked("ekez")],
+                denylist: vec![]
             },
         }
     );
@@ -2124,8 +2124,8 @@ fn test_withdraw() {
         }),
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         },
     );
 
@@ -2172,8 +2172,8 @@ fn test_withdraw() {
         }),
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         },
     );
 
@@ -2566,7 +2566,7 @@ fn test_migrate_from_v241() {
     assert_eq!(
         Config {
             deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None }
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] }
         },
         config
     );
@@ -2889,8 +2889,8 @@ fn test_migrate_from_v241_with_policy_update() {
                                 msg: to_json_binary(&MigrateMsg::FromUnderV250 {
                                     policy: Some(PreProposeSubmissionPolicy::Specific {
                                         dao_members: false,
-                                        allowlist: Some(vec!["noob".to_string()]),
-                                        denylist: None,
+                                        allowlist: vec![Addr::unchecked("noob")],
+                                        denylist: vec![],
                                     }),
                                 })
                                 .unwrap(),
@@ -2956,8 +2956,8 @@ fn test_migrate_from_v241_with_policy_update() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: false,
-                allowlist: Some(vec!["noob".to_string()]),
-                denylist: None
+                allowlist: vec![Addr::unchecked("noob")],
+                denylist: vec![]
             }
         },
         config

--- a/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
+++ b/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
@@ -41,6 +41,10 @@
     },
     "additionalProperties": false,
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "DepositRefundPolicy": {
         "oneOf": [
           {
@@ -131,15 +135,15 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "required": [
+                  "denylist"
+                ],
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -158,17 +162,16 @@
               "specific": {
                 "type": "object",
                 "required": [
-                  "dao_members"
+                  "allowlist",
+                  "dao_members",
+                  "denylist"
                 ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   },
                   "dao_members": {
@@ -177,12 +180,9 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -523,6 +523,10 @@
       }
     ],
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "BankMsg": {
         "description": "The message types of the bank module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/bank/v1beta1/tx.proto",
         "oneOf": [
@@ -1122,15 +1126,15 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "required": [
+                  "denylist"
+                ],
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -1149,17 +1153,16 @@
               "specific": {
                 "type": "object",
                 "required": [
-                  "dao_members"
+                  "allowlist",
+                  "dao_members",
+                  "denylist"
                 ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   },
                   "dao_members": {
@@ -1168,12 +1171,9 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -1987,6 +1987,10 @@
       }
     ],
     "definitions": {
+      "Addr": {
+        "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+        "type": "string"
+      },
       "Empty": {
         "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
         "type": "object"
@@ -2003,15 +2007,15 @@
             "properties": {
               "anyone": {
                 "type": "object",
+                "required": [
+                  "denylist"
+                ],
                 "properties": {
                   "denylist": {
                     "description": "Addresses that may not create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -2030,17 +2034,16 @@
               "specific": {
                 "type": "object",
                 "required": [
-                  "dao_members"
+                  "allowlist",
+                  "dao_members",
+                  "denylist"
                 ],
                 "properties": {
                   "allowlist": {
                     "description": "Addresses that may create proposals.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   },
                   "dao_members": {
@@ -2049,12 +2052,9 @@
                   },
                   "denylist": {
                     "description": "Addresses that may not create proposals, overriding other settings.",
-                    "type": [
-                      "array",
-                      "null"
-                    ],
+                    "type": "array",
                     "items": {
-                      "type": "string"
+                      "$ref": "#/definitions/Addr"
                     }
                   }
                 },
@@ -2212,15 +2212,15 @@
               "properties": {
                 "anyone": {
                   "type": "object",
+                  "required": [
+                    "denylist"
+                  ],
                   "properties": {
                     "denylist": {
                       "description": "Addresses that may not create proposals.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": "array",
                       "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/Addr"
                       }
                     }
                   },
@@ -2239,17 +2239,16 @@
                 "specific": {
                   "type": "object",
                   "required": [
-                    "dao_members"
+                    "allowlist",
+                    "dao_members",
+                    "denylist"
                   ],
                   "properties": {
                     "allowlist": {
                       "description": "Addresses that may create proposals.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": "array",
                       "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/Addr"
                       }
                     },
                     "dao_members": {
@@ -2258,12 +2257,9 @@
                     },
                     "denylist": {
                       "description": "Addresses that may not create proposals, overriding other settings.",
-                      "type": [
-                        "array",
-                        "null"
-                      ],
+                      "type": "array",
                       "items": {
-                        "type": "string"
+                        "$ref": "#/definitions/Addr"
                       }
                     }
                   },

--- a/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
@@ -65,12 +65,12 @@ fn get_default_proposal_module_instantiate(
     let pre_propose_id = app.store_code(dao_pre_propose_single_contract());
 
     let submission_policy = if open_proposal_submission {
-        PreProposeSubmissionPolicy::Anyone { denylist: None }
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] }
     } else {
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         }
     };
 
@@ -1002,7 +1002,7 @@ fn test_anyone_denylist() {
         pre_propose.clone(),
         core_addr.as_str(),
         None,
-        PreProposeSubmissionPolicy::Anyone { denylist: None },
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
     );
 
     let rando = "rando";
@@ -1023,7 +1023,7 @@ fn test_anyone_denylist() {
         core_addr.as_str(),
         None,
         PreProposeSubmissionPolicy::Anyone {
-            denylist: Some(vec![rando.to_string()]),
+            denylist: vec![Addr::unchecked(rando)],
         },
     );
 
@@ -1072,8 +1072,8 @@ fn test_specific_allowlist_denylist() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         },
     );
 
@@ -1120,8 +1120,8 @@ fn test_specific_allowlist_denylist() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: Some(vec![rando.to_string()]),
-            denylist: None,
+            allowlist: vec![Addr::unchecked(rando)],
+            denylist: vec![],
         },
     );
 
@@ -1142,8 +1142,8 @@ fn test_specific_allowlist_denylist() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: Some(vec![rando.to_string()]),
-            denylist: Some(vec!["ekez".to_string()]),
+            allowlist: vec![Addr::unchecked(rando)],
+            denylist: vec![Addr::unchecked("ekez")],
         },
     );
 
@@ -1178,8 +1178,8 @@ fn test_specific_allowlist_denylist() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: false,
-            allowlist: Some(vec![rando.to_string()]),
-            denylist: None,
+            allowlist: vec![Addr::unchecked(rando)],
+            denylist: vec![],
         },
     );
 
@@ -1281,8 +1281,8 @@ fn test_instantiate_with_zero_native_deposit() {
                         }),
                         submission_policy: PreProposeSubmissionPolicy::Specific {
                             dao_members: true,
-                            allowlist: None,
-                            denylist: None,
+                            allowlist: vec![],
+                            denylist: vec![],
                         },
                         extension: Empty::default(),
                     })
@@ -1348,8 +1348,8 @@ fn test_instantiate_with_zero_cw20_deposit() {
                         }),
                         submission_policy: PreProposeSubmissionPolicy::Specific {
                             dao_members: true,
-                            allowlist: None,
-                            denylist: None,
+                            allowlist: vec![],
+                            denylist: vec![],
                         },
                         extension: Empty::default(),
                     })
@@ -1398,8 +1398,8 @@ fn test_update_config() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None
+                allowlist: vec![],
+                denylist: vec![]
             },
         }
     );
@@ -1423,7 +1423,7 @@ fn test_update_config() {
             amount: Uint128::new(10),
             refund_policy: DepositRefundPolicy::Never,
         }),
-        PreProposeSubmissionPolicy::Anyone { denylist: None },
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
     );
 
     let config = get_config(&app, pre_propose.clone());
@@ -1435,7 +1435,7 @@ fn test_update_config() {
                 amount: Uint128::new(10),
                 refund_policy: DepositRefundPolicy::Never
             }),
-            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
         }
     );
 
@@ -1486,7 +1486,7 @@ fn test_update_config() {
         pre_propose.clone(),
         proposal_single.as_str(),
         None,
-        PreProposeSubmissionPolicy::Anyone { denylist: None },
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
     );
     assert_eq!(err, PreProposeError::NotDao {});
 
@@ -1498,8 +1498,8 @@ fn test_update_config() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: false,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         },
     );
     assert_eq!(
@@ -1515,8 +1515,8 @@ fn test_update_config() {
         None,
         PreProposeSubmissionPolicy::Specific {
             dao_members: false,
-            allowlist: Some(vec!["ekez".to_string()]),
-            denylist: Some(vec!["ekez".to_string()]),
+            allowlist: vec![Addr::unchecked("ekez")],
+            denylist: vec![Addr::unchecked("ekez")],
         },
     );
     assert_eq!(
@@ -1543,7 +1543,7 @@ fn test_update_config() {
         config,
         Config {
             deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
         }
     );
 }
@@ -1562,7 +1562,7 @@ fn test_update_submission_policy() {
         config,
         Config {
             deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
         }
     );
 
@@ -1606,7 +1606,7 @@ fn test_update_submission_policy() {
         Config {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Anyone {
-                denylist: Some(vec!["ekez".to_string()]),
+                denylist: vec![Addr::unchecked("ekez")],
             },
         }
     );
@@ -1632,7 +1632,7 @@ fn test_update_submission_policy() {
         Config {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Anyone {
-                denylist: Some(vec!["someone".to_string(), "else".to_string()]),
+                denylist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
             },
         }
     );
@@ -1657,7 +1657,7 @@ fn test_update_submission_policy() {
         config,
         Config {
             deposit_info: None,
-            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
         }
     );
 
@@ -1737,8 +1737,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: Some(PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None,
+                allowlist: vec![],
+                denylist: vec![],
             }),
         },
         &[],
@@ -1752,8 +1752,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None,
+                allowlist: vec![],
+                denylist: vec![],
             },
         }
     );
@@ -1780,8 +1780,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: Some(vec!["ekez".to_string()]),
+                allowlist: vec![],
+                denylist: vec![Addr::unchecked("ekez")],
             },
         }
     );
@@ -1808,8 +1808,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: Some(vec!["someone".to_string(), "else".to_string()]),
+                allowlist: vec![],
+                denylist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
             },
         }
     );
@@ -1836,8 +1836,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None
+                allowlist: vec![],
+                denylist: vec![]
             },
         }
     );
@@ -1864,8 +1864,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: Some(vec!["ekez".to_string()]),
-                denylist: None,
+                allowlist: vec![Addr::unchecked("ekez")],
+                denylist: vec![],
             },
         }
     );
@@ -1892,8 +1892,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: Some(vec!["someone".to_string(), "else".to_string()]),
-                denylist: None,
+                allowlist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
+                denylist: vec![],
             },
         }
     );
@@ -1920,8 +1920,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None
+                allowlist: vec![],
+                denylist: vec![]
             },
         }
     );
@@ -1970,8 +1970,8 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: false,
-                allowlist: Some(vec!["ekez".to_string()]),
-                denylist: None
+                allowlist: vec![Addr::unchecked("ekez")],
+                denylist: vec![]
             },
         }
     );
@@ -2044,8 +2044,8 @@ fn test_withdraw() {
         }),
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         },
     );
 
@@ -2092,8 +2092,8 @@ fn test_withdraw() {
         }),
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         },
     );
 
@@ -2466,8 +2466,8 @@ fn test_migrate_from_v241() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None
+                allowlist: vec![],
+                denylist: vec![]
             }
         },
         config
@@ -2741,8 +2741,8 @@ fn test_migrate_from_v241_with_policy_update() {
                     msg: to_json_binary(&MigrateMsg::FromUnderV250 {
                         policy: Some(PreProposeSubmissionPolicy::Specific {
                             dao_members: false,
-                            allowlist: Some(vec!["noob".to_string()]),
-                            denylist: None,
+                            allowlist: vec![Addr::unchecked("noob")],
+                            denylist: vec![],
                         }),
                     })
                     .unwrap(),
@@ -2800,8 +2800,8 @@ fn test_migrate_from_v241_with_policy_update() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: false,
-                allowlist: Some(vec!["noob".to_string()]),
-                denylist: None
+                allowlist: vec![Addr::unchecked("noob")],
+                denylist: vec![]
             }
         },
         config

--- a/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-single/src/tests.rs
@@ -1632,7 +1632,7 @@ fn test_update_submission_policy() {
         Config {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Anyone {
-                denylist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
+                denylist: vec![Addr::unchecked("else"), Addr::unchecked("someone")],
             },
         }
     );
@@ -1809,7 +1809,7 @@ fn test_update_submission_policy() {
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
                 allowlist: vec![],
-                denylist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
+                denylist: vec![Addr::unchecked("else"), Addr::unchecked("someone")],
             },
         }
     );
@@ -1892,7 +1892,7 @@ fn test_update_submission_policy() {
             deposit_info: None,
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: vec![Addr::unchecked("someone"), Addr::unchecked("else")],
+                allowlist: vec![Addr::unchecked("else"), Addr::unchecked("someone")],
                 denylist: vec![],
             },
         }

--- a/contracts/proposal/dao-proposal-condorcet/src/testing/suite.rs
+++ b/contracts/proposal/dao-proposal-condorcet/src/testing/suite.rs
@@ -146,7 +146,7 @@ impl SuiteBuilder {
         if let Some(candidates) = self.with_proposal {
             suite
                 .propose(
-                    &suite.sender(),
+                    suite.sender(),
                     (0..candidates)
                         .map(|_| vec![unimportant_message()])
                         .collect(),

--- a/contracts/proposal/dao-proposal-multiple/src/testing/instantiate.rs
+++ b/contracts/proposal/dao-proposal-multiple/src/testing/instantiate.rs
@@ -34,12 +34,12 @@ fn get_pre_propose_info(
     let pre_propose_contract = app.store_code(pre_propose_multiple_contract());
 
     let submission_policy = if open_proposal_submission {
-        PreProposeSubmissionPolicy::Anyone { denylist: None }
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] }
     } else {
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         }
     };
 

--- a/contracts/proposal/dao-proposal-multiple/src/testing/tests.rs
+++ b/contracts/proposal/dao-proposal-multiple/src/testing/tests.rs
@@ -99,12 +99,12 @@ pub fn get_pre_propose_info(
     let pre_propose_contract = app.store_code(pre_propose_multiple_contract());
 
     let submission_policy = if open_proposal_submission {
-        PreProposeSubmissionPolicy::Anyone { denylist: None }
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] }
     } else {
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         }
     };
 

--- a/contracts/proposal/dao-proposal-single/src/testing/instantiate.rs
+++ b/contracts/proposal/dao-proposal-single/src/testing/instantiate.rs
@@ -33,12 +33,12 @@ pub(crate) fn get_pre_propose_info(
         app.store_code(crate::testing::contracts::pre_propose_single_contract());
 
     let submission_policy = if open_proposal_submission {
-        PreProposeSubmissionPolicy::Anyone { denylist: None }
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] }
     } else {
         PreProposeSubmissionPolicy::Specific {
             dao_members: true,
-            allowlist: None,
-            denylist: None,
+            allowlist: vec![],
+            denylist: vec![],
         }
     };
 

--- a/contracts/proposal/dao-proposal-single/src/testing/tests.rs
+++ b/contracts/proposal/dao-proposal-single/src/testing/tests.rs
@@ -3957,8 +3957,8 @@ fn test_update_pre_propose_module() {
                             }),
                             submission_policy: PreProposeSubmissionPolicy::Specific {
                                 dao_members: true,
-                                allowlist: None,
-                                denylist: None,
+                                allowlist: vec![],
+                                denylist: vec![],
                             },
                             extension: Empty::default(),
                         })
@@ -4012,8 +4012,8 @@ fn test_update_pre_propose_module() {
             }),
             submission_policy: PreProposeSubmissionPolicy::Specific {
                 dao_members: true,
-                allowlist: None,
-                denylist: None
+                allowlist: vec![],
+                denylist: vec![]
             },
         }
     );

--- a/contracts/voting/dao-voting-token-staked/src/tests/test_tube/mod.rs
+++ b/contracts/voting/dao-voting-token-staked/src/tests/test_tube/mod.rs
@@ -1,6 +1,2 @@
-// Ignore integration tests for code coverage since there will be problems with dynamic linking libosmosistesttube
-// and also, tarpaulin will not be able read coverage out of wasm binary anyway
-#![cfg(not(tarpaulin))]
-
 mod integration_tests;
 mod test_env;

--- a/packages/dao-pre-propose-base/src/execute.rs
+++ b/packages/dao-pre-propose-base/src/execute.rs
@@ -19,6 +19,7 @@ use serde::Serialize;
 
 use crate::{
     error::PreProposeError,
+    helpers::add_and_remove_addresses,
     msg::{DepositInfoResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg},
     state::{Config, PreProposeContract},
 };
@@ -257,28 +258,12 @@ where
                     ));
                 }
 
-                // Add to denylist.
-                if let Some(denylist_add) = denylist_add {
-                    // Validate addresses.
-                    let mut addrs = denylist_add
-                        .iter()
-                        .map(|addr| deps.api.addr_validate(addr))
-                        .collect::<StdResult<Vec<Addr>>>()?;
-
-                    denylist.append(&mut addrs);
-                    denylist.dedup();
-                }
-
-                // Remove from denylist.
-                if let Some(denylist_remove) = denylist_remove {
-                    // Validate addresses.
-                    let addrs = denylist_remove
-                        .iter()
-                        .map(|addr| deps.api.addr_validate(addr))
-                        .collect::<StdResult<Vec<Addr>>>()?;
-
-                    denylist.retain(|a| !addrs.contains(a));
-                }
+                add_and_remove_addresses(
+                    deps.as_ref(),
+                    &mut denylist,
+                    denylist_add,
+                    denylist_remove,
+                )?;
 
                 config.submission_policy = PreProposeSubmissionPolicy::Anyone { denylist };
             }
@@ -293,51 +278,18 @@ where
                     dao_members
                 };
 
-                // Add to allowlist.
-                if let Some(allowlist_add) = allowlist_add {
-                    // Validate addresses.
-                    let mut addrs = allowlist_add
-                        .iter()
-                        .map(|addr| deps.api.addr_validate(addr))
-                        .collect::<StdResult<Vec<Addr>>>()?;
-
-                    allowlist.append(&mut addrs);
-                    allowlist.dedup();
-                }
-
-                // Remove from allowlist.
-                if let Some(allowlist_remove) = allowlist_remove {
-                    // Validate addresses.
-                    let addrs = allowlist_remove
-                        .iter()
-                        .map(|addr| deps.api.addr_validate(addr))
-                        .collect::<StdResult<Vec<Addr>>>()?;
-
-                    allowlist.retain(|a| !addrs.contains(a));
-                }
-
-                // Add to denylist.
-                if let Some(denylist_add) = denylist_add {
-                    // Validate addresses.
-                    let mut addrs = denylist_add
-                        .iter()
-                        .map(|addr| deps.api.addr_validate(addr))
-                        .collect::<StdResult<Vec<Addr>>>()?;
-
-                    denylist.append(&mut addrs);
-                    denylist.dedup();
-                }
-
-                // Remove from denylist.
-                if let Some(denylist_remove) = denylist_remove {
-                    // Validate addresses.
-                    let addrs = denylist_remove
-                        .iter()
-                        .map(|addr| deps.api.addr_validate(addr))
-                        .collect::<StdResult<Vec<Addr>>>()?;
-
-                    denylist.retain(|a| !addrs.contains(a));
-                }
+                add_and_remove_addresses(
+                    deps.as_ref(),
+                    &mut allowlist,
+                    allowlist_add,
+                    allowlist_remove,
+                )?;
+                add_and_remove_addresses(
+                    deps.as_ref(),
+                    &mut denylist,
+                    denylist_add,
+                    denylist_remove,
+                )?;
 
                 config.submission_policy = PreProposeSubmissionPolicy::Specific {
                     dao_members,

--- a/packages/dao-pre-propose-base/src/helpers.rs
+++ b/packages/dao-pre-propose-base/src/helpers.rs
@@ -1,0 +1,32 @@
+use cosmwasm_std::{Addr, Deps, StdResult};
+
+/// validate addresses and add to and/or remove from an existing list of
+/// addresses, removing any duplicates. mutates the original list.
+pub fn add_and_remove_addresses(
+    deps: Deps,
+    list: &mut Vec<Addr>,
+    add: Option<Vec<String>>,
+    remove: Option<Vec<String>>,
+) -> StdResult<()> {
+    if let Some(add) = add {
+        let mut addrs = add
+            .iter()
+            .map(|addr| deps.api.addr_validate(addr))
+            .collect::<StdResult<Vec<Addr>>>()?;
+
+        list.append(&mut addrs);
+        list.sort();
+        list.dedup();
+    }
+
+    if let Some(remove) = remove {
+        let addrs = remove
+            .iter()
+            .map(|addr| deps.api.addr_validate(addr))
+            .collect::<StdResult<Vec<Addr>>>()?;
+
+        list.retain(|a| !addrs.contains(a));
+    }
+
+    Ok(())
+}

--- a/packages/dao-pre-propose-base/src/lib.rs
+++ b/packages/dao-pre-propose-base/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod error;
 pub mod execute;
+pub mod helpers;
 pub mod msg;
 pub mod state;
 

--- a/packages/dao-pre-propose-base/src/tests.rs
+++ b/packages/dao-pre-propose-base/src/tests.rs
@@ -87,7 +87,7 @@ fn test_proposal_submitted_hooks() {
             &mut deps.storage,
             &Config {
                 deposit_info: None,
-                submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: None },
+                submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
             },
         )
         .unwrap();

--- a/packages/dao-testing/src/test_tube/mod.rs
+++ b/packages/dao-testing/src/test_tube/mod.rs
@@ -1,7 +1,3 @@
-// Ignore integration tests for code coverage since there will be problems with dynamic linking libosmosistesttube
-// and also, tarpaulin will not be able read coverage out of wasm binary anyway
-#![cfg(not(tarpaulin))]
-
 // Integrationg tests using an actual chain binary, requires
 // the "test-tube" feature to be enabled
 // cargo test --features test-tube

--- a/packages/dao-voting/src/pre_propose.rs
+++ b/packages/dao-voting/src/pre_propose.rs
@@ -71,16 +71,16 @@ pub enum PreProposeSubmissionPolicy {
     /// Anyone may create proposals, except for those in the denylist.
     Anyone {
         /// Addresses that may not create proposals.
-        denylist: Option<Vec<String>>,
+        denylist: Vec<Addr>,
     },
     /// Specific people may create proposals.
     Specific {
         /// Whether or not DAO members may create proposals.
         dao_members: bool,
         /// Addresses that may create proposals.
-        allowlist: Option<Vec<String>>,
+        allowlist: Vec<Addr>,
         /// Addresses that may not create proposals, overriding other settings.
-        denylist: Option<Vec<String>>,
+        denylist: Vec<Addr>,
     },
 }
 
@@ -108,9 +108,6 @@ impl PreProposeSubmissionPolicy {
             denylist,
         } = self
         {
-            let allowlist = allowlist.as_deref().unwrap_or_default();
-            let denylist = denylist.as_deref().unwrap_or_default();
-
             // prevent allowlist and denylist from overlapping
             if denylist.iter().any(|a| allowlist.iter().any(|b| a == b)) {
                 return Err(PreProposeSubmissionPolicyError::DenylistAllowlistOverlap {});


### PR DESCRIPTION
From Oak:

10:

> The Option<Vec<...>> type is prevalent across the codebase. Although it can distinguish between an empty and an absent list in certain scenarios, its usage is generally discouraged.
>
> For example, in packages/dao-voting/src/pre_propose.rs:72-84, the PreProposeSubmissionPolicy enum declares the denylist and allowlist fields to Option<Vec<String>>. The lists are parsed with unwrap_or_default, which converts empty lists to None before updating the submission policy configuration in packages/dao-pre-propose-base/src/execute.rs:291 and 365. This indicates there is no meaningful distinction between None and an empty vector.
>
> Hence, we conclude that Option<Vec<...>> serves more as an optimization than a necessity. Given that modern Rust minimizes the memory footprint of empty vectors, the complexity added by Option<Vec<...>> pattern outweighs its benefits.
>
> Consequently, the code complexity is increased due to additional checks and unwrapping without a significant memory efficiency gain.

12:

> The code segments in packages/dao-pre-propose-base/src/execute.rs:262-283, 307-328, and 330-351 are identical. These segments implement modifying permission lists with iteration, deduplication, and address validation, which can be abstracted as reusable components to reduce the attack surface and increase code maintainability.

This fix replaces all `Option<Vec<String>>` instances with `Vec<Addr>`, except those in the update submission policy message, since that allows the caller to omit fields from the JSON entirely, which is a desirable optimization for frontends.

It also de-dupes some redundant code.