### PR TITLE
Reward distributor improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,12 +271,12 @@ dependencies = [
  "cw-admin-factory",
  "cw-utils 1.0.3",
  "cw20 1.1.2",
- "cw20-stake 2.5.0",
- "dao-dao-core 2.5.0",
- "dao-interface 2.5.0",
- "dao-pre-propose-single 2.5.0",
- "dao-proposal-single 2.5.0",
- "dao-voting 2.5.0",
+ "cw20-stake 2.5.1",
+ "dao-dao-core 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-pre-propose-single 2.5.1",
+ "dao-proposal-single 2.5.1",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
  "env_logger",
  "serde",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "btsg-ft-factory"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -304,11 +304,11 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "dao-dao-core 2.5.0",
- "dao-interface 2.5.0",
- "dao-proposal-single 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-proposal-single 2.5.1",
  "dao-testing",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-token-staked",
  "osmosis-std-derive",
  "prost 0.12.3",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "cw-admin-factory"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "bech32",
  "cosmwasm-schema",
@@ -698,12 +698,12 @@ dependencies = [
  "cw2 1.1.2",
  "cw20-base 1.1.2",
  "cw4 1.1.2",
- "dao-dao-core 2.5.0",
- "dao-interface 2.5.0",
- "dao-proposal-single 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-proposal-single 2.5.1",
  "dao-testing",
- "dao-voting 2.5.0",
- "dao-voting-cw4 2.5.0",
+ "dao-voting 2.5.1",
+ "dao-voting-cw4 2.5.1",
  "osmosis-test-tube",
  "thiserror",
 ]
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "cw-denom"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -844,20 +844,20 @@ dependencies = [
 
 [[package]]
 name = "cw-fund-distributor"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-paginate-storage 2.5.0",
+ "cw-paginate-storage 2.5.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
- "dao-dao-core 2.5.0",
- "dao-interface 2.5.0",
+ "cw20-stake 2.5.1",
+ "dao-dao-core 2.5.1",
+ "dao-interface 2.5.1",
  "dao-voting-cw20-staked",
  "thiserror",
 ]
@@ -876,7 +876,7 @@ dependencies = [
 
 [[package]]
 name = "cw-hooks"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cw-paginate-storage"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
@@ -965,11 +965,11 @@ dependencies = [
 
 [[package]]
 name = "cw-payroll-factory"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
+ "cw-denom 2.5.1",
  "cw-multi-test",
  "cw-ownable",
  "cw-storage-plus 1.2.0",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "cw-stake-tracker"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "cw-token-swap"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "cw-tokenfactory-issuer"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1086,7 +1086,7 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-tokenfactory-types",
  "cw2 1.1.2",
- "dao-interface 2.5.0",
+ "dao-interface 2.5.1",
  "osmosis-std",
  "osmosis-test-tube",
  "prost 0.12.3",
@@ -1099,11 +1099,11 @@ dependencies = [
 
 [[package]]
 name = "cw-tokenfactory-types"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "dao-interface 2.5.0",
+ "dao-interface 2.5.1",
  "osmosis-std",
  "osmosis-std-derive",
  "prost 0.12.3",
@@ -1170,12 +1170,12 @@ dependencies = [
 
 [[package]]
 name = "cw-vesting"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
+ "cw-denom 2.5.1",
  "cw-multi-test",
  "cw-ownable",
  "cw-stake-tracker",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "cw-wormhole"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1360,16 +1360,16 @@ dependencies = [
 
 [[package]]
 name = "cw20-stake"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-hooks 2.5.0",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-ownable",
- "cw-paginate-storage 2.5.0",
+ "cw-paginate-storage 2.5.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 0.13.4",
  "cw-utils 1.0.3",
@@ -1377,14 +1377,14 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw20-stake 0.2.6",
- "dao-hooks 2.5.0",
- "dao-voting 2.5.0",
+ "dao-hooks 2.5.1",
+ "dao-voting 2.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "cw20-stake-external-rewards"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1398,15 +1398,15 @@ dependencies = [
  "cw20 0.13.4",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
- "dao-hooks 2.5.0",
+ "cw20-stake 2.5.1",
+ "dao-hooks 2.5.1",
  "stake-cw20-external-rewards",
  "thiserror",
 ]
 
 [[package]]
 name = "cw20-stake-reward-distributor"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1417,7 +1417,7 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
+ "cw20-stake 2.5.1",
  "stake-cw20-reward-distributor",
  "thiserror",
 ]
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-controllers"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-roles"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1643,7 +1643,7 @@ dependencies = [
 
 [[package]]
 name = "dao-cw721-extensions"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1673,13 +1673,13 @@ dependencies = [
 
 [[package]]
 name = "dao-dao-core"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-core",
  "cw-multi-test",
- "cw-paginate-storage 2.5.0",
+ "cw-paginate-storage 2.5.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1687,8 +1687,8 @@ dependencies = [
  "cw20-base 1.1.2",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
  "dao-proposal-sudo",
  "dao-voting-cw20-balance",
  "thiserror",
@@ -1708,13 +1708,13 @@ dependencies = [
 
 [[package]]
 name = "dao-dao-macros"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-hooks 2.5.0",
- "dao-interface 2.5.0",
- "dao-voting 2.5.0",
+ "cw-hooks 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-voting 2.5.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1736,14 +1736,14 @@ dependencies = [
 
 [[package]]
 name = "dao-hooks"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-hooks 2.5.0",
+ "cw-hooks 2.5.1",
  "cw4 1.1.2",
- "dao-pre-propose-base 2.5.0",
- "dao-voting 2.5.0",
+ "dao-pre-propose-base 2.5.1",
+ "dao-voting 2.5.1",
 ]
 
 [[package]]
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "dao-interface"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "dao-migrator"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1793,18 +1793,18 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw20-stake 0.2.6",
- "cw20-stake 2.5.0",
+ "cw20-stake 2.5.1",
  "cw20-staked-balance-voting",
  "cw4 0.13.4",
  "cw4-voting",
- "dao-dao-core 2.5.0",
- "dao-interface 2.5.0",
- "dao-proposal-single 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-proposal-single 2.5.1",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
  "thiserror",
 ]
 
@@ -1827,13 +1827,13 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-approval-single"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
+ "cw-denom 2.5.1",
  "cw-multi-test",
- "cw-paginate-storage 2.5.0",
+ "cw-paginate-storage 2.5.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1842,30 +1842,30 @@ dependencies = [
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "dao-dao-core 2.4.1",
- "dao-dao-core 2.5.0",
- "dao-hooks 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-hooks 2.5.1",
  "dao-interface 2.4.1",
- "dao-interface 2.5.0",
+ "dao-interface 2.5.1",
  "dao-pre-propose-approval-single 2.4.1",
- "dao-pre-propose-base 2.5.0",
+ "dao-pre-propose-base 2.5.1",
  "dao-proposal-single 2.4.1",
- "dao-proposal-single 2.5.0",
+ "dao-proposal-single 2.5.1",
  "dao-testing",
  "dao-voting 2.4.1",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
  "dao-voting-cw4 2.4.1",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-pre-propose-approver"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
+ "cw-denom 2.5.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -1873,16 +1873,16 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw4-group 1.1.2",
- "dao-dao-core 2.5.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
- "dao-pre-propose-approval-single 2.5.0",
- "dao-pre-propose-base 2.5.0",
- "dao-proposal-single 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-pre-propose-approval-single 2.5.1",
+ "dao-pre-propose-base 2.5.1",
+ "dao-proposal-single 2.5.1",
  "dao-testing",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
 ]
 
 [[package]]
@@ -1906,21 +1906,21 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-base"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-denom 2.4.1",
- "cw-denom 2.5.0",
- "cw-hooks 2.5.0",
+ "cw-denom 2.5.1",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "dao-interface 2.5.0",
+ "dao-interface 2.5.1",
  "dao-pre-propose-base 2.4.1",
  "dao-voting 2.4.1",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "semver",
  "serde",
  "thiserror",
@@ -1941,11 +1941,11 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-multiple"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
+ "cw-denom 2.5.1",
  "cw-multi-test",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1954,20 +1954,20 @@ dependencies = [
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "dao-dao-core 2.4.1",
- "dao-dao-core 2.5.0",
- "dao-hooks 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-hooks 2.5.1",
  "dao-interface 2.4.1",
- "dao-interface 2.5.0",
- "dao-pre-propose-base 2.5.0",
+ "dao-interface 2.5.1",
+ "dao-pre-propose-base 2.5.1",
  "dao-pre-propose-multiple 2.4.1",
  "dao-proposal-multiple 2.4.1",
- "dao-proposal-multiple 2.5.0",
+ "dao-proposal-multiple 2.5.1",
  "dao-testing",
  "dao-voting 2.4.1",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
  "dao-voting-cw4 2.4.1",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
 ]
 
 [[package]]
@@ -1985,12 +1985,12 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-single"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
- "cw-hooks 2.5.0",
+ "cw-denom 2.5.1",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1999,25 +1999,25 @@ dependencies = [
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "dao-dao-core 2.4.1",
- "dao-dao-core 2.5.0",
- "dao-hooks 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-hooks 2.5.1",
  "dao-interface 2.4.1",
- "dao-interface 2.5.0",
- "dao-pre-propose-base 2.5.0",
+ "dao-interface 2.5.1",
+ "dao-pre-propose-base 2.5.1",
  "dao-pre-propose-single 2.4.1",
  "dao-proposal-single 2.4.1",
- "dao-proposal-single 2.5.0",
+ "dao-proposal-single 2.5.1",
  "dao-testing",
  "dao-voting 2.4.1",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
  "dao-voting-cw4 2.4.1",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
 ]
 
 [[package]]
 name = "dao-proposal-condorcet"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2028,33 +2028,33 @@ dependencies = [
  "cw2 1.1.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
- "dao-dao-core 2.5.0",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
  "dao-testing",
- "dao-voting 2.5.0",
- "dao-voting-cw4 2.5.0",
+ "dao-voting 2.5.1",
+ "dao-voting-cw4 2.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-proposal-hook-counter"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-hooks 2.5.0",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "dao-dao-core 2.5.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
- "dao-proposal-single 2.5.0",
- "dao-voting 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-proposal-single 2.5.1",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-balance",
  "thiserror",
 ]
@@ -2084,34 +2084,34 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-multiple"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
- "cw-hooks 2.5.0",
+ "cw-denom 2.5.1",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
+ "cw20-stake 2.5.1",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
- "dao-dao-macros 2.5.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
- "dao-pre-propose-base 2.5.0",
- "dao-pre-propose-multiple 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-pre-propose-base 2.5.1",
+ "dao-pre-propose-multiple 2.5.1",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
  "dao-voting-cw721-staked",
  "dao-voting-token-staked",
  "rand",
@@ -2144,14 +2144,14 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-single"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-core",
- "cw-denom 2.5.0",
- "cw-hooks 2.5.0",
+ "cw-denom 2.5.1",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-proposal-single",
  "cw-storage-plus 1.2.0",
@@ -2160,22 +2160,22 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
+ "cw20-stake 2.5.1",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
- "dao-dao-core 2.5.0",
- "dao-dao-macros 2.5.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
- "dao-pre-propose-base 2.5.0",
- "dao-pre-propose-single 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-dao-macros 2.5.1",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-pre-propose-base 2.5.1",
+ "dao-pre-propose-single 2.5.1",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
  "dao-voting-cw721-staked",
  "dao-voting-token-staked",
  "thiserror",
@@ -2183,21 +2183,21 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-sudo"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-rewards-distributor"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2210,16 +2210,16 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
+ "cw20-stake 2.5.1",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
  "dao-testing",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
  "dao-voting-cw721-staked",
  "dao-voting-token-staked",
  "semver",
@@ -2228,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "dao-test-custom-factory"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2240,21 +2240,21 @@ dependencies = [
  "cw2 1.1.2",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
- "dao-voting 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-voting 2.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-testing"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-admin-factory",
  "cw-core",
- "cw-hooks 2.5.0",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-proposal-single",
  "cw-tokenfactory-issuer",
@@ -2263,23 +2263,23 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
+ "cw20-stake 2.5.1",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
  "cw721-roles",
- "dao-dao-core 2.5.0",
- "dao-interface 2.5.0",
- "dao-pre-propose-multiple 2.5.0",
- "dao-pre-propose-single 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-pre-propose-multiple 2.5.1",
+ "dao-pre-propose-single 2.5.1",
  "dao-proposal-condorcet",
- "dao-proposal-single 2.5.0",
+ "dao-proposal-single 2.5.1",
  "dao-test-custom-factory",
  "dao-voting 0.1.0",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
  "dao-voting-cw721-roles",
  "dao-voting-cw721-staked",
  "dao-voting-onft-staked",
@@ -2323,22 +2323,22 @@ dependencies = [
 
 [[package]]
 name = "dao-voting"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
+ "cw-denom 2.5.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw20 1.1.2",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw20-balance"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2348,14 +2348,14 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw20-staked"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2365,10 +2365,10 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
- "dao-voting 2.5.0",
+ "cw20-stake 2.5.1",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-voting 2.5.1",
  "thiserror",
 ]
 
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-cw4"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2402,14 +2402,14 @@ dependencies = [
  "cw2 1.1.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw721-roles"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2425,21 +2425,21 @@ dependencies = [
  "cw721-controllers",
  "cw721-roles",
  "dao-cw721-extensions",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
  "dao-testing",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw721-staked"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-hooks 2.5.0",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -2447,14 +2447,14 @@ dependencies = [
  "cw721 0.18.0",
  "cw721-base 0.18.0",
  "cw721-controllers",
- "dao-dao-macros 2.5.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
  "dao-proposal-hook-counter",
- "dao-proposal-single 2.5.0",
+ "dao-proposal-single 2.5.1",
  "dao-test-custom-factory",
  "dao-testing",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "osmosis-std",
  "osmosis-test-tube",
  "serde",
@@ -2463,26 +2463,26 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-onft-staked"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-hooks 2.5.0",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw721-controllers",
- "dao-dao-macros 2.5.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
  "dao-proposal-hook-counter",
- "dao-proposal-single 2.5.0",
+ "dao-proposal-single 2.5.1",
  "dao-test-custom-factory",
  "dao-testing",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "omniflix-std",
  "osmosis-test-tube",
  "prost 0.12.3",
@@ -2493,27 +2493,27 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-token-staked"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-hooks 2.5.0",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-ownable",
  "cw-storage-plus 1.2.0",
  "cw-tokenfactory-issuer",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "dao-dao-macros 2.5.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
  "dao-proposal-hook-counter",
- "dao-proposal-single 2.5.0",
+ "dao-proposal-single 2.5.1",
  "dao-test-custom-factory",
  "dao-testing",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "osmosis-std",
  "osmosis-test-tube",
  "serde",
@@ -3201,16 +3201,16 @@ dependencies = [
  "cw-vesting",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
+ "cw20-stake 2.5.1",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
  "cw721-roles",
- "dao-dao-core 2.5.0",
- "dao-interface 2.5.0",
- "dao-pre-propose-single 2.5.0",
- "dao-proposal-single 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-pre-propose-single 2.5.1",
+ "dao-proposal-single 2.5.1",
  "dao-test-custom-factory",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
  "dao-voting-cw721-staked",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "2"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/DA0-DA0/dao-contracts"
-version = "2.5.0"
+version = "2.5.1"
 
 [profile.release]
 codegen-units = 1
@@ -85,46 +85,46 @@ wynd-utils = "0.4"
 # optional owner.
 cw-ownable = "0.5"
 
-cw-admin-factory = { path = "./contracts/external/cw-admin-factory", version = "2.5.0" }
-cw-denom = { path = "./packages/cw-denom", version = "2.5.0" }
-cw-fund-distributor = { path = "./contracts/distribution/cw-fund-distributor", version = "2.5.0" }
-cw-hooks = { path = "./packages/cw-hooks", version = "2.5.0" }
-cw-paginate-storage = { path = "./packages/cw-paginate-storage", version = "2.5.0" }
-cw-payroll-factory = { path = "./contracts/external/cw-payroll-factory", version = "2.5.0" }
-cw-stake-tracker = { path = "./packages/cw-stake-tracker", version = "2.5.0" }
-cw-tokenfactory-issuer = { path = "./contracts/external/cw-tokenfactory-issuer", version = "2.5.0", default-features = false }
-cw-tokenfactory-types = { path = "./packages/cw-tokenfactory-types", version = "2.5.0", default-features = false }
-cw-vesting = { path = "./contracts/external/cw-vesting", version = "2.5.0" }
-cw-wormhole = { path = "./packages/cw-wormhole", version = "2.5.0" }
-cw20-stake = { path = "./contracts/staking/cw20-stake", version = "2.5.0" }
-cw721-controllers = { path = "./packages/cw721-controllers", version = "2.5.0" }
-cw721-roles = { path = "./contracts/external/cw721-roles", version = "2.5.0" }
-dao-cw721-extensions = { path = "./packages/dao-cw721-extensions", version = "2.5.0" }
-dao-dao-core = { path = "./contracts/dao-dao-core", version = "2.5.0" }
-dao-dao-macros = { path = "./packages/dao-dao-macros", version = "2.5.0" }
-dao-hooks = { path = "./packages/dao-hooks", version = "2.5.0" }
-dao-interface = { path = "./packages/dao-interface", version = "2.5.0" }
-dao-pre-propose-approval-single = { path = "./contracts/pre-propose/dao-pre-propose-approval-single", version = "2.5.0" }
-dao-pre-propose-approver = { path = "./contracts/pre-propose/dao-pre-propose-approver", version = "2.5.0" }
-dao-pre-propose-base = { path = "./packages/dao-pre-propose-base", version = "2.5.0" }
-dao-pre-propose-multiple = { path = "./contracts/pre-propose/dao-pre-propose-multiple", version = "2.5.0" }
-dao-pre-propose-single = { path = "./contracts/pre-propose/dao-pre-propose-single", version = "2.5.0" }
-dao-proposal-condorcet = { path = "./contracts/proposal/dao-proposal-condorcet", version = "2.5.0" }
-dao-proposal-hook-counter = { path = "./contracts/test/dao-proposal-hook-counter", version = "2.5.0" }
-dao-proposal-multiple = { path = "./contracts/proposal/dao-proposal-multiple", version = "2.5.0" }
-dao-proposal-single = { path = "./contracts/proposal/dao-proposal-single", version = "2.5.0" }
-dao-proposal-sudo = { path = "./contracts/test/dao-proposal-sudo", version = "2.5.0" }
-dao-rewards-distributor = { path = "./contracts/distribution/dao-rewards-distributor", version = "2.5.0" }
-dao-test-custom-factory = { path = "./contracts/test/dao-test-custom-factory", version = "2.5.0" }
-dao-testing = { path = "./packages/dao-testing", version = "2.5.0" }
-dao-voting = { path = "./packages/dao-voting", version = "2.5.0" }
-dao-voting-cw20-balance = { path = "./contracts/test/dao-voting-cw20-balance", version = "2.5.0" }
-dao-voting-cw20-staked = { path = "./contracts/voting/dao-voting-cw20-staked", version = "2.5.0" }
-dao-voting-cw4 = { path = "./contracts/voting/dao-voting-cw4", version = "2.5.0" }
-dao-voting-cw721-roles = { path = "./contracts/voting/dao-voting-cw721-roles", version = "2.5.0" }
-dao-voting-cw721-staked = { path = "./contracts/voting/dao-voting-cw721-staked", version = "2.5.0" }
-dao-voting-onft-staked = { path = "./contracts/voting/dao-voting-onft-staked", version = "2.5.0" }
-dao-voting-token-staked = { path = "./contracts/voting/dao-voting-token-staked", version = "2.5.0" }
+cw-admin-factory = { path = "./contracts/external/cw-admin-factory", version = "2.5.1" }
+cw-denom = { path = "./packages/cw-denom", version = "2.5.1" }
+cw-fund-distributor = { path = "./contracts/distribution/cw-fund-distributor", version = "2.5.1" }
+cw-hooks = { path = "./packages/cw-hooks", version = "2.5.1" }
+cw-paginate-storage = { path = "./packages/cw-paginate-storage", version = "2.5.1" }
+cw-payroll-factory = { path = "./contracts/external/cw-payroll-factory", version = "2.5.1" }
+cw-stake-tracker = { path = "./packages/cw-stake-tracker", version = "2.5.1" }
+cw-tokenfactory-issuer = { path = "./contracts/external/cw-tokenfactory-issuer", version = "2.5.1", default-features = false }
+cw-tokenfactory-types = { path = "./packages/cw-tokenfactory-types", version = "2.5.1", default-features = false }
+cw-vesting = { path = "./contracts/external/cw-vesting", version = "2.5.1" }
+cw-wormhole = { path = "./packages/cw-wormhole", version = "2.5.1" }
+cw20-stake = { path = "./contracts/staking/cw20-stake", version = "2.5.1" }
+cw721-controllers = { path = "./packages/cw721-controllers", version = "2.5.1" }
+cw721-roles = { path = "./contracts/external/cw721-roles", version = "2.5.1" }
+dao-cw721-extensions = { path = "./packages/dao-cw721-extensions", version = "2.5.1" }
+dao-dao-core = { path = "./contracts/dao-dao-core", version = "2.5.1" }
+dao-dao-macros = { path = "./packages/dao-dao-macros", version = "2.5.1" }
+dao-hooks = { path = "./packages/dao-hooks", version = "2.5.1" }
+dao-interface = { path = "./packages/dao-interface", version = "2.5.1" }
+dao-pre-propose-approval-single = { path = "./contracts/pre-propose/dao-pre-propose-approval-single", version = "2.5.1" }
+dao-pre-propose-approver = { path = "./contracts/pre-propose/dao-pre-propose-approver", version = "2.5.1" }
+dao-pre-propose-base = { path = "./packages/dao-pre-propose-base", version = "2.5.1" }
+dao-pre-propose-multiple = { path = "./contracts/pre-propose/dao-pre-propose-multiple", version = "2.5.1" }
+dao-pre-propose-single = { path = "./contracts/pre-propose/dao-pre-propose-single", version = "2.5.1" }
+dao-proposal-condorcet = { path = "./contracts/proposal/dao-proposal-condorcet", version = "2.5.1" }
+dao-proposal-hook-counter = { path = "./contracts/test/dao-proposal-hook-counter", version = "2.5.1" }
+dao-proposal-multiple = { path = "./contracts/proposal/dao-proposal-multiple", version = "2.5.1" }
+dao-proposal-single = { path = "./contracts/proposal/dao-proposal-single", version = "2.5.1" }
+dao-proposal-sudo = { path = "./contracts/test/dao-proposal-sudo", version = "2.5.1" }
+dao-rewards-distributor = { path = "./contracts/distribution/dao-rewards-distributor", version = "2.5.1" }
+dao-test-custom-factory = { path = "./contracts/test/dao-test-custom-factory", version = "2.5.1" }
+dao-testing = { path = "./packages/dao-testing", version = "2.5.1" }
+dao-voting = { path = "./packages/dao-voting", version = "2.5.1" }
+dao-voting-cw20-balance = { path = "./contracts/test/dao-voting-cw20-balance", version = "2.5.1" }
+dao-voting-cw20-staked = { path = "./contracts/voting/dao-voting-cw20-staked", version = "2.5.1" }
+dao-voting-cw4 = { path = "./contracts/voting/dao-voting-cw4", version = "2.5.1" }
+dao-voting-cw721-roles = { path = "./contracts/voting/dao-voting-cw721-roles", version = "2.5.1" }
+dao-voting-cw721-staked = { path = "./contracts/voting/dao-voting-cw721-staked", version = "2.5.1" }
+dao-voting-onft-staked = { path = "./contracts/voting/dao-voting-onft-staked", version = "2.5.1" }
+dao-voting-token-staked = { path = "./contracts/voting/dao-voting-token-staked", version = "2.5.1" }
 
 # v1 dependencies. used for state migrations.
 cw-core-v1 = { package = "cw-core", version = "0.1.0" }

--- a/contracts/dao-dao-core/schema/dao-dao-core.json
+++ b/contracts/dao-dao-core/schema/dao-dao-core.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-dao-core",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/distribution/cw-fund-distributor/schema/cw-fund-distributor.json
+++ b/contracts/distribution/cw-fund-distributor/schema/cw-fund-distributor.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-fund-distributor",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
+++ b/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
@@ -110,6 +110,13 @@
                 "format": "uint64",
                 "minimum": 0.0
               },
+              "open_funding": {
+                "description": "whether or not non-owners can fund the distribution",
+                "type": [
+                  "boolean",
+                  "null"
+                ]
+              },
               "vp_contract": {
                 "description": "address to query the voting power",
                 "type": [
@@ -321,12 +328,19 @@
             "description": "address that will update the reward split when the voting power distribution changes",
             "type": "string"
           },
+          "open_funding": {
+            "description": "whether or not non-owners can fund the distribution. defaults to true.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "vp_contract": {
             "description": "address to query the voting power",
             "type": "string"
           },
           "withdraw_destination": {
-            "description": "destination address for reward clawbacks. defaults to owner",
+            "description": "destination address for reward clawbacks. defaults to owner.",
             "type": [
               "string",
               "null"
@@ -902,6 +916,7 @@
         "historical_earned_puvp",
         "hook_caller",
         "id",
+        "open_funding",
         "vp_contract",
         "withdraw_destination"
       ],
@@ -951,6 +966,10 @@
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
+        },
+        "open_funding": {
+          "description": "whether or not non-owners can fund the distribution",
+          "type": "boolean"
         },
         "vp_contract": {
           "description": "address to query the voting power",
@@ -1292,6 +1311,7 @@
             "historical_earned_puvp",
             "hook_caller",
             "id",
+            "open_funding",
             "vp_contract",
             "withdraw_destination"
           ],
@@ -1341,6 +1361,10 @@
               "type": "integer",
               "format": "uint64",
               "minimum": 0.0
+            },
+            "open_funding": {
+              "description": "whether or not non-owners can fund the distribution",
+              "type": "boolean"
             },
             "vp_contract": {
               "description": "address to query the voting power",

--- a/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
+++ b/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-rewards-distributor",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
+++ b/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
@@ -157,6 +157,20 @@
         "additionalProperties": false
       },
       {
+        "description": "Used to fund the latest distribution with native tokens.",
+        "type": "object",
+        "required": [
+          "fund_latest"
+        ],
+        "properties": {
+          "fund_latest": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Claims rewards for the sender.",
         "type": "object",
         "required": [
@@ -777,6 +791,30 @@
                   "integer",
                   "null"
                 ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the undistributed rewards for a distribution.",
+        "type": "object",
+        "required": [
+          "undistributed_rewards"
+        ],
+        "properties": {
+          "undistributed_rewards": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
                 "format": "uint64",
                 "minimum": 0.0
               }
@@ -1781,6 +1819,12 @@
           "type": "string"
         }
       }
+    },
+    "undistributed_rewards": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Uint128",
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
     }
   }
 }

--- a/contracts/distribution/dao-rewards-distributor/src/contract.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/contract.rs
@@ -561,6 +561,14 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             start_after,
             limit,
         )?)?),
+        QueryMsg::UndistributedRewards { id } => {
+            let state = DISTRIBUTIONS.load(deps.storage, id)?;
+            Ok(to_json_binary(
+                &state
+                    .get_undistributed_rewards(&env.block)
+                    .map_err(|e| StdError::generic_err(e.to_string()))?,
+            )?)
+        }
         QueryMsg::Distribution { id } => {
             let state = DISTRIBUTIONS.load(deps.storage, id)?;
             Ok(to_json_binary(&state)?)

--- a/contracts/distribution/dao-rewards-distributor/src/msg.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/msg.rs
@@ -50,6 +50,8 @@ pub enum ExecuteMsg {
     Receive(Cw20ReceiveMsg),
     /// Used to fund this contract with native tokens.
     Fund(FundMsg),
+    /// Used to fund the latest distribution with native tokens.
+    FundLatest {},
     /// Claims rewards for the sender.
     Claim { id: u64 },
     /// withdraws the undistributed rewards for a distribution. members can
@@ -83,6 +85,15 @@ pub struct FundMsg {
 pub enum ReceiveCw20Msg {
     /// Used to fund this contract with cw20 tokens.
     Fund(FundMsg),
+    /// Used to fund the latest distribution with cw20 tokens. We can't verify
+    /// the sender of CW20 token send contract executions; since the create
+    /// function is restricted to the contract owner, we cannot allow creating
+    /// new distributions and funding with CW20 tokens in one message (like we
+    /// can with native tokens via the funds field). To prevent DAOs from having
+    /// to submit two proposals to create+fund a CW20 distribution, we allow
+    /// creating and funding a distribution in one transaction via this message
+    /// that funds the latest distribution without knowing the ID ahead of time.
+    FundLatest {},
 }
 
 #[cw_serde]

--- a/contracts/distribution/dao-rewards-distributor/src/msg.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/msg.rs
@@ -101,6 +101,9 @@ pub enum QueryMsg {
         start_after: Option<u64>,
         limit: Option<u32>,
     },
+    /// Returns the undistributed rewards for a distribution.
+    #[returns(Uint128)]
+    UndistributedRewards { id: u64 },
     /// Returns the state of the given distribution.
     #[returns(DistributionState)]
     Distribution { id: u64 },

--- a/contracts/distribution/dao-rewards-distributor/src/msg.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/msg.rs
@@ -43,6 +43,8 @@ pub enum ExecuteMsg {
         /// address that will update the reward split when the voting power
         /// distribution changes
         hook_caller: Option<String>,
+        /// whether or not non-owners can fund the distribution
+        open_funding: Option<bool>,
         /// destination address for reward clawbacks. defaults to owner
         withdraw_destination: Option<String>,
     },
@@ -71,7 +73,9 @@ pub struct CreateMsg {
     /// address that will update the reward split when the voting power
     /// distribution changes
     pub hook_caller: String,
-    /// destination address for reward clawbacks. defaults to owner
+    /// whether or not non-owners can fund the distribution. defaults to true.
+    pub open_funding: Option<bool>,
+    /// destination address for reward clawbacks. defaults to owner.
     pub withdraw_destination: Option<String>,
 }
 

--- a/contracts/distribution/dao-rewards-distributor/src/rewards.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/rewards.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::{Addr, BlockInfo, Deps, DepsMut, Env, StdResult, Uint128, Uint256};
+use cw20::Expiration;
 
 use crate::{
     helpers::{
@@ -94,6 +95,12 @@ pub fn get_active_total_earned_puvp(
 
             let last_time_rewards_distributed =
                 distribution.get_latest_reward_distribution_time(block);
+
+            // if never distributed rewards (i.e. not yet funded), return
+            // current, which must be 0.
+            if let Expiration::Never {} = last_time_rewards_distributed {
+                return Ok(curr);
+            }
 
             // get the duration from the last time rewards were updated to the
             // last time rewards were distributed. this will be 0 if the rewards

--- a/contracts/distribution/dao-rewards-distributor/src/state.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/state.rs
@@ -237,6 +237,11 @@ impl DistributionState {
             EmissionRate::Linear {
                 amount, duration, ..
             } => {
+                // if not yet started, return 0.
+                if let Expiration::Never {} = self.active_epoch.started_at {
+                    return Ok(Uint128::zero());
+                }
+
                 let epoch_duration = expiration.duration_since(&self.active_epoch.started_at)?;
 
                 // count total intervals of the rewards emission that will pass

--- a/contracts/distribution/dao-rewards-distributor/src/state.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/state.rs
@@ -183,6 +183,8 @@ pub struct DistributionState {
     /// address that will update the reward split when the voting power
     /// distribution changes
     pub hook_caller: Addr,
+    /// whether or not non-owners can fund the distribution
+    pub open_funding: bool,
     /// total amount of rewards funded that will be distributed in the active
     /// epoch.
     pub funded_amount: Uint128,

--- a/contracts/distribution/dao-rewards-distributor/src/testing/suite.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/testing/suite.rs
@@ -407,6 +407,19 @@ impl Suite {
         resp
     }
 
+    pub fn get_undistributed_rewards(&mut self, id: u64) -> Uint128 {
+        let undistributed_rewards: Uint128 = self
+            .app
+            .borrow_mut()
+            .wrap()
+            .query_wasm_smart(
+                self.distribution_contract.clone(),
+                &QueryMsg::UndistributedRewards { id },
+            )
+            .unwrap();
+        undistributed_rewards
+    }
+
     pub fn get_owner(&mut self) -> Addr {
         let ownable_response: cw_ownable::Ownership<Addr> = self
             .app
@@ -490,6 +503,17 @@ impl Suite {
             "expected {} pending rewards, got {}",
             expected,
             pending
+        );
+    }
+
+    pub fn assert_undistributed_rewards(&mut self, id: u64, expected: u128) {
+        let undistributed_rewards = self.get_undistributed_rewards(id);
+        assert_eq!(
+            undistributed_rewards,
+            &Uint128::new(expected),
+            "expected {} undistributed rewards, got {}",
+            expected,
+            undistributed_rewards
         );
     }
 

--- a/contracts/distribution/dao-rewards-distributor/src/testing/suite.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/testing/suite.rs
@@ -634,8 +634,37 @@ impl Suite {
             .unwrap();
     }
 
+    pub fn fund_latest_native(&mut self, coin: Coin) {
+        self.mint_native(coin.clone(), OWNER);
+        self.app
+            .borrow_mut()
+            .execute_contract(
+                Addr::unchecked(OWNER),
+                self.distribution_contract.clone(),
+                &ExecuteMsg::FundLatest {},
+                &[coin],
+            )
+            .unwrap();
+    }
+
     pub fn fund_cw20(&mut self, id: u64, coin: Cw20Coin) {
         let fund_sub_msg = to_json_binary(&ReceiveCw20Msg::Fund(FundMsg { id })).unwrap();
+        self.app
+            .execute_contract(
+                Addr::unchecked(OWNER),
+                Addr::unchecked(coin.address),
+                &cw20::Cw20ExecuteMsg::Send {
+                    contract: self.distribution_contract.to_string(),
+                    amount: coin.amount,
+                    msg: fund_sub_msg,
+                },
+                &[],
+            )
+            .unwrap();
+    }
+
+    pub fn fund_latest_cw20(&mut self, coin: Cw20Coin) {
+        let fund_sub_msg = to_json_binary(&ReceiveCw20Msg::FundLatest {}).unwrap();
         self.app
             .execute_contract(
                 Addr::unchecked(OWNER),

--- a/contracts/distribution/dao-rewards-distributor/src/testing/suite.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/testing/suite.rs
@@ -580,6 +580,7 @@ impl Suite {
             },
             hook_caller: hook_caller.to_string(),
             vp_contract: self.voting_power_addr.to_string(),
+            open_funding: None,
             withdraw_destination: reward_config.destination,
         });
 
@@ -785,6 +786,7 @@ impl Suite {
             }),
             vp_contract: None,
             hook_caller: None,
+            open_funding: None,
             withdraw_destination: None,
         };
 
@@ -805,6 +807,7 @@ impl Suite {
             emission_rate: Some(EmissionRate::Immediate {}),
             vp_contract: None,
             hook_caller: None,
+            open_funding: None,
             withdraw_destination: None,
         };
 
@@ -825,6 +828,7 @@ impl Suite {
             emission_rate: Some(EmissionRate::Paused {}),
             vp_contract: None,
             hook_caller: None,
+            open_funding: None,
             withdraw_destination: None,
         };
 
@@ -845,6 +849,7 @@ impl Suite {
             emission_rate: None,
             vp_contract: Some(vp_contract.to_string()),
             hook_caller: None,
+            open_funding: None,
             withdraw_destination: None,
         };
 
@@ -865,6 +870,28 @@ impl Suite {
             emission_rate: None,
             vp_contract: None,
             hook_caller: Some(hook_caller.to_string()),
+            open_funding: None,
+            withdraw_destination: None,
+        };
+
+        let _resp = self
+            .app
+            .execute_contract(
+                Addr::unchecked(OWNER),
+                self.distribution_contract.clone(),
+                &msg,
+                &[],
+            )
+            .unwrap();
+    }
+
+    pub fn update_open_funding(&mut self, id: u64, open_funding: bool) {
+        let msg: ExecuteMsg = ExecuteMsg::Update {
+            id,
+            emission_rate: None,
+            vp_contract: None,
+            hook_caller: None,
+            open_funding: Some(open_funding),
             withdraw_destination: None,
         };
 
@@ -885,6 +912,7 @@ impl Suite {
             emission_rate: None,
             vp_contract: None,
             hook_caller: None,
+            open_funding: None,
             withdraw_destination: Some(withdraw_destination.to_string()),
         };
 

--- a/contracts/distribution/dao-rewards-distributor/src/testing/tests.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/testing/tests.rs
@@ -2585,6 +2585,55 @@ fn test_large_stake_before_claim() {
 }
 
 #[test]
+fn test_fund_latest_native() {
+    let mut suite = SuiteBuilder::base(super::suite::DaoType::Native).build();
+
+    suite.assert_amount(1_000);
+    suite.assert_ends_at(Expiration::AtHeight(1_000_000));
+    suite.assert_duration(10);
+
+    // double duration by 1_000_000 blocks
+    suite.fund_latest_native(coin(100_000_000, DENOM));
+
+    // skip all of the time
+    suite.skip_blocks(2_000_000);
+
+    suite.assert_pending_rewards(ADDR1, 1, 100_000_000);
+    suite.assert_pending_rewards(ADDR2, 1, 50_000_000);
+    suite.assert_pending_rewards(ADDR3, 1, 50_000_000);
+}
+
+#[test]
+fn test_fund_latest_cw20() {
+    let mut suite = SuiteBuilder::base(super::suite::DaoType::CW20)
+        .with_rewards_config(RewardsConfig {
+            amount: 1_000,
+            denom: UncheckedDenom::Cw20(DENOM.to_string()),
+            duration: Duration::Height(10),
+            destination: None,
+            continuous: true,
+        })
+        .build();
+
+    suite.assert_amount(1_000);
+    suite.assert_ends_at(Expiration::AtHeight(1_000_000));
+    suite.assert_duration(10);
+
+    // double duration by 1_000_000 blocks
+    suite.fund_latest_cw20(Cw20Coin {
+        address: suite.reward_denom.clone(),
+        amount: Uint128::new(100_000_000),
+    });
+
+    // skip all of the time
+    suite.skip_blocks(2_000_000);
+
+    suite.assert_pending_rewards(ADDR1, 1, 100_000_000);
+    suite.assert_pending_rewards(ADDR2, 1, 50_000_000);
+    suite.assert_pending_rewards(ADDR3, 1, 50_000_000);
+}
+
+#[test]
 fn test_migrate() {
     let mut deps = mock_dependencies();
 

--- a/contracts/external/btsg-ft-factory/schema/btsg-ft-factory.json
+++ b/contracts/external/btsg-ft-factory/schema/btsg-ft-factory.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "btsg-ft-factory",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
+++ b/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-admin-factory",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
+++ b/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-payroll-factory",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-token-swap/schema/cw-token-swap.json
+++ b/contracts/external/cw-token-swap/schema/cw-token-swap.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-token-swap",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-tokenfactory-issuer/schema/cw-tokenfactory-issuer.json
+++ b/contracts/external/cw-tokenfactory-issuer/schema/cw-tokenfactory-issuer.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-tokenfactory-issuer",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-vesting/schema/cw-vesting.json
+++ b/contracts/external/cw-vesting/schema/cw-vesting.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-vesting",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw721-roles/schema/cw721-roles.json
+++ b/contracts/external/cw721-roles/schema/cw721-roles.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw721-roles",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/dao-migrator/schema/dao-migrator.json
+++ b/contracts/external/dao-migrator/schema/dao-migrator.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-migrator",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-approval-single",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
+++ b/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-approver",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-multiple",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
+++ b/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-single",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
+++ b/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-condorcet",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
+++ b/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-multiple",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
+++ b/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-single",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/staking/cw20-stake-external-rewards/schema/cw20-stake-external-rewards.json
+++ b/contracts/staking/cw20-stake-external-rewards/schema/cw20-stake-external-rewards.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw20-stake-external-rewards",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/staking/cw20-stake-reward-distributor/schema/cw20-stake-reward-distributor.json
+++ b/contracts/staking/cw20-stake-reward-distributor/schema/cw20-stake-reward-distributor.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw20-stake-reward-distributor",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/staking/cw20-stake/schema/cw20-stake.json
+++ b/contracts/staking/cw20-stake/schema/cw20-stake.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw20-stake",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw20-staked/schema/dao-voting-cw20-staked.json
+++ b/contracts/voting/dao-voting-cw20-staked/schema/dao-voting-cw20-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw20-staked",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw4/schema/dao-voting-cw4.json
+++ b/contracts/voting/dao-voting-cw4/schema/dao-voting-cw4.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw4",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw721-roles/schema/dao-voting-cw721-roles.json
+++ b/contracts/voting/dao-voting-cw721-roles/schema/dao-voting-cw721-roles.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw721-roles",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw721-staked/schema/dao-voting-cw721-staked.json
+++ b/contracts/voting/dao-voting-cw721-staked/schema/dao-voting-cw721-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw721-staked",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-onft-staked/schema/dao-voting-onft-staked.json
+++ b/contracts/voting/dao-voting-onft-staked/schema/dao-voting-onft-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-onft-staked",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-token-staked/schema/dao-voting-token-staked.json
+++ b/contracts/voting/dao-voting-token-staked/schema/dao-voting-token-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-token-staked",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
This does a few things:

1. Adds an undistributed rewards query to the distributor so that you can check how many rewards would be withdrawn.

2. Fixes a bug pausing an already expired linear distribution. This isn't a vulnerability, but it should be possible, and there was just a minor logic error.

3. Adds the ability to fund the most recent distribution, without knowing its ID. This is useful when creating CW20 distributions. Because we can't verify the sender of a CW20 token send contract execution, we can't allow creating new distributions with initial CW20 funds (since the contract owner must create new distributions). Instead, the DAO can create a distribution AND fund the latest distribution (without knowing its ID) in one proposal.

4. Adds an `open_funding` flag so the owner can decide if a distribution can be funded by accounts other than the owner. The owner can always fund a distribution.

5. Fixes a bug causing pending rewards and undistributed rewards queries to fail if a linear distribution has not yet been funded.