### PR TITLE
Add pre-propose-approval support for multiple choice proposals, and freeze approver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,6 +1825,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "dao-pre-propose-approval-multiple"
+version = "2.5.0"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-denom 2.5.0",
+ "cw-multi-test",
+ "cw-paginate-storage 2.5.0",
+ "cw-storage-plus 1.2.0",
+ "cw-utils 1.0.3",
+ "cw2 1.1.2",
+ "cw20 1.1.2",
+ "cw20-base 1.1.2",
+ "cw4 1.1.2",
+ "cw4-group 1.1.2",
+ "dao-dao-core 2.5.0",
+ "dao-hooks 2.5.0",
+ "dao-interface 2.5.0",
+ "dao-pre-propose-base 2.5.0",
+ "dao-proposal-multiple 2.5.0",
+ "dao-testing",
+ "dao-voting 2.5.0",
+ "dao-voting-cw20-staked",
+ "dao-voting-cw4 2.5.0",
+ "thiserror",
+]
+
+[[package]]
 name = "dao-pre-propose-approval-single"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,13 +1826,13 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-approval-multiple"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
+ "cw-denom 2.5.1",
  "cw-multi-test",
- "cw-paginate-storage 2.5.0",
+ "cw-paginate-storage 2.5.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1840,15 +1840,15 @@ dependencies = [
  "cw20-base 1.1.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
- "dao-dao-core 2.5.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
- "dao-pre-propose-base 2.5.0",
- "dao-proposal-multiple 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-pre-propose-base 2.5.1",
+ "dao-proposal-multiple 2.5.1",
  "dao-testing",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
  "thiserror",
 ]
 
@@ -1920,8 +1920,10 @@ dependencies = [
  "dao-dao-core 2.5.1",
  "dao-hooks 2.5.1",
  "dao-interface 2.5.1",
+ "dao-pre-propose-approval-multiple",
  "dao-pre-propose-approval-single 2.5.1",
  "dao-pre-propose-base 2.5.1",
+ "dao-proposal-multiple 2.5.1",
  "dao-proposal-single 2.5.1",
  "dao-testing",
  "dao-voting 2.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ dao-dao-core = { path = "./contracts/dao-dao-core", version = "2.5.1" }
 dao-dao-macros = { path = "./packages/dao-dao-macros", version = "2.5.1" }
 dao-hooks = { path = "./packages/dao-hooks", version = "2.5.1" }
 dao-interface = { path = "./packages/dao-interface", version = "2.5.1" }
+dao-pre-propose-approval-multiple = { path = "./contracts/pre-propose/dao-pre-propose-approval-multiple", version = "2.5.1" }
 dao-migrator = { path = "./contracts/external/dao-migrator", version = "2.5.1" }
 dao-pre-propose-approval-single = { path = "./contracts/pre-propose/dao-pre-propose-approval-single", version = "2.5.1" }
 dao-pre-propose-approver = { path = "./contracts/pre-propose/dao-pre-propose-approver", version = "2.5.1" }

--- a/contracts/pre-propose/dao-pre-propose-approval-multiple/Cargo.toml
+++ b/contracts/pre-propose/dao-pre-propose-approval-multiple/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "dao-pre-propose-approval-multiple"
+authors = ["ekez <ekez@withoutdoing.com>", "Jake Hartnell <no-reply@no-reply.com>", "noah <noah@daodao.zone>"]
+description = "A DAO DAO pre-propose module handling a proposal approval flow for for dao-proposal-multiple."
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+version = { workspace = true }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[dependencies]
+cosmwasm-std = { workspace = true }
+cosmwasm-schema = { workspace = true }
+cw-storage-plus = { workspace = true }
+cw2 = { workspace = true }
+cw-paginate-storage = { workspace = true }
+dao-pre-propose-base = { workspace = true }
+dao-voting = { workspace = true }
+thiserror = { workspace = true }
+dao-interface = { workspace = true }
+
+[dev-dependencies]
+cw-denom = { workspace = true }
+cw-multi-test = { workspace = true }
+cw-utils = { workspace = true }
+cw4 = { workspace = true }
+cw4-group = { workspace = true }
+cw20 = { workspace = true }
+cw20-base = { workspace = true }
+dao-dao-core = { workspace = true }
+dao-hooks = { workspace = true }
+dao-testing = { workspace = true }
+dao-voting = { workspace = true }
+dao-voting-cw4 = { workspace = true }
+dao-voting-cw20-staked = { workspace = true }
+dao-proposal-multiple = { workspace = true }

--- a/contracts/pre-propose/dao-pre-propose-approval-multiple/README.md
+++ b/contracts/pre-propose/dao-pre-propose-approval-multiple/README.md
@@ -1,9 +1,9 @@
-# Single choice proposal approval contract
+# Multi choice proposal approval contract
 
-[![dao-pre-propose-approval-single on crates.io](https://img.shields.io/crates/v/dao-pre-propose-approval-single.svg?logo=rust)](https://crates.io/crates/dao-pre-propose-approval-single)
-[![docs.rs](https://img.shields.io/docsrs/dao-pre-propose-approval-single?logo=docsdotrs)](https://docs.rs/dao-pre-propose-approval-single/latest/dao_pre_propose_approval_single/)
+[![dao-pre-propose-approval-multiple on crates.io](https://img.shields.io/crates/v/dao-pre-propose-approval-multiple.svg?logo=rust)](https://crates.io/crates/dao-pre-propose-approval-multiple)
+[![docs.rs](https://img.shields.io/docsrs/dao-pre-propose-approval-multiple?logo=docsdotrs)](https://docs.rs/dao-pre-propose-approval-multiple/latest/dao_pre_propose_approval_multiple/)
 
-This contract implements an approval flow for proposals, it also handles deposit logic. It works with the `dao-proposal-single` proposal module.
+This contract implements an approval flow for proposals, it also handles deposit logic. It works with the `dao-proposal-multiple` proposal module.
 
 ## Approval Logic
 
@@ -29,11 +29,11 @@ immediately, whereas a rejected proposal is simply discarded.
             │ Creates prop
             │ on approval
             ▼
-┌────────────────────────┐
-│                        │
-│     Proposal Single    │
-│                        │
-└───────────┬────────────┘
+┌──────────────────────────┐
+│                          │
+│     Proposal Multiple    │
+│                          │
+└───────────┬──────────────┘
             │
             │ Normal voting
             │
@@ -45,7 +45,7 @@ immediately, whereas a rejected proposal is simply discarded.
 └────────────────────────┘
 ```
 
-The `approver` may also register a `ProposalSubmitHook`, which fires every time a proposal is submitted to the `dao-pre-propose-approval-single` contract.
+The `approver` may also register a `ProposalSubmitHook`, which fires every time a proposal is submitted to the `dao-pre-propose-approval-multiple` contract.
 
 ## Deposit Logic
 

--- a/contracts/pre-propose/dao-pre-propose-approval-multiple/examples/schema.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-multiple/examples/schema.rs
@@ -1,0 +1,11 @@
+use cosmwasm_schema::write_api;
+use dao_pre_propose_approval_multiple::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        query: QueryMsg,
+        execute: ExecuteMsg,
+        migrate: MigrateMsg,
+    }
+}

--- a/contracts/pre-propose/dao-pre-propose-approval-multiple/schema/dao-pre-propose-approval-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-multiple/schema/dao-pre-propose-approval-multiple.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-approval-multiple",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-approval-multiple/schema/dao-pre-propose-approval-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-multiple/schema/dao-pre-propose-approval-multiple.json
@@ -1,6 +1,6 @@
 {
-  "contract_name": "dao-pre-propose-approval-single",
-  "contract_version": "2.5.1",
+  "contract_name": "dao-pre-propose-approval-multiple",
+  "contract_version": "2.5.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1196,6 +1196,85 @@
           }
         }
       },
+      "MultipleChoiceAutoVote": {
+        "type": "object",
+        "required": [
+          "vote"
+        ],
+        "properties": {
+          "rationale": {
+            "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "vote": {
+            "description": "The proposer's position on the proposal.",
+            "allOf": [
+              {
+                "$ref": "#/definitions/MultipleChoiceVote"
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "MultipleChoiceOption": {
+        "description": "Unchecked multiple choice option",
+        "type": "object",
+        "required": [
+          "description",
+          "msgs",
+          "title"
+        ],
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "msgs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/CosmosMsg_for_Empty"
+            }
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MultipleChoiceOptions": {
+        "description": "Represents unchecked multiple choice options",
+        "type": "object",
+        "required": [
+          "options"
+        ],
+        "properties": {
+          "options": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/MultipleChoiceOption"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "MultipleChoiceVote": {
+        "description": "A multiple choice vote, picking the desired option",
+        "type": "object",
+        "required": [
+          "option_id"
+        ],
+        "properties": {
+          "option_id": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        "additionalProperties": false
+      },
       "PreProposeSubmissionPolicy": {
         "description": "The policy configured in a pre-propose module that determines who can submit proposals. This is the preferred way to restrict proposal creation (as opposed to the ProposalCreationPolicy above) since pre-propose modules support other features, such as proposal deposits.",
         "oneOf": [
@@ -1269,7 +1348,7 @@
       "ProposeMessage": {
         "oneOf": [
           {
-            "description": "The propose message used to make a proposal to this module. Note that this is identical to the propose message used by dao-proposal-single, except that it omits the `proposer` field which it fills in for the sender.",
+            "description": "The propose message used to make a proposal to this module. Note that this is identical to the propose message used by dao-proposal-multiple, except that it omits the `proposer` field which it fills in for the sender.",
             "type": "object",
             "required": [
               "propose"
@@ -1278,19 +1357,16 @@
               "propose": {
                 "type": "object",
                 "required": [
+                  "choices",
                   "description",
-                  "msgs",
                   "title"
                 ],
                 "properties": {
+                  "choices": {
+                    "$ref": "#/definitions/MultipleChoiceOptions"
+                  },
                   "description": {
                     "type": "string"
-                  },
-                  "msgs": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/definitions/CosmosMsg_for_Empty"
-                    }
                   },
                   "title": {
                     "type": "string"
@@ -1298,7 +1374,7 @@
                   "vote": {
                     "anyOf": [
                       {
-                        "$ref": "#/definitions/SingleChoiceAutoVote"
+                        "$ref": "#/definitions/MultipleChoiceAutoVote"
                       },
                       {
                         "type": "null"
@@ -1312,30 +1388,6 @@
             "additionalProperties": false
           }
         ]
-      },
-      "SingleChoiceAutoVote": {
-        "type": "object",
-        "required": [
-          "vote"
-        ],
-        "properties": {
-          "rationale": {
-            "description": "An optional rationale for why this vote was cast. This can be updated, set, or removed later by the address casting the vote.",
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "vote": {
-            "description": "The proposer's position on the proposal.",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Vote"
-              }
-            ]
-          }
-        },
-        "additionalProperties": false
       },
       "StakingMsg": {
         "description": "The message types of the staking module.\n\nSee https://github.com/cosmos/cosmos-sdk/blob/v0.40.0/proto/cosmos/staking/v1beta1/tx.proto",
@@ -1578,31 +1630,6 @@
           }
         },
         "additionalProperties": false
-      },
-      "Vote": {
-        "oneOf": [
-          {
-            "description": "Marks support for the proposal.",
-            "type": "string",
-            "enum": [
-              "yes"
-            ]
-          },
-          {
-            "description": "Marks opposition to the proposal.",
-            "type": "string",
-            "enum": [
-              "no"
-            ]
-          },
-          {
-            "description": "Marks participation but does not count towards the ratio of support / opposed.",
-            "type": "string",
-            "enum": [
-              "abstain"
-            ]
-          }
-        ]
       },
       "VoteOption": {
         "type": "string",

--- a/contracts/pre-propose/dao-pre-propose-approval-multiple/src/contract.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-multiple/src/contract.rs
@@ -1,0 +1,413 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+use cosmwasm_std::{
+    to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Order, Response, StdResult,
+    SubMsg, WasmMsg,
+};
+use cw2::set_contract_version;
+use cw_paginate_storage::paginate_map_values;
+use dao_pre_propose_base::{
+    error::PreProposeError, msg::ExecuteMsg as ExecuteBase, state::PreProposeContract,
+};
+use dao_voting::approval::{ApprovalProposalStatus, ApproverProposeMessage};
+use dao_voting::deposit::DepositRefundPolicy;
+use dao_voting::proposal::MultipleChoiceProposeMsg as ProposeMsg;
+
+use crate::msg::{
+    ExecuteExt, ExecuteMsg, InstantiateExt, InstantiateMsg, MigrateMsg, ProposeMessage,
+    ProposeMessageInternal, QueryExt, QueryMsg,
+};
+use crate::state::{
+    advance_approval_id, Proposal, APPROVER, COMPLETED_PROPOSALS,
+    CREATED_PROPOSAL_TO_COMPLETED_PROPOSAL, PENDING_PROPOSALS,
+};
+
+pub(crate) const CONTRACT_NAME: &str = "crates.io:dao-pre-propose-approval-multiple";
+pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+type PrePropose = PreProposeContract<InstantiateExt, ExecuteExt, QueryExt, Empty, ProposeMessage>;
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    mut deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, PreProposeError> {
+    let approver = deps.api.addr_validate(&msg.extension.approver)?;
+    APPROVER.save(deps.storage, &approver)?;
+
+    let resp = PrePropose::default().instantiate(deps.branch(), env, info, msg)?;
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(resp.add_attribute("approver", approver.to_string()))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, PreProposeError> {
+    match msg {
+        ExecuteMsg::Propose { msg } => execute_propose(deps, env, info, msg),
+
+        ExecuteMsg::AddProposalSubmittedHook { address } => {
+            execute_add_approver_hook(deps, info, address)
+        }
+        ExecuteMsg::RemoveProposalSubmittedHook { address } => {
+            execute_remove_approver_hook(deps, info, address)
+        }
+
+        ExecuteMsg::Extension { msg } => match msg {
+            ExecuteExt::Approve { id } => execute_approve(deps, info, id),
+            ExecuteExt::Reject { id } => execute_reject(deps, info, id),
+            ExecuteExt::UpdateApprover { address } => execute_update_approver(deps, info, address),
+        },
+        // Default pre-propose-base behavior for all other messages
+        _ => PrePropose::default().execute(deps, env, info, msg),
+    }
+}
+
+pub fn execute_propose(
+    deps: DepsMut,
+    env: Env,
+    info: MessageInfo,
+    msg: ProposeMessage,
+) -> Result<Response, PreProposeError> {
+    let pre_propose_base = PrePropose::default();
+    let config = pre_propose_base.config.load(deps.storage)?;
+
+    pre_propose_base.check_can_submit(deps.as_ref(), info.sender.clone())?;
+
+    // Take deposit, if configured.
+    let deposit_messages = if let Some(ref deposit_info) = config.deposit_info {
+        deposit_info.check_native_deposit_paid(&info)?;
+        deposit_info.get_take_deposit_messages(&info.sender, &env.contract.address)?
+    } else {
+        vec![]
+    };
+
+    let approval_id = advance_approval_id(deps.storage)?;
+
+    let propose_msg_internal = match msg {
+        ProposeMessage::Propose {
+            title,
+            description,
+            choices,
+            vote,
+        } => ProposeMsg {
+            title,
+            description,
+            choices,
+            proposer: Some(info.sender.to_string()),
+            vote,
+        },
+    };
+
+    // Prepare proposal submitted hooks msg to notify approver.  Make
+    // a proposal on the approver DAO to approve this pre-proposal
+    let hooks_msgs =
+        pre_propose_base
+            .proposal_submitted_hooks
+            .prepare_hooks(deps.storage, |a| {
+                let execute_msg = WasmMsg::Execute {
+                    contract_addr: a.into_string(),
+                    msg: to_json_binary(&ExecuteBase::<ApproverProposeMessage, Empty>::Propose {
+                        msg: ApproverProposeMessage::Propose {
+                            title: propose_msg_internal.title.clone(),
+                            description: propose_msg_internal.description.clone(),
+                            approval_id,
+                        },
+                    })?,
+                    funds: vec![],
+                };
+                Ok(SubMsg::new(execute_msg))
+            })?;
+
+    // Save the proposal and its information as pending.
+    PENDING_PROPOSALS.save(
+        deps.storage,
+        approval_id,
+        &Proposal {
+            status: ApprovalProposalStatus::Pending {},
+            approval_id,
+            proposer: info.sender,
+            msg: propose_msg_internal,
+            deposit: config.deposit_info,
+        },
+    )?;
+
+    Ok(Response::default()
+        .add_messages(deposit_messages)
+        .add_submessages(hooks_msgs)
+        .add_attribute("method", "pre-propose")
+        .add_attribute("id", approval_id.to_string()))
+}
+
+pub fn execute_approve(
+    deps: DepsMut,
+    info: MessageInfo,
+    id: u64,
+) -> Result<Response, PreProposeError> {
+    // Check sender is the approver
+    let approver = APPROVER.load(deps.storage)?;
+    if approver != info.sender {
+        return Err(PreProposeError::Unauthorized {});
+    }
+
+    // Load proposal and send propose message to the proposal module
+    let proposal = PENDING_PROPOSALS.may_load(deps.storage, id)?;
+    match proposal {
+        Some(proposal) => {
+            let proposal_module = PrePropose::default().proposal_module.load(deps.storage)?;
+
+            // Snapshot the deposit for the proposal that we're about
+            // to create.
+            let proposal_id = deps.querier.query_wasm_smart(
+                &proposal_module,
+                &dao_interface::proposal::Query::NextProposalId {},
+            )?;
+            PrePropose::default().deposits.save(
+                deps.storage,
+                proposal_id,
+                &(proposal.deposit.clone(), proposal.proposer.clone()),
+            )?;
+
+            let propose_messsage = WasmMsg::Execute {
+                contract_addr: proposal_module.into_string(),
+                msg: to_json_binary(&ProposeMessageInternal::Propose(proposal.msg.clone()))?,
+                funds: vec![],
+            };
+
+            COMPLETED_PROPOSALS.save(
+                deps.storage,
+                id,
+                &Proposal {
+                    status: ApprovalProposalStatus::Approved {
+                        created_proposal_id: proposal_id,
+                    },
+                    approval_id: proposal.approval_id,
+                    proposer: proposal.proposer,
+                    msg: proposal.msg,
+                    deposit: proposal.deposit,
+                },
+            )?;
+            CREATED_PROPOSAL_TO_COMPLETED_PROPOSAL.save(deps.storage, proposal_id, &id)?;
+            PENDING_PROPOSALS.remove(deps.storage, id);
+
+            Ok(Response::default()
+                .add_message(propose_messsage)
+                .add_attribute("method", "proposal_approved")
+                .add_attribute("approval_id", id.to_string())
+                .add_attribute("proposal_id", proposal_id.to_string()))
+        }
+        None => Err(PreProposeError::ProposalNotFound {}),
+    }
+}
+
+pub fn execute_reject(
+    deps: DepsMut,
+    info: MessageInfo,
+    id: u64,
+) -> Result<Response, PreProposeError> {
+    // Check sender is the approver
+    let approver = APPROVER.load(deps.storage)?;
+    if approver != info.sender {
+        return Err(PreProposeError::Unauthorized {});
+    }
+
+    let Proposal {
+        approval_id,
+        proposer,
+        msg,
+        deposit,
+        ..
+    } = PENDING_PROPOSALS
+        .may_load(deps.storage, id)?
+        .ok_or(PreProposeError::ProposalNotFound {})?;
+
+    COMPLETED_PROPOSALS.save(
+        deps.storage,
+        id,
+        &Proposal {
+            status: ApprovalProposalStatus::Rejected {},
+            approval_id,
+            proposer: proposer.clone(),
+            msg: msg.clone(),
+            deposit: deposit.clone(),
+        },
+    )?;
+    PENDING_PROPOSALS.remove(deps.storage, id);
+
+    let messages = if let Some(ref deposit_info) = deposit {
+        // Refund can be issued if proposal if deposits are always
+        // refunded. `OnlyPassed` and `Never` refund deposit policies
+        // do not apply here.
+        if deposit_info.refund_policy == DepositRefundPolicy::Always {
+            deposit_info.get_return_deposit_message(&proposer)?
+        } else {
+            // If the proposer doesn't get the deposit, the DAO does.
+            let dao = PrePropose::default().dao.load(deps.storage)?;
+            deposit_info.get_return_deposit_message(&dao)?
+        }
+    } else {
+        vec![]
+    };
+
+    Ok(Response::default()
+        .add_attribute("method", "proposal_rejected")
+        .add_attribute("proposal", id.to_string())
+        .add_attribute("deposit_info", to_json_binary(&deposit)?.to_string())
+        .add_messages(messages))
+}
+
+pub fn execute_update_approver(
+    deps: DepsMut,
+    info: MessageInfo,
+    address: String,
+) -> Result<Response, PreProposeError> {
+    // Check sender is the approver
+    let approver = APPROVER.load(deps.storage)?;
+    if approver != info.sender {
+        return Err(PreProposeError::Unauthorized {});
+    }
+
+    // Validate address and save new approver
+    let addr = deps.api.addr_validate(&address)?;
+    APPROVER.save(deps.storage, &addr)?;
+
+    Ok(Response::default())
+}
+
+pub fn execute_add_approver_hook(
+    deps: DepsMut,
+    info: MessageInfo,
+    address: String,
+) -> Result<Response, PreProposeError> {
+    let pre_propose_base = PrePropose::default();
+
+    let dao = pre_propose_base.dao.load(deps.storage)?;
+    let approver = APPROVER.load(deps.storage)?;
+
+    // Check sender is the approver or the parent DAO
+    if approver != info.sender && dao != info.sender {
+        return Err(PreProposeError::Unauthorized {});
+    }
+
+    let addr = deps.api.addr_validate(&address)?;
+    pre_propose_base
+        .proposal_submitted_hooks
+        .add_hook(deps.storage, addr)?;
+
+    Ok(Response::default())
+}
+
+pub fn execute_remove_approver_hook(
+    deps: DepsMut,
+    info: MessageInfo,
+    address: String,
+) -> Result<Response, PreProposeError> {
+    let pre_propose_base = PrePropose::default();
+
+    let dao = pre_propose_base.dao.load(deps.storage)?;
+    let approver = APPROVER.load(deps.storage)?;
+
+    // Check sender is the approver or the parent DAO
+    if approver != info.sender && dao != info.sender {
+        return Err(PreProposeError::Unauthorized {});
+    }
+
+    // Validate address
+    let addr = deps.api.addr_validate(&address)?;
+
+    // remove hook
+    pre_propose_base
+        .proposal_submitted_hooks
+        .remove_hook(deps.storage, addr)?;
+
+    Ok(Response::default())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::QueryExtension { msg } => match msg {
+            QueryExt::Approver {} => to_json_binary(&APPROVER.load(deps.storage)?),
+            QueryExt::IsPending { id } => {
+                let pending = PENDING_PROPOSALS.may_load(deps.storage, id)?.is_some();
+                // Force load completed proposal if not pending, throwing error
+                // if not found.
+                if !pending {
+                    COMPLETED_PROPOSALS.load(deps.storage, id)?;
+                }
+
+                to_json_binary(&pending)
+            }
+            QueryExt::Proposal { id } => {
+                if let Some(pending) = PENDING_PROPOSALS.may_load(deps.storage, id)? {
+                    to_json_binary(&pending)
+                } else {
+                    // Force load completed proposal if not pending, throwing
+                    // error if not found.
+                    to_json_binary(&COMPLETED_PROPOSALS.load(deps.storage, id)?)
+                }
+            }
+            QueryExt::PendingProposal { id } => {
+                to_json_binary(&PENDING_PROPOSALS.load(deps.storage, id)?)
+            }
+            QueryExt::PendingProposals { start_after, limit } => {
+                to_json_binary(&paginate_map_values(
+                    deps,
+                    &PENDING_PROPOSALS,
+                    start_after,
+                    limit,
+                    Order::Ascending,
+                )?)
+            }
+            QueryExt::ReversePendingProposals {
+                start_before,
+                limit,
+            } => to_json_binary(&paginate_map_values(
+                deps,
+                &PENDING_PROPOSALS,
+                start_before,
+                limit,
+                Order::Descending,
+            )?),
+            QueryExt::CompletedProposal { id } => {
+                to_json_binary(&COMPLETED_PROPOSALS.load(deps.storage, id)?)
+            }
+            QueryExt::CompletedProposals { start_after, limit } => {
+                to_json_binary(&paginate_map_values(
+                    deps,
+                    &COMPLETED_PROPOSALS,
+                    start_after,
+                    limit,
+                    Order::Ascending,
+                )?)
+            }
+            QueryExt::ReverseCompletedProposals {
+                start_before,
+                limit,
+            } => to_json_binary(&paginate_map_values(
+                deps,
+                &COMPLETED_PROPOSALS,
+                start_before,
+                limit,
+                Order::Descending,
+            )?),
+            QueryExt::CompletedProposalIdForCreatedProposalId { id } => {
+                to_json_binary(&CREATED_PROPOSAL_TO_COMPLETED_PROPOSAL.may_load(deps.storage, id)?)
+            }
+        },
+        _ => PrePropose::default().query(deps, env, msg),
+    }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(mut deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, PreProposeError> {
+    let res = PrePropose::default().migrate(deps.branch(), msg);
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    res
+}

--- a/contracts/pre-propose/dao-pre-propose-approval-multiple/src/lib.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-multiple/src/lib.rs
@@ -1,0 +1,13 @@
+#![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
+
+pub mod contract;
+pub mod msg;
+pub mod state;
+
+#[cfg(test)]
+mod tests;
+
+// Exporting these means that contracts interacting with this one don't
+// need an explicit dependency on the base contract to read queries.
+pub use dao_pre_propose_base::msg::DepositInfoResponse;
+pub use dao_pre_propose_base::state::Config;

--- a/contracts/pre-propose/dao-pre-propose-approval-multiple/src/msg.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-multiple/src/msg.rs
@@ -1,10 +1,13 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{CosmosMsg, Empty};
+use cosmwasm_std::Empty;
 use dao_pre_propose_base::msg::{
     ExecuteMsg as ExecuteBase, InstantiateMsg as InstantiateBase, MigrateMsg as MigrateBase,
     QueryMsg as QueryBase,
 };
-use dao_voting::{proposal::SingleChoiceProposeMsg as ProposeMsg, voting::SingleChoiceAutoVote};
+use dao_voting::{
+    multiple_choice::{MultipleChoiceAutoVote, MultipleChoiceOptions},
+    proposal::MultipleChoiceProposeMsg as ProposeMsg,
+};
 
 pub use dao_voting::approval::ApprovalExecuteExt as ExecuteExt;
 
@@ -12,13 +15,13 @@ pub use dao_voting::approval::ApprovalExecuteExt as ExecuteExt;
 pub enum ProposeMessage {
     /// The propose message used to make a proposal to this
     /// module. Note that this is identical to the propose message
-    /// used by dao-proposal-single, except that it omits the
+    /// used by dao-proposal-multiple, except that it omits the
     /// `proposer` field which it fills in for the sender.
     Propose {
         title: String,
         description: String,
-        msgs: Vec<CosmosMsg<Empty>>,
-        vote: Option<SingleChoiceAutoVote>,
+        choices: MultipleChoiceOptions,
+        vote: Option<MultipleChoiceAutoVote>,
     },
 }
 

--- a/contracts/pre-propose/dao-pre-propose-approval-multiple/src/state.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-multiple/src/state.rs
@@ -1,0 +1,21 @@
+use cosmwasm_std::{Addr, StdResult, Storage};
+use cw_storage_plus::{Item, Map};
+
+use dao_voting::{approval::ApprovalProposal, proposal::MultipleChoiceProposeMsg};
+
+pub type Proposal = ApprovalProposal<MultipleChoiceProposeMsg>;
+
+pub const APPROVER: Item<Addr> = Item::new("approver");
+pub const PENDING_PROPOSALS: Map<u64, Proposal> = Map::new("pending_proposals");
+pub const COMPLETED_PROPOSALS: Map<u64, Proposal> = Map::new("completed_proposals");
+pub const CREATED_PROPOSAL_TO_COMPLETED_PROPOSAL: Map<u64, u64> =
+    Map::new("created_to_completed_proposal");
+
+/// Used internally to track the current approval_id.
+const CURRENT_ID: Item<u64> = Item::new("current_id");
+
+pub(crate) fn advance_approval_id(store: &mut dyn Storage) -> StdResult<u64> {
+    let id: u64 = CURRENT_ID.may_load(store)?.unwrap_or_default() + 1;
+    CURRENT_ID.save(store, &id)?;
+    Ok(id)
+}

--- a/contracts/pre-propose/dao-pre-propose-approval-multiple/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-multiple/src/tests.rs
@@ -1,0 +1,2552 @@
+use cosmwasm_std::{coins, from_json, to_json_binary, Addr, Coin, Empty, Uint128};
+use cw2::ContractVersion;
+use cw20::Cw20Coin;
+use cw_denom::UncheckedDenom;
+use cw_multi_test::{App, BankSudo, Contract, ContractWrapper, Executor};
+use cw_utils::Duration;
+use dao_interface::proposal::InfoResponse;
+use dao_interface::state::ProposalModule;
+use dao_interface::state::{Admin, ModuleInstantiateInfo};
+use dao_pre_propose_base::{error::PreProposeError, msg::DepositInfoResponse, state::Config};
+use dao_proposal_multiple::query::ProposalResponse;
+use dao_testing::helpers::instantiate_with_cw4_groups_governance;
+use dao_voting::multiple_choice::{
+    MultipleChoiceOption, MultipleChoiceOptions, MultipleChoiceVote, VotingStrategy,
+};
+use dao_voting::pre_propose::{PreProposeSubmissionPolicy, PreProposeSubmissionPolicyError};
+use dao_voting::{
+    approval::ApprovalProposalStatus,
+    deposit::{CheckedDepositInfo, DepositRefundPolicy, DepositToken, UncheckedDepositInfo},
+    pre_propose::{PreProposeInfo, ProposalCreationPolicy},
+    status::Status,
+    threshold::PercentageThreshold,
+};
+
+use crate::state::Proposal;
+use crate::{contract::*, msg::*};
+
+fn dao_proposal_multiple_contract() -> Box<dyn Contract<Empty>> {
+    let contract = ContractWrapper::new(
+        dao_proposal_multiple::contract::execute,
+        dao_proposal_multiple::contract::instantiate,
+        dao_proposal_multiple::contract::query,
+    )
+    .with_migrate(dao_proposal_multiple::contract::migrate)
+    .with_reply(dao_proposal_multiple::contract::reply);
+    Box::new(contract)
+}
+
+fn dao_pre_propose_approval_multiple_contract() -> Box<dyn Contract<Empty>> {
+    let contract = ContractWrapper::new(execute, instantiate, query).with_migrate(migrate);
+    Box::new(contract)
+}
+
+fn cw20_base_contract() -> Box<dyn Contract<Empty>> {
+    let contract = ContractWrapper::new(
+        cw20_base::contract::execute,
+        cw20_base::contract::instantiate,
+        cw20_base::contract::query,
+    );
+    Box::new(contract)
+}
+
+fn get_default_proposal_module_instantiate(
+    app: &mut App,
+    deposit_info: Option<UncheckedDepositInfo>,
+    open_proposal_submission: bool,
+) -> dao_proposal_multiple::msg::InstantiateMsg {
+    let pre_propose_id = app.store_code(dao_pre_propose_approval_multiple_contract());
+
+    let submission_policy = if open_proposal_submission {
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] }
+    } else {
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: vec![],
+            denylist: vec![],
+        }
+    };
+
+    dao_proposal_multiple::msg::InstantiateMsg {
+        voting_strategy: VotingStrategy::SingleChoice {
+            quorum: PercentageThreshold::Majority {},
+        },
+        max_voting_period: cw_utils::Duration::Time(86400),
+        min_voting_period: None,
+        only_members_execute: false,
+        allow_revoting: false,
+        pre_propose_info: PreProposeInfo::ModuleMayPropose {
+            info: ModuleInstantiateInfo {
+                code_id: pre_propose_id,
+                msg: to_json_binary(&InstantiateMsg {
+                    deposit_info,
+                    submission_policy,
+                    extension: InstantiateExt {
+                        approver: "approver".to_string(),
+                    },
+                })
+                .unwrap(),
+                admin: Some(Admin::CoreModule {}),
+                funds: vec![],
+                label: "baby's first pre-propose module".to_string(),
+            },
+        },
+        close_proposal_on_execution_failure: false,
+        veto: None,
+    }
+}
+
+fn instantiate_cw20_base_default(app: &mut App) -> Addr {
+    let cw20_id = app.store_code(cw20_base_contract());
+    let cw20_instantiate = cw20_base::msg::InstantiateMsg {
+        name: "cw20 token".to_string(),
+        symbol: "cwtwenty".to_string(),
+        decimals: 6,
+        initial_balances: vec![Cw20Coin {
+            address: "ekez".to_string(),
+            amount: Uint128::new(10),
+        }],
+        mint: None,
+        marketing: None,
+    };
+    app.instantiate_contract(
+        cw20_id,
+        Addr::unchecked("ekez"),
+        &cw20_instantiate,
+        &[],
+        "cw20-base",
+        None,
+    )
+    .unwrap()
+}
+
+struct DefaultTestSetup {
+    core_addr: Addr,
+    proposal_multiple: Addr,
+    pre_propose: Addr,
+}
+
+fn setup_default_test(
+    app: &mut App,
+    deposit_info: Option<UncheckedDepositInfo>,
+    open_proposal_submission: bool,
+) -> DefaultTestSetup {
+    let dao_proposal_multiple_id = app.store_code(dao_proposal_multiple_contract());
+
+    let proposal_module_instantiate =
+        get_default_proposal_module_instantiate(app, deposit_info, open_proposal_submission);
+
+    let core_addr = instantiate_with_cw4_groups_governance(
+        app,
+        dao_proposal_multiple_id,
+        to_json_binary(&proposal_module_instantiate).unwrap(),
+        Some(vec![
+            cw20::Cw20Coin {
+                address: "ekez".to_string(),
+                amount: Uint128::new(9),
+            },
+            cw20::Cw20Coin {
+                address: "keze".to_string(),
+                amount: Uint128::new(8),
+            },
+        ]),
+    );
+    let proposal_modules: Vec<ProposalModule> = app
+        .wrap()
+        .query_wasm_smart(
+            core_addr.clone(),
+            &dao_interface::msg::QueryMsg::ProposalModules {
+                start_after: None,
+                limit: None,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(proposal_modules.len(), 1);
+    let proposal_multiple = proposal_modules.into_iter().next().unwrap().address;
+    let proposal_creation_policy = app
+        .wrap()
+        .query_wasm_smart(
+            proposal_multiple.clone(),
+            &dao_proposal_multiple::msg::QueryMsg::ProposalCreationPolicy {},
+        )
+        .unwrap();
+
+    let pre_propose = match proposal_creation_policy {
+        ProposalCreationPolicy::Module { addr } => addr,
+        _ => panic!("expected a module for the proposal creation policy"),
+    };
+
+    // Make sure things were set up correctly.
+    assert_eq!(
+        proposal_multiple,
+        get_proposal_module(app, pre_propose.clone())
+    );
+    assert_eq!(core_addr, get_dao(app, pre_propose.clone()));
+    assert_eq!(
+        InfoResponse {
+            info: ContractVersion {
+                contract: "crates.io:dao-pre-propose-approval-multiple".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string()
+            }
+        },
+        get_info(app, pre_propose.clone())
+    );
+
+    DefaultTestSetup {
+        core_addr,
+        proposal_multiple,
+        pre_propose,
+    }
+}
+
+fn make_pre_proposal(app: &mut App, pre_propose: Addr, proposer: &str, funds: &[Coin]) -> u64 {
+    app.execute_contract(
+        Addr::unchecked(proposer),
+        pre_propose.clone(),
+        &ExecuteMsg::Propose {
+            msg: ProposeMessage::Propose {
+                title: "title".to_string(),
+                description: "description".to_string(),
+                choices: MultipleChoiceOptions {
+                    options: vec![
+                        MultipleChoiceOption {
+                            title: "A".to_string(),
+                            description: "A".to_string(),
+                            msgs: vec![],
+                        },
+                        MultipleChoiceOption {
+                            title: "B".to_string(),
+                            description: "B".to_string(),
+                            msgs: vec![],
+                        },
+                    ],
+                },
+                vote: None,
+            },
+        },
+        funds,
+    )
+    .unwrap();
+
+    // Query for pending proposal and return latest id.
+    let mut pending: Vec<Proposal> = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose,
+            &QueryMsg::QueryExtension {
+                msg: QueryExt::PendingProposals {
+                    start_after: None,
+                    limit: None,
+                },
+            },
+        )
+        .unwrap();
+
+    // Return last item in ascending list, id is first element of tuple
+    pending.pop().unwrap().approval_id
+}
+
+fn mint_natives(app: &mut App, receiver: &str, coins: Vec<Coin>) {
+    // Mint some ekez tokens for ekez so we can pay the deposit.
+    app.sudo(cw_multi_test::SudoMsg::Bank(BankSudo::Mint {
+        to_address: receiver.to_string(),
+        amount: coins,
+    }))
+    .unwrap();
+}
+
+fn increase_allowance(app: &mut App, sender: &str, receiver: &Addr, cw20: Addr, amount: Uint128) {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        cw20,
+        &cw20::Cw20ExecuteMsg::IncreaseAllowance {
+            spender: receiver.to_string(),
+            amount,
+            expires: None,
+        },
+        &[],
+    )
+    .unwrap();
+}
+
+fn get_balance_cw20<T: Into<String>, U: Into<String>>(
+    app: &App,
+    contract_addr: T,
+    address: U,
+) -> Uint128 {
+    let msg = cw20::Cw20QueryMsg::Balance {
+        address: address.into(),
+    };
+    let result: cw20::BalanceResponse = app.wrap().query_wasm_smart(contract_addr, &msg).unwrap();
+    result.balance
+}
+
+fn get_balance_native(app: &App, who: &str, denom: &str) -> Uint128 {
+    let res = app.wrap().query_balance(who, denom).unwrap();
+    res.amount
+}
+
+fn vote(app: &mut App, module: Addr, sender: &str, id: u64, option_id: u32) -> Status {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        module.clone(),
+        &dao_proposal_multiple::msg::ExecuteMsg::Vote {
+            proposal_id: id,
+            vote: MultipleChoiceVote { option_id },
+            rationale: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let proposal: ProposalResponse = app
+        .wrap()
+        .query_wasm_smart(
+            module,
+            &dao_proposal_multiple::msg::QueryMsg::Proposal { proposal_id: id },
+        )
+        .unwrap();
+
+    proposal.proposal.status
+}
+
+fn get_config(app: &App, module: Addr) -> Config {
+    app.wrap()
+        .query_wasm_smart(module, &QueryMsg::Config {})
+        .unwrap()
+}
+
+fn get_dao(app: &App, module: Addr) -> Addr {
+    app.wrap()
+        .query_wasm_smart(module, &QueryMsg::Dao {})
+        .unwrap()
+}
+
+fn get_info(app: &App, module: Addr) -> InfoResponse {
+    app.wrap()
+        .query_wasm_smart(module, &QueryMsg::Info {})
+        .unwrap()
+}
+
+fn get_proposal_module(app: &App, module: Addr) -> Addr {
+    app.wrap()
+        .query_wasm_smart(module, &QueryMsg::ProposalModule {})
+        .unwrap()
+}
+
+fn get_deposit_info(app: &App, module: Addr, id: u64) -> DepositInfoResponse {
+    app.wrap()
+        .query_wasm_smart(module, &QueryMsg::DepositInfo { proposal_id: id })
+        .unwrap()
+}
+
+fn query_can_propose(app: &App, module: Addr, address: impl Into<String>) -> bool {
+    app.wrap()
+        .query_wasm_smart(
+            module,
+            &QueryMsg::CanPropose {
+                address: address.into(),
+            },
+        )
+        .unwrap()
+}
+
+fn update_config(
+    app: &mut App,
+    module: Addr,
+    sender: &str,
+    deposit_info: Option<UncheckedDepositInfo>,
+    submission_policy: PreProposeSubmissionPolicy,
+) -> Config {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        module.clone(),
+        &ExecuteMsg::UpdateConfig {
+            deposit_info,
+            submission_policy: Some(submission_policy),
+        },
+        &[],
+    )
+    .unwrap();
+
+    get_config(app, module)
+}
+
+fn update_config_should_fail(
+    app: &mut App,
+    module: Addr,
+    sender: &str,
+    deposit_info: Option<UncheckedDepositInfo>,
+    submission_policy: PreProposeSubmissionPolicy,
+) -> PreProposeError {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        module,
+        &ExecuteMsg::UpdateConfig {
+            deposit_info,
+            submission_policy: Some(submission_policy),
+        },
+        &[],
+    )
+    .unwrap_err()
+    .downcast()
+    .unwrap()
+}
+
+fn withdraw(app: &mut App, module: Addr, sender: &str, denom: Option<UncheckedDenom>) {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        module,
+        &ExecuteMsg::Withdraw { denom },
+        &[],
+    )
+    .unwrap();
+}
+
+fn withdraw_should_fail(
+    app: &mut App,
+    module: Addr,
+    sender: &str,
+    denom: Option<UncheckedDenom>,
+) -> PreProposeError {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        module,
+        &ExecuteMsg::Withdraw { denom },
+        &[],
+    )
+    .unwrap_err()
+    .downcast()
+    .unwrap()
+}
+
+fn close_proposal(app: &mut App, module: Addr, sender: &str, proposal_id: u64) {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        module,
+        &dao_proposal_multiple::msg::ExecuteMsg::Close { proposal_id },
+        &[],
+    )
+    .unwrap();
+}
+
+fn execute_proposal(app: &mut App, module: Addr, sender: &str, proposal_id: u64) {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        module,
+        &dao_proposal_multiple::msg::ExecuteMsg::Execute { proposal_id },
+        &[],
+    )
+    .unwrap();
+}
+
+fn approve_proposal(app: &mut App, module: Addr, sender: &str, proposal_id: u64) -> u64 {
+    let res = app
+        .execute_contract(
+            Addr::unchecked(sender),
+            module,
+            &ExecuteMsg::Extension {
+                msg: ExecuteExt::Approve { id: proposal_id },
+            },
+            &[],
+        )
+        .unwrap();
+
+    // Parse attrs from approve_proposal response
+    let attrs = res.custom_attrs(res.events.len() - 1);
+    // Return ID
+    attrs[attrs.len() - 2].value.parse().unwrap()
+}
+
+fn reject_proposal(app: &mut App, module: Addr, sender: &str, proposal_id: u64) {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        module,
+        &ExecuteMsg::Extension {
+            msg: ExecuteExt::Reject { id: proposal_id },
+        },
+        &[],
+    )
+    .unwrap();
+}
+
+enum ApprovalStatus {
+    Approved,
+    Rejected,
+}
+
+enum EndStatus {
+    PassedA,
+    PassedB,
+    Failed,
+}
+
+enum RefundReceiver {
+    Proposer,
+    Dao,
+}
+
+fn test_native_permutation(
+    end_status: EndStatus,
+    refund_policy: DepositRefundPolicy,
+    receiver: RefundReceiver,
+    approval_status: ApprovalStatus,
+) {
+    let mut app = App::default();
+
+    let DefaultTestSetup {
+        core_addr,
+        proposal_multiple,
+        pre_propose,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy,
+        }),
+        false,
+    );
+
+    mint_natives(&mut app, "ekez", coins(10, "ujuno"));
+    let pre_propose_id =
+        make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &coins(10, "ujuno"));
+
+    // Make sure it went away.
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(balance, Uint128::zero());
+
+    // Approver approves or rejects proposal
+    match approval_status {
+        ApprovalStatus::Approved => {
+            // Approver approves, new proposal id is returned
+            let id = approve_proposal(&mut app, pre_propose, "approver", pre_propose_id);
+
+            // Voting happens on newly created proposal
+            #[allow(clippy::type_complexity)]
+            let (position, expected_status, trigger_refund): (
+                _,
+                _,
+                fn(&mut App, Addr, &str, u64) -> (),
+            ) = match end_status {
+                EndStatus::PassedA => (0, Status::Passed, execute_proposal),
+                EndStatus::PassedB => (1, Status::Passed, execute_proposal),
+                EndStatus::Failed => (2, Status::Rejected, close_proposal),
+            };
+            let new_status = vote(&mut app, proposal_multiple.clone(), "ekez", id, position);
+            assert_eq!(new_status, expected_status);
+
+            // Close or execute the proposal to trigger a refund.
+            trigger_refund(&mut app, proposal_multiple, "ekez", id);
+        }
+        ApprovalStatus::Rejected => {
+            // Proposal is rejected by approver
+            // No proposal is created so there is no voting
+            reject_proposal(&mut app, pre_propose, "approver", pre_propose_id);
+        }
+    };
+
+    let (dao_expected, proposer_expected) = match receiver {
+        RefundReceiver::Proposer => (0, 10),
+        RefundReceiver::Dao => (10, 0),
+    };
+
+    let proposer_balance = get_balance_native(&app, "ekez", "ujuno");
+    let dao_balance = get_balance_native(&app, core_addr.as_str(), "ujuno");
+    assert_eq!(proposer_expected, proposer_balance.u128());
+    assert_eq!(dao_expected, dao_balance.u128())
+}
+
+fn test_cw20_permutation(
+    end_status: EndStatus,
+    refund_policy: DepositRefundPolicy,
+    receiver: RefundReceiver,
+    approval_status: ApprovalStatus,
+) {
+    let mut app = App::default();
+
+    let cw20_address = instantiate_cw20_base_default(&mut app);
+
+    let DefaultTestSetup {
+        core_addr,
+        proposal_multiple,
+        pre_propose,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Cw20(cw20_address.to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy,
+        }),
+        false,
+    );
+
+    increase_allowance(
+        &mut app,
+        "ekez",
+        &pre_propose,
+        cw20_address.clone(),
+        Uint128::new(10),
+    );
+    let pre_propose_id = make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &[]);
+
+    // Make sure it went await.
+    let balance = get_balance_cw20(&app, cw20_address.clone(), "ekez");
+    assert_eq!(balance, Uint128::zero());
+
+    // Approver approves or rejects proposal
+    match approval_status {
+        ApprovalStatus::Approved => {
+            // Approver approves, new proposal id is returned
+            let id = approve_proposal(&mut app, pre_propose.clone(), "approver", pre_propose_id);
+
+            // Voting happens on newly created proposal
+            #[allow(clippy::type_complexity)]
+            let (position, expected_status, trigger_refund): (
+                _,
+                _,
+                fn(&mut App, Addr, &str, u64) -> (),
+            ) = match end_status {
+                EndStatus::PassedA => (0, Status::Passed, execute_proposal),
+                EndStatus::PassedB => (1, Status::Passed, execute_proposal),
+                EndStatus::Failed => (2, Status::Rejected, close_proposal),
+            };
+            let new_status = vote(&mut app, proposal_multiple.clone(), "ekez", id, position);
+            assert_eq!(new_status, expected_status);
+
+            // Close or execute the proposal to trigger a refund.
+            trigger_refund(&mut app, proposal_multiple, "ekez", id);
+        }
+        ApprovalStatus::Rejected => {
+            // Proposal is rejected by approver
+            // No proposal is created so there is no voting
+            reject_proposal(&mut app, pre_propose.clone(), "approver", pre_propose_id);
+        }
+    };
+
+    let (dao_expected, proposer_expected) = match receiver {
+        RefundReceiver::Proposer => (0, 10),
+        RefundReceiver::Dao => (10, 0),
+    };
+
+    let proposer_balance = get_balance_cw20(&app, &cw20_address, "ekez");
+    let dao_balance = get_balance_cw20(&app, &cw20_address, core_addr);
+    assert_eq!(proposer_expected, proposer_balance.u128());
+    assert_eq!(dao_expected, dao_balance.u128())
+}
+
+#[test]
+fn test_native_failed_always_refund() {
+    test_native_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::Always,
+        RefundReceiver::Proposer,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_native_rejected_always_refund() {
+    test_native_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::Always,
+        RefundReceiver::Proposer,
+        ApprovalStatus::Rejected,
+    )
+}
+
+#[test]
+fn test_cw20_failed_always_refund() {
+    test_cw20_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::Always,
+        RefundReceiver::Proposer,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_cw20_rejected_always_refund() {
+    test_cw20_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::Always,
+        RefundReceiver::Proposer,
+        ApprovalStatus::Rejected,
+    )
+}
+
+#[test]
+fn test_native_passed_always_refund() {
+    test_native_permutation(
+        EndStatus::PassedA,
+        DepositRefundPolicy::Always,
+        RefundReceiver::Proposer,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_cw20_passed_always_refund() {
+    test_cw20_permutation(
+        EndStatus::PassedB,
+        DepositRefundPolicy::Always,
+        RefundReceiver::Proposer,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_native_passed_never_refund() {
+    test_native_permutation(
+        EndStatus::PassedB,
+        DepositRefundPolicy::Never,
+        RefundReceiver::Dao,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_cw20_passed_never_refund() {
+    test_cw20_permutation(
+        EndStatus::PassedA,
+        DepositRefundPolicy::Never,
+        RefundReceiver::Dao,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_native_failed_never_refund() {
+    test_native_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::Never,
+        RefundReceiver::Dao,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_native_rejected_never_refund() {
+    test_native_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::Never,
+        RefundReceiver::Dao,
+        ApprovalStatus::Rejected,
+    )
+}
+
+#[test]
+fn test_cw20_failed_never_refund() {
+    test_cw20_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::Never,
+        RefundReceiver::Dao,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_cw20_rejected_never_refund() {
+    test_cw20_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::Never,
+        RefundReceiver::Dao,
+        ApprovalStatus::Rejected,
+    )
+}
+
+#[test]
+fn test_native_passed_passed_refund() {
+    test_native_permutation(
+        EndStatus::PassedA,
+        DepositRefundPolicy::OnlyPassed,
+        RefundReceiver::Proposer,
+        ApprovalStatus::Approved,
+    )
+}
+#[test]
+fn test_cw20_passed_passed_refund() {
+    test_cw20_permutation(
+        EndStatus::PassedA,
+        DepositRefundPolicy::OnlyPassed,
+        RefundReceiver::Proposer,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_native_failed_passed_refund() {
+    test_native_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::OnlyPassed,
+        RefundReceiver::Dao,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_native_rejected_passed_refund() {
+    test_native_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::OnlyPassed,
+        RefundReceiver::Dao,
+        ApprovalStatus::Rejected,
+    )
+}
+
+#[test]
+fn test_cw20_failed_passed_refund() {
+    test_cw20_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::OnlyPassed,
+        RefundReceiver::Dao,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_cw20_rejected_passed_refund() {
+    test_cw20_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::OnlyPassed,
+        RefundReceiver::Dao,
+        ApprovalStatus::Rejected,
+    )
+}
+
+// See: <https://github.com/DA0-DA0/dao-contracts/pull/465#discussion_r960092321>
+#[test]
+fn test_multiple_open_proposals() {
+    let mut app = App::default();
+
+    let DefaultTestSetup {
+        core_addr: _,
+        proposal_multiple,
+        pre_propose,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        false,
+    );
+
+    mint_natives(&mut app, "ekez", coins(20, "ujuno"));
+    let first_pre_propose_id =
+        make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &coins(10, "ujuno"));
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(10, balance.u128());
+
+    // Approver approves prop, balance remains the same
+    let first_id = approve_proposal(
+        &mut app,
+        pre_propose.clone(),
+        "approver",
+        first_pre_propose_id,
+    );
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(10, balance.u128());
+
+    let second_pre_propose_id =
+        make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &coins(10, "ujuno"));
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(0, balance.u128());
+
+    // Approver approves prop, balance remains the same
+    let second_id = approve_proposal(&mut app, pre_propose, "approver", second_pre_propose_id);
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(0, balance.u128());
+
+    // Finish up the first proposal.
+    let new_status = vote(&mut app, proposal_multiple.clone(), "ekez", first_id, 0);
+    assert_eq!(Status::Passed, new_status);
+
+    // Still zero.
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(0, balance.u128());
+
+    execute_proposal(&mut app, proposal_multiple.clone(), "ekez", first_id);
+
+    // First proposal refunded.
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(10, balance.u128());
+
+    // Finish up the second proposal.
+    let new_status = vote(&mut app, proposal_multiple.clone(), "ekez", second_id, 2);
+    assert_eq!(Status::Rejected, new_status);
+
+    // Still zero.
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(10, balance.u128());
+
+    close_proposal(&mut app, proposal_multiple, "ekez", second_id);
+
+    // All deposits have been refunded.
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(20, balance.u128());
+}
+
+#[test]
+fn test_pending_proposal_queries() {
+    let mut app = App::default();
+
+    let DefaultTestSetup {
+        core_addr: _,
+        proposal_multiple: _,
+        pre_propose,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        false,
+    );
+
+    mint_natives(&mut app, "ekez", coins(20, "ujuno"));
+    make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &coins(10, "ujuno"));
+    make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &coins(10, "ujuno"));
+
+    // Query for individual proposal
+    let prop1: Proposal = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose.clone(),
+            &QueryMsg::QueryExtension {
+                msg: QueryExt::PendingProposal { id: 1 },
+            },
+        )
+        .unwrap();
+    assert_eq!(prop1.approval_id, 1);
+    assert_eq!(prop1.status, ApprovalProposalStatus::Pending {});
+
+    let prop1: Proposal = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose.clone(),
+            &QueryMsg::QueryExtension {
+                msg: QueryExt::Proposal { id: 1 },
+            },
+        )
+        .unwrap();
+    assert_eq!(prop1.approval_id, 1);
+    assert_eq!(prop1.status, ApprovalProposalStatus::Pending {});
+
+    // Query for the pre-propose proposals
+    let pre_propose_props: Vec<Proposal> = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose.clone(),
+            &QueryMsg::QueryExtension {
+                msg: QueryExt::PendingProposals {
+                    start_after: None,
+                    limit: None,
+                },
+            },
+        )
+        .unwrap();
+    assert_eq!(pre_propose_props.len(), 2);
+    assert_eq!(pre_propose_props[0].approval_id, 1);
+
+    // Query props in reverse
+    let reverse_pre_propose_props: Vec<Proposal> = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose,
+            &QueryMsg::QueryExtension {
+                msg: QueryExt::ReversePendingProposals {
+                    start_before: None,
+                    limit: None,
+                },
+            },
+        )
+        .unwrap();
+
+    assert_eq!(reverse_pre_propose_props.len(), 2);
+    assert_eq!(reverse_pre_propose_props[0].approval_id, 2);
+}
+
+#[test]
+fn test_completed_proposal_queries() {
+    let mut app = App::default();
+
+    let DefaultTestSetup {
+        core_addr: _,
+        proposal_multiple: _,
+        pre_propose,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        false,
+    );
+
+    mint_natives(&mut app, "ekez", coins(20, "ujuno"));
+    let approve_id = make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &coins(10, "ujuno"));
+    let reject_id = make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &coins(10, "ujuno"));
+
+    let is_pending: bool = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose.clone(),
+            &QueryMsg::QueryExtension {
+                msg: QueryExt::IsPending { id: approve_id },
+            },
+        )
+        .unwrap();
+    assert!(is_pending);
+
+    let created_approved_id =
+        approve_proposal(&mut app, pre_propose.clone(), "approver", approve_id);
+    reject_proposal(&mut app, pre_propose.clone(), "approver", reject_id);
+
+    let is_pending: bool = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose.clone(),
+            &QueryMsg::QueryExtension {
+                msg: QueryExt::IsPending { id: approve_id },
+            },
+        )
+        .unwrap();
+    assert!(!is_pending);
+
+    // Query for individual proposals
+    let prop1: Proposal = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose.clone(),
+            &QueryMsg::QueryExtension {
+                msg: QueryExt::CompletedProposal { id: approve_id },
+            },
+        )
+        .unwrap();
+    assert_eq!(
+        prop1.status,
+        ApprovalProposalStatus::Approved {
+            created_proposal_id: created_approved_id
+        }
+    );
+    let prop1: Proposal = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose.clone(),
+            &QueryMsg::QueryExtension {
+                msg: QueryExt::Proposal { id: approve_id },
+            },
+        )
+        .unwrap();
+    assert_eq!(
+        prop1.status,
+        ApprovalProposalStatus::Approved {
+            created_proposal_id: created_approved_id
+        }
+    );
+
+    let prop1_id: Option<u64> = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose.clone(),
+            &QueryMsg::QueryExtension {
+                msg: QueryExt::CompletedProposalIdForCreatedProposalId {
+                    id: created_approved_id,
+                },
+            },
+        )
+        .unwrap();
+    assert_eq!(prop1_id, Some(approve_id));
+
+    let prop2: Proposal = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose.clone(),
+            &QueryMsg::QueryExtension {
+                msg: QueryExt::CompletedProposal { id: reject_id },
+            },
+        )
+        .unwrap();
+    assert_eq!(prop2.status, ApprovalProposalStatus::Rejected {});
+
+    // Query for the pre-propose proposals
+    let pre_propose_props: Vec<Proposal> = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose.clone(),
+            &QueryMsg::QueryExtension {
+                msg: QueryExt::CompletedProposals {
+                    start_after: None,
+                    limit: None,
+                },
+            },
+        )
+        .unwrap();
+    assert_eq!(pre_propose_props.len(), 2);
+    assert_eq!(pre_propose_props[0].approval_id, approve_id);
+    assert_eq!(pre_propose_props[1].approval_id, reject_id);
+
+    // Query props in reverse
+    let reverse_pre_propose_props: Vec<Proposal> = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose,
+            &QueryMsg::QueryExtension {
+                msg: QueryExt::ReverseCompletedProposals {
+                    start_before: None,
+                    limit: None,
+                },
+            },
+        )
+        .unwrap();
+
+    assert_eq!(reverse_pre_propose_props.len(), 2);
+    assert_eq!(reverse_pre_propose_props[0].approval_id, reject_id);
+    assert_eq!(reverse_pre_propose_props[1].approval_id, approve_id);
+}
+
+#[test]
+fn test_set_version() {
+    let mut app = App::default();
+
+    let DefaultTestSetup {
+        core_addr: _,
+        proposal_multiple: _,
+        pre_propose,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        false,
+    );
+
+    let info: ContractVersion = from_json(
+        app.wrap()
+            .query_wasm_raw(pre_propose, "contract_info".as_bytes())
+            .unwrap()
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        ContractVersion {
+            contract: CONTRACT_NAME.to_string(),
+            version: CONTRACT_VERSION.to_string()
+        },
+        info
+    )
+}
+
+#[test]
+fn test_permissions() {
+    let mut app = App::default();
+
+    let DefaultTestSetup {
+        core_addr,
+        proposal_multiple: _,
+        pre_propose,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        false, // no open proposal submission.
+    );
+
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr,
+            pre_propose.clone(),
+            &ExecuteMsg::ProposalCompletedHook {
+                proposal_id: 1,
+                new_status: Status::Closed,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, PreProposeError::NotModule {});
+
+    // Non-members may not propose when open_propose_submission is
+    // disabled.
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("nonmember"),
+            pre_propose,
+            &ExecuteMsg::Propose {
+                msg: ProposeMessage::Propose {
+                    title: "I would like to join the DAO".to_string(),
+                    description: "though, I am currently not a member.".to_string(),
+                    choices: MultipleChoiceOptions {
+                        options: vec![
+                            MultipleChoiceOption {
+                                title: "A".to_string(),
+                                description: "A".to_string(),
+                                msgs: vec![],
+                            },
+                            MultipleChoiceOption {
+                                title: "B".to_string(),
+                                description: "B".to_string(),
+                                msgs: vec![],
+                            },
+                        ],
+                    },
+                    vote: None,
+                },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
+    );
+}
+
+#[test]
+fn test_approval_and_rejection_permissions() {
+    let mut app = App::default();
+    let DefaultTestSetup {
+        core_addr: _,
+        proposal_multiple: _,
+        pre_propose,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        true, // yes, open proposal submission.
+    );
+
+    // Non-member proposes.
+    mint_natives(&mut app, "nonmember", coins(10, "ujuno"));
+    let pre_propose_id = make_pre_proposal(
+        &mut app,
+        pre_propose.clone(),
+        "nonmember",
+        &coins(10, "ujuno"),
+    );
+
+    // Only approver can propose
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("nonmember"),
+            pre_propose.clone(),
+            &ExecuteMsg::Extension {
+                msg: ExecuteExt::Approve { id: pre_propose_id },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, PreProposeError::Unauthorized {});
+
+    // Only approver can propose
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("nonmember"),
+            pre_propose,
+            &ExecuteMsg::Extension {
+                msg: ExecuteExt::Reject { id: pre_propose_id },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, PreProposeError::Unauthorized {});
+}
+
+#[test]
+fn test_propose_open_proposal_submission() {
+    let mut app = App::default();
+    let DefaultTestSetup {
+        core_addr: _,
+        proposal_multiple,
+        pre_propose,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        true, // yes, open proposal submission.
+    );
+
+    // Non-member proposes.
+    mint_natives(&mut app, "nonmember", coins(10, "ujuno"));
+    let pre_propose_id = make_pre_proposal(
+        &mut app,
+        pre_propose.clone(),
+        "nonmember",
+        &coins(10, "ujuno"),
+    );
+
+    // Approver approves
+    let id = approve_proposal(&mut app, pre_propose, "approver", pre_propose_id);
+
+    // Member votes.
+    let new_status = vote(&mut app, proposal_multiple, "ekez", id, 0);
+    assert_eq!(Status::Passed, new_status)
+}
+
+#[test]
+fn test_no_deposit_required_open_submission() {
+    let mut app = App::default();
+    let DefaultTestSetup {
+        core_addr: _,
+        proposal_multiple,
+        pre_propose,
+    } = setup_default_test(
+        &mut app, None, true, // yes, open proposal submission.
+    );
+
+    // Non-member proposes.
+    let pre_propose_id = make_pre_proposal(&mut app, pre_propose.clone(), "nonmember", &[]);
+
+    // Approver approves
+    let id = approve_proposal(&mut app, pre_propose, "approver", pre_propose_id);
+
+    // Member votes.
+    let new_status = vote(&mut app, proposal_multiple, "ekez", id, 0);
+    assert_eq!(Status::Passed, new_status)
+}
+
+#[test]
+fn test_no_deposit_required_members_submission() {
+    let mut app = App::default();
+    let DefaultTestSetup {
+        core_addr: _,
+        proposal_multiple,
+        pre_propose,
+    } = setup_default_test(
+        &mut app, None, false, // no open proposal submission.
+    );
+
+    // Non-member proposes and this fails.
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("nonmember"),
+            pre_propose.clone(),
+            &ExecuteMsg::Propose {
+                msg: ProposeMessage::Propose {
+                    title: "I would like to join the DAO".to_string(),
+                    description: "though, I am currently not a member.".to_string(),
+                    choices: MultipleChoiceOptions {
+                        options: vec![
+                            MultipleChoiceOption {
+                                title: "A".to_string(),
+                                description: "A".to_string(),
+                                msgs: vec![],
+                            },
+                            MultipleChoiceOption {
+                                title: "B".to_string(),
+                                description: "B".to_string(),
+                                msgs: vec![],
+                            },
+                        ],
+                    },
+                    vote: None,
+                },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
+    );
+
+    let pre_propose_id = make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &[]);
+
+    // Approver approves
+    let id = approve_proposal(&mut app, pre_propose, "approver", pre_propose_id);
+
+    let new_status = vote(&mut app, proposal_multiple, "ekez", id, 0);
+    assert_eq!(Status::Passed, new_status)
+}
+
+#[test]
+fn test_anyone_denylist() {
+    let mut app = App::default();
+    let DefaultTestSetup {
+        core_addr,
+        pre_propose,
+        ..
+    } = setup_default_test(&mut app, None, false);
+
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
+    );
+
+    let rando = "rando";
+
+    // Proposal succeeds when anyone can propose.
+    assert!(query_can_propose(&app, pre_propose.clone(), rando));
+    make_pre_proposal(&mut app, pre_propose.clone(), rando, &[]);
+
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Anyone {
+            denylist: vec![Addr::unchecked(rando)],
+        },
+    );
+
+    // Proposing fails if on denylist.
+    assert!(!query_can_propose(&app, pre_propose.clone(), rando));
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked(rando),
+            pre_propose.clone(),
+            &ExecuteMsg::Propose {
+                msg: ProposeMessage::Propose {
+                    title: "I would like to join the DAO".to_string(),
+                    description: "though, I am currently not a member.".to_string(),
+                    choices: MultipleChoiceOptions {
+                        options: vec![
+                            MultipleChoiceOption {
+                                title: "A".to_string(),
+                                description: "A".to_string(),
+                                msgs: vec![],
+                            },
+                            MultipleChoiceOption {
+                                title: "B".to_string(),
+                                description: "B".to_string(),
+                                msgs: vec![],
+                            },
+                        ],
+                    },
+                    vote: None,
+                },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
+    );
+
+    // Proposing succeeds if not on denylist.
+    assert!(query_can_propose(&app, pre_propose.clone(), "ekez"));
+    make_pre_proposal(&mut app, pre_propose, "ekez", &[]);
+}
+
+#[test]
+fn test_specific_allowlist_denylist() {
+    let mut app = App::default();
+    let DefaultTestSetup {
+        core_addr,
+        pre_propose,
+        ..
+    } = setup_default_test(&mut app, None, false);
+
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: vec![],
+            denylist: vec![],
+        },
+    );
+
+    // Proposal succeeds for member.
+    assert!(query_can_propose(&app, pre_propose.clone(), "ekez"));
+    make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &[]);
+
+    let rando = "rando";
+
+    // Proposing fails for non-member.
+    assert!(!query_can_propose(&app, pre_propose.clone(), rando));
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked(rando),
+            pre_propose.clone(),
+            &ExecuteMsg::Propose {
+                msg: ProposeMessage::Propose {
+                    title: "I would like to join the DAO".to_string(),
+                    description: "though, I am currently not a member.".to_string(),
+                    choices: MultipleChoiceOptions {
+                        options: vec![
+                            MultipleChoiceOption {
+                                title: "A".to_string(),
+                                description: "A".to_string(),
+                                msgs: vec![],
+                            },
+                            MultipleChoiceOption {
+                                title: "B".to_string(),
+                                description: "B".to_string(),
+                                msgs: vec![],
+                            },
+                        ],
+                    },
+                    vote: None,
+                },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
+    );
+
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: vec![Addr::unchecked(rando)],
+            denylist: vec![],
+        },
+    );
+
+    // Proposal succeeds if on allowlist.
+    assert!(query_can_propose(&app, pre_propose.clone(), rando));
+    make_pre_proposal(&mut app, pre_propose.clone(), rando, &[]);
+
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: vec![Addr::unchecked(rando)],
+            denylist: vec![Addr::unchecked("ekez")],
+        },
+    );
+
+    // Proposing fails if on denylist.
+    assert!(!query_can_propose(&app, pre_propose.clone(), "ekez"));
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("ekez"),
+            pre_propose.clone(),
+            &ExecuteMsg::Propose {
+                msg: ProposeMessage::Propose {
+                    title: "Let me propose!".to_string(),
+                    description: "I am a member!!!".to_string(),
+                    choices: MultipleChoiceOptions {
+                        options: vec![
+                            MultipleChoiceOption {
+                                title: "A".to_string(),
+                                description: "A".to_string(),
+                                msgs: vec![],
+                            },
+                            MultipleChoiceOption {
+                                title: "B".to_string(),
+                                description: "B".to_string(),
+                                msgs: vec![],
+                            },
+                        ],
+                    },
+                    vote: None,
+                },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
+    );
+
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: false,
+            allowlist: vec![Addr::unchecked(rando)],
+            denylist: vec![],
+        },
+    );
+
+    // Proposing fails if members not allowed.
+    assert!(!query_can_propose(&app, pre_propose.clone(), "ekez"));
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("ekez"),
+            pre_propose.clone(),
+            &ExecuteMsg::Propose {
+                msg: ProposeMessage::Propose {
+                    title: "Let me propose!".to_string(),
+                    description: "I am a member!!!".to_string(),
+                    choices: MultipleChoiceOptions {
+                        options: vec![
+                            MultipleChoiceOption {
+                                title: "A".to_string(),
+                                description: "A".to_string(),
+                                msgs: vec![],
+                            },
+                            MultipleChoiceOption {
+                                title: "B".to_string(),
+                                description: "B".to_string(),
+                                msgs: vec![],
+                            },
+                        ],
+                    },
+                    vote: None,
+                },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
+    );
+
+    // Proposal succeeds if on allowlist.
+    assert!(query_can_propose(&app, pre_propose.clone(), rando));
+    make_pre_proposal(&mut app, pre_propose.clone(), rando, &[]);
+}
+
+#[test]
+#[should_panic(expected = "invalid zero deposit. set the deposit to `None` to have no deposit")]
+fn test_instantiate_with_zero_native_deposit() {
+    let mut app = App::default();
+
+    let dao_proposal_multiple_id = app.store_code(dao_proposal_multiple_contract());
+
+    let proposal_module_instantiate = {
+        let pre_propose_id = app.store_code(dao_pre_propose_approval_multiple_contract());
+
+        dao_proposal_multiple::msg::InstantiateMsg {
+            voting_strategy: VotingStrategy::SingleChoice {
+                quorum: PercentageThreshold::Majority {},
+            },
+            max_voting_period: Duration::Time(86400),
+            min_voting_period: None,
+            only_members_execute: false,
+            allow_revoting: false,
+            pre_propose_info: PreProposeInfo::ModuleMayPropose {
+                info: ModuleInstantiateInfo {
+                    code_id: pre_propose_id,
+                    msg: to_json_binary(&InstantiateMsg {
+                        deposit_info: Some(UncheckedDepositInfo {
+                            denom: DepositToken::Token {
+                                denom: UncheckedDenom::Native("ujuno".to_string()),
+                            },
+                            amount: Uint128::zero(),
+                            refund_policy: DepositRefundPolicy::OnlyPassed,
+                        }),
+                        submission_policy: PreProposeSubmissionPolicy::Specific {
+                            dao_members: true,
+                            allowlist: vec![],
+                            denylist: vec![],
+                        },
+                        extension: InstantiateExt {
+                            approver: "approver".to_string(),
+                        },
+                    })
+                    .unwrap(),
+                    admin: Some(Admin::CoreModule {}),
+                    funds: vec![],
+                    label: "baby's first pre-propose module".to_string(),
+                },
+            },
+            close_proposal_on_execution_failure: false,
+            veto: None,
+        }
+    };
+
+    // Should panic.
+    instantiate_with_cw4_groups_governance(
+        &mut app,
+        dao_proposal_multiple_id,
+        to_json_binary(&proposal_module_instantiate).unwrap(),
+        Some(vec![
+            cw20::Cw20Coin {
+                address: "ekez".to_string(),
+                amount: Uint128::new(9),
+            },
+            cw20::Cw20Coin {
+                address: "keze".to_string(),
+                amount: Uint128::new(8),
+            },
+        ]),
+    );
+}
+
+#[test]
+#[should_panic(expected = "invalid zero deposit. set the deposit to `None` to have no deposit")]
+fn test_instantiate_with_zero_cw20_deposit() {
+    let mut app = App::default();
+
+    let cw20_addr = instantiate_cw20_base_default(&mut app);
+
+    let dao_proposal_multiple_id = app.store_code(dao_proposal_multiple_contract());
+
+    let proposal_module_instantiate = {
+        let pre_propose_id = app.store_code(dao_pre_propose_approval_multiple_contract());
+
+        dao_proposal_multiple::msg::InstantiateMsg {
+            voting_strategy: VotingStrategy::SingleChoice {
+                quorum: PercentageThreshold::Majority {},
+            },
+            max_voting_period: Duration::Time(86400),
+            min_voting_period: None,
+            only_members_execute: false,
+            allow_revoting: false,
+            pre_propose_info: PreProposeInfo::ModuleMayPropose {
+                info: ModuleInstantiateInfo {
+                    code_id: pre_propose_id,
+                    msg: to_json_binary(&InstantiateMsg {
+                        deposit_info: Some(UncheckedDepositInfo {
+                            denom: DepositToken::Token {
+                                denom: UncheckedDenom::Cw20(cw20_addr.into_string()),
+                            },
+                            amount: Uint128::zero(),
+                            refund_policy: DepositRefundPolicy::OnlyPassed,
+                        }),
+                        submission_policy: PreProposeSubmissionPolicy::Specific {
+                            dao_members: true,
+                            allowlist: vec![],
+                            denylist: vec![],
+                        },
+                        extension: InstantiateExt {
+                            approver: "approver".to_string(),
+                        },
+                    })
+                    .unwrap(),
+                    admin: Some(Admin::CoreModule {}),
+                    funds: vec![],
+                    label: "baby's first pre-propose module".to_string(),
+                },
+            },
+            close_proposal_on_execution_failure: false,
+            veto: None,
+        }
+    };
+
+    // Should panic.
+    instantiate_with_cw4_groups_governance(
+        &mut app,
+        dao_proposal_multiple_id,
+        to_json_binary(&proposal_module_instantiate).unwrap(),
+        Some(vec![
+            cw20::Cw20Coin {
+                address: "ekez".to_string(),
+                amount: Uint128::new(9),
+            },
+            cw20::Cw20Coin {
+                address: "keze".to_string(),
+                amount: Uint128::new(8),
+            },
+        ]),
+    );
+}
+
+#[test]
+fn test_update_config() {
+    let mut app = App::default();
+    let DefaultTestSetup {
+        core_addr,
+        proposal_multiple,
+        pre_propose,
+    } = setup_default_test(&mut app, None, false);
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: vec![],
+                denylist: vec![]
+            }
+        }
+    );
+
+    let pre_propose_id = make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &[]);
+
+    // Approver approves
+    let id = approve_proposal(&mut app, pre_propose.clone(), "approver", pre_propose_id);
+
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Never,
+        }),
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
+    );
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: Some(CheckedDepositInfo {
+                denom: cw_denom::CheckedDenom::Native("ujuno".to_string()),
+                amount: Uint128::new(10),
+                refund_policy: DepositRefundPolicy::Never
+            }),
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
+        }
+    );
+
+    // Old proposal should still have same deposit info.
+    let info = get_deposit_info(&app, pre_propose.clone(), id);
+    assert_eq!(
+        info,
+        DepositInfoResponse {
+            deposit_info: None,
+            proposer: Addr::unchecked("ekez"),
+        }
+    );
+
+    // New proposals should have the new deposit info.
+    mint_natives(&mut app, "ekez", coins(10, "ujuno"));
+    let new_pre_propose_id =
+        make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &coins(10, "ujuno"));
+
+    // Approver approves
+    let new_id = approve_proposal(
+        &mut app,
+        pre_propose.clone(),
+        "approver",
+        new_pre_propose_id,
+    );
+
+    let info = get_deposit_info(&app, pre_propose.clone(), new_id);
+    assert_eq!(
+        info,
+        DepositInfoResponse {
+            deposit_info: Some(CheckedDepositInfo {
+                denom: cw_denom::CheckedDenom::Native("ujuno".to_string()),
+                amount: Uint128::new(10),
+                refund_policy: DepositRefundPolicy::Never
+            }),
+            proposer: Addr::unchecked("ekez"),
+        }
+    );
+
+    // Both proposals should be allowed to complete.
+    vote(&mut app, proposal_multiple.clone(), "ekez", id, 0);
+    vote(&mut app, proposal_multiple.clone(), "ekez", new_id, 0);
+    execute_proposal(&mut app, proposal_multiple.clone(), "ekez", id);
+    execute_proposal(&mut app, proposal_multiple.clone(), "ekez", new_id);
+    // Deposit should not have been refunded (never policy in use).
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(balance, Uint128::new(0));
+
+    // Only the core module can update the config.
+    let err = update_config_should_fail(
+        &mut app,
+        pre_propose.clone(),
+        proposal_multiple.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
+    );
+    assert_eq!(err, PreProposeError::NotDao {});
+
+    // Errors when no one is authorized to create proposals.
+    let err = update_config_should_fail(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: false,
+            allowlist: vec![],
+            denylist: vec![],
+        },
+    );
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::NoOneAllowed {})
+    );
+
+    // Errors when allowlist and denylist overlap.
+    let err = update_config_should_fail(
+        &mut app,
+        pre_propose,
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: false,
+            allowlist: vec![Addr::unchecked("ekez")],
+            denylist: vec![Addr::unchecked("ekez")],
+        },
+    );
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::DenylistAllowlistOverlap {}
+        )
+    );
+}
+
+#[test]
+fn test_update_submission_policy() {
+    let mut app = App::default();
+    let DefaultTestSetup {
+        core_addr,
+        pre_propose,
+        ..
+    } = setup_default_test(&mut app, None, true);
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
+        }
+    );
+
+    // Only the core module can update the submission policy.
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("ekez"),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: Some(vec!["ekez".to_string()]),
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, PreProposeError::NotDao {});
+
+    // Append to denylist, with auto de-dupe.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: Some(vec!["ekez".to_string(), "ekez".to_string()]),
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone {
+                denylist: vec![Addr::unchecked("ekez")],
+            },
+        }
+    );
+
+    // Add and remove to/from denylist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: Some(vec!["someone".to_string(), "else".to_string()]),
+            denylist_remove: Some(vec!["ekez".to_string()]),
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone {
+                denylist: vec![Addr::unchecked("else"), Addr::unchecked("someone")],
+            },
+        }
+    );
+
+    // Remove from denylist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: Some(vec!["someone".to_string(), "else".to_string()]),
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
+        }
+    );
+
+    // Error if try to change Specific fields when set to Anyone.
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: None,
+                denylist_remove: None,
+                set_dao_members: Some(true),
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::AnyoneInvalidUpdateFields {}
+        )
+    );
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: None,
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: Some(vec!["ekez".to_string()]),
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::AnyoneInvalidUpdateFields {}
+        )
+    );
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: None,
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: None,
+                allowlist_remove: Some(vec!["ekez".to_string()]),
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::AnyoneInvalidUpdateFields {}
+        )
+    );
+
+    // Change to Specific policy.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateConfig {
+            deposit_info: None,
+            submission_policy: Some(PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: vec![],
+                denylist: vec![],
+            }),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: vec![],
+                denylist: vec![],
+            },
+        }
+    );
+
+    // Append to denylist, with auto de-dupe.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: Some(vec!["ekez".to_string(), "ekez".to_string()]),
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: vec![],
+                denylist: vec![Addr::unchecked("ekez")],
+            },
+        }
+    );
+
+    // Add and remove to/from denylist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: Some(vec!["someone".to_string(), "else".to_string()]),
+            denylist_remove: Some(vec!["ekez".to_string()]),
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: vec![],
+                denylist: vec![Addr::unchecked("else"), Addr::unchecked("someone")],
+            },
+        }
+    );
+
+    // Remove from denylist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: Some(vec!["someone".to_string(), "else".to_string()]),
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: vec![],
+                denylist: vec![]
+            },
+        }
+    );
+
+    // Append to allowlist, with auto de-dupe.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: Some(vec!["ekez".to_string(), "ekez".to_string()]),
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: vec![Addr::unchecked("ekez")],
+                denylist: vec![],
+            },
+        }
+    );
+
+    // Add and remove to/from allowlist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: Some(vec!["someone".to_string(), "else".to_string()]),
+            allowlist_remove: Some(vec!["ekez".to_string()]),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: vec![Addr::unchecked("else"), Addr::unchecked("someone")],
+                denylist: vec![],
+            },
+        }
+    );
+
+    // Remove from allowlist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: None,
+            set_dao_members: None,
+            allowlist_add: None,
+            allowlist_remove: Some(vec!["someone".to_string(), "else".to_string()]),
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: vec![],
+                denylist: vec![]
+            },
+        }
+    );
+
+    // Setting dao_members to false fails if allowlist is empty.
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: None,
+                denylist_remove: None,
+                set_dao_members: Some(false),
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::NoOneAllowed {})
+    );
+
+    // Set dao_members to false and add allowlist.
+    app.execute_contract(
+        core_addr.clone(),
+        pre_propose.clone(),
+        &ExecuteMsg::UpdateSubmissionPolicy {
+            denylist_add: None,
+            denylist_remove: None,
+            set_dao_members: Some(false),
+            allowlist_add: Some(vec!["ekez".to_string()]),
+            allowlist_remove: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: false,
+                allowlist: vec![Addr::unchecked("ekez")],
+                denylist: vec![]
+            },
+        }
+    );
+
+    // Errors when allowlist and denylist overlap.
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr.clone(),
+            pre_propose.clone(),
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: Some(vec!["ekez".to_string()]),
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::DenylistAllowlistOverlap {}
+        )
+    );
+}
+
+#[test]
+fn test_withdraw() {
+    let mut app = App::default();
+
+    let DefaultTestSetup {
+        core_addr,
+        proposal_multiple,
+        pre_propose,
+    } = setup_default_test(&mut app, None, false);
+
+    let err = withdraw_should_fail(
+        &mut app,
+        pre_propose.clone(),
+        proposal_multiple.as_str(),
+        Some(UncheckedDenom::Native("ujuno".to_string())),
+    );
+    assert_eq!(err, PreProposeError::NotDao {});
+
+    let err = withdraw_should_fail(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        Some(UncheckedDenom::Native("ujuno".to_string())),
+    );
+    assert_eq!(err, PreProposeError::NothingToWithdraw {});
+
+    let err = withdraw_should_fail(&mut app, pre_propose.clone(), core_addr.as_str(), None);
+    assert_eq!(err, PreProposeError::NoWithdrawalDenom {});
+
+    // Turn on native deposits.
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: vec![],
+            denylist: vec![],
+        },
+    );
+
+    // Withdraw with no specified denom - should fall back to the one
+    // in the config.
+    mint_natives(&mut app, pre_propose.as_str(), coins(10, "ujuno"));
+    withdraw(&mut app, pre_propose.clone(), core_addr.as_str(), None);
+    let balance = get_balance_native(&app, core_addr.as_str(), "ujuno");
+    assert_eq!(balance, Uint128::new(10));
+
+    // Withdraw again, this time specifying a native denomination.
+    mint_natives(&mut app, pre_propose.as_str(), coins(10, "ujuno"));
+    withdraw(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        Some(UncheckedDenom::Native("ujuno".to_string())),
+    );
+    let balance = get_balance_native(&app, core_addr.as_str(), "ujuno");
+    assert_eq!(balance, Uint128::new(20));
+
+    // Make a proposal with the native tokens to put some in the system.
+    mint_natives(&mut app, "ekez", coins(10, "ujuno"));
+    let native_pre_propose_id =
+        make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &coins(10, "ujuno"));
+
+    // Approver approves
+    let native_id = approve_proposal(
+        &mut app,
+        pre_propose.clone(),
+        "approver",
+        native_pre_propose_id,
+    );
+
+    // Update the config to use a cw20 token.
+    let cw20_address = instantiate_cw20_base_default(&mut app);
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Cw20(cw20_address.to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: vec![],
+            denylist: vec![],
+        },
+    );
+
+    increase_allowance(
+        &mut app,
+        "ekez",
+        &pre_propose,
+        cw20_address.clone(),
+        Uint128::new(10),
+    );
+    let cw20_pre_propose_id = make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &[]);
+
+    // Approver approves
+    let cw20_id = approve_proposal(
+        &mut app,
+        pre_propose.clone(),
+        "approver",
+        cw20_pre_propose_id,
+    );
+
+    // There is now a pending proposal and cw20 tokens in the
+    // pre-propose module that should be returned on that proposal's
+    // completion. To make things interesting, we withdraw those
+    // tokens which should cause the status change hook on the
+    // proposal's execution to fail as we don't have sufficent balance
+    // to return the deposit.
+    withdraw(&mut app, pre_propose.clone(), core_addr.as_str(), None);
+    let balance = get_balance_cw20(&app, &cw20_address, core_addr.as_str());
+    assert_eq!(balance, Uint128::new(10));
+
+    // Proposal should still be executable! We just get removed from
+    // the proposal module's hook receiver list.
+    vote(&mut app, proposal_multiple.clone(), "ekez", cw20_id, 1);
+    execute_proposal(&mut app, proposal_multiple.clone(), "ekez", cw20_id);
+
+    // Make sure the proposal module has fallen back to anyone can
+    // propose becuase of our malfunction.
+    let proposal_creation_policy: ProposalCreationPolicy = app
+        .wrap()
+        .query_wasm_smart(
+            proposal_multiple.clone(),
+            &dao_proposal_multiple::msg::QueryMsg::ProposalCreationPolicy {},
+        )
+        .unwrap();
+
+    assert_eq!(proposal_creation_policy, ProposalCreationPolicy::Anyone {});
+
+    // Close out the native proposal and it's deposit as well.
+    vote(&mut app, proposal_multiple.clone(), "ekez", native_id, 2);
+    close_proposal(&mut app, proposal_multiple.clone(), "ekez", native_id);
+    withdraw(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        Some(UncheckedDenom::Native("ujuno".to_string())),
+    );
+    let balance = get_balance_native(&app, core_addr.as_str(), "ujuno");
+    assert_eq!(balance, Uint128::new(30));
+}

--- a/contracts/pre-propose/dao-pre-propose-approval-single/Cargo.toml
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "dao-pre-propose-approval-single"
-authors = ["ekez <ekez@withoutdoing.com>", "Jake Hartnell <no-reply@no-reply.com>"]
+authors = [
+  "ekez <ekez@withoutdoing.com>",
+  "Jake Hartnell <no-reply@no-reply.com>",
+]
 description = "A DAO DAO pre-propose module handling a proposal approval flow for for dao-proposal-single."
 edition = { workspace = true }
 license = { workspace = true }
@@ -21,6 +24,7 @@ cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
+cw-denom = { workspace = true }
 cw-paginate-storage = { workspace = true }
 dao-pre-propose-base = { workspace = true }
 dao-voting = { workspace = true }
@@ -28,7 +32,6 @@ thiserror = { workspace = true }
 dao-interface = { workspace = true }
 
 [dev-dependencies]
-cw-denom = { workspace = true }
 cw-multi-test = { workspace = true }
 cw-utils = { workspace = true }
 cw4 = { workspace = true }
@@ -47,6 +50,6 @@ dao-proposal-single = { workspace = true }
 dao-dao-core-v241 = { workspace = true }
 dao-interface-v241 = { workspace = true }
 dao-pre-propose-approval-single-v241 = { workspace = true }
-dao-proposal-single-v241  = { workspace = true }
+dao-proposal-single-v241 = { workspace = true }
 dao-voting-cw4-v241 = { workspace = true }
 dao-voting-v241 = { workspace = true }

--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/contract.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/contract.rs
@@ -9,15 +9,16 @@ use cw_paginate_storage::paginate_map_values;
 use dao_pre_propose_base::{
     error::PreProposeError, msg::ExecuteMsg as ExecuteBase, state::PreProposeContract,
 };
+use dao_voting::approval::{ApprovalProposalStatus, ApproverProposeMessage};
 use dao_voting::deposit::DepositRefundPolicy;
 use dao_voting::proposal::SingleChoiceProposeMsg as ProposeMsg;
 
 use crate::msg::{
-    ApproverProposeMessage, ExecuteExt, ExecuteMsg, InstantiateExt, InstantiateMsg, MigrateMsg,
-    ProposeMessage, ProposeMessageInternal, QueryExt, QueryMsg,
+    ExecuteExt, ExecuteMsg, InstantiateExt, InstantiateMsg, MigrateMsg, ProposeMessage,
+    ProposeMessageInternal, QueryExt, QueryMsg,
 };
 use crate::state::{
-    advance_approval_id, Proposal, ProposalStatus, APPROVER, COMPLETED_PROPOSALS,
+    advance_approval_id, Proposal, APPROVER, COMPLETED_PROPOSALS,
     CREATED_PROPOSAL_TO_COMPLETED_PROPOSAL, PENDING_PROPOSALS,
 };
 
@@ -129,7 +130,7 @@ pub fn execute_propose(
         deps.storage,
         approval_id,
         &Proposal {
-            status: ProposalStatus::Pending {},
+            status: ApprovalProposalStatus::Pending {},
             approval_id,
             proposer: info.sender,
             msg: propose_msg_internal,
@@ -183,7 +184,7 @@ pub fn execute_approve(
                 deps.storage,
                 id,
                 &Proposal {
-                    status: ProposalStatus::Approved {
+                    status: ApprovalProposalStatus::Approved {
                         created_proposal_id: proposal_id,
                     },
                     approval_id: proposal.approval_id,
@@ -230,7 +231,7 @@ pub fn execute_reject(
         deps.storage,
         id,
         &Proposal {
-            status: ProposalStatus::Rejected {},
+            status: ApprovalProposalStatus::Rejected {},
             approval_id,
             proposer: proposer.clone(),
             msg: msg.clone(),

--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/contract.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/contract.rs
@@ -1,17 +1,21 @@
+use cosmwasm_schema::cw_serde;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Order, Response, StdResult,
-    SubMsg, WasmMsg,
+    to_json_binary, Addr, Binary, CosmosMsg, Deps, DepsMut, Empty, Env, MessageInfo, Order,
+    Response, StdError, StdResult, SubMsg, Uint128, WasmMsg,
 };
 use cw2::set_contract_version;
+use cw_denom::CheckedDenom;
 use cw_paginate_storage::paginate_map_values;
+use cw_storage_plus::Map;
 use dao_pre_propose_base::{
     error::PreProposeError, msg::ExecuteMsg as ExecuteBase, state::PreProposeContract,
 };
 use dao_voting::approval::{ApprovalProposalStatus, ApproverProposeMessage};
-use dao_voting::deposit::DepositRefundPolicy;
+use dao_voting::deposit::{CheckedDepositInfo, DepositRefundPolicy};
 use dao_voting::proposal::SingleChoiceProposeMsg as ProposeMsg;
+use dao_voting::voting::{SingleChoiceAutoVote, Vote};
 
 use crate::msg::{
     ExecuteExt, ExecuteMsg, InstantiateExt, InstantiateMsg, MigrateMsg, ProposeMessage,
@@ -125,6 +129,8 @@ pub fn execute_propose(
                 Ok(SubMsg::new(execute_msg))
             })?;
 
+    let approver = APPROVER.load(deps.storage)?;
+
     // Save the proposal and its information as pending.
     PENDING_PROPOSALS.save(
         deps.storage,
@@ -132,6 +138,7 @@ pub fn execute_propose(
         &Proposal {
             status: ApprovalProposalStatus::Pending {},
             approval_id,
+            approver: approver.clone(),
             proposer: info.sender,
             msg: propose_msg_internal,
             deposit: config.deposit_info,
@@ -142,7 +149,8 @@ pub fn execute_propose(
         .add_messages(deposit_messages)
         .add_submessages(hooks_msgs)
         .add_attribute("method", "pre-propose")
-        .add_attribute("id", approval_id.to_string()))
+        .add_attribute("id", approval_id.to_string())
+        .add_attribute("approver", approver.to_string()))
 }
 
 pub fn execute_approve(
@@ -150,16 +158,15 @@ pub fn execute_approve(
     info: MessageInfo,
     id: u64,
 ) -> Result<Response, PreProposeError> {
-    // Check sender is the approver
-    let approver = APPROVER.load(deps.storage)?;
-    if approver != info.sender {
-        return Err(PreProposeError::Unauthorized {});
-    }
-
     // Load proposal and send propose message to the proposal module
     let proposal = PENDING_PROPOSALS.may_load(deps.storage, id)?;
     match proposal {
         Some(proposal) => {
+            // Check sender is the approver
+            if proposal.approver != info.sender {
+                return Err(PreProposeError::Unauthorized {});
+            }
+
             let proposal_module = PrePropose::default().proposal_module.load(deps.storage)?;
 
             // Snapshot the deposit for the proposal that we're about
@@ -188,6 +195,7 @@ pub fn execute_approve(
                         created_proposal_id: proposal_id,
                     },
                     approval_id: proposal.approval_id,
+                    approver: proposal.approver,
                     proposer: proposal.proposer,
                     msg: proposal.msg,
                     deposit: proposal.deposit,
@@ -211,14 +219,9 @@ pub fn execute_reject(
     info: MessageInfo,
     id: u64,
 ) -> Result<Response, PreProposeError> {
-    // Check sender is the approver
-    let approver = APPROVER.load(deps.storage)?;
-    if approver != info.sender {
-        return Err(PreProposeError::Unauthorized {});
-    }
-
     let Proposal {
         approval_id,
+        approver,
         proposer,
         msg,
         deposit,
@@ -227,12 +230,18 @@ pub fn execute_reject(
         .may_load(deps.storage, id)?
         .ok_or(PreProposeError::ProposalNotFound {})?;
 
+    // Check sender is the approver
+    if approver != info.sender {
+        return Err(PreProposeError::Unauthorized {});
+    }
+
     COMPLETED_PROPOSALS.save(
         deps.storage,
         id,
         &Proposal {
             status: ApprovalProposalStatus::Rejected {},
             approval_id,
+            approver,
             proposer: proposer.clone(),
             msg: msg.clone(),
             deposit: deposit.clone(),
@@ -407,7 +416,234 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(mut deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, PreProposeError> {
-    let res = PrePropose::default().migrate(deps.branch(), msg);
+    let res: Result<Response, PreProposeError> =
+        PrePropose::default().migrate(deps.branch(), msg.clone());
+    match msg {
+        MigrateMsg::FromUnderV250 { .. } => {
+            // the default migrate function above ensures >= v2.4.1 and < v2.5.0
+
+            #[cw_serde]
+            struct ProposalV241 {
+                /// The status of a completed proposal.
+                pub status: ProposalStatusV241,
+                /// The approval ID used to identify this pending proposal.
+                pub approval_id: u64,
+                /// The address that created the proposal.
+                pub proposer: Addr,
+                /// The propose message that ought to be executed on the
+                /// proposal message if this proposal is approved.
+                pub msg: SingleChoiceProposeMsgV241,
+                /// Snapshot of the deposit info at the time of proposal
+                /// submission.
+                pub deposit: Option<CheckedDepositInfoV241>,
+            }
+
+            #[cw_serde]
+            enum ProposalStatusV241 {
+                /// The proposal is pending approval.
+                Pending {},
+                /// The proposal has been approved.
+                Approved {
+                    /// The created proposal ID.
+                    created_proposal_id: u64,
+                },
+                /// The proposal has been rejected.
+                Rejected {},
+            }
+
+            #[cw_serde]
+            struct SingleChoiceProposeMsgV241 {
+                /// The title of the proposal.
+                pub title: String,
+                /// A description of the proposal.
+                pub description: String,
+                /// The messages that should be executed in response to this
+                /// proposal passing.
+                pub msgs: Vec<CosmosMsg<Empty>>,
+                /// The address creating the proposal. If no pre-propose
+                /// module is attached to this module this must always be None
+                /// as the proposer is the sender of the propose message. If a
+                /// pre-propose module is attached, this must be Some and will
+                /// set the proposer of the proposal it creates.
+                pub proposer: Option<String>,
+                /// An optional vote cast by the proposer.
+                pub vote: Option<SingleChoiceAutoVoteV241>,
+            }
+
+            #[cw_serde]
+            #[derive(Copy)]
+            #[repr(u8)]
+            enum VoteV241 {
+                /// Marks support for the proposal.
+                Yes,
+                /// Marks opposition to the proposal.
+                No,
+                /// Marks participation but does not count towards the ratio of
+                /// support / opposed.
+                Abstain,
+            }
+
+            #[cw_serde]
+            struct SingleChoiceAutoVoteV241 {
+                /// The proposer's position on the proposal.
+                pub vote: VoteV241,
+                /// An optional rationale for why this vote was cast. This can
+                /// be updated, set, or removed later by the address casting
+                /// the vote.
+                pub rationale: Option<String>,
+            }
+
+            #[cw_serde]
+            enum DepositRefundPolicyV241 {
+                /// Deposits should always be refunded.
+                Always,
+                /// Deposits should only be refunded for passed proposals.
+                OnlyPassed,
+                /// Deposits should never be refunded.
+                Never,
+            }
+
+            /// Counterpart to the `DepositInfo` struct which has been
+            /// processed. This type should never be constructed literally and
+            /// should always by built by calling `into_checked` on a
+            /// `DepositInfo` instance.
+            #[cw_serde]
+            struct CheckedDepositInfoV241 {
+                /// The address of the cw20 token to be used for proposal
+                /// deposits.
+                pub denom: CheckedDenomV241,
+                /// The number of tokens that must be deposited to create a
+                /// proposal. This is validated to be non-zero if this struct is
+                /// constructed by converted via the `into_checked` method on
+                /// `DepositInfo`.
+                pub amount: Uint128,
+                /// The policy used for refunding proposal deposits.
+                pub refund_policy: DepositRefundPolicyV241,
+            }
+
+            #[cw_serde]
+            enum CheckedDenomV241 {
+                /// A native (bank module) asset.
+                Native(String),
+                /// A cw20 asset.
+                Cw20(Addr),
+            }
+
+            let pending_proposals_v241: Map<u64, ProposalV241> = Map::new("pending_proposals");
+            let completed_proposals_v241: Map<u64, ProposalV241> = Map::new("completed_proposals");
+
+            // migrate proposals to add approver
+
+            let approver = APPROVER.load(deps.storage)?;
+
+            let pending_proposals = pending_proposals_v241
+                .range(deps.storage, None, None, Order::Ascending)
+                .collect::<StdResult<Vec<_>>>()?;
+            for (id, proposal) in pending_proposals {
+                PENDING_PROPOSALS.save(
+                    deps.storage,
+                    id,
+                    &Proposal {
+                        status: ApprovalProposalStatus::Pending {},
+                        approval_id: proposal.approval_id,
+                        approver: approver.clone(),
+                        proposer: proposal.proposer,
+                        msg: ProposeMsg {
+                            title: proposal.msg.title,
+                            description: proposal.msg.description,
+                            msgs: proposal.msg.msgs,
+                            proposer: proposal.msg.proposer,
+                            vote: proposal.msg.vote.map(|vote| SingleChoiceAutoVote {
+                                vote: match vote.vote {
+                                    VoteV241::Yes => Vote::Yes,
+                                    VoteV241::No => Vote::No,
+                                    VoteV241::Abstain => Vote::Abstain,
+                                },
+                                rationale: vote.rationale,
+                            }),
+                        },
+                        deposit: proposal.deposit.map(|deposit| CheckedDepositInfo {
+                            denom: match deposit.denom {
+                                CheckedDenomV241::Native(denom) => CheckedDenom::Native(denom),
+                                CheckedDenomV241::Cw20(addr) => CheckedDenom::Cw20(addr),
+                            },
+                            amount: deposit.amount,
+                            refund_policy: match deposit.refund_policy {
+                                DepositRefundPolicyV241::Always => DepositRefundPolicy::Always,
+                                DepositRefundPolicyV241::OnlyPassed => {
+                                    DepositRefundPolicy::OnlyPassed
+                                }
+                                DepositRefundPolicyV241::Never => DepositRefundPolicy::Never,
+                            },
+                        }),
+                    },
+                )?;
+            }
+
+            let completed_proposals = completed_proposals_v241
+                .range(deps.storage, None, None, Order::Ascending)
+                .collect::<StdResult<Vec<_>>>()?;
+            for (id, proposal) in completed_proposals {
+                COMPLETED_PROPOSALS.save(
+                    deps.storage,
+                    id,
+                    &Proposal {
+                        status: match proposal.status {
+                            ProposalStatusV241::Approved {
+                                created_proposal_id,
+                            } => ApprovalProposalStatus::Approved {
+                                created_proposal_id,
+                            },
+                            ProposalStatusV241::Rejected {} => ApprovalProposalStatus::Rejected {},
+                            // should not be possible since these are completed
+                            // proposals only
+                            ProposalStatusV241::Pending {} => {
+                                return Err(PreProposeError::Std(StdError::generic_err(
+                                    "unexpected proposal status",
+                                )))
+                            }
+                        },
+                        approval_id: proposal.approval_id,
+                        approver: approver.clone(),
+                        proposer: proposal.proposer,
+                        msg: ProposeMsg {
+                            title: proposal.msg.title,
+                            description: proposal.msg.description,
+                            msgs: proposal.msg.msgs,
+                            proposer: proposal.msg.proposer,
+                            vote: proposal.msg.vote.map(|vote| SingleChoiceAutoVote {
+                                vote: match vote.vote {
+                                    VoteV241::Yes => Vote::Yes,
+                                    VoteV241::No => Vote::No,
+                                    VoteV241::Abstain => Vote::Abstain,
+                                },
+                                rationale: vote.rationale,
+                            }),
+                        },
+                        deposit: proposal.deposit.map(|deposit| CheckedDepositInfo {
+                            denom: match deposit.denom {
+                                CheckedDenomV241::Native(denom) => CheckedDenom::Native(denom),
+                                CheckedDenomV241::Cw20(addr) => CheckedDenom::Cw20(addr),
+                            },
+                            amount: deposit.amount,
+                            refund_policy: match deposit.refund_policy {
+                                DepositRefundPolicyV241::Always => DepositRefundPolicy::Always,
+                                DepositRefundPolicyV241::OnlyPassed => {
+                                    DepositRefundPolicy::OnlyPassed
+                                }
+                                DepositRefundPolicyV241::Never => DepositRefundPolicy::Never,
+                            },
+                        }),
+                    },
+                )?;
+            }
+        }
+        _ => {
+            return Err(PreProposeError::Std(StdError::generic_err(
+                "not implemented",
+            )))
+        }
+    }
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     res
 }

--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/msg.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/msg.rs
@@ -6,14 +6,7 @@ use dao_pre_propose_base::msg::{
 };
 use dao_voting::{proposal::SingleChoiceProposeMsg as ProposeMsg, voting::SingleChoiceAutoVote};
 
-#[cw_serde]
-pub enum ApproverProposeMessage {
-    Propose {
-        title: String,
-        description: String,
-        approval_id: u64,
-    },
-}
+pub use dao_voting::approval::ApprovalExecuteExt as ExecuteExt;
 
 #[cw_serde]
 pub enum ProposeMessage {
@@ -28,16 +21,6 @@ pub enum ProposeMessage {
 #[cw_serde]
 pub struct InstantiateExt {
     pub approver: String,
-}
-
-#[cw_serde]
-pub enum ExecuteExt {
-    /// Approve a proposal, only callable by approver
-    Approve { id: u64 },
-    /// Reject a proposal, only callable by approver
-    Reject { id: u64 },
-    /// Updates the approver, can only be called the current approver
-    UpdateApprover { address: String },
 }
 
 #[cw_serde]

--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/state.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/state.rs
@@ -1,38 +1,9 @@
-use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, StdResult, Storage};
 use cw_storage_plus::{Item, Map};
 
-use dao_voting::deposit::CheckedDepositInfo;
-use dao_voting::proposal::SingleChoiceProposeMsg as ProposeMsg;
+use dao_voting::{approval::ApprovalProposal, proposal::SingleChoiceProposeMsg};
 
-#[cw_serde]
-pub enum ProposalStatus {
-    /// The proposal is pending approval.
-    Pending {},
-    /// The proposal has been approved.
-    Approved {
-        /// The created proposal ID.
-        created_proposal_id: u64,
-    },
-    /// The proposal has been rejected.
-    Rejected {},
-}
-
-#[cw_serde]
-pub struct Proposal {
-    /// The status of a completed proposal.
-    pub status: ProposalStatus,
-    /// The approval ID used to identify this pending proposal.
-    pub approval_id: u64,
-    /// The address that created the proposal.
-    pub proposer: Addr,
-    /// The propose message that ought to be executed on the proposal
-    /// message if this proposal is approved.
-    pub msg: ProposeMsg,
-    /// Snapshot of the deposit info at the time of proposal
-    /// submission.
-    pub deposit: Option<CheckedDepositInfo>,
-}
+pub type Proposal = ApprovalProposal<SingleChoiceProposeMsg>;
 
 pub const APPROVER: Item<Addr> = Item::new("approver");
 pub const PENDING_PROPOSALS: Map<u64, Proposal> = Map::new("pending_proposals");

--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
@@ -22,6 +22,7 @@ use dao_testing::{
 };
 use dao_voting::pre_propose::{PreProposeSubmissionPolicy, PreProposeSubmissionPolicyError};
 use dao_voting::{
+    approval::ApprovalProposalStatus,
     deposit::{CheckedDepositInfo, DepositRefundPolicy, DepositToken, UncheckedDepositInfo},
     pre_propose::{PreProposeInfo, ProposalCreationPolicy},
     status::Status,
@@ -36,7 +37,7 @@ use dao_proposal_single_v241 as dps_v241;
 use dao_voting_cw4_v241 as dvcw4_v241;
 use dao_voting_v241 as dv_v241;
 
-use crate::state::{Proposal, ProposalStatus};
+use crate::state::Proposal;
 use crate::{contract::*, msg::*};
 
 fn get_default_proposal_module_instantiate(
@@ -915,7 +916,7 @@ fn test_pending_proposal_queries() {
         )
         .unwrap();
     assert_eq!(prop1.approval_id, 1);
-    assert_eq!(prop1.status, ProposalStatus::Pending {});
+    assert_eq!(prop1.status, ApprovalProposalStatus::Pending {});
 
     let prop1: Proposal = app
         .wrap()
@@ -927,7 +928,7 @@ fn test_pending_proposal_queries() {
         )
         .unwrap();
     assert_eq!(prop1.approval_id, 1);
-    assert_eq!(prop1.status, ProposalStatus::Pending {});
+    assert_eq!(prop1.status, ApprovalProposalStatus::Pending {});
 
     // Query for the pre-propose proposals
     let pre_propose_props: Vec<Proposal> = app
@@ -1025,7 +1026,7 @@ fn test_completed_proposal_queries() {
         .unwrap();
     assert_eq!(
         prop1.status,
-        ProposalStatus::Approved {
+        ApprovalProposalStatus::Approved {
             created_proposal_id: created_approved_id
         }
     );
@@ -1040,7 +1041,7 @@ fn test_completed_proposal_queries() {
         .unwrap();
     assert_eq!(
         prop1.status,
-        ProposalStatus::Approved {
+        ApprovalProposalStatus::Approved {
             created_proposal_id: created_approved_id
         }
     );
@@ -1067,7 +1068,7 @@ fn test_completed_proposal_queries() {
             },
         )
         .unwrap();
-    assert_eq!(prop2.status, ProposalStatus::Rejected {});
+    assert_eq!(prop2.status, ApprovalProposalStatus::Rejected {});
 
     // Query for the pre-propose proposals
     let pre_propose_props: Vec<Proposal> = app

--- a/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/src/tests.rs
@@ -1230,10 +1230,10 @@ fn test_approval_and_rejection_permissions() {
         &coins(10, "ujuno"),
     );
 
-    // Only approver can propose
+    // Only approver can approve
     let err: PreProposeError = app
         .execute_contract(
-            Addr::unchecked("nonmember"),
+            Addr::unchecked("nonapprover"),
             pre_propose.clone(),
             &ExecuteMsg::Extension {
                 msg: ExecuteExt::Approve { id: pre_propose_id },
@@ -1245,11 +1245,11 @@ fn test_approval_and_rejection_permissions() {
         .unwrap();
     assert_eq!(err, PreProposeError::Unauthorized {});
 
-    // Only approver can propose
+    // Only approver can reject
     let err: PreProposeError = app
         .execute_contract(
-            Addr::unchecked("nonmember"),
-            pre_propose,
+            Addr::unchecked("nonapprover"),
+            pre_propose.clone(),
             &ExecuteMsg::Extension {
                 msg: ExecuteExt::Reject { id: pre_propose_id },
             },
@@ -1259,6 +1259,94 @@ fn test_approval_and_rejection_permissions() {
         .downcast()
         .unwrap();
     assert_eq!(err, PreProposeError::Unauthorized {});
+
+    // Updating approver after proposal created does not change old proposal's
+    // approver
+    app.execute_contract(
+        Addr::unchecked("approver"),
+        pre_propose.clone(),
+        &ExecuteMsg::Extension {
+            msg: ExecuteExt::UpdateApprover {
+                address: "newapprover".to_string(),
+            },
+        },
+        &[],
+    )
+    .unwrap();
+
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("newapprover"),
+            pre_propose.clone(),
+            &ExecuteMsg::Extension {
+                msg: ExecuteExt::Approve { id: pre_propose_id },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, PreProposeError::Unauthorized {});
+
+    // Old approver can still approve.
+    app.execute_contract(
+        Addr::unchecked("approver"),
+        pre_propose.clone(),
+        &ExecuteMsg::Extension {
+            msg: ExecuteExt::Approve { id: pre_propose_id },
+        },
+        &[],
+    )
+    .unwrap();
+
+    // Non-member proposes.
+    mint_natives(&mut app, "nonmember", coins(10, "ujuno"));
+    let pre_propose_id = make_pre_proposal(
+        &mut app,
+        pre_propose.clone(),
+        "nonmember",
+        &coins(10, "ujuno"),
+    );
+
+    // Old approver cannot approve nor reject.
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("approver"),
+            pre_propose.clone(),
+            &ExecuteMsg::Extension {
+                msg: ExecuteExt::Approve { id: pre_propose_id },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, PreProposeError::Unauthorized {});
+
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("approver"),
+            pre_propose.clone(),
+            &ExecuteMsg::Extension {
+                msg: ExecuteExt::Reject { id: pre_propose_id },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, PreProposeError::Unauthorized {});
+
+    // New approver can now approve.
+    app.execute_contract(
+        Addr::unchecked("newapprover"),
+        pre_propose.clone(),
+        &ExecuteMsg::Extension {
+            msg: ExecuteExt::Approve { id: pre_propose_id },
+        },
+        &[],
+    )
+    .unwrap();
 }
 
 #[test]

--- a/contracts/pre-propose/dao-pre-propose-approver/Cargo.toml
+++ b/contracts/pre-propose/dao-pre-propose-approver/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "dao-pre-propose-approver"
-authors = ["ekez <ekez@withoutdoing.com>", "Jake Hartnell <no-reply@no-reply.com>"]
+authors = [
+  "ekez <ekez@withoutdoing.com>",
+  "Jake Hartnell <no-reply@no-reply.com>",
+]
 description = "A DAO DAO pre-propose module for automatically making approval proposals for dao-pre-propose-approval-single."
 edition = { workspace = true }
 license = { workspace = true }
@@ -35,7 +38,9 @@ cw20 = { workspace = true }
 cw20-base = { workspace = true }
 dao-dao-core = { workspace = true }
 dao-hooks = { workspace = true }
+dao-pre-propose-approval-multiple = { workspace = true, features = ["library"] }
 dao-pre-propose-approval-single = { workspace = true, features = ["library"] }
+dao-proposal-multiple = { workspace = true, features = ["library"] }
 dao-proposal-single = { workspace = true, features = ["library"] }
 dao-testing = { workspace = true }
 dao-voting = { workspace = true }

--- a/contracts/pre-propose/dao-pre-propose-approver/Cargo.toml
+++ b/contracts/pre-propose/dao-pre-propose-approver/Cargo.toml
@@ -24,7 +24,6 @@ cw-utils = { workspace = true }
 cw2 = { workspace = true }
 dao-interface = { workspace = true }
 dao-pre-propose-base = { workspace = true }
-dao-pre-propose-approval-single = { workspace = true, features = ["library"] }
 dao-voting = { workspace = true }
 
 [dev-dependencies]
@@ -36,6 +35,7 @@ cw20 = { workspace = true }
 cw20-base = { workspace = true }
 dao-dao-core = { workspace = true }
 dao-hooks = { workspace = true }
+dao-pre-propose-approval-single = { workspace = true, features = ["library"] }
 dao-proposal-single = { workspace = true, features = ["library"] }
 dao-testing = { workspace = true }
 dao-voting = { workspace = true }

--- a/contracts/pre-propose/dao-pre-propose-approver/src/msg.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/msg.rs
@@ -1,10 +1,10 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{CosmosMsg, Empty};
-use dao_pre_propose_approval_single::msg::ApproverProposeMessage;
 use dao_pre_propose_base::msg::{
     ExecuteMsg as ExecuteBase, InstantiateMsg as InstantiateBase, MigrateMsg as MigrateBase,
     QueryMsg as QueryBase,
 };
+use dao_voting::approval::ApproverProposeMessage;
 
 #[cw_serde]
 pub struct InstantiateMsg {

--- a/contracts/pre-propose/dao-pre-propose-approver/src/tests/mod.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/tests/mod.rs
@@ -1,0 +1,2 @@
+pub mod multiple;
+pub mod single;

--- a/contracts/pre-propose/dao-pre-propose-approver/src/tests/multiple.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/tests/multiple.rs
@@ -1,32 +1,33 @@
-use cosmwasm_std::{coins, from_json, to_json_binary, Addr, Coin, Uint128};
+use cosmwasm_std::{coins, from_json, to_json_binary, Addr, Coin, Empty, Uint128};
 use cw2::ContractVersion;
 use cw20::Cw20Coin;
 use cw_denom::UncheckedDenom;
-use cw_multi_test::{App, BankSudo, Executor};
+use cw_multi_test::{App, BankSudo, Contract, ContractWrapper, Executor};
 use dao_interface::proposal::InfoResponse;
+use dao_proposal_multiple::query::{ProposalListResponse, ProposalResponse};
+use dao_voting::multiple_choice::{
+    MultipleChoiceOption, MultipleChoiceOptions, MultipleChoiceVote, VotingStrategy,
+};
 use dao_voting::pre_propose::{PreProposeSubmissionPolicy, PreProposeSubmissionPolicyError};
-use dps::query::{ProposalListResponse, ProposalResponse};
 
 use dao_interface::state::ProposalModule;
 use dao_interface::state::{Admin, ModuleInstantiateInfo};
-use dao_pre_propose_approval_single::{
+use dao_pre_propose_approval_multiple::{
     msg::{
         ExecuteExt, ExecuteMsg, InstantiateExt, InstantiateMsg, ProposeMessage, QueryExt, QueryMsg,
     },
     state::Proposal,
 };
 use dao_pre_propose_base::{error::PreProposeError, msg::DepositInfoResponse, state::Config};
+use dao_proposal_multiple as dpm;
 use dao_proposal_single as dps;
-use dao_testing::contracts::{
-    cw20_base_contract, dao_pre_propose_approval_single_contract,
-    dao_pre_propose_approver_contract, dao_proposal_single_contract,
-};
 use dao_testing::helpers::instantiate_with_cw4_groups_governance;
+use dao_voting::threshold::Threshold;
 use dao_voting::{
     deposit::{CheckedDepositInfo, DepositRefundPolicy, DepositToken, UncheckedDepositInfo},
     pre_propose::{PreProposeInfo, ProposalCreationPolicy},
     status::Status,
-    threshold::{PercentageThreshold, Threshold},
+    threshold::PercentageThreshold,
     voting::Vote,
 };
 
@@ -40,12 +41,61 @@ use crate::msg::{
 // The approver dao contract is the 6th contract instantiated
 const APPROVER: &str = "contract6";
 
-fn get_proposal_module_approval_single_instantiate(
+fn dao_proposal_single_contract() -> Box<dyn Contract<Empty>> {
+    let contract = ContractWrapper::new(
+        dps::contract::execute,
+        dps::contract::instantiate,
+        dps::contract::query,
+    )
+    .with_migrate(dps::contract::migrate)
+    .with_reply(dps::contract::reply);
+    Box::new(contract)
+}
+
+fn dao_proposal_multiple_contract() -> Box<dyn Contract<Empty>> {
+    let contract = ContractWrapper::new(
+        dpm::contract::execute,
+        dpm::contract::instantiate,
+        dpm::contract::query,
+    )
+    .with_migrate(dpm::contract::migrate)
+    .with_reply(dpm::contract::reply);
+    Box::new(contract)
+}
+
+fn cw_pre_propose_base_proposal_multiple() -> Box<dyn Contract<Empty>> {
+    let contract = ContractWrapper::new(
+        dao_pre_propose_approval_multiple::contract::execute,
+        dao_pre_propose_approval_multiple::contract::instantiate,
+        dao_pre_propose_approval_multiple::contract::query,
+    );
+    Box::new(contract)
+}
+
+fn cw20_base_contract() -> Box<dyn Contract<Empty>> {
+    let contract = ContractWrapper::new(
+        cw20_base::contract::execute,
+        cw20_base::contract::instantiate,
+        cw20_base::contract::query,
+    );
+    Box::new(contract)
+}
+
+fn pre_propose_approver_contract() -> Box<dyn Contract<Empty>> {
+    let contract = ContractWrapper::new(
+        crate::contract::execute,
+        crate::contract::instantiate,
+        crate::contract::query,
+    );
+    Box::new(contract)
+}
+
+fn get_proposal_module_approval_multiple_instantiate(
     app: &mut App,
     deposit_info: Option<UncheckedDepositInfo>,
     open_proposal_submission: bool,
-) -> dps::msg::InstantiateMsg {
-    let pre_propose_id = app.store_code(dao_pre_propose_approval_single_contract());
+) -> dpm::msg::InstantiateMsg {
+    let pre_propose_id = app.store_code(cw_pre_propose_base_proposal_multiple());
 
     let submission_policy = if open_proposal_submission {
         PreProposeSubmissionPolicy::Anyone { denylist: vec![] }
@@ -57,9 +107,9 @@ fn get_proposal_module_approval_single_instantiate(
         }
     };
 
-    dps::msg::InstantiateMsg {
-        threshold: Threshold::AbsolutePercentage {
-            percentage: PercentageThreshold::Majority {},
+    dpm::msg::InstantiateMsg {
+        voting_strategy: VotingStrategy::SingleChoice {
+            quorum: PercentageThreshold::Majority {},
         },
         max_voting_period: cw_utils::Duration::Time(86400),
         min_voting_period: None,
@@ -92,7 +142,7 @@ fn get_proposal_module_approver_instantiate(
     _open_proposal_submission: bool,
     pre_propose_approval_contract: String,
 ) -> dps::msg::InstantiateMsg {
-    let pre_propose_id = app.store_code(dao_pre_propose_approver_contract());
+    let pre_propose_id = app.store_code(pre_propose_approver_contract());
 
     dps::msg::InstantiateMsg {
         threshold: Threshold::AbsolutePercentage {
@@ -145,7 +195,7 @@ fn instantiate_cw20_base_default(app: &mut App) -> Addr {
 
 struct DefaultTestSetup {
     core_addr: Addr,
-    proposal_single: Addr,
+    proposal_multiple: Addr,
     pre_propose: Addr,
     approver_core_addr: Addr,
     pre_propose_approver: Addr,
@@ -158,16 +208,17 @@ fn setup_default_test(
     open_proposal_submission: bool,
 ) -> DefaultTestSetup {
     let dps_id = app.store_code(dao_proposal_single_contract());
+    let dpm_id = app.store_code(dao_proposal_multiple_contract());
 
-    // Instantiate SubDAO with pre-propose-approval-single
-    let proposal_module_instantiate = get_proposal_module_approval_single_instantiate(
+    // Instantiate SubDAO with pre-propose-approval-multiple
+    let proposal_module_instantiate = get_proposal_module_approval_multiple_instantiate(
         app,
         deposit_info.clone(),
         open_proposal_submission,
     );
     let core_addr = instantiate_with_cw4_groups_governance(
         app,
-        dps_id,
+        dpm_id,
         to_json_binary(&proposal_module_instantiate).unwrap(),
         Some(vec![
             cw20::Cw20Coin {
@@ -193,12 +244,12 @@ fn setup_default_test(
 
     // Make sure things were set up correctly.
     assert_eq!(proposal_modules.len(), 1);
-    let proposal_single = proposal_modules.into_iter().next().unwrap().address;
+    let proposal_multiple = proposal_modules.into_iter().next().unwrap().address;
     let proposal_creation_policy = app
         .wrap()
         .query_wasm_smart(
-            proposal_single.clone(),
-            &dps::msg::QueryMsg::ProposalCreationPolicy {},
+            proposal_multiple.clone(),
+            &dpm::msg::QueryMsg::ProposalCreationPolicy {},
         )
         .unwrap();
     let pre_propose = match proposal_creation_policy {
@@ -206,7 +257,7 @@ fn setup_default_test(
         _ => panic!("expected a module for the proposal creation policy"),
     };
     assert_eq!(
-        proposal_single,
+        proposal_multiple,
         get_proposal_module(app, pre_propose.clone())
     );
     assert_eq!(core_addr, get_dao(app, pre_propose.clone()));
@@ -279,7 +330,7 @@ fn setup_default_test(
 
     DefaultTestSetup {
         core_addr,
-        proposal_single,
+        proposal_multiple,
         pre_propose,
         approver_core_addr,
         proposal_single_approver,
@@ -295,7 +346,20 @@ fn make_pre_proposal(app: &mut App, pre_propose: Addr, proposer: &str, funds: &[
             msg: ProposeMessage::Propose {
                 title: "title".to_string(),
                 description: "description".to_string(),
-                msgs: vec![],
+                choices: MultipleChoiceOptions {
+                    options: vec![
+                        MultipleChoiceOption {
+                            title: "A".to_string(),
+                            description: "A".to_string(),
+                            msgs: vec![],
+                        },
+                        MultipleChoiceOption {
+                            title: "B".to_string(),
+                            description: "B".to_string(),
+                            msgs: vec![],
+                        },
+                    ],
+                },
                 vote: None,
             },
         },
@@ -361,7 +425,7 @@ fn get_balance_native(app: &App, who: &str, denom: &str) -> Uint128 {
     res.amount
 }
 
-fn vote(app: &mut App, module: Addr, sender: &str, id: u64, position: Vote) -> Status {
+fn vote_single(app: &mut App, module: Addr, sender: &str, id: u64, position: Vote) -> Status {
     app.execute_contract(
         Addr::unchecked(sender),
         module.clone(),
@@ -374,9 +438,32 @@ fn vote(app: &mut App, module: Addr, sender: &str, id: u64, position: Vote) -> S
     )
     .unwrap();
 
-    let proposal: ProposalResponse = app
+    let proposal: dps::query::ProposalResponse = app
         .wrap()
         .query_wasm_smart(module, &dps::msg::QueryMsg::Proposal { proposal_id: id })
+        .unwrap();
+
+    proposal.proposal.status
+}
+
+fn vote_multiple(app: &mut App, module: Addr, sender: &str, id: u64, position: u32) -> Status {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        module.clone(),
+        &dpm::msg::ExecuteMsg::Vote {
+            proposal_id: id,
+            vote: MultipleChoiceVote {
+                option_id: position,
+            },
+            rationale: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let proposal: ProposalResponse = app
+        .wrap()
+        .query_wasm_smart(module, &dpm::msg::QueryMsg::Proposal { proposal_id: id })
         .unwrap();
 
     proposal.proposal.status
@@ -412,11 +499,11 @@ fn get_deposit_info(app: &App, module: Addr, id: u64) -> DepositInfoResponse {
         .unwrap()
 }
 
-fn get_proposals(app: &App, module: Addr) -> ProposalListResponse {
+fn get_multiple_proposals(app: &App, module: Addr) -> ProposalListResponse {
     app.wrap()
         .query_wasm_smart(
             module,
-            &dps::msg::QueryMsg::ListProposals {
+            &dpm::msg::QueryMsg::ListProposals {
                 start_after: None,
                 limit: None,
             },
@@ -424,13 +511,28 @@ fn get_proposals(app: &App, module: Addr) -> ProposalListResponse {
         .unwrap()
 }
 
-fn get_latest_proposal_id(app: &App, module: Addr) -> u64 {
+fn get_latest_single_proposal_id(app: &App, module: Addr) -> u64 {
+    // Check prop was created in the main DAO
+    let props: dps::query::ProposalListResponse = app
+        .wrap()
+        .query_wasm_smart(
+            module,
+            &dps::msg::QueryMsg::ListProposals {
+                start_after: None,
+                limit: None,
+            },
+        )
+        .unwrap();
+    props.proposals[props.proposals.len() - 1].id
+}
+
+fn get_latest_multiple_proposal_id(app: &App, module: Addr) -> u64 {
     // Check prop was created in the main DAO
     let props: ProposalListResponse = app
         .wrap()
         .query_wasm_smart(
             module,
-            &dps::msg::QueryMsg::ListProposals {
+            &dpm::msg::QueryMsg::ListProposals {
                 start_after: None,
                 limit: None,
             },
@@ -523,7 +625,7 @@ fn close_proposal(app: &mut App, module: Addr, sender: &str, proposal_id: u64) {
     app.execute_contract(
         Addr::unchecked(sender),
         module,
-        &dps::msg::ExecuteMsg::Close { proposal_id },
+        &dpm::msg::ExecuteMsg::Close { proposal_id },
         &[],
     )
     .unwrap();
@@ -533,7 +635,7 @@ fn execute_proposal(app: &mut App, module: Addr, sender: &str, proposal_id: u64)
     app.execute_contract(
         Addr::unchecked(sender),
         module,
-        &dps::msg::ExecuteMsg::Execute { proposal_id },
+        &dpm::msg::ExecuteMsg::Execute { proposal_id },
         &[],
     )
     .unwrap();
@@ -541,7 +643,7 @@ fn execute_proposal(app: &mut App, module: Addr, sender: &str, proposal_id: u64)
 
 fn approve_proposal(app: &mut App, module: Addr, sender: &str, proposal_id: u64) {
     // Approver votes on prop
-    vote(app, module.clone(), sender, proposal_id, Vote::Yes);
+    vote_single(app, module.clone(), sender, proposal_id, Vote::Yes);
     // Approver executes prop
     execute_proposal(app, module, sender, proposal_id);
 }
@@ -574,7 +676,7 @@ fn test_native_permutation(
 
     let DefaultTestSetup {
         core_addr,
-        proposal_single,
+        proposal_multiple,
         pre_propose,
         approver_core_addr: _,
         proposal_single_approver,
@@ -595,7 +697,7 @@ fn test_native_permutation(
     let _pre_propose_id = make_pre_proposal(&mut app, pre_propose, "ekez", &coins(10, "ujuno"));
 
     // Check no props created on main DAO yet
-    let props = get_proposals(&app, proposal_single.clone());
+    let props = get_multiple_proposals(&app, proposal_multiple.clone());
     assert_eq!(props.proposals.len(), 0);
 
     // Make sure it went away.
@@ -606,10 +708,10 @@ fn test_native_permutation(
     match approval_status {
         ApprovalStatus::Approved => {
             // Get approver proposal id
-            let id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+            let id = get_latest_single_proposal_id(&app, proposal_single_approver.clone());
 
             // Approver votes on prop
-            vote(
+            vote_single(
                 &mut app,
                 proposal_single_approver.clone(),
                 "ekez",
@@ -620,8 +722,8 @@ fn test_native_permutation(
             execute_proposal(&mut app, proposal_single_approver, "ekez", id);
 
             // Check prop was created in the main DAO
-            let id = get_latest_proposal_id(&app, proposal_single.clone());
-            let props = get_proposals(&app, proposal_single.clone());
+            let id = get_latest_multiple_proposal_id(&app, proposal_multiple.clone());
+            let props = get_multiple_proposals(&app, proposal_multiple.clone());
             assert_eq!(props.proposals.len(), 1);
 
             // Voting happens on newly created proposal
@@ -631,19 +733,20 @@ fn test_native_permutation(
                 _,
                 fn(&mut App, Addr, &str, u64) -> (),
             ) = match end_status {
-                EndStatus::Passed => (Vote::Yes, Status::Passed, execute_proposal),
-                EndStatus::Failed => (Vote::No, Status::Rejected, close_proposal),
+                EndStatus::Passed => (0, Status::Passed, execute_proposal),
+                EndStatus::Failed => (2, Status::Rejected, close_proposal),
             };
-            let new_status = vote(&mut app, proposal_single.clone(), "ekez", id, position);
+            let new_status =
+                vote_multiple(&mut app, proposal_multiple.clone(), "ekez", id, position);
             assert_eq!(new_status, expected_status);
 
             // Close or execute the proposal to trigger a refund.
-            trigger_refund(&mut app, proposal_single, "ekez", id);
+            trigger_refund(&mut app, proposal_multiple, "ekez", id);
         }
         ApprovalStatus::Rejected => {
             // Approver votes on prop
             // No proposal is created so there is no voting
-            vote(
+            vote_single(
                 &mut app,
                 proposal_single_approver.clone(),
                 "ekez",
@@ -654,7 +757,7 @@ fn test_native_permutation(
             close_proposal(&mut app, proposal_single_approver, "ekez", 1);
 
             // No prop created
-            let props = get_proposals(&app, proposal_single);
+            let props = get_multiple_proposals(&app, proposal_multiple);
             assert_eq!(props.proposals.len(), 0);
         }
     };
@@ -682,7 +785,7 @@ fn test_cw20_permutation(
 
     let DefaultTestSetup {
         core_addr,
-        proposal_single,
+        proposal_multiple,
         pre_propose,
         approver_core_addr: _,
         proposal_single_approver,
@@ -709,7 +812,7 @@ fn test_cw20_permutation(
     let _pre_propose_id = make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &[]);
 
     // Check no props created on main DAO yet
-    let props = get_proposals(&app, proposal_single.clone());
+    let props = get_multiple_proposals(&app, proposal_multiple.clone());
     assert_eq!(props.proposals.len(), 0);
 
     // Make sure it went await.
@@ -720,10 +823,10 @@ fn test_cw20_permutation(
     match approval_status {
         ApprovalStatus::Approved => {
             // Get approver proposal id
-            let id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+            let id = get_latest_single_proposal_id(&app, proposal_single_approver.clone());
 
             // Approver votes on prop
-            vote(
+            vote_single(
                 &mut app,
                 proposal_single_approver.clone(),
                 "ekez",
@@ -734,8 +837,8 @@ fn test_cw20_permutation(
             execute_proposal(&mut app, proposal_single_approver, "ekez", id);
 
             // Check prop was created in the main DAO
-            let id = get_latest_proposal_id(&app, proposal_single.clone());
-            let props = get_proposals(&app, proposal_single.clone());
+            let id = get_latest_multiple_proposal_id(&app, proposal_multiple.clone());
+            let props = get_multiple_proposals(&app, proposal_multiple.clone());
             assert_eq!(props.proposals.len(), 1);
 
             // Voting happens on newly created proposal
@@ -745,19 +848,20 @@ fn test_cw20_permutation(
                 _,
                 fn(&mut App, Addr, &str, u64) -> (),
             ) = match end_status {
-                EndStatus::Passed => (Vote::Yes, Status::Passed, execute_proposal),
-                EndStatus::Failed => (Vote::No, Status::Rejected, close_proposal),
+                EndStatus::Passed => (1, Status::Passed, execute_proposal),
+                EndStatus::Failed => (2, Status::Rejected, close_proposal),
             };
-            let new_status = vote(&mut app, proposal_single.clone(), "ekez", id, position);
+            let new_status =
+                vote_multiple(&mut app, proposal_multiple.clone(), "ekez", id, position);
             assert_eq!(new_status, expected_status);
 
             // Close or execute the proposal to trigger a refund.
-            trigger_refund(&mut app, proposal_single, "ekez", id);
+            trigger_refund(&mut app, proposal_multiple, "ekez", id);
         }
         ApprovalStatus::Rejected => {
             // Approver votes on prop
             // No proposal is created so there is no voting
-            vote(
+            vote_single(
                 &mut app,
                 proposal_single_approver.clone(),
                 "ekez",
@@ -768,7 +872,7 @@ fn test_cw20_permutation(
             close_proposal(&mut app, proposal_single_approver, "ekez", 1);
 
             // No prop created
-            let props = get_proposals(&app, proposal_single);
+            let props = get_multiple_proposals(&app, proposal_multiple);
             assert_eq!(props.proposals.len(), 0);
         }
     };
@@ -974,7 +1078,7 @@ fn test_multiple_open_proposals() {
 
     let DefaultTestSetup {
         core_addr: _,
-        proposal_single,
+        proposal_multiple,
         pre_propose,
         approver_core_addr: _,
         proposal_single_approver,
@@ -998,14 +1102,14 @@ fn test_multiple_open_proposals() {
     assert_eq!(10, balance.u128());
 
     // Approver DAO approves prop, balance remains the same
-    let approver_prop_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+    let approver_prop_id = get_latest_single_proposal_id(&app, proposal_single_approver.clone());
     approve_proposal(
         &mut app,
         proposal_single_approver.clone(),
         "ekez",
         approver_prop_id,
     );
-    let first_id = get_latest_proposal_id(&app, proposal_single.clone());
+    let first_id = get_latest_multiple_proposal_id(&app, proposal_multiple.clone());
     let balance = get_balance_native(&app, "ekez", "ujuno");
     assert_eq!(10, balance.u128());
 
@@ -1015,47 +1119,35 @@ fn test_multiple_open_proposals() {
     assert_eq!(0, balance.u128());
 
     // Approver DAO votes to approves, balance remains the same
-    let approver_prop_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+    let approver_prop_id = get_latest_single_proposal_id(&app, proposal_single_approver.clone());
     approve_proposal(&mut app, proposal_single_approver, "ekez", approver_prop_id);
-    let second_id = get_latest_proposal_id(&app, proposal_single.clone());
+    let second_id = get_latest_multiple_proposal_id(&app, proposal_multiple.clone());
     let balance = get_balance_native(&app, "ekez", "ujuno");
     assert_eq!(0, balance.u128());
 
     // Finish up the first proposal.
-    let new_status = vote(
-        &mut app,
-        proposal_single.clone(),
-        "ekez",
-        first_id,
-        Vote::Yes,
-    );
+    let new_status = vote_multiple(&mut app, proposal_multiple.clone(), "ekez", first_id, 0);
     assert_eq!(Status::Passed, new_status);
 
     // Still zero.
     let balance = get_balance_native(&app, "ekez", "ujuno");
     assert_eq!(0, balance.u128());
 
-    execute_proposal(&mut app, proposal_single.clone(), "ekez", first_id);
+    execute_proposal(&mut app, proposal_multiple.clone(), "ekez", first_id);
 
     // First proposal refunded.
     let balance = get_balance_native(&app, "ekez", "ujuno");
     assert_eq!(10, balance.u128());
 
     // Finish up the second proposal.
-    let new_status = vote(
-        &mut app,
-        proposal_single.clone(),
-        "ekez",
-        second_id,
-        Vote::No,
-    );
+    let new_status = vote_multiple(&mut app, proposal_multiple.clone(), "ekez", second_id, 2);
     assert_eq!(Status::Rejected, new_status);
 
     // Still zero.
     let balance = get_balance_native(&app, "ekez", "ujuno");
     assert_eq!(10, balance.u128());
 
-    close_proposal(&mut app, proposal_single, "ekez", second_id);
+    close_proposal(&mut app, proposal_multiple, "ekez", second_id);
 
     // All deposits have been refunded.
     let balance = get_balance_native(&app, "ekez", "ujuno");
@@ -1071,7 +1163,7 @@ fn test_set_version() {
 
     let DefaultTestSetup {
         core_addr: _,
-        proposal_single: _,
+        proposal_multiple: _,
         pre_propose: _,
         approver_core_addr: _,
         proposal_single_approver: _,
@@ -1113,7 +1205,7 @@ fn test_permissions() {
 
     let DefaultTestSetup {
         core_addr,
-        proposal_single: _,
+        proposal_multiple: _,
         pre_propose,
         approver_core_addr: _,
         proposal_single_approver: _,
@@ -1155,7 +1247,20 @@ fn test_permissions() {
                 msg: ProposeMessage::Propose {
                     title: "I would like to join the DAO".to_string(),
                     description: "though, I am currently not a member.".to_string(),
-                    msgs: vec![],
+                    choices: MultipleChoiceOptions {
+                        options: vec![
+                            MultipleChoiceOption {
+                                title: "A".to_string(),
+                                description: "A".to_string(),
+                                msgs: vec![],
+                            },
+                            MultipleChoiceOption {
+                                title: "B".to_string(),
+                                description: "B".to_string(),
+                                msgs: vec![],
+                            },
+                        ],
+                    },
                     vote: None,
                 },
             },
@@ -1179,7 +1284,7 @@ fn test_approval_and_rejection_permissions() {
 
     let DefaultTestSetup {
         core_addr: _,
-        proposal_single: _,
+        proposal_multiple: _,
         pre_propose,
         approver_core_addr: _,
         proposal_single_approver: _,
@@ -1245,7 +1350,7 @@ fn test_propose_open_proposal_submission() {
 
     let DefaultTestSetup {
         core_addr: _,
-        proposal_single,
+        proposal_multiple,
         pre_propose,
         approver_core_addr: _,
         proposal_single_approver,
@@ -1266,7 +1371,7 @@ fn test_propose_open_proposal_submission() {
     mint_natives(&mut app, "nonmember", coins(10, "ujuno"));
     let pre_propose_id = make_pre_proposal(&mut app, pre_propose, "nonmember", &coins(10, "ujuno"));
 
-    let approver_prop_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+    let approver_prop_id = get_latest_single_proposal_id(&app, proposal_single_approver.clone());
     let pre_propose_id_from_proposal: u64 = app
         .wrap()
         .query_wasm_smart(
@@ -1295,10 +1400,10 @@ fn test_propose_open_proposal_submission() {
 
     // Approver DAO votes to approves
     approve_proposal(&mut app, proposal_single_approver, "ekez", approver_prop_id);
-    let id = get_latest_proposal_id(&app, proposal_single.clone());
+    let id = get_latest_multiple_proposal_id(&app, proposal_multiple.clone());
 
     // Member votes.
-    let new_status = vote(&mut app, proposal_single, "ekez", id, Vote::Yes);
+    let new_status = vote_multiple(&mut app, proposal_multiple, "ekez", id, 1);
     assert_eq!(Status::Passed, new_status)
 }
 
@@ -1311,7 +1416,7 @@ fn test_update_config() {
 
     let DefaultTestSetup {
         core_addr,
-        proposal_single,
+        proposal_multiple,
         pre_propose,
         approver_core_addr: _,
         proposal_single_approver,
@@ -1334,14 +1439,14 @@ fn test_update_config() {
     let _pre_propose_id = make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &[]);
 
     // Approver DAO votes to approves
-    let approver_prop_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+    let approver_prop_id = get_latest_single_proposal_id(&app, proposal_single_approver.clone());
     approve_proposal(
         &mut app,
         proposal_single_approver.clone(),
         "ekez",
         approver_prop_id,
     );
-    let id = get_latest_proposal_id(&app, proposal_single.clone());
+    let id = get_latest_multiple_proposal_id(&app, proposal_multiple.clone());
 
     update_config(
         &mut app,
@@ -1386,14 +1491,14 @@ fn test_update_config() {
         make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &coins(10, "ujuno"));
 
     // Approver DAO votes to approve prop
-    let approver_prop_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+    let approver_prop_id = get_latest_single_proposal_id(&app, proposal_single_approver.clone());
     approve_proposal(
         &mut app,
         proposal_single_approver.clone(),
         "ekez",
         approver_prop_id,
     );
-    let new_id = get_latest_proposal_id(&app, proposal_single_approver);
+    let new_id = get_latest_single_proposal_id(&app, proposal_single_approver);
 
     let info = get_deposit_info(&app, pre_propose.clone(), new_id);
     assert_eq!(
@@ -1409,10 +1514,10 @@ fn test_update_config() {
     );
 
     // Both proposals should be allowed to complete.
-    vote(&mut app, proposal_single.clone(), "ekez", id, Vote::Yes);
-    vote(&mut app, proposal_single.clone(), "ekez", new_id, Vote::Yes);
-    execute_proposal(&mut app, proposal_single.clone(), "ekez", id);
-    execute_proposal(&mut app, proposal_single.clone(), "ekez", new_id);
+    vote_multiple(&mut app, proposal_multiple.clone(), "ekez", id, 0);
+    vote_multiple(&mut app, proposal_multiple.clone(), "ekez", new_id, 1);
+    execute_proposal(&mut app, proposal_multiple.clone(), "ekez", id);
+    execute_proposal(&mut app, proposal_multiple.clone(), "ekez", new_id);
     // Deposit should not have been refunded (never policy in use).
     let balance = get_balance_native(&app, "ekez", "ujuno");
     assert_eq!(balance, Uint128::new(0));
@@ -1421,7 +1526,7 @@ fn test_update_config() {
     let err = update_config_should_fail(
         &mut app,
         pre_propose.clone(),
-        proposal_single.as_str(),
+        proposal_multiple.as_str(),
         None,
         PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
     );
@@ -1540,7 +1645,7 @@ fn test_approver_can_propose() {
         ..
     } = setup_default_test(&mut app, None, true);
 
-    // Only the pre-propose-approval-single contract can propose.
+    // Only the pre-propose-approval-multiple contract can propose.
     assert!(query_can_propose(
         &app,
         pre_propose_approver.clone(),
@@ -1562,7 +1667,7 @@ fn test_withdraw() {
 
     let DefaultTestSetup {
         core_addr,
-        proposal_single,
+        proposal_multiple,
         pre_propose,
         approver_core_addr: _,
         proposal_single_approver,
@@ -1572,7 +1677,7 @@ fn test_withdraw() {
     let err = withdraw_should_fail(
         &mut app,
         pre_propose.clone(),
-        proposal_single.as_str(),
+        proposal_multiple.as_str(),
         Some(UncheckedDenom::Native("ujuno".to_string())),
     );
     assert_eq!(err, PreProposeError::NotDao {});
@@ -1631,14 +1736,14 @@ fn test_withdraw() {
         make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &coins(10, "ujuno"));
 
     // Approver DAO votes to approve
-    let approver_prop_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+    let approver_prop_id = get_latest_single_proposal_id(&app, proposal_single_approver.clone());
     approve_proposal(
         &mut app,
         proposal_single_approver.clone(),
         "ekez",
         approver_prop_id,
     );
-    let native_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+    let native_id = get_latest_single_proposal_id(&app, proposal_single_approver.clone());
 
     // Update the config to use a cw20 token.
     let cw20_address = instantiate_cw20_base_default(&mut app);
@@ -1670,9 +1775,9 @@ fn test_withdraw() {
     let _cw20_pre_propose_id = make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &[]);
 
     // Approver DAO votes to approve
-    let approver_prop_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+    let approver_prop_id = get_latest_single_proposal_id(&app, proposal_single_approver.clone());
     approve_proposal(&mut app, proposal_single_approver, "ekez", approver_prop_id);
-    let cw20_id = get_latest_proposal_id(&app, proposal_single.clone());
+    let cw20_id = get_latest_multiple_proposal_id(&app, proposal_multiple.clone());
 
     // There is now a pending proposal and cw20 tokens in the
     // pre-propose module that should be returned on that proposal's
@@ -1686,36 +1791,24 @@ fn test_withdraw() {
 
     // Proposal should still be executable! We just get removed from
     // the proposal module's hook receiver list.
-    vote(
-        &mut app,
-        proposal_single.clone(),
-        "ekez",
-        cw20_id,
-        Vote::Yes,
-    );
-    execute_proposal(&mut app, proposal_single.clone(), "ekez", cw20_id);
+    vote_multiple(&mut app, proposal_multiple.clone(), "ekez", cw20_id, 0);
+    execute_proposal(&mut app, proposal_multiple.clone(), "ekez", cw20_id);
 
     // Make sure the proposal module has fallen back to anyone can
     // propose becuase of our malfunction.
     let proposal_creation_policy: ProposalCreationPolicy = app
         .wrap()
         .query_wasm_smart(
-            proposal_single.clone(),
-            &dps::msg::QueryMsg::ProposalCreationPolicy {},
+            proposal_multiple.clone(),
+            &dpm::msg::QueryMsg::ProposalCreationPolicy {},
         )
         .unwrap();
 
     assert_eq!(proposal_creation_policy, ProposalCreationPolicy::Anyone {});
 
     // Close out the native proposal and it's deposit as well.
-    vote(
-        &mut app,
-        proposal_single.clone(),
-        "ekez",
-        native_id,
-        Vote::No,
-    );
-    close_proposal(&mut app, proposal_single.clone(), "ekez", native_id);
+    vote_multiple(&mut app, proposal_multiple.clone(), "ekez", native_id, 2);
+    close_proposal(&mut app, proposal_multiple.clone(), "ekez", native_id);
     withdraw(
         &mut app,
         pre_propose.clone(),
@@ -1735,7 +1828,7 @@ fn test_reset_approver() {
 
     let DefaultTestSetup {
         core_addr: _,
-        proposal_single: _,
+        proposal_multiple: _,
         pre_propose,
         approver_core_addr,
         proposal_single_approver: _,

--- a/contracts/pre-propose/dao-pre-propose-approver/src/tests/single.rs
+++ b/contracts/pre-propose/dao-pre-propose-approver/src/tests/single.rs
@@ -1,0 +1,1821 @@
+use cosmwasm_std::{coins, from_json, to_json_binary, Addr, Coin, Uint128};
+use cw2::ContractVersion;
+use cw20::Cw20Coin;
+use cw_denom::UncheckedDenom;
+use cw_multi_test::{App, BankSudo, Executor};
+use dao_interface::proposal::InfoResponse;
+use dao_proposal_single::query::{ProposalListResponse, ProposalResponse};
+use dao_voting::pre_propose::{PreProposeSubmissionPolicy, PreProposeSubmissionPolicyError};
+
+use dao_interface::state::ProposalModule;
+use dao_interface::state::{Admin, ModuleInstantiateInfo};
+use dao_pre_propose_approval_single::{
+    msg::{
+        ExecuteExt, ExecuteMsg, InstantiateExt, InstantiateMsg, ProposeMessage, QueryExt, QueryMsg,
+    },
+    state::Proposal,
+};
+use dao_pre_propose_base::{error::PreProposeError, msg::DepositInfoResponse, state::Config};
+use dao_proposal_single as dps;
+use dao_testing::contracts::{
+    cw20_base_contract, dao_pre_propose_approval_single_contract,
+    dao_pre_propose_approver_contract, dao_proposal_single_contract,
+};
+use dao_testing::helpers::instantiate_with_cw4_groups_governance;
+use dao_voting::{
+    deposit::{CheckedDepositInfo, DepositRefundPolicy, DepositToken, UncheckedDepositInfo},
+    pre_propose::{PreProposeInfo, ProposalCreationPolicy},
+    status::Status,
+    threshold::{PercentageThreshold, Threshold},
+    voting::Vote,
+};
+
+use crate::contract::{CONTRACT_NAME, CONTRACT_VERSION};
+use crate::msg::InstantiateMsg as ApproverInstantiateMsg;
+use crate::msg::{
+    ExecuteExt as ApproverExecuteExt, ExecuteMsg as ApproverExecuteMsg,
+    QueryExt as ApproverQueryExt, QueryMsg as ApproverQueryMsg,
+};
+
+// The approver dao contract is the 6th contract instantiated
+const APPROVER: &str = "contract6";
+
+fn get_proposal_module_approval_single_instantiate(
+    app: &mut App,
+    deposit_info: Option<UncheckedDepositInfo>,
+    open_proposal_submission: bool,
+) -> dps::msg::InstantiateMsg {
+    let pre_propose_id = app.store_code(dao_pre_propose_approval_single_contract());
+
+    let submission_policy = if open_proposal_submission {
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] }
+    } else {
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: vec![],
+            denylist: vec![],
+        }
+    };
+
+    dps::msg::InstantiateMsg {
+        threshold: Threshold::AbsolutePercentage {
+            percentage: PercentageThreshold::Majority {},
+        },
+        max_voting_period: cw_utils::Duration::Time(86400),
+        min_voting_period: None,
+        only_members_execute: false,
+        allow_revoting: false,
+        pre_propose_info: PreProposeInfo::ModuleMayPropose {
+            info: ModuleInstantiateInfo {
+                code_id: pre_propose_id,
+                msg: to_json_binary(&InstantiateMsg {
+                    deposit_info,
+                    submission_policy,
+                    extension: InstantiateExt {
+                        approver: APPROVER.to_string(),
+                    },
+                })
+                .unwrap(),
+                admin: Some(Admin::CoreModule {}),
+                funds: vec![],
+                label: "baby's first pre-propose module, needs supervision".to_string(),
+            },
+        },
+        close_proposal_on_execution_failure: false,
+        veto: None,
+    }
+}
+
+fn get_proposal_module_approver_instantiate(
+    app: &mut App,
+    _deposit_info: Option<UncheckedDepositInfo>,
+    _open_proposal_submission: bool,
+    pre_propose_approval_contract: String,
+) -> dps::msg::InstantiateMsg {
+    let pre_propose_id = app.store_code(dao_pre_propose_approver_contract());
+
+    dps::msg::InstantiateMsg {
+        threshold: Threshold::AbsolutePercentage {
+            percentage: PercentageThreshold::Majority {},
+        },
+        max_voting_period: cw_utils::Duration::Time(86400),
+        min_voting_period: None,
+        only_members_execute: false,
+        allow_revoting: false,
+        pre_propose_info: PreProposeInfo::ModuleMayPropose {
+            info: ModuleInstantiateInfo {
+                code_id: pre_propose_id,
+                msg: to_json_binary(&ApproverInstantiateMsg {
+                    pre_propose_approval_contract,
+                })
+                .unwrap(),
+                admin: Some(Admin::CoreModule {}),
+                funds: vec![],
+                label: "approver module".to_string(),
+            },
+        },
+        close_proposal_on_execution_failure: false,
+        veto: None,
+    }
+}
+
+fn instantiate_cw20_base_default(app: &mut App) -> Addr {
+    let cw20_id = app.store_code(cw20_base_contract());
+    let cw20_instantiate = cw20_base::msg::InstantiateMsg {
+        name: "cw20 token".to_string(),
+        symbol: "cwtwenty".to_string(),
+        decimals: 6,
+        initial_balances: vec![Cw20Coin {
+            address: "ekez".to_string(),
+            amount: Uint128::new(10),
+        }],
+        mint: None,
+        marketing: None,
+    };
+    app.instantiate_contract(
+        cw20_id,
+        Addr::unchecked("ekez"),
+        &cw20_instantiate,
+        &[],
+        "cw20-base",
+        None,
+    )
+    .unwrap()
+}
+
+struct DefaultTestSetup {
+    core_addr: Addr,
+    proposal_single: Addr,
+    pre_propose: Addr,
+    approver_core_addr: Addr,
+    pre_propose_approver: Addr,
+    proposal_single_approver: Addr,
+}
+
+fn setup_default_test(
+    app: &mut App,
+    deposit_info: Option<UncheckedDepositInfo>,
+    open_proposal_submission: bool,
+) -> DefaultTestSetup {
+    let dps_id = app.store_code(dao_proposal_single_contract());
+
+    // Instantiate SubDAO with pre-propose-approval-single
+    let proposal_module_instantiate = get_proposal_module_approval_single_instantiate(
+        app,
+        deposit_info.clone(),
+        open_proposal_submission,
+    );
+    let core_addr = instantiate_with_cw4_groups_governance(
+        app,
+        dps_id,
+        to_json_binary(&proposal_module_instantiate).unwrap(),
+        Some(vec![
+            cw20::Cw20Coin {
+                address: "ekez".to_string(),
+                amount: Uint128::new(9),
+            },
+            cw20::Cw20Coin {
+                address: "keze".to_string(),
+                amount: Uint128::new(8),
+            },
+        ]),
+    );
+    let proposal_modules: Vec<ProposalModule> = app
+        .wrap()
+        .query_wasm_smart(
+            core_addr.clone(),
+            &dao_interface::msg::QueryMsg::ProposalModules {
+                start_after: None,
+                limit: None,
+            },
+        )
+        .unwrap();
+
+    // Make sure things were set up correctly.
+    assert_eq!(proposal_modules.len(), 1);
+    let proposal_single = proposal_modules.into_iter().next().unwrap().address;
+    let proposal_creation_policy = app
+        .wrap()
+        .query_wasm_smart(
+            proposal_single.clone(),
+            &dps::msg::QueryMsg::ProposalCreationPolicy {},
+        )
+        .unwrap();
+    let pre_propose = match proposal_creation_policy {
+        ProposalCreationPolicy::Module { addr } => addr,
+        _ => panic!("expected a module for the proposal creation policy"),
+    };
+    assert_eq!(
+        proposal_single,
+        get_proposal_module(app, pre_propose.clone())
+    );
+    assert_eq!(core_addr, get_dao(app, pre_propose.clone()));
+
+    // Instantiate SubDAO with pre-propose-approver
+    let proposal_module_instantiate = get_proposal_module_approver_instantiate(
+        app,
+        deposit_info,
+        open_proposal_submission,
+        pre_propose.to_string(),
+    );
+
+    let approver_core_addr = instantiate_with_cw4_groups_governance(
+        app,
+        dps_id,
+        to_json_binary(&proposal_module_instantiate).unwrap(),
+        Some(vec![
+            cw20::Cw20Coin {
+                address: "ekez".to_string(),
+                amount: Uint128::new(9),
+            },
+            cw20::Cw20Coin {
+                address: "keze".to_string(),
+                amount: Uint128::new(8),
+            },
+        ]),
+    );
+    let proposal_modules: Vec<ProposalModule> = app
+        .wrap()
+        .query_wasm_smart(
+            approver_core_addr.clone(),
+            &dao_interface::msg::QueryMsg::ProposalModules {
+                start_after: None,
+                limit: None,
+            },
+        )
+        .unwrap();
+
+    // Make sure things were set up correctly.
+    assert_eq!(proposal_modules.len(), 1);
+    let proposal_single_approver = proposal_modules.into_iter().next().unwrap().address;
+    let proposal_creation_policy = app
+        .wrap()
+        .query_wasm_smart(
+            proposal_single_approver.clone(),
+            &dps::msg::QueryMsg::ProposalCreationPolicy {},
+        )
+        .unwrap();
+    let pre_propose_approver = match proposal_creation_policy {
+        ProposalCreationPolicy::Module { addr } => addr,
+        _ => panic!("expected a module for the proposal creation policy"),
+    };
+    assert_eq!(
+        proposal_single_approver,
+        get_proposal_module(app, pre_propose_approver.clone())
+    );
+    assert_eq!(
+        approver_core_addr,
+        get_dao(app, pre_propose_approver.clone())
+    );
+    assert_eq!(
+        InfoResponse {
+            info: ContractVersion {
+                contract: "crates.io:dao-pre-propose-approver".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string()
+            }
+        },
+        get_info(app, pre_propose_approver.clone())
+    );
+
+    DefaultTestSetup {
+        core_addr,
+        proposal_single,
+        pre_propose,
+        approver_core_addr,
+        proposal_single_approver,
+        pre_propose_approver,
+    }
+}
+
+fn make_pre_proposal(app: &mut App, pre_propose: Addr, proposer: &str, funds: &[Coin]) -> u64 {
+    app.execute_contract(
+        Addr::unchecked(proposer),
+        pre_propose.clone(),
+        &ExecuteMsg::Propose {
+            msg: ProposeMessage::Propose {
+                title: "title".to_string(),
+                description: "description".to_string(),
+                msgs: vec![],
+                vote: None,
+            },
+        },
+        funds,
+    )
+    .unwrap();
+
+    // Query for pending proposal and return latest id
+    let mut pending: Vec<Proposal> = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose,
+            &QueryMsg::QueryExtension {
+                msg: QueryExt::PendingProposals {
+                    start_after: None,
+                    limit: None,
+                },
+            },
+        )
+        .unwrap();
+
+    // Return last item in list, id is first element of tuple
+    pending.pop().unwrap().approval_id
+}
+
+fn mint_natives(app: &mut App, receiver: &str, coins: Vec<Coin>) {
+    // Mint some ekez tokens for ekez so we can pay the deposit.
+    app.sudo(cw_multi_test::SudoMsg::Bank(BankSudo::Mint {
+        to_address: receiver.to_string(),
+        amount: coins,
+    }))
+    .unwrap();
+}
+
+fn increase_allowance(app: &mut App, sender: &str, receiver: &Addr, cw20: Addr, amount: Uint128) {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        cw20,
+        &cw20::Cw20ExecuteMsg::IncreaseAllowance {
+            spender: receiver.to_string(),
+            amount,
+            expires: None,
+        },
+        &[],
+    )
+    .unwrap();
+}
+
+fn get_balance_cw20<T: Into<String>, U: Into<String>>(
+    app: &App,
+    contract_addr: T,
+    address: U,
+) -> Uint128 {
+    let msg = cw20::Cw20QueryMsg::Balance {
+        address: address.into(),
+    };
+    let result: cw20::BalanceResponse = app.wrap().query_wasm_smart(contract_addr, &msg).unwrap();
+    result.balance
+}
+
+fn get_balance_native(app: &App, who: &str, denom: &str) -> Uint128 {
+    let res = app.wrap().query_balance(who, denom).unwrap();
+    res.amount
+}
+
+fn vote(app: &mut App, module: Addr, sender: &str, id: u64, position: Vote) -> Status {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        module.clone(),
+        &dps::msg::ExecuteMsg::Vote {
+            proposal_id: id,
+            vote: position,
+            rationale: None,
+        },
+        &[],
+    )
+    .unwrap();
+
+    let proposal: ProposalResponse = app
+        .wrap()
+        .query_wasm_smart(module, &dps::msg::QueryMsg::Proposal { proposal_id: id })
+        .unwrap();
+
+    proposal.proposal.status
+}
+
+fn get_config(app: &App, module: Addr) -> Config {
+    app.wrap()
+        .query_wasm_smart(module, &QueryMsg::Config {})
+        .unwrap()
+}
+
+fn get_dao(app: &App, module: Addr) -> Addr {
+    app.wrap()
+        .query_wasm_smart(module, &QueryMsg::Dao {})
+        .unwrap()
+}
+
+fn get_info(app: &App, module: Addr) -> InfoResponse {
+    app.wrap()
+        .query_wasm_smart(module, &QueryMsg::Info {})
+        .unwrap()
+}
+
+fn get_proposal_module(app: &App, module: Addr) -> Addr {
+    app.wrap()
+        .query_wasm_smart(module, &QueryMsg::ProposalModule {})
+        .unwrap()
+}
+
+fn get_deposit_info(app: &App, module: Addr, id: u64) -> DepositInfoResponse {
+    app.wrap()
+        .query_wasm_smart(module, &QueryMsg::DepositInfo { proposal_id: id })
+        .unwrap()
+}
+
+fn get_proposals(app: &App, module: Addr) -> ProposalListResponse {
+    app.wrap()
+        .query_wasm_smart(
+            module,
+            &dps::msg::QueryMsg::ListProposals {
+                start_after: None,
+                limit: None,
+            },
+        )
+        .unwrap()
+}
+
+fn get_latest_proposal_id(app: &App, module: Addr) -> u64 {
+    // Check prop was created in the main DAO
+    let props: ProposalListResponse = app
+        .wrap()
+        .query_wasm_smart(
+            module,
+            &dps::msg::QueryMsg::ListProposals {
+                start_after: None,
+                limit: None,
+            },
+        )
+        .unwrap();
+    props.proposals[props.proposals.len() - 1].id
+}
+
+fn query_can_propose(app: &App, module: Addr, address: impl Into<String>) -> bool {
+    app.wrap()
+        .query_wasm_smart(
+            module,
+            &QueryMsg::CanPropose {
+                address: address.into(),
+            },
+        )
+        .unwrap()
+}
+
+fn update_config(
+    app: &mut App,
+    module: Addr,
+    sender: &str,
+    deposit_info: Option<UncheckedDepositInfo>,
+    submission_policy: PreProposeSubmissionPolicy,
+) -> Config {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        module.clone(),
+        &ExecuteMsg::UpdateConfig {
+            deposit_info,
+            submission_policy: Some(submission_policy),
+        },
+        &[],
+    )
+    .unwrap();
+
+    get_config(app, module)
+}
+
+fn update_config_should_fail(
+    app: &mut App,
+    module: Addr,
+    sender: &str,
+    deposit_info: Option<UncheckedDepositInfo>,
+    submission_policy: PreProposeSubmissionPolicy,
+) -> PreProposeError {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        module,
+        &ExecuteMsg::UpdateConfig {
+            deposit_info,
+            submission_policy: Some(submission_policy),
+        },
+        &[],
+    )
+    .unwrap_err()
+    .downcast()
+    .unwrap()
+}
+
+fn withdraw(app: &mut App, module: Addr, sender: &str, denom: Option<UncheckedDenom>) {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        module,
+        &ExecuteMsg::Withdraw { denom },
+        &[],
+    )
+    .unwrap();
+}
+
+fn withdraw_should_fail(
+    app: &mut App,
+    module: Addr,
+    sender: &str,
+    denom: Option<UncheckedDenom>,
+) -> PreProposeError {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        module,
+        &ExecuteMsg::Withdraw { denom },
+        &[],
+    )
+    .unwrap_err()
+    .downcast()
+    .unwrap()
+}
+
+fn close_proposal(app: &mut App, module: Addr, sender: &str, proposal_id: u64) {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        module,
+        &dps::msg::ExecuteMsg::Close { proposal_id },
+        &[],
+    )
+    .unwrap();
+}
+
+fn execute_proposal(app: &mut App, module: Addr, sender: &str, proposal_id: u64) {
+    app.execute_contract(
+        Addr::unchecked(sender),
+        module,
+        &dps::msg::ExecuteMsg::Execute { proposal_id },
+        &[],
+    )
+    .unwrap();
+}
+
+fn approve_proposal(app: &mut App, module: Addr, sender: &str, proposal_id: u64) {
+    // Approver votes on prop
+    vote(app, module.clone(), sender, proposal_id, Vote::Yes);
+    // Approver executes prop
+    execute_proposal(app, module, sender, proposal_id);
+}
+
+enum ApprovalStatus {
+    Approved,
+    Rejected,
+}
+
+enum EndStatus {
+    Passed,
+    Failed,
+}
+
+enum RefundReceiver {
+    Proposer,
+    Dao,
+}
+
+fn test_native_permutation(
+    end_status: EndStatus,
+    refund_policy: DepositRefundPolicy,
+    receiver: RefundReceiver,
+    approval_status: ApprovalStatus,
+) {
+    let mut app = App::default();
+
+    // Need to instantiate this so contract addresses match with cw20 test cases
+    let _ = instantiate_cw20_base_default(&mut app);
+
+    let DefaultTestSetup {
+        core_addr,
+        proposal_single,
+        pre_propose,
+        approver_core_addr: _,
+        proposal_single_approver,
+        pre_propose_approver: _,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy,
+        }),
+        false,
+    );
+
+    mint_natives(&mut app, "ekez", coins(10, "ujuno"));
+    let _pre_propose_id = make_pre_proposal(&mut app, pre_propose, "ekez", &coins(10, "ujuno"));
+
+    // Check no props created on main DAO yet
+    let props = get_proposals(&app, proposal_single.clone());
+    assert_eq!(props.proposals.len(), 0);
+
+    // Make sure it went away.
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(balance, Uint128::zero());
+
+    // Approver approves or rejects proposal
+    match approval_status {
+        ApprovalStatus::Approved => {
+            // Get approver proposal id
+            let id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+
+            // Approver votes on prop
+            vote(
+                &mut app,
+                proposal_single_approver.clone(),
+                "ekez",
+                id,
+                Vote::Yes,
+            );
+            // Approver executes prop
+            execute_proposal(&mut app, proposal_single_approver, "ekez", id);
+
+            // Check prop was created in the main DAO
+            let id = get_latest_proposal_id(&app, proposal_single.clone());
+            let props = get_proposals(&app, proposal_single.clone());
+            assert_eq!(props.proposals.len(), 1);
+
+            // Voting happens on newly created proposal
+            #[allow(clippy::type_complexity)]
+            let (position, expected_status, trigger_refund): (
+                _,
+                _,
+                fn(&mut App, Addr, &str, u64) -> (),
+            ) = match end_status {
+                EndStatus::Passed => (Vote::Yes, Status::Passed, execute_proposal),
+                EndStatus::Failed => (Vote::No, Status::Rejected, close_proposal),
+            };
+            let new_status = vote(&mut app, proposal_single.clone(), "ekez", id, position);
+            assert_eq!(new_status, expected_status);
+
+            // Close or execute the proposal to trigger a refund.
+            trigger_refund(&mut app, proposal_single, "ekez", id);
+        }
+        ApprovalStatus::Rejected => {
+            // Approver votes on prop
+            // No proposal is created so there is no voting
+            vote(
+                &mut app,
+                proposal_single_approver.clone(),
+                "ekez",
+                1,
+                Vote::No,
+            );
+            // Approver executes prop
+            close_proposal(&mut app, proposal_single_approver, "ekez", 1);
+
+            // No prop created
+            let props = get_proposals(&app, proposal_single);
+            assert_eq!(props.proposals.len(), 0);
+        }
+    };
+
+    let (dao_expected, proposer_expected) = match receiver {
+        RefundReceiver::Proposer => (0, 10),
+        RefundReceiver::Dao => (10, 0),
+    };
+
+    let proposer_balance = get_balance_native(&app, "ekez", "ujuno");
+    let dao_balance = get_balance_native(&app, core_addr.as_str(), "ujuno");
+    assert_eq!(proposer_expected, proposer_balance.u128());
+    assert_eq!(dao_expected, dao_balance.u128())
+}
+
+fn test_cw20_permutation(
+    end_status: EndStatus,
+    refund_policy: DepositRefundPolicy,
+    receiver: RefundReceiver,
+    approval_status: ApprovalStatus,
+) {
+    let mut app = App::default();
+
+    let cw20_address = instantiate_cw20_base_default(&mut app);
+
+    let DefaultTestSetup {
+        core_addr,
+        proposal_single,
+        pre_propose,
+        approver_core_addr: _,
+        proposal_single_approver,
+        pre_propose_approver: _,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Cw20(cw20_address.to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy,
+        }),
+        false,
+    );
+
+    increase_allowance(
+        &mut app,
+        "ekez",
+        &pre_propose,
+        cw20_address.clone(),
+        Uint128::new(10),
+    );
+    let _pre_propose_id = make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &[]);
+
+    // Check no props created on main DAO yet
+    let props = get_proposals(&app, proposal_single.clone());
+    assert_eq!(props.proposals.len(), 0);
+
+    // Make sure it went await.
+    let balance = get_balance_cw20(&app, cw20_address.clone(), "ekez");
+    assert_eq!(balance, Uint128::zero());
+
+    // Approver approves or rejects proposal
+    match approval_status {
+        ApprovalStatus::Approved => {
+            // Get approver proposal id
+            let id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+
+            // Approver votes on prop
+            vote(
+                &mut app,
+                proposal_single_approver.clone(),
+                "ekez",
+                id,
+                Vote::Yes,
+            );
+            // Approver executes prop
+            execute_proposal(&mut app, proposal_single_approver, "ekez", id);
+
+            // Check prop was created in the main DAO
+            let id = get_latest_proposal_id(&app, proposal_single.clone());
+            let props = get_proposals(&app, proposal_single.clone());
+            assert_eq!(props.proposals.len(), 1);
+
+            // Voting happens on newly created proposal
+            #[allow(clippy::type_complexity)]
+            let (position, expected_status, trigger_refund): (
+                _,
+                _,
+                fn(&mut App, Addr, &str, u64) -> (),
+            ) = match end_status {
+                EndStatus::Passed => (Vote::Yes, Status::Passed, execute_proposal),
+                EndStatus::Failed => (Vote::No, Status::Rejected, close_proposal),
+            };
+            let new_status = vote(&mut app, proposal_single.clone(), "ekez", id, position);
+            assert_eq!(new_status, expected_status);
+
+            // Close or execute the proposal to trigger a refund.
+            trigger_refund(&mut app, proposal_single, "ekez", id);
+        }
+        ApprovalStatus::Rejected => {
+            // Approver votes on prop
+            // No proposal is created so there is no voting
+            vote(
+                &mut app,
+                proposal_single_approver.clone(),
+                "ekez",
+                1,
+                Vote::No,
+            );
+            // Approver executes prop
+            close_proposal(&mut app, proposal_single_approver, "ekez", 1);
+
+            // No prop created
+            let props = get_proposals(&app, proposal_single);
+            assert_eq!(props.proposals.len(), 0);
+        }
+    };
+
+    let (dao_expected, proposer_expected) = match receiver {
+        RefundReceiver::Proposer => (0, 10),
+        RefundReceiver::Dao => (10, 0),
+    };
+
+    let proposer_balance = get_balance_cw20(&app, &cw20_address, "ekez");
+    let dao_balance = get_balance_cw20(&app, &cw20_address, core_addr);
+    assert_eq!(proposer_expected, proposer_balance.u128());
+    assert_eq!(dao_expected, dao_balance.u128())
+}
+
+#[test]
+fn test_native_failed_always_refund() {
+    test_native_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::Always,
+        RefundReceiver::Proposer,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_native_rejected_always_refund() {
+    test_native_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::Always,
+        RefundReceiver::Proposer,
+        ApprovalStatus::Rejected,
+    )
+}
+
+#[test]
+fn test_cw20_failed_always_refund() {
+    test_cw20_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::Always,
+        RefundReceiver::Proposer,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_cw20_rejected_always_refund() {
+    test_cw20_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::Always,
+        RefundReceiver::Proposer,
+        ApprovalStatus::Rejected,
+    )
+}
+
+#[test]
+fn test_native_passed_always_refund() {
+    test_native_permutation(
+        EndStatus::Passed,
+        DepositRefundPolicy::Always,
+        RefundReceiver::Proposer,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_cw20_passed_always_refund() {
+    test_cw20_permutation(
+        EndStatus::Passed,
+        DepositRefundPolicy::Always,
+        RefundReceiver::Proposer,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_native_passed_never_refund() {
+    test_native_permutation(
+        EndStatus::Passed,
+        DepositRefundPolicy::Never,
+        RefundReceiver::Dao,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_cw20_passed_never_refund() {
+    test_cw20_permutation(
+        EndStatus::Passed,
+        DepositRefundPolicy::Never,
+        RefundReceiver::Dao,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_native_failed_never_refund() {
+    test_native_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::Never,
+        RefundReceiver::Dao,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_native_rejected_never_refund() {
+    test_native_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::Never,
+        RefundReceiver::Dao,
+        ApprovalStatus::Rejected,
+    )
+}
+
+#[test]
+fn test_cw20_failed_never_refund() {
+    test_cw20_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::Never,
+        RefundReceiver::Dao,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_cw20_rejected_never_refund() {
+    test_cw20_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::Never,
+        RefundReceiver::Dao,
+        ApprovalStatus::Rejected,
+    )
+}
+
+#[test]
+fn test_native_passed_passed_refund() {
+    test_native_permutation(
+        EndStatus::Passed,
+        DepositRefundPolicy::OnlyPassed,
+        RefundReceiver::Proposer,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_cw20_passed_passed_refund() {
+    test_cw20_permutation(
+        EndStatus::Passed,
+        DepositRefundPolicy::OnlyPassed,
+        RefundReceiver::Proposer,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_native_failed_passed_refund() {
+    test_native_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::OnlyPassed,
+        RefundReceiver::Dao,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_native_rejected_passed_refund() {
+    test_native_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::OnlyPassed,
+        RefundReceiver::Dao,
+        ApprovalStatus::Rejected,
+    )
+}
+
+#[test]
+fn test_cw20_failed_passed_refund() {
+    test_cw20_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::OnlyPassed,
+        RefundReceiver::Dao,
+        ApprovalStatus::Approved,
+    )
+}
+
+#[test]
+fn test_cw20_rejected_passed_refund() {
+    test_cw20_permutation(
+        EndStatus::Failed,
+        DepositRefundPolicy::OnlyPassed,
+        RefundReceiver::Dao,
+        ApprovalStatus::Rejected,
+    )
+}
+
+// See: <https://github.com/DA0-DA0/dao-contracts/pull/465#discussion_r960092321>
+#[test]
+fn test_multiple_open_proposals() {
+    let mut app = App::default();
+
+    // Need to instantiate this so contract addresses match with cw20 test cases
+    let _ = instantiate_cw20_base_default(&mut app);
+
+    let DefaultTestSetup {
+        core_addr: _,
+        proposal_single,
+        pre_propose,
+        approver_core_addr: _,
+        proposal_single_approver,
+        pre_propose_approver: _,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        false,
+    );
+
+    mint_natives(&mut app, "ekez", coins(20, "ujuno"));
+    let _first_pre_propose_id =
+        make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &coins(10, "ujuno"));
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(10, balance.u128());
+
+    // Approver DAO approves prop, balance remains the same
+    let approver_prop_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+    approve_proposal(
+        &mut app,
+        proposal_single_approver.clone(),
+        "ekez",
+        approver_prop_id,
+    );
+    let first_id = get_latest_proposal_id(&app, proposal_single.clone());
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(10, balance.u128());
+
+    let _second_pre_propose_id =
+        make_pre_proposal(&mut app, pre_propose, "ekez", &coins(10, "ujuno"));
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(0, balance.u128());
+
+    // Approver DAO votes to approves, balance remains the same
+    let approver_prop_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+    approve_proposal(&mut app, proposal_single_approver, "ekez", approver_prop_id);
+    let second_id = get_latest_proposal_id(&app, proposal_single.clone());
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(0, balance.u128());
+
+    // Finish up the first proposal.
+    let new_status = vote(
+        &mut app,
+        proposal_single.clone(),
+        "ekez",
+        first_id,
+        Vote::Yes,
+    );
+    assert_eq!(Status::Passed, new_status);
+
+    // Still zero.
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(0, balance.u128());
+
+    execute_proposal(&mut app, proposal_single.clone(), "ekez", first_id);
+
+    // First proposal refunded.
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(10, balance.u128());
+
+    // Finish up the second proposal.
+    let new_status = vote(
+        &mut app,
+        proposal_single.clone(),
+        "ekez",
+        second_id,
+        Vote::No,
+    );
+    assert_eq!(Status::Rejected, new_status);
+
+    // Still zero.
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(10, balance.u128());
+
+    close_proposal(&mut app, proposal_single, "ekez", second_id);
+
+    // All deposits have been refunded.
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(20, balance.u128());
+}
+
+#[test]
+fn test_set_version() {
+    let mut app = App::default();
+
+    // Need to instantiate this so contract addresses match with cw20 test cases
+    let _ = instantiate_cw20_base_default(&mut app);
+
+    let DefaultTestSetup {
+        core_addr: _,
+        proposal_single: _,
+        pre_propose: _,
+        approver_core_addr: _,
+        proposal_single_approver: _,
+        pre_propose_approver,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        false,
+    );
+
+    let info: ContractVersion = from_json(
+        app.wrap()
+            .query_wasm_raw(pre_propose_approver, "contract_info".as_bytes())
+            .unwrap()
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        ContractVersion {
+            contract: CONTRACT_NAME.to_string(),
+            version: CONTRACT_VERSION.to_string()
+        },
+        info
+    )
+}
+
+#[test]
+fn test_permissions() {
+    let mut app = App::default();
+
+    // Need to instantiate this so contract addresses match with cw20 test cases
+    let _ = instantiate_cw20_base_default(&mut app);
+
+    let DefaultTestSetup {
+        core_addr,
+        proposal_single: _,
+        pre_propose,
+        approver_core_addr: _,
+        proposal_single_approver: _,
+        pre_propose_approver: _,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        false, // no open proposal submission.
+    );
+
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr,
+            pre_propose.clone(),
+            &ExecuteMsg::ProposalCompletedHook {
+                proposal_id: 1,
+                new_status: Status::Closed,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, PreProposeError::NotModule {});
+
+    // Non-members may not propose when open_propose_submission is
+    // disabled.
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("nonmember"),
+            pre_propose,
+            &ExecuteMsg::Propose {
+                msg: ProposeMessage::Propose {
+                    title: "I would like to join the DAO".to_string(),
+                    description: "though, I am currently not a member.".to_string(),
+                    msgs: vec![],
+                    vote: None,
+                },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::Unauthorized {})
+    );
+}
+
+#[test]
+fn test_approval_and_rejection_permissions() {
+    let mut app = App::default();
+
+    // Need to instantiate this so contract addresses match with cw20 test cases
+    let _ = instantiate_cw20_base_default(&mut app);
+
+    let DefaultTestSetup {
+        core_addr: _,
+        proposal_single: _,
+        pre_propose,
+        approver_core_addr: _,
+        proposal_single_approver: _,
+        pre_propose_approver: _,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        true, // yes, open proposal submission.
+    );
+
+    // Non-member proposes.
+    mint_natives(&mut app, "nonmember", coins(10, "ujuno"));
+    let pre_propose_id = make_pre_proposal(
+        &mut app,
+        pre_propose.clone(),
+        "nonmember",
+        &coins(10, "ujuno"),
+    );
+
+    // Only approver can propose
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("nonmember"),
+            pre_propose.clone(),
+            &ExecuteMsg::Extension {
+                msg: ExecuteExt::Approve { id: pre_propose_id },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, PreProposeError::Unauthorized {});
+
+    // Only approver can propose
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("nonmember"),
+            pre_propose,
+            &ExecuteMsg::Extension {
+                msg: ExecuteExt::Reject { id: pre_propose_id },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, PreProposeError::Unauthorized {});
+}
+
+#[test]
+fn test_propose_open_proposal_submission() {
+    let mut app = App::default();
+
+    // Need to instantiate this so contract addresses match with cw20 test cases
+    let _ = instantiate_cw20_base_default(&mut app);
+
+    let DefaultTestSetup {
+        core_addr: _,
+        proposal_single,
+        pre_propose,
+        approver_core_addr: _,
+        proposal_single_approver,
+        pre_propose_approver,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        true, // yes, open proposal submission.
+    );
+
+    // Non-member proposes.
+    mint_natives(&mut app, "nonmember", coins(10, "ujuno"));
+    let pre_propose_id = make_pre_proposal(&mut app, pre_propose, "nonmember", &coins(10, "ujuno"));
+
+    let approver_prop_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+    let pre_propose_id_from_proposal: u64 = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose_approver.clone(),
+            &ApproverQueryMsg::QueryExtension {
+                msg: ApproverQueryExt::PreProposeApprovalIdForApproverProposalId {
+                    id: approver_prop_id,
+                },
+            },
+        )
+        .unwrap();
+    assert_eq!(pre_propose_id_from_proposal, pre_propose_id);
+
+    let proposal_id_from_pre_propose: u64 = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose_approver.clone(),
+            &ApproverQueryMsg::QueryExtension {
+                msg: ApproverQueryExt::ApproverProposalIdForPreProposeApprovalId {
+                    id: pre_propose_id,
+                },
+            },
+        )
+        .unwrap();
+    assert_eq!(proposal_id_from_pre_propose, approver_prop_id);
+
+    // Approver DAO votes to approves
+    approve_proposal(&mut app, proposal_single_approver, "ekez", approver_prop_id);
+    let id = get_latest_proposal_id(&app, proposal_single.clone());
+
+    // Member votes.
+    let new_status = vote(&mut app, proposal_single, "ekez", id, Vote::Yes);
+    assert_eq!(Status::Passed, new_status)
+}
+
+#[test]
+fn test_update_config() {
+    let mut app = App::default();
+
+    // Need to instantiate this so contract addresses match with cw20 test cases
+    let _ = instantiate_cw20_base_default(&mut app);
+
+    let DefaultTestSetup {
+        core_addr,
+        proposal_single,
+        pre_propose,
+        approver_core_addr: _,
+        proposal_single_approver,
+        pre_propose_approver: _,
+    } = setup_default_test(&mut app, None, false);
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: None,
+            submission_policy: PreProposeSubmissionPolicy::Specific {
+                dao_members: true,
+                allowlist: vec![],
+                denylist: vec![]
+            }
+        }
+    );
+
+    let _pre_propose_id = make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &[]);
+
+    // Approver DAO votes to approves
+    let approver_prop_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+    approve_proposal(
+        &mut app,
+        proposal_single_approver.clone(),
+        "ekez",
+        approver_prop_id,
+    );
+    let id = get_latest_proposal_id(&app, proposal_single.clone());
+
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Never,
+        }),
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
+    );
+
+    let config = get_config(&app, pre_propose.clone());
+    assert_eq!(
+        config,
+        Config {
+            deposit_info: Some(CheckedDepositInfo {
+                denom: cw_denom::CheckedDenom::Native("ujuno".to_string()),
+                amount: Uint128::new(10),
+                refund_policy: DepositRefundPolicy::Never
+            }),
+            submission_policy: PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
+        }
+    );
+
+    // Old proposal should still have same deposit info.
+    let info = get_deposit_info(&app, pre_propose.clone(), id);
+    assert_eq!(
+        info,
+        DepositInfoResponse {
+            deposit_info: None,
+            proposer: Addr::unchecked("ekez"),
+        }
+    );
+
+    // New proposals should have the new deposit info.
+    mint_natives(&mut app, "ekez", coins(10, "ujuno"));
+    let _new_pre_propose_id =
+        make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &coins(10, "ujuno"));
+
+    // Approver DAO votes to approve prop
+    let approver_prop_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+    approve_proposal(
+        &mut app,
+        proposal_single_approver.clone(),
+        "ekez",
+        approver_prop_id,
+    );
+    let new_id = get_latest_proposal_id(&app, proposal_single_approver);
+
+    let info = get_deposit_info(&app, pre_propose.clone(), new_id);
+    assert_eq!(
+        info,
+        DepositInfoResponse {
+            deposit_info: Some(CheckedDepositInfo {
+                denom: cw_denom::CheckedDenom::Native("ujuno".to_string()),
+                amount: Uint128::new(10),
+                refund_policy: DepositRefundPolicy::Never
+            }),
+            proposer: Addr::unchecked("ekez"),
+        }
+    );
+
+    // Both proposals should be allowed to complete.
+    vote(&mut app, proposal_single.clone(), "ekez", id, Vote::Yes);
+    vote(&mut app, proposal_single.clone(), "ekez", new_id, Vote::Yes);
+    execute_proposal(&mut app, proposal_single.clone(), "ekez", id);
+    execute_proposal(&mut app, proposal_single.clone(), "ekez", new_id);
+    // Deposit should not have been refunded (never policy in use).
+    let balance = get_balance_native(&app, "ekez", "ujuno");
+    assert_eq!(balance, Uint128::new(0));
+
+    // Only the core module can update the config.
+    let err = update_config_should_fail(
+        &mut app,
+        pre_propose.clone(),
+        proposal_single.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Anyone { denylist: vec![] },
+    );
+    assert_eq!(err, PreProposeError::NotDao {});
+
+    // Errors when no one is authorized to create proposals.
+    let err = update_config_should_fail(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: false,
+            allowlist: vec![],
+            denylist: vec![],
+        },
+    );
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(PreProposeSubmissionPolicyError::NoOneAllowed {})
+    );
+
+    // Errors when allowlist and denylist overlap.
+    let err = update_config_should_fail(
+        &mut app,
+        pre_propose,
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: false,
+            allowlist: vec![Addr::unchecked("ekez")],
+            denylist: vec![Addr::unchecked("ekez")],
+        },
+    );
+    assert_eq!(
+        err,
+        PreProposeError::SubmissionPolicy(
+            PreProposeSubmissionPolicyError::DenylistAllowlistOverlap {}
+        )
+    );
+}
+
+#[test]
+fn test_approver_unsupported_update_config() {
+    let mut app = App::default();
+
+    // Need to instantiate this so contract addresses match with cw20 test cases
+    let _ = instantiate_cw20_base_default(&mut app);
+
+    let DefaultTestSetup {
+        core_addr,
+        pre_propose_approver,
+        ..
+    } = setup_default_test(&mut app, None, true);
+
+    // Should fail because config is not supported for the approver pre-propose
+    // contract.
+    let err = update_config_should_fail(
+        &mut app,
+        pre_propose_approver,
+        core_addr.as_str(),
+        None,
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: false,
+            allowlist: vec![Addr::unchecked("ekez")],
+            denylist: vec![],
+        },
+    );
+    assert_eq!(err, PreProposeError::Unsupported {});
+}
+
+#[test]
+fn test_approver_unsupported_update_submission_policy() {
+    let mut app = App::default();
+
+    // Need to instantiate this so contract addresses match with cw20 test cases
+    let _ = instantiate_cw20_base_default(&mut app);
+
+    let DefaultTestSetup {
+        core_addr,
+        pre_propose_approver,
+        ..
+    } = setup_default_test(&mut app, None, true);
+
+    // Should fail because submission policy is not supported for the approver
+    // pre-propose contract.
+    let err: PreProposeError = app
+        .execute_contract(
+            core_addr,
+            pre_propose_approver,
+            &ExecuteMsg::UpdateSubmissionPolicy {
+                denylist_add: Some(vec!["ekez".to_string()]),
+                denylist_remove: None,
+                set_dao_members: None,
+                allowlist_add: None,
+                allowlist_remove: None,
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, PreProposeError::Unsupported {});
+}
+
+#[test]
+fn test_approver_can_propose() {
+    let mut app = App::default();
+
+    // Need to instantiate this so contract addresses match with cw20 test cases
+    let _ = instantiate_cw20_base_default(&mut app);
+
+    let DefaultTestSetup {
+        pre_propose,
+        pre_propose_approver,
+        ..
+    } = setup_default_test(&mut app, None, true);
+
+    // Only the pre-propose-approval-single contract can propose.
+    assert!(query_can_propose(
+        &app,
+        pre_propose_approver.clone(),
+        pre_propose
+    ));
+    assert!(!query_can_propose(
+        &app,
+        pre_propose_approver,
+        "someone_else"
+    ));
+}
+
+#[test]
+fn test_withdraw() {
+    let mut app = App::default();
+
+    // Need to instantiate this so contract addresses match with cw20 test cases
+    let _ = instantiate_cw20_base_default(&mut app);
+
+    let DefaultTestSetup {
+        core_addr,
+        proposal_single,
+        pre_propose,
+        approver_core_addr: _,
+        proposal_single_approver,
+        pre_propose_approver: _,
+    } = setup_default_test(&mut app, None, false);
+
+    let err = withdraw_should_fail(
+        &mut app,
+        pre_propose.clone(),
+        proposal_single.as_str(),
+        Some(UncheckedDenom::Native("ujuno".to_string())),
+    );
+    assert_eq!(err, PreProposeError::NotDao {});
+
+    let err = withdraw_should_fail(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        Some(UncheckedDenom::Native("ujuno".to_string())),
+    );
+    assert_eq!(err, PreProposeError::NothingToWithdraw {});
+
+    let err = withdraw_should_fail(&mut app, pre_propose.clone(), core_addr.as_str(), None);
+    assert_eq!(err, PreProposeError::NoWithdrawalDenom {});
+
+    // Turn on native deposits.
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: vec![],
+            denylist: vec![],
+        },
+    );
+
+    // Withdraw with no specified denom - should fall back to the one
+    // in the config.
+    mint_natives(&mut app, pre_propose.as_str(), coins(10, "ujuno"));
+    withdraw(&mut app, pre_propose.clone(), core_addr.as_str(), None);
+    let balance = get_balance_native(&app, core_addr.as_str(), "ujuno");
+    assert_eq!(balance, Uint128::new(10));
+
+    // Withdraw again, this time specifying a native denomination.
+    mint_natives(&mut app, pre_propose.as_str(), coins(10, "ujuno"));
+    withdraw(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        Some(UncheckedDenom::Native("ujuno".to_string())),
+    );
+    let balance = get_balance_native(&app, core_addr.as_str(), "ujuno");
+    assert_eq!(balance, Uint128::new(20));
+
+    // Make a proposal with the native tokens to put some in the system.
+    mint_natives(&mut app, "ekez", coins(10, "ujuno"));
+    let _native_pre_propose_id =
+        make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &coins(10, "ujuno"));
+
+    // Approver DAO votes to approve
+    let approver_prop_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+    approve_proposal(
+        &mut app,
+        proposal_single_approver.clone(),
+        "ekez",
+        approver_prop_id,
+    );
+    let native_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+
+    // Update the config to use a cw20 token.
+    let cw20_address = instantiate_cw20_base_default(&mut app);
+    update_config(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Cw20(cw20_address.to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        PreProposeSubmissionPolicy::Specific {
+            dao_members: true,
+            allowlist: vec![],
+            denylist: vec![],
+        },
+    );
+
+    increase_allowance(
+        &mut app,
+        "ekez",
+        &pre_propose,
+        cw20_address.clone(),
+        Uint128::new(10),
+    );
+    let _cw20_pre_propose_id = make_pre_proposal(&mut app, pre_propose.clone(), "ekez", &[]);
+
+    // Approver DAO votes to approve
+    let approver_prop_id = get_latest_proposal_id(&app, proposal_single_approver.clone());
+    approve_proposal(&mut app, proposal_single_approver, "ekez", approver_prop_id);
+    let cw20_id = get_latest_proposal_id(&app, proposal_single.clone());
+
+    // There is now a pending proposal and cw20 tokens in the
+    // pre-propose module that should be returned on that proposal's
+    // completion. To make things interesting, we withdraw those
+    // tokens which should cause the status change hook on the
+    // proposal's execution to fail as we don't have sufficent balance
+    // to return the deposit.
+    withdraw(&mut app, pre_propose.clone(), core_addr.as_str(), None);
+    let balance = get_balance_cw20(&app, &cw20_address, core_addr.as_str());
+    assert_eq!(balance, Uint128::new(10));
+
+    // Proposal should still be executable! We just get removed from
+    // the proposal module's hook receiver list.
+    vote(
+        &mut app,
+        proposal_single.clone(),
+        "ekez",
+        cw20_id,
+        Vote::Yes,
+    );
+    execute_proposal(&mut app, proposal_single.clone(), "ekez", cw20_id);
+
+    // Make sure the proposal module has fallen back to anyone can
+    // propose becuase of our malfunction.
+    let proposal_creation_policy: ProposalCreationPolicy = app
+        .wrap()
+        .query_wasm_smart(
+            proposal_single.clone(),
+            &dps::msg::QueryMsg::ProposalCreationPolicy {},
+        )
+        .unwrap();
+
+    assert_eq!(proposal_creation_policy, ProposalCreationPolicy::Anyone {});
+
+    // Close out the native proposal and it's deposit as well.
+    vote(
+        &mut app,
+        proposal_single.clone(),
+        "ekez",
+        native_id,
+        Vote::No,
+    );
+    close_proposal(&mut app, proposal_single.clone(), "ekez", native_id);
+    withdraw(
+        &mut app,
+        pre_propose.clone(),
+        core_addr.as_str(),
+        Some(UncheckedDenom::Native("ujuno".to_string())),
+    );
+    let balance = get_balance_native(&app, core_addr.as_str(), "ujuno");
+    assert_eq!(balance, Uint128::new(30));
+}
+
+#[test]
+fn test_reset_approver() {
+    let mut app = App::default();
+
+    // Need to instantiate this so contract addresses match with cw20 test cases
+    let _ = instantiate_cw20_base_default(&mut app);
+
+    let DefaultTestSetup {
+        core_addr: _,
+        proposal_single: _,
+        pre_propose,
+        approver_core_addr,
+        proposal_single_approver: _,
+        pre_propose_approver,
+    } = setup_default_test(
+        &mut app,
+        Some(UncheckedDepositInfo {
+            denom: DepositToken::Token {
+                denom: UncheckedDenom::Native("ujuno".to_string()),
+            },
+            amount: Uint128::new(10),
+            refund_policy: DepositRefundPolicy::Always,
+        }),
+        false,
+    );
+
+    // Ensure approver is set to the pre_propose_approver
+    let approver: Addr = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose.clone(),
+            &QueryMsg::QueryExtension {
+                msg: QueryExt::Approver {},
+            },
+        )
+        .unwrap();
+    assert_eq!(approver, pre_propose_approver);
+
+    // Fail to change approver by non-approver.
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("someone"),
+            pre_propose.clone(),
+            &ExecuteMsg::Extension {
+                msg: ExecuteExt::UpdateApprover {
+                    address: "someone".to_string(),
+                },
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, PreProposeError::Unauthorized {});
+
+    // Fail to reset approver back to approver DAO by non-approver.
+    let err: PreProposeError = app
+        .execute_contract(
+            Addr::unchecked("someone"),
+            pre_propose_approver.clone(),
+            &ApproverExecuteMsg::Extension {
+                msg: ApproverExecuteExt::ResetApprover {},
+            },
+            &[],
+        )
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, PreProposeError::Unauthorized {});
+
+    // Reset approver back to approver DAO.
+    app.execute_contract(
+        approver_core_addr.clone(),
+        pre_propose_approver.clone(),
+        &ApproverExecuteMsg::Extension {
+            msg: ApproverExecuteExt::ResetApprover {},
+        },
+        &[],
+    )
+    .unwrap();
+
+    // Ensure approver is reset back to the approver DAO
+    let approver: Addr = app
+        .wrap()
+        .query_wasm_smart(
+            pre_propose.clone(),
+            &QueryMsg::QueryExtension {
+                msg: QueryExt::Approver {},
+            },
+        )
+        .unwrap();
+    assert_eq!(approver, approver_core_addr);
+}

--- a/packages/dao-testing/src/helpers.rs
+++ b/packages/dao-testing/src/helpers.rs
@@ -301,7 +301,7 @@ pub fn instantiate_with_staking_active_threshold(
 
 pub fn instantiate_with_cw4_groups_governance(
     app: &mut App,
-    core_code_id: u64,
+    proposal_module_code_id: u64,
     proposal_module_instantiate: Binary,
     initial_weights: Option<Vec<Cw20Coin>>,
 ) -> Addr {
@@ -353,7 +353,7 @@ pub fn instantiate_with_cw4_groups_governance(
             label: "DAO DAO voting module".to_string(),
         },
         proposal_modules_instantiate_info: vec![ModuleInstantiateInfo {
-            code_id: core_code_id,
+            code_id: proposal_module_code_id,
             msg: proposal_module_instantiate,
             admin: Some(Admin::CoreModule {}),
             funds: vec![],

--- a/packages/dao-voting/src/approval.rs
+++ b/packages/dao-voting/src/approval.rs
@@ -1,0 +1,52 @@
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::Addr;
+
+use crate::deposit::CheckedDepositInfo;
+
+#[cw_serde]
+pub enum ApproverProposeMessage {
+    Propose {
+        title: String,
+        description: String,
+        approval_id: u64,
+    },
+}
+
+#[cw_serde]
+pub enum ApprovalExecuteExt {
+    /// Approve a proposal, only callable by approver
+    Approve { id: u64 },
+    /// Reject a proposal, only callable by approver
+    Reject { id: u64 },
+    /// Updates the approver, can only be called the current approver
+    UpdateApprover { address: String },
+}
+
+#[cw_serde]
+pub enum ApprovalProposalStatus {
+    /// The proposal is pending approval.
+    Pending {},
+    /// The proposal has been approved.
+    Approved {
+        /// The created proposal ID.
+        created_proposal_id: u64,
+    },
+    /// The proposal has been rejected.
+    Rejected {},
+}
+
+#[cw_serde]
+pub struct ApprovalProposal<ProposeMsg> {
+    /// The status of a completed proposal.
+    pub status: ApprovalProposalStatus,
+    /// The approval ID used to identify this pending proposal.
+    pub approval_id: u64,
+    /// The address that created the proposal.
+    pub proposer: Addr,
+    /// The propose message that ought to be executed on the proposal
+    /// message if this proposal is approved.
+    pub msg: ProposeMsg,
+    /// Snapshot of the deposit info at the time of proposal
+    /// submission.
+    pub deposit: Option<CheckedDepositInfo>,
+}

--- a/packages/dao-voting/src/approval.rs
+++ b/packages/dao-voting/src/approval.rs
@@ -37,10 +37,12 @@ pub enum ApprovalProposalStatus {
 
 #[cw_serde]
 pub struct ApprovalProposal<ProposeMsg> {
-    /// The status of a completed proposal.
+    /// The status of an approval proposal.
     pub status: ApprovalProposalStatus,
     /// The approval ID used to identify this pending proposal.
     pub approval_id: u64,
+    /// The address that can approve/reject this proposal.
+    pub approver: Addr,
     /// The address that created the proposal.
     pub proposer: Addr,
     /// The propose message that ought to be executed on the proposal

--- a/packages/dao-voting/src/approval.rs
+++ b/packages/dao-voting/src/approval.rs
@@ -44,7 +44,7 @@ pub struct ApprovalProposal<ProposeMsg> {
     /// The address that created the proposal.
     pub proposer: Addr,
     /// The propose message that ought to be executed on the proposal
-    /// message if this proposal is approved.
+    /// module if this proposal is approved.
     pub msg: ProposeMsg,
     /// Snapshot of the deposit info at the time of proposal
     /// submission.

--- a/packages/dao-voting/src/lib.rs
+++ b/packages/dao-voting/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 
+pub mod approval;
 pub mod deposit;
 pub mod duration;
 pub mod error;


### PR DESCRIPTION
this does two things:

1. it creates a dao-pre-propose-approval-multiple contract so that multiple choice proposal modules can have approvers, just like single choice proposal modules. it also ensures the approver contract works for both approval-single and approval-multiple

2. it freezes the `approver` in the proposal so that a previously created pending proposal does not change approvers if the approver gets updated while it's still pending. this maintains consistency with other DAO logic to keep things intuitive, where the members who can vote on a proposal are frozen upon proposal creation.