### PR TITLE
bump optimizer to v0.16.0

### DIFF
--- a/.github/workflows/release-contracts.yml
+++ b/.github/workflows/release-contracts.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
     branches:
       - main
       - ci/release-contracts
@@ -14,7 +14,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    container: cosmwasm/workspace-optimizer:0.14.0
+    container: cosmwasm/optimizer:0.16.0
     steps:
       - uses: actions/checkout@v3
 
@@ -29,7 +29,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/            
+            target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Compile contracts

--- a/justfile
+++ b/justfile
@@ -55,18 +55,13 @@ download-deps:
 
 workspace-optimize:
     #!/bin/bash
-    if [[ $(uname -m) == 'arm64' ]]; then docker run --rm -v "$(pwd)":/code \
+    if [[ $(uname -m) == 'arm64' ]] || [ $(uname -m) == 'aarch64' ]]; then docker run --rm -v "$(pwd)":/code \
             --mount type=volume,source="$(basename "$(pwd)")_cache",target=/target \
             --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
             --platform linux/arm64 \
-            cosmwasm/workspace-optimizer-arm64:0.14.0; \
-    elif [[ $(uname -m) == 'aarch64' ]]; then docker run --rm -v "$(pwd)":/code \
-            --mount type=volume,source="$(basename "$(pwd)")_cache",target=/target \
-            --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-            --platform linux/arm64 \
-            cosmwasm/workspace-optimizer-arm64:0.14.0; \
+            cosmwasm/optimizer-arm64:0.16.0; \
     elif [[ $(uname -m) == 'x86_64' ]]; then docker run --rm -v "$(pwd)":/code \
             --mount type=volume,source="$(basename "$(pwd)")_cache",target=/target \
             --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
             --platform linux/amd64 \
-            cosmwasm/workspace-optimizer:0.14.0; fi
+            cosmwasm/optimizer:0.16.0; fi


### PR DESCRIPTION
replace deprecated workspace-optimizer v0.14.0 with optimizer v0.16.0