### PR TITLE
added support for querying the address from an NFT ID, closes #820

### DIFF
--- a/contracts/voting/dao-voting-cw721-staked/src/msg.rs
+++ b/contracts/voting/dao-voting-cw721-staked/src/msg.rs
@@ -92,7 +92,14 @@ pub enum QueryMsg {
     },
     #[returns(ActiveThresholdResponse)]
     ActiveThreshold {},
+    #[returns(AddressResponse)]
+    NftOwner { token_id: String },
 }
 
 #[cw_serde]
 pub struct MigrateMsg {}
+
+#[cw_serde]
+pub struct AddressResponse {
+    pub owner: Option<String>,
+}


### PR DESCRIPTION
This implementation follows these steps:
1. Query the NFT contract to get the current owner of the token.
2. Check if the token is staked in this contract by iterating through `STAKED_NFTS_PER_OWNER` map.
3. If the token is staked, it returns the staker’s address.
4. If the token is not staked, it returns the owner from the NFT contract. So this way, whether the NFT is staked or not, the owner/staker can be queried.
5. Write tests for:
    1. Querying the owner of a staked NFT.
    2. Querying the owner of an unstaked NFT.
    3. Querying a non-existent nFT.
    4. Querying the owner of an NFT after unstacking
    5. Querying owners for multiple staked NFTs from different users.
