### PR TITLE
[audit] 14. “Migrate only if newer” pattern is not followed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2222,6 +2222,7 @@ dependencies = [
  "dao-voting-cw4 2.5.0",
  "dao-voting-cw721-staked",
  "dao-voting-token-staked",
+ "semver",
  "thiserror",
 ]
 

--- a/contracts/distribution/dao-rewards-distributor/Cargo.toml
+++ b/contracts/distribution/dao-rewards-distributor/Cargo.toml
@@ -29,6 +29,7 @@ cw-utils = { workspace = true }
 dao-hooks = { workspace = true }
 dao-interface = { workspace = true }
 dao-voting = { workspace = true }
+semver = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
+++ b/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
@@ -847,8 +847,8 @@
   "migrate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MigrateMsg",
-    "type": "string",
-    "enum": []
+    "type": "object",
+    "additionalProperties": false
   },
   "sudo": null,
   "responses": {

--- a/contracts/distribution/dao-rewards-distributor/src/error.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/error.rs
@@ -22,6 +22,9 @@ pub enum ContractError {
     #[error(transparent)]
     Payment(#[from] PaymentError),
 
+    #[error("semver parsing error: {0}")]
+    SemVer(String),
+
     #[error("Invalid CW20")]
     InvalidCw20 {},
 
@@ -54,4 +57,16 @@ pub enum ContractError {
 
     #[error("Cannot update emission rate because this distribution has accumulated the maximum rewards. Start a new distribution with the new emission rate instead. (Overflow: {err})")]
     DistributionHistoryTooLarge { err: String },
+
+    #[error("Invalid version migration. {new} is not newer than {current}.")]
+    MigrationErrorInvalidVersion { new: String, current: String },
+
+    #[error("Expected to migrate from contract {expected}. Got {actual}.")]
+    MigrationErrorIncorrectContract { expected: String, actual: String },
+}
+
+impl From<semver::Error> for ContractError {
+    fn from(err: semver::Error) -> Self {
+        Self::SemVer(err.to_string())
+    }
 }

--- a/contracts/distribution/dao-rewards-distributor/src/msg.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/msg.rs
@@ -133,4 +133,4 @@ pub struct DistributionPendingRewards {
 }
 
 #[cw_serde]
-pub enum MigrateMsg {}
+pub struct MigrateMsg {}

--- a/contracts/distribution/dao-rewards-distributor/src/testing/suite.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/testing/suite.rs
@@ -109,6 +109,7 @@ impl SuiteBuilder {
             owner: Some(owner.clone()),
             staking_addr: Addr::unchecked(""),
             voting_power_addr: Addr::unchecked(""),
+            reward_code_id: 0,
             distribution_contract: Addr::unchecked(""),
             cw20_addr: Addr::unchecked(""),
             reward_denom: DENOM.to_string(),
@@ -229,12 +230,12 @@ impl SuiteBuilder {
         };
 
         // initialize the rewards distributor
-        let reward_code_id = suite_built.app.borrow_mut().store_code(contract_rewards());
+        suite_built.reward_code_id = suite_built.app.borrow_mut().store_code(contract_rewards());
         let reward_addr = suite_built
             .app
             .borrow_mut()
             .instantiate_contract(
-                reward_code_id,
+                suite_built.reward_code_id,
                 owner.clone(),
                 &InstantiateMsg {
                     owner: Some(owner.clone().into_string()),
@@ -327,6 +328,7 @@ pub struct Suite {
     pub voting_power_addr: Addr,
     pub reward_denom: String,
 
+    pub reward_code_id: u64,
     pub distribution_contract: Addr,
 
     // cw20 type fields


### PR DESCRIPTION
From Oak:

> In contracts/distribution/dao-rewards-distributor/src/contract.rs:594 -597, the rewards distributor contract can be migrated without regard to their version. This can be improved by adding validation to ensure that the migration is only performed if the supplied version is newer.

This fix adds contract name and version checks before allowing migration.