### PR TITLE
fix reward distributor interval delay bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,12 +271,12 @@ dependencies = [
  "cw-admin-factory",
  "cw-utils 1.0.3",
  "cw20 1.1.2",
- "cw20-stake 2.5.0",
- "dao-dao-core 2.5.0",
- "dao-interface 2.5.0",
- "dao-pre-propose-single 2.5.0",
- "dao-proposal-single 2.5.0",
- "dao-voting 2.5.0",
+ "cw20-stake 2.5.1",
+ "dao-dao-core 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-pre-propose-single 2.5.1",
+ "dao-proposal-single 2.5.1",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
  "env_logger",
  "serde",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "btsg-ft-factory"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -304,11 +304,11 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "dao-dao-core 2.5.0",
- "dao-interface 2.5.0",
- "dao-proposal-single 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-proposal-single 2.5.1",
  "dao-testing",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-token-staked",
  "osmosis-std-derive",
  "prost 0.12.3",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "cw-admin-factory"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "bech32",
  "cosmwasm-schema",
@@ -698,11 +698,11 @@ dependencies = [
  "cw2 1.1.2",
  "cw20-base 1.1.2",
  "cw4 1.1.2",
- "dao-interface 2.5.0",
- "dao-proposal-single 2.5.0",
+ "dao-interface 2.5.1",
+ "dao-proposal-single 2.5.1",
  "dao-testing",
- "dao-voting 2.5.0",
- "dao-voting-cw4 2.5.0",
+ "dao-voting 2.5.1",
+ "dao-voting-cw4 2.5.1",
  "osmosis-test-tube",
  "thiserror",
 ]
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "cw-denom"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -844,21 +844,21 @@ dependencies = [
 
 [[package]]
 name = "cw-fund-distributor"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-fund-distributor",
  "cw-multi-test",
- "cw-paginate-storage 2.5.0",
+ "cw-paginate-storage 2.5.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
- "dao-dao-core 2.5.0",
- "dao-interface 2.5.0",
+ "cw20-stake 2.5.1",
+ "dao-dao-core 2.5.1",
+ "dao-interface 2.5.1",
  "dao-testing",
  "dao-voting-cw20-staked",
  "thiserror",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "cw-hooks"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "cw-paginate-storage"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
@@ -967,11 +967,11 @@ dependencies = [
 
 [[package]]
 name = "cw-payroll-factory"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
+ "cw-denom 2.5.1",
  "cw-multi-test",
  "cw-ownable",
  "cw-payroll-factory",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "cw-stake-tracker"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "cw-token-swap"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "cw-tokenfactory-issuer"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1092,7 +1092,7 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-tokenfactory-types",
  "cw2 1.1.2",
- "dao-interface 2.5.0",
+ "dao-interface 2.5.1",
  "osmosis-std",
  "osmosis-test-tube",
  "prost 0.12.3",
@@ -1105,11 +1105,11 @@ dependencies = [
 
 [[package]]
 name = "cw-tokenfactory-types"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "dao-interface 2.5.0",
+ "dao-interface 2.5.1",
  "osmosis-std",
  "osmosis-std-derive",
  "prost 0.12.3",
@@ -1176,12 +1176,12 @@ dependencies = [
 
 [[package]]
 name = "cw-vesting"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
+ "cw-denom 2.5.1",
  "cw-multi-test",
  "cw-ownable",
  "cw-stake-tracker",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "cw-wormhole"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1367,16 +1367,16 @@ dependencies = [
 
 [[package]]
 name = "cw20-stake"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-hooks 2.5.0",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-ownable",
- "cw-paginate-storage 2.5.0",
+ "cw-paginate-storage 2.5.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 0.13.4",
  "cw-utils 1.0.3",
@@ -1384,16 +1384,16 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw20-stake 0.2.6",
- "cw20-stake 2.5.0",
- "dao-hooks 2.5.0",
+ "cw20-stake 2.5.1",
+ "dao-hooks 2.5.1",
  "dao-testing",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "cw20-stake-external-rewards"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1407,9 +1407,9 @@ dependencies = [
  "cw20 0.13.4",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
+ "cw20-stake 2.5.1",
  "cw20-stake-external-rewards",
- "dao-hooks 2.5.0",
+ "dao-hooks 2.5.1",
  "dao-testing",
  "stake-cw20-external-rewards",
  "thiserror",
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-stake-reward-distributor"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1428,7 +1428,7 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
+ "cw20-stake 2.5.1",
  "cw20-stake-reward-distributor",
  "dao-testing",
  "stake-cw20-reward-distributor",
@@ -1623,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-controllers"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-roles"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "dao-cw721-extensions"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1686,13 +1686,13 @@ dependencies = [
 
 [[package]]
 name = "dao-dao-core"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-core",
  "cw-multi-test",
- "cw-paginate-storage 2.5.0",
+ "cw-paginate-storage 2.5.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1700,9 +1700,9 @@ dependencies = [
  "cw20-base 1.1.2",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
- "dao-dao-core 2.5.0",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
  "dao-proposal-sudo",
  "dao-testing",
  "dao-voting-cw20-balance",
@@ -1723,13 +1723,13 @@ dependencies = [
 
 [[package]]
 name = "dao-dao-macros"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-hooks 2.5.0",
- "dao-interface 2.5.0",
- "dao-voting 2.5.0",
+ "cw-hooks 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-voting 2.5.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1751,14 +1751,14 @@ dependencies = [
 
 [[package]]
 name = "dao-hooks"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-hooks 2.5.0",
+ "cw-hooks 2.5.1",
  "cw4 1.1.2",
- "dao-pre-propose-base 2.5.0",
- "dao-voting 2.5.0",
+ "dao-pre-propose-base 2.5.1",
+ "dao-voting 2.5.1",
 ]
 
 [[package]]
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "dao-interface"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "dao-migrator"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1808,19 +1808,19 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw20-stake 0.2.6",
- "cw20-stake 2.5.0",
+ "cw20-stake 2.5.1",
  "cw20-staked-balance-voting",
  "cw4 0.13.4",
  "cw4-voting",
- "dao-dao-core 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-interface 2.5.1",
  "dao-migrator",
- "dao-proposal-single 2.5.0",
+ "dao-proposal-single 2.5.1",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
  "thiserror",
 ]
 
@@ -1843,13 +1843,13 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-approval-single"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
+ "cw-denom 2.5.1",
  "cw-multi-test",
- "cw-paginate-storage 2.5.0",
+ "cw-paginate-storage 2.5.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1858,30 +1858,30 @@ dependencies = [
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "dao-dao-core 2.4.1",
- "dao-dao-core 2.5.0",
- "dao-hooks 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-hooks 2.5.1",
  "dao-interface 2.4.1",
- "dao-interface 2.5.0",
+ "dao-interface 2.5.1",
  "dao-pre-propose-approval-single 2.4.1",
- "dao-pre-propose-base 2.5.0",
+ "dao-pre-propose-base 2.5.1",
  "dao-proposal-single 2.4.1",
- "dao-proposal-single 2.5.0",
+ "dao-proposal-single 2.5.1",
  "dao-testing",
  "dao-voting 2.4.1",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
  "dao-voting-cw4 2.4.1",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-pre-propose-approver"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
+ "cw-denom 2.5.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -1889,16 +1889,16 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw4-group 1.1.2",
- "dao-dao-core 2.5.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
- "dao-pre-propose-approval-single 2.5.0",
- "dao-pre-propose-base 2.5.0",
- "dao-proposal-single 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-pre-propose-approval-single 2.5.1",
+ "dao-pre-propose-base 2.5.1",
+ "dao-proposal-single 2.5.1",
  "dao-testing",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
 ]
 
 [[package]]
@@ -1922,21 +1922,21 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-base"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-denom 2.4.1",
- "cw-denom 2.5.0",
- "cw-hooks 2.5.0",
+ "cw-denom 2.5.1",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "dao-interface 2.5.0",
+ "dao-interface 2.5.1",
  "dao-pre-propose-base 2.4.1",
  "dao-voting 2.4.1",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "semver",
  "serde",
  "thiserror",
@@ -1957,11 +1957,11 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-multiple"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
+ "cw-denom 2.5.1",
  "cw-multi-test",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1970,20 +1970,20 @@ dependencies = [
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "dao-dao-core 2.4.1",
- "dao-dao-core 2.5.0",
- "dao-hooks 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-hooks 2.5.1",
  "dao-interface 2.4.1",
- "dao-interface 2.5.0",
- "dao-pre-propose-base 2.5.0",
+ "dao-interface 2.5.1",
+ "dao-pre-propose-base 2.5.1",
  "dao-pre-propose-multiple 2.4.1",
  "dao-proposal-multiple 2.4.1",
- "dao-proposal-multiple 2.5.0",
+ "dao-proposal-multiple 2.5.1",
  "dao-testing",
  "dao-voting 2.4.1",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
  "dao-voting-cw4 2.4.1",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
 ]
 
 [[package]]
@@ -2001,12 +2001,12 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-single"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
- "cw-hooks 2.5.0",
+ "cw-denom 2.5.1",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -2015,25 +2015,25 @@ dependencies = [
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "dao-dao-core 2.4.1",
- "dao-dao-core 2.5.0",
- "dao-hooks 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-hooks 2.5.1",
  "dao-interface 2.4.1",
- "dao-interface 2.5.0",
- "dao-pre-propose-base 2.5.0",
+ "dao-interface 2.5.1",
+ "dao-pre-propose-base 2.5.1",
  "dao-pre-propose-single 2.4.1",
  "dao-proposal-single 2.4.1",
- "dao-proposal-single 2.5.0",
+ "dao-proposal-single 2.5.1",
  "dao-testing",
  "dao-voting 2.4.1",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
  "dao-voting-cw4 2.4.1",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
 ]
 
 [[package]]
 name = "dao-proposal-condorcet"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2044,34 +2044,34 @@ dependencies = [
  "cw2 1.1.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
- "dao-dao-core 2.5.0",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
  "dao-testing",
- "dao-voting 2.5.0",
- "dao-voting-cw4 2.5.0",
+ "dao-voting 2.5.1",
+ "dao-voting-cw4 2.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-proposal-hook-counter"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-hooks 2.5.0",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "dao-dao-core 2.5.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
- "dao-proposal-single 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-proposal-single 2.5.1",
  "dao-testing",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-balance",
  "thiserror",
 ]
@@ -2101,35 +2101,35 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-multiple"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
- "cw-hooks 2.5.0",
+ "cw-denom 2.5.1",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
+ "cw20-stake 2.5.1",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
- "dao-dao-macros 2.5.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
- "dao-pre-propose-base 2.5.0",
- "dao-pre-propose-multiple 2.5.0",
- "dao-proposal-multiple 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-pre-propose-base 2.5.1",
+ "dao-pre-propose-multiple 2.5.1",
+ "dao-proposal-multiple 2.5.1",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
  "dao-voting-cw721-staked",
  "dao-voting-token-staked",
  "rand",
@@ -2162,14 +2162,14 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-single"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-core",
- "cw-denom 2.5.0",
- "cw-hooks 2.5.0",
+ "cw-denom 2.5.1",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-proposal-single",
  "cw-storage-plus 1.2.0",
@@ -2178,23 +2178,23 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
+ "cw20-stake 2.5.1",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
- "dao-dao-core 2.5.0",
- "dao-dao-macros 2.5.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
- "dao-pre-propose-base 2.5.0",
- "dao-pre-propose-single 2.5.0",
- "dao-proposal-single 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-dao-macros 2.5.1",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-pre-propose-base 2.5.1",
+ "dao-pre-propose-single 2.5.1",
+ "dao-proposal-single 2.5.1",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
  "dao-voting-cw721-staked",
  "dao-voting-token-staked",
  "thiserror",
@@ -2202,21 +2202,21 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-sudo"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-rewards-distributor"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2229,17 +2229,17 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
+ "cw20-stake 2.5.1",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
  "dao-rewards-distributor",
  "dao-testing",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
  "dao-voting-cw721-staked",
  "dao-voting-token-staked",
  "semver",
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "dao-test-custom-factory"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2260,15 +2260,15 @@ dependencies = [
  "cw2 1.1.2",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
- "dao-voting 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-voting 2.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-testing"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "btsg-ft-factory",
  "cosmwasm-schema",
@@ -2276,7 +2276,7 @@ dependencies = [
  "cw-admin-factory",
  "cw-core",
  "cw-fund-distributor",
- "cw-hooks 2.5.0",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-payroll-factory",
  "cw-proposal-single",
@@ -2288,7 +2288,7 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw20-stake 0.2.6",
- "cw20-stake 2.5.0",
+ "cw20-stake 2.5.1",
  "cw20-stake-external-rewards",
  "cw20-stake-reward-distributor",
  "cw4 1.1.2",
@@ -2297,33 +2297,33 @@ dependencies = [
  "cw721-base 0.18.0",
  "cw721-roles",
  "dao-dao-core 2.4.1",
- "dao-dao-core 2.5.0",
+ "dao-dao-core 2.5.1",
  "dao-interface 2.4.1",
- "dao-interface 2.5.0",
+ "dao-interface 2.5.1",
  "dao-migrator",
  "dao-pre-propose-approval-single 2.4.1",
- "dao-pre-propose-approval-single 2.5.0",
+ "dao-pre-propose-approval-single 2.5.1",
  "dao-pre-propose-approver",
  "dao-pre-propose-multiple 2.4.1",
- "dao-pre-propose-multiple 2.5.0",
+ "dao-pre-propose-multiple 2.5.1",
  "dao-pre-propose-single 2.4.1",
- "dao-pre-propose-single 2.5.0",
+ "dao-pre-propose-single 2.5.1",
  "dao-proposal-condorcet",
  "dao-proposal-hook-counter",
  "dao-proposal-multiple 2.4.1",
- "dao-proposal-multiple 2.5.0",
+ "dao-proposal-multiple 2.5.1",
  "dao-proposal-single 2.4.1",
- "dao-proposal-single 2.5.0",
+ "dao-proposal-single 2.5.1",
  "dao-proposal-sudo",
  "dao-rewards-distributor",
  "dao-test-custom-factory",
  "dao-voting 0.1.0",
  "dao-voting 2.4.1",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
  "dao-voting-cw4 2.4.1",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
  "dao-voting-cw721-roles",
  "dao-voting-cw721-staked",
  "dao-voting-onft-staked",
@@ -2369,22 +2369,22 @@ dependencies = [
 
 [[package]]
 name = "dao-voting"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.5.0",
+ "cw-denom 2.5.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw20 1.1.2",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw20-balance"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2394,15 +2394,15 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
  "dao-testing",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw20-staked"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2412,11 +2412,11 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
+ "cw20-stake 2.5.1",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
  "dao-testing",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "thiserror",
 ]
 
@@ -2440,7 +2440,7 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-cw4"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2450,16 +2450,16 @@ dependencies = [
  "cw2 1.1.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
  "dao-testing",
- "dao-voting-cw4 2.5.0",
+ "dao-voting-cw4 2.5.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw721-roles"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2475,21 +2475,21 @@ dependencies = [
  "cw721-controllers",
  "cw721-roles",
  "dao-cw721-extensions",
- "dao-dao-macros 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-interface 2.5.1",
  "dao-testing",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw721-staked"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-hooks 2.5.0",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -2497,14 +2497,14 @@ dependencies = [
  "cw721 0.18.0",
  "cw721-base 0.18.0",
  "cw721-controllers",
- "dao-dao-macros 2.5.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
  "dao-proposal-hook-counter",
- "dao-proposal-single 2.5.0",
+ "dao-proposal-single 2.5.1",
  "dao-test-custom-factory",
  "dao-testing",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "osmosis-std",
  "osmosis-test-tube",
  "serde",
@@ -2513,26 +2513,26 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-onft-staked"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-hooks 2.5.0",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw721-controllers",
- "dao-dao-macros 2.5.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
  "dao-proposal-hook-counter",
- "dao-proposal-single 2.5.0",
+ "dao-proposal-single 2.5.1",
  "dao-test-custom-factory",
  "dao-testing",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "omniflix-std",
  "osmosis-test-tube",
  "prost 0.12.3",
@@ -2543,27 +2543,27 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-token-staked"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-hooks 2.5.0",
+ "cw-hooks 2.5.1",
  "cw-multi-test",
  "cw-ownable",
  "cw-storage-plus 1.2.0",
  "cw-tokenfactory-issuer",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "dao-dao-macros 2.5.0",
- "dao-hooks 2.5.0",
- "dao-interface 2.5.0",
+ "dao-dao-macros 2.5.1",
+ "dao-hooks 2.5.1",
+ "dao-interface 2.5.1",
  "dao-proposal-hook-counter",
- "dao-proposal-single 2.5.0",
+ "dao-proposal-single 2.5.1",
  "dao-test-custom-factory",
  "dao-testing",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "osmosis-std",
  "osmosis-test-tube",
  "serde",
@@ -3251,16 +3251,16 @@ dependencies = [
  "cw-vesting",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.5.0",
+ "cw20-stake 2.5.1",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
  "cw721-roles",
- "dao-dao-core 2.5.0",
- "dao-interface 2.5.0",
- "dao-pre-propose-single 2.5.0",
- "dao-proposal-single 2.5.0",
+ "dao-dao-core 2.5.1",
+ "dao-interface 2.5.1",
+ "dao-pre-propose-single 2.5.1",
+ "dao-proposal-single 2.5.1",
  "dao-test-custom-factory",
- "dao-voting 2.5.0",
+ "dao-voting 2.5.1",
  "dao-voting-cw20-staked",
  "dao-voting-cw721-staked",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "2"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/DA0-DA0/dao-contracts"
-version = "2.5.0"
+version = "2.5.1"
 
 [profile.release]
 codegen-units = 1
@@ -85,51 +85,51 @@ wynd-utils = "0.4"
 # optional owner.
 cw-ownable = "0.5"
 
-btsg-ft-factory = { path = "./contracts/external/btsg-ft-factory", version = "2.5.0" }
-cw-admin-factory = { path = "./contracts/external/cw-admin-factory", version = "2.5.0" }
-cw-denom = { path = "./packages/cw-denom", version = "2.5.0" }
-cw-fund-distributor = { path = "./contracts/distribution/cw-fund-distributor", version = "2.5.0" }
-cw-hooks = { path = "./packages/cw-hooks", version = "2.5.0" }
-cw-paginate-storage = { path = "./packages/cw-paginate-storage", version = "2.5.0" }
-cw-payroll-factory = { path = "./contracts/external/cw-payroll-factory", version = "2.5.0" }
-cw-stake-tracker = { path = "./packages/cw-stake-tracker", version = "2.5.0" }
-cw-token-swap = { path = "./contracts/external/cw-token-swap", version = "2.5.0" }
-cw-tokenfactory-issuer = { path = "./contracts/external/cw-tokenfactory-issuer", version = "2.5.0", default-features = false }
-cw-tokenfactory-types = { path = "./packages/cw-tokenfactory-types", version = "2.5.0", default-features = false }
-cw-vesting = { path = "./contracts/external/cw-vesting", version = "2.5.0" }
-cw-wormhole = { path = "./packages/cw-wormhole", version = "2.5.0" }
-cw20-stake = { path = "./contracts/staking/cw20-stake", version = "2.5.0" }
-cw20-stake-external-rewards = { path = "./contracts/staking/cw20-stake-external-rewards", version = "2.5.0" }
-cw20-stake-reward-distributor = { path = "./contracts/staking/cw20-stake-reward-distributor", version = "2.5.0" }
-cw721-controllers = { path = "./packages/cw721-controllers", version = "2.5.0" }
-cw721-roles = { path = "./contracts/external/cw721-roles", version = "2.5.0" }
-dao-cw721-extensions = { path = "./packages/dao-cw721-extensions", version = "2.5.0" }
-dao-dao-core = { path = "./contracts/dao-dao-core", version = "2.5.0" }
-dao-dao-macros = { path = "./packages/dao-dao-macros", version = "2.5.0" }
-dao-hooks = { path = "./packages/dao-hooks", version = "2.5.0" }
-dao-interface = { path = "./packages/dao-interface", version = "2.5.0" }
-dao-migrator = { path = "./contracts/external/dao-migrator", version = "2.5.0" }
-dao-pre-propose-approval-single = { path = "./contracts/pre-propose/dao-pre-propose-approval-single", version = "2.5.0" }
-dao-pre-propose-approver = { path = "./contracts/pre-propose/dao-pre-propose-approver", version = "2.5.0" }
-dao-pre-propose-base = { path = "./packages/dao-pre-propose-base", version = "2.5.0" }
-dao-pre-propose-multiple = { path = "./contracts/pre-propose/dao-pre-propose-multiple", version = "2.5.0" }
-dao-pre-propose-single = { path = "./contracts/pre-propose/dao-pre-propose-single", version = "2.5.0" }
-dao-proposal-condorcet = { path = "./contracts/proposal/dao-proposal-condorcet", version = "2.5.0" }
-dao-proposal-hook-counter = { path = "./contracts/test/dao-proposal-hook-counter", version = "2.5.0" }
-dao-proposal-multiple = { path = "./contracts/proposal/dao-proposal-multiple", version = "2.5.0" }
-dao-proposal-single = { path = "./contracts/proposal/dao-proposal-single", version = "2.5.0" }
-dao-proposal-sudo = { path = "./contracts/test/dao-proposal-sudo", version = "2.5.0" }
-dao-rewards-distributor = { path = "./contracts/distribution/dao-rewards-distributor", version = "2.5.0" }
-dao-test-custom-factory = { path = "./contracts/test/dao-test-custom-factory", version = "2.5.0" }
-dao-testing = { path = "./packages/dao-testing", version = "2.5.0" }
-dao-voting = { path = "./packages/dao-voting", version = "2.5.0" }
-dao-voting-cw20-balance = { path = "./contracts/test/dao-voting-cw20-balance", version = "2.5.0" }
-dao-voting-cw20-staked = { path = "./contracts/voting/dao-voting-cw20-staked", version = "2.5.0" }
-dao-voting-cw4 = { path = "./contracts/voting/dao-voting-cw4", version = "2.5.0" }
-dao-voting-cw721-roles = { path = "./contracts/voting/dao-voting-cw721-roles", version = "2.5.0" }
-dao-voting-cw721-staked = { path = "./contracts/voting/dao-voting-cw721-staked", version = "2.5.0" }
-dao-voting-onft-staked = { path = "./contracts/voting/dao-voting-onft-staked", version = "2.5.0" }
-dao-voting-token-staked = { path = "./contracts/voting/dao-voting-token-staked", version = "2.5.0" }
+btsg-ft-factory = { path = "./contracts/external/btsg-ft-factory", version = "2.5.1" }
+cw-admin-factory = { path = "./contracts/external/cw-admin-factory", version = "2.5.1" }
+cw-denom = { path = "./packages/cw-denom", version = "2.5.1" }
+cw-fund-distributor = { path = "./contracts/distribution/cw-fund-distributor", version = "2.5.1" }
+cw-hooks = { path = "./packages/cw-hooks", version = "2.5.1" }
+cw-paginate-storage = { path = "./packages/cw-paginate-storage", version = "2.5.1" }
+cw-payroll-factory = { path = "./contracts/external/cw-payroll-factory", version = "2.5.1" }
+cw-stake-tracker = { path = "./packages/cw-stake-tracker", version = "2.5.1" }
+cw-token-swap = { path = "./contracts/external/cw-token-swap", version = "2.5.1" }
+cw-tokenfactory-issuer = { path = "./contracts/external/cw-tokenfactory-issuer", version = "2.5.1", default-features = false }
+cw-tokenfactory-types = { path = "./packages/cw-tokenfactory-types", version = "2.5.1", default-features = false }
+cw-vesting = { path = "./contracts/external/cw-vesting", version = "2.5.1" }
+cw-wormhole = { path = "./packages/cw-wormhole", version = "2.5.1" }
+cw20-stake = { path = "./contracts/staking/cw20-stake", version = "2.5.1" }
+cw20-stake-external-rewards = { path = "./contracts/staking/cw20-stake-external-rewards", version = "2.5.1" }
+cw20-stake-reward-distributor = { path = "./contracts/staking/cw20-stake-reward-distributor", version = "2.5.1" }
+cw721-controllers = { path = "./packages/cw721-controllers", version = "2.5.1" }
+cw721-roles = { path = "./contracts/external/cw721-roles", version = "2.5.1" }
+dao-cw721-extensions = { path = "./packages/dao-cw721-extensions", version = "2.5.1" }
+dao-dao-core = { path = "./contracts/dao-dao-core", version = "2.5.1" }
+dao-dao-macros = { path = "./packages/dao-dao-macros", version = "2.5.1" }
+dao-hooks = { path = "./packages/dao-hooks", version = "2.5.1" }
+dao-interface = { path = "./packages/dao-interface", version = "2.5.1" }
+dao-migrator = { path = "./contracts/external/dao-migrator", version = "2.5.1" }
+dao-pre-propose-approval-single = { path = "./contracts/pre-propose/dao-pre-propose-approval-single", version = "2.5.1" }
+dao-pre-propose-approver = { path = "./contracts/pre-propose/dao-pre-propose-approver", version = "2.5.1" }
+dao-pre-propose-base = { path = "./packages/dao-pre-propose-base", version = "2.5.1" }
+dao-pre-propose-multiple = { path = "./contracts/pre-propose/dao-pre-propose-multiple", version = "2.5.1" }
+dao-pre-propose-single = { path = "./contracts/pre-propose/dao-pre-propose-single", version = "2.5.1" }
+dao-proposal-condorcet = { path = "./contracts/proposal/dao-proposal-condorcet", version = "2.5.1" }
+dao-proposal-hook-counter = { path = "./contracts/test/dao-proposal-hook-counter", version = "2.5.1" }
+dao-proposal-multiple = { path = "./contracts/proposal/dao-proposal-multiple", version = "2.5.1" }
+dao-proposal-single = { path = "./contracts/proposal/dao-proposal-single", version = "2.5.1" }
+dao-proposal-sudo = { path = "./contracts/test/dao-proposal-sudo", version = "2.5.1" }
+dao-rewards-distributor = { path = "./contracts/distribution/dao-rewards-distributor", version = "2.5.1" }
+dao-test-custom-factory = { path = "./contracts/test/dao-test-custom-factory", version = "2.5.1" }
+dao-testing = { path = "./packages/dao-testing", version = "2.5.1" }
+dao-voting = { path = "./packages/dao-voting", version = "2.5.1" }
+dao-voting-cw20-balance = { path = "./contracts/test/dao-voting-cw20-balance", version = "2.5.1" }
+dao-voting-cw20-staked = { path = "./contracts/voting/dao-voting-cw20-staked", version = "2.5.1" }
+dao-voting-cw4 = { path = "./contracts/voting/dao-voting-cw4", version = "2.5.1" }
+dao-voting-cw721-roles = { path = "./contracts/voting/dao-voting-cw721-roles", version = "2.5.1" }
+dao-voting-cw721-staked = { path = "./contracts/voting/dao-voting-cw721-staked", version = "2.5.1" }
+dao-voting-onft-staked = { path = "./contracts/voting/dao-voting-onft-staked", version = "2.5.1" }
+dao-voting-token-staked = { path = "./contracts/voting/dao-voting-token-staked", version = "2.5.1" }
 
 # v1 dependencies. used for state migrations.
 cw-core-v1 = { package = "cw-core", version = "0.1.0" }

--- a/contracts/dao-dao-core/schema/dao-dao-core.json
+++ b/contracts/dao-dao-core/schema/dao-dao-core.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-dao-core",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/distribution/cw-fund-distributor/schema/cw-fund-distributor.json
+++ b/contracts/distribution/cw-fund-distributor/schema/cw-fund-distributor.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-fund-distributor",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
+++ b/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
@@ -936,22 +936,8 @@
   "migrate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MigrateMsg",
-    "oneOf": [
-      {
-        "description": "Migrate from v2.5.0",
-        "type": "object",
-        "required": [
-          "from_v250"
-        ],
-        "properties": {
-          "from_v250": {
-            "type": "object",
-            "additionalProperties": false
-          }
-        },
-        "additionalProperties": false
-      }
-    ]
+    "type": "object",
+    "additionalProperties": false
   },
   "sudo": null,
   "responses": {

--- a/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
+++ b/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-rewards-distributor",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -226,6 +226,28 @@
         "additionalProperties": false
       },
       {
+        "description": "forcibly withdraw funds from the contract. this is unsafe and should only be used to recover funds that are stuck in the contract.",
+        "type": "object",
+        "required": [
+          "unsafe_force_withdraw"
+        ],
+        "properties": {
+          "unsafe_force_withdraw": {
+            "type": "object",
+            "required": [
+              "amount"
+            ],
+            "properties": {
+              "amount": {
+                "$ref": "#/definitions/Coin"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
         "required": [
@@ -298,6 +320,21 @@
       "Binary": {
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
+      },
+      "Coin": {
+        "type": "object",
+        "required": [
+          "amount",
+          "denom"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint128"
+          },
+          "denom": {
+            "type": "string"
+          }
+        }
       },
       "CreateMsg": {
         "type": "object",
@@ -899,8 +936,22 @@
   "migrate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MigrateMsg",
-    "type": "object",
-    "additionalProperties": false
+    "oneOf": [
+      {
+        "description": "Migrate from v2.5.0",
+        "type": "object",
+        "required": [
+          "from_v250"
+        ],
+        "properties": {
+          "from_v250": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
   },
   "sudo": null,
   "responses": {

--- a/contracts/distribution/dao-rewards-distributor/src/error.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/error.rs
@@ -1,4 +1,6 @@
-use cosmwasm_std::{DivideByZeroError, OverflowError, StdError};
+use cosmwasm_std::{
+    CheckedFromRatioError, CheckedMultiplyFractionError, DivideByZeroError, OverflowError, StdError,
+};
 use cw_utils::PaymentError;
 use thiserror::Error;
 
@@ -18,6 +20,12 @@ pub enum ContractError {
 
     #[error(transparent)]
     DivideByZero(#[from] DivideByZeroError),
+
+    #[error(transparent)]
+    CheckedFromRatio(#[from] CheckedFromRatioError),
+
+    #[error(transparent)]
+    CheckedMultiplyFraction(#[from] CheckedMultiplyFractionError),
 
     #[error(transparent)]
     Payment(#[from] PaymentError),

--- a/contracts/distribution/dao-rewards-distributor/src/error.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/error.rs
@@ -67,7 +67,7 @@ pub enum ContractError {
     DistributionHistoryTooLarge { err: String },
 
     #[error("Invalid version migration. {new} is not newer than {current}.")]
-    MigrationErrorInvalidVersion { new: String, current: String },
+    MigrationErrorInvalidVersionNotNewer { new: String, current: String },
 
     #[error("Expected to migrate from contract {expected}. Got {actual}.")]
     MigrationErrorIncorrectContract { expected: String, actual: String },

--- a/contracts/distribution/dao-rewards-distributor/src/msg.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Uint128;
+use cosmwasm_std::{Coin, Uint128};
 use cw20::{Cw20ReceiveMsg, Denom, UncheckedDenom};
 use cw4::MemberChangedHookMsg;
 use cw_ownable::cw_ownable_execute;
@@ -60,6 +60,9 @@ pub enum ExecuteMsg {
     /// claim whatever they earned until this point. this is effectively an
     /// inverse to fund and does not affect any already-distributed rewards.
     Withdraw { id: u64 },
+    /// forcibly withdraw funds from the contract. this is unsafe and should
+    /// only be used to recover funds that are stuck in the contract.
+    UnsafeForceWithdraw { amount: Coin },
 }
 
 #[cw_serde]

--- a/contracts/distribution/dao-rewards-distributor/src/rewards.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/rewards.rs
@@ -121,17 +121,13 @@ pub fn get_active_total_earned_puvp(
             if total_power.is_zero() {
                 Ok(curr)
             } else {
-                // count intervals of the rewards emission that have passed
-                // since the last update which need to be distributed
+                // count (partial) intervals of the rewards emission that have
+                // passed since the last update which need to be distributed
                 let complete_distribution_periods =
-                    new_reward_distribution_duration.checked_div(&duration)?;
+                    new_reward_distribution_duration.ratio(&duration)?;
 
-                // It is impossible for this to overflow as total rewards can
-                // never exceed max value of Uint128 as total tokens in
-                // existence cannot exceed Uint128 (because the bank module Coin
-                // type uses Uint128).
-                let new_rewards_distributed = amount
-                    .full_mul(complete_distribution_periods)
+                let new_rewards_distributed = Uint256::from(amount)
+                    .checked_mul_floor(complete_distribution_periods)?
                     .checked_mul(scale_factor())?;
 
                 // the new rewards per unit voting power that have been

--- a/contracts/distribution/dao-rewards-distributor/src/state.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/state.rs
@@ -246,9 +246,9 @@ impl DistributionState {
 
                 // count total intervals of the rewards emission that will pass
                 // based on the start and end times.
-                let complete_distribution_periods = epoch_duration.checked_div(&duration)?;
+                let complete_distribution_periods = epoch_duration.ratio(&duration)?;
 
-                Ok(amount.checked_mul(complete_distribution_periods)?)
+                Ok(amount.checked_mul_floor(complete_distribution_periods)?)
             }
         }
     }

--- a/contracts/distribution/dao-rewards-distributor/src/testing/suite.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/testing/suite.rs
@@ -974,4 +974,32 @@ impl Suite {
             )
             .unwrap();
     }
+
+    pub fn unsafe_force_withdraw(&mut self, amount: Coin) {
+        let msg = ExecuteMsg::UnsafeForceWithdraw { amount };
+        self.base
+            .app
+            .execute_contract(
+                Addr::unchecked(OWNER),
+                self.distribution_contract.clone(),
+                &msg,
+                &[],
+            )
+            .unwrap();
+    }
+
+    pub fn unsafe_force_withdraw_unauthorized(&mut self, amount: Coin) -> ContractError {
+        let msg = ExecuteMsg::UnsafeForceWithdraw { amount };
+        self.base
+            .app
+            .execute_contract(
+                Addr::unchecked("no_one"),
+                self.distribution_contract.clone(),
+                &msg,
+                &[],
+            )
+            .unwrap_err()
+            .downcast()
+            .unwrap()
+    }
 }

--- a/contracts/distribution/dao-rewards-distributor/src/testing/tests.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/testing/tests.rs
@@ -2697,6 +2697,49 @@ fn test_stake_during_interval() {
 }
 
 #[test]
+fn test_stake_on_edges_of_interval() {
+    let mut suite = SuiteBuilder::base(super::suite::DaoType::Native)
+        .with_rewards_config(RewardsConfig {
+            amount: 100,
+            denom: UncheckedDenom::Native(GOV_DENOM.to_string()),
+            duration: Duration::Height(100),
+            destination: None,
+            continuous: true,
+        })
+        .build();
+
+    suite.assert_amount(100);
+    suite.assert_ends_at(Expiration::AtHeight(100_000_000));
+    suite.assert_duration(100);
+
+    // after half the duration, half the rewards (50) should be distributed.
+    suite.skip_blocks(50);
+
+    // MEMBER1 has 50% voting power, so should receive 50% of the rewards.
+    suite.assert_pending_rewards(MEMBER1, 1, 25);
+
+    // after the full duration, all the rewards (50) should be distributed.
+    suite.skip_blocks(50);
+
+    // MEMBER1 has 50% voting power, so should receive 50% of the rewards.
+    suite.assert_pending_rewards(MEMBER1, 1, 50);
+
+    // change voting power right at the end of the distribution interval.
+    // MEMBER1 now has 80% voting power, an increase from 50%.
+    suite.mint_native(coin(300, GOV_DENOM), MEMBER1);
+    suite.stake_native_tokens(MEMBER1, 300);
+
+    // after another interval, they should earn rewards at the increased rate
+    // (50 more tokens, and they own 80% of them). 50 + 40 = 90
+    suite.skip_blocks(50);
+    suite.assert_pending_rewards(MEMBER1, 1, 90);
+
+    // after 50 more blocks from VP change, there are 40 more rewards.
+    suite.skip_blocks(50);
+    suite.assert_pending_rewards(MEMBER1, 1, 130);
+}
+
+#[test]
 fn test_fund_latest_native() {
     let mut suite = SuiteBuilder::base(super::suite::DaoType::Native).build();
 

--- a/contracts/distribution/dao-rewards-distributor/src/testing/tests.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/testing/tests.rs
@@ -2660,6 +2660,43 @@ fn test_large_stake_before_claim() {
 }
 
 #[test]
+fn test_stake_during_interval() {
+    let mut suite = SuiteBuilder::base(super::suite::DaoType::Native)
+        .with_rewards_config(RewardsConfig {
+            amount: 100,
+            denom: UncheckedDenom::Native(GOV_DENOM.to_string()),
+            duration: Duration::Height(100),
+            destination: None,
+            continuous: true,
+        })
+        .build();
+
+    suite.assert_amount(100);
+    suite.assert_ends_at(Expiration::AtHeight(100_000_000));
+    suite.assert_duration(100);
+
+    // after half the duration, half the rewards (50) should be distributed.
+    suite.skip_blocks(50);
+
+    // MEMBER1 has 50% voting power, so should receive 50% of the rewards.
+    suite.assert_pending_rewards(MEMBER1, 1, 25);
+
+    // change voting power before the next distribution interval. MEMBER1 now
+    // has 80% voting power, an increase from 50%.
+    suite.mint_native(coin(300, GOV_DENOM), MEMBER1);
+    suite.stake_native_tokens(MEMBER1, 300);
+
+    // after the rest of the initial duration, they should earn rewards at the
+    // increased rate (50 more tokens, and they own 80% of them). 25 + 40 = 65
+    suite.skip_blocks(50);
+    suite.assert_pending_rewards(MEMBER1, 1, 65);
+
+    // after 50 more blocks from VP change, there are 40 more rewards.
+    suite.skip_blocks(50);
+    suite.assert_pending_rewards(MEMBER1, 1, 105);
+}
+
+#[test]
 fn test_fund_latest_native() {
     let mut suite = SuiteBuilder::base(super::suite::DaoType::Native).build();
 

--- a/contracts/external/btsg-ft-factory/schema/btsg-ft-factory.json
+++ b/contracts/external/btsg-ft-factory/schema/btsg-ft-factory.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "btsg-ft-factory",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
+++ b/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
@@ -9,7 +9,10 @@
     "properties": {
       "admin": {
         "description": "The account allowed to execute this contract. If no admin, anyone can execute it.",
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       }
     },
     "additionalProperties": false
@@ -21,11 +24,17 @@
       {
         "description": "Instantiates the target contract with the provided instantiate message, code ID, and label and updates the contract's admin to be itself.",
         "type": "object",
-        "required": ["instantiate_contract_with_self_admin"],
+        "required": [
+          "instantiate_contract_with_self_admin"
+        ],
         "properties": {
           "instantiate_contract_with_self_admin": {
             "type": "object",
-            "required": ["code_id", "instantiate_msg", "label"],
+            "required": [
+              "code_id",
+              "instantiate_msg",
+              "label"
+            ],
             "properties": {
               "code_id": {
                 "type": "integer",
@@ -47,11 +56,18 @@
       {
         "description": "Instantiates the target contract with the provided instantiate message, code ID, label, and salt, via instantiate2 to give a predictable address, and updates the contract's admin to be itself.",
         "type": "object",
-        "required": ["instantiate2_contract_with_self_admin"],
+        "required": [
+          "instantiate2_contract_with_self_admin"
+        ],
         "properties": {
           "instantiate2_contract_with_self_admin": {
             "type": "object",
-            "required": ["code_id", "instantiate_msg", "label", "salt"],
+            "required": [
+              "code_id",
+              "instantiate_msg",
+              "label",
+              "salt"
+            ],
             "properties": {
               "code_id": {
                 "type": "integer",
@@ -60,7 +76,10 @@
               },
               "expect": {
                 "description": "Optionally specify the expected address and fail if it doesn't match the instantiated contract. This makes it easy for a consumer to validate that they are using the correct address elsewhere.",
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "instantiate_msg": {
                 "$ref": "#/definitions/Binary"
@@ -91,7 +110,9 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["admin"],
+        "required": [
+          "admin"
+        ],
         "properties": {
           "admin": {
             "type": "object",

--- a/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
+++ b/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-admin-factory",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -9,10 +9,7 @@
     "properties": {
       "admin": {
         "description": "The account allowed to execute this contract. If no admin, anyone can execute it.",
-        "type": [
-          "string",
-          "null"
-        ]
+        "type": ["string", "null"]
       }
     },
     "additionalProperties": false
@@ -24,17 +21,11 @@
       {
         "description": "Instantiates the target contract with the provided instantiate message, code ID, and label and updates the contract's admin to be itself.",
         "type": "object",
-        "required": [
-          "instantiate_contract_with_self_admin"
-        ],
+        "required": ["instantiate_contract_with_self_admin"],
         "properties": {
           "instantiate_contract_with_self_admin": {
             "type": "object",
-            "required": [
-              "code_id",
-              "instantiate_msg",
-              "label"
-            ],
+            "required": ["code_id", "instantiate_msg", "label"],
             "properties": {
               "code_id": {
                 "type": "integer",
@@ -56,18 +47,11 @@
       {
         "description": "Instantiates the target contract with the provided instantiate message, code ID, label, and salt, via instantiate2 to give a predictable address, and updates the contract's admin to be itself.",
         "type": "object",
-        "required": [
-          "instantiate2_contract_with_self_admin"
-        ],
+        "required": ["instantiate2_contract_with_self_admin"],
         "properties": {
           "instantiate2_contract_with_self_admin": {
             "type": "object",
-            "required": [
-              "code_id",
-              "instantiate_msg",
-              "label",
-              "salt"
-            ],
+            "required": ["code_id", "instantiate_msg", "label", "salt"],
             "properties": {
               "code_id": {
                 "type": "integer",
@@ -76,10 +60,7 @@
               },
               "expect": {
                 "description": "Optionally specify the expected address and fail if it doesn't match the instantiated contract. This makes it easy for a consumer to validate that they are using the correct address elsewhere.",
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               },
               "instantiate_msg": {
                 "$ref": "#/definitions/Binary"
@@ -110,9 +91,7 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "admin"
-        ],
+        "required": ["admin"],
         "properties": {
           "admin": {
             "type": "object",

--- a/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
+++ b/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
@@ -6,10 +6,15 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["vesting_code_id"],
+    "required": [
+      "vesting_code_id"
+    ],
     "properties": {
       "owner": {
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "vesting_code_id": {
         "type": "integer",
@@ -26,7 +31,9 @@
       {
         "description": "Instantiates a new vesting contract that is funded by a cw20 token.",
         "type": "object",
-        "required": ["receive"],
+        "required": [
+          "receive"
+        ],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -37,11 +44,16 @@
       {
         "description": "Instantiates a new vesting contract that is funded by a native token.",
         "type": "object",
-        "required": ["instantiate_native_payroll_contract"],
+        "required": [
+          "instantiate_native_payroll_contract"
+        ],
         "properties": {
           "instantiate_native_payroll_contract": {
             "type": "object",
-            "required": ["instantiate_msg", "label"],
+            "required": [
+              "instantiate_msg",
+              "label"
+            ],
             "properties": {
               "instantiate_msg": {
                 "$ref": "#/definitions/InstantiateMsg"
@@ -58,11 +70,15 @@
       {
         "description": "Callable only by the current owner. Updates the code ID used while instantiating vesting contracts.",
         "type": "object",
-        "required": ["update_code_id"],
+        "required": [
+          "update_code_id"
+        ],
         "properties": {
           "update_code_id": {
             "type": "object",
-            "required": ["vesting_code_id"],
+            "required": [
+              "vesting_code_id"
+            ],
             "properties": {
               "vesting_code_id": {
                 "type": "integer",
@@ -78,7 +94,9 @@
       {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": ["update_ownership"],
+        "required": [
+          "update_ownership"
+        ],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -94,11 +112,15 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": ["transfer_ownership"],
+            "required": [
+              "transfer_ownership"
+            ],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": ["new_owner"],
+                "required": [
+                  "new_owner"
+                ],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -122,12 +144,16 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": ["accept_ownership"]
+            "enum": [
+              "accept_ownership"
+            ]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": ["renounce_ownership"]
+            "enum": [
+              "renounce_ownership"
+            ]
           }
         ]
       },
@@ -138,7 +164,11 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": ["amount", "msg", "sender"],
+        "required": [
+          "amount",
+          "msg",
+          "sender"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -158,7 +188,9 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": ["at_height"],
+            "required": [
+              "at_height"
+            ],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -171,7 +203,9 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": ["at_time"],
+            "required": [
+              "at_time"
+            ],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -182,7 +216,9 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": ["never"],
+            "required": [
+              "never"
+            ],
             "properties": {
               "never": {
                 "type": "object",
@@ -215,11 +251,17 @@
           },
           "description": {
             "description": "A description for the payment to provide more context.",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "owner": {
             "description": "The optional owner address of the contract. If an owner is specified, the owner may cancel the vesting contract at any time and withdraw unvested funds.",
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "recipient": {
             "description": "The receiver address of the vesting tokens.",
@@ -276,12 +318,16 @@
           {
             "description": "Vests linearally from `0` to `total`.",
             "type": "string",
-            "enum": ["saturating_linear"]
+            "enum": [
+              "saturating_linear"
+            ]
           },
           {
             "description": "Vests by linearally interpolating between the provided (seconds, amount) points. The first amount must be zero and the last amount the total vesting amount. `seconds` are seconds since the vest start time.\n\nThere is a problem in the underlying Curve library that doesn't allow zero start values, so the first value of `seconds` must be > 1. To start at a particular time (if you need that level of percision), subtract one from the true start time, and make the first `seconds` value `1`.\n\n<https://github.com/cosmorama/wynddao/pull/4>",
             "type": "object",
-            "required": ["piecewise_linear"],
+            "required": [
+              "piecewise_linear"
+            ],
             "properties": {
               "piecewise_linear": {
                 "type": "array",
@@ -328,7 +374,9 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": ["native"],
+            "required": [
+              "native"
+            ],
             "properties": {
               "native": {
                 "type": "string"
@@ -339,7 +387,9 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": ["cw20"],
+            "required": [
+              "cw20"
+            ],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -358,18 +408,26 @@
       {
         "description": "Returns list of all vesting payment contracts",
         "type": "object",
-        "required": ["list_vesting_contracts"],
+        "required": [
+          "list_vesting_contracts"
+        ],
         "properties": {
           "list_vesting_contracts": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -380,18 +438,26 @@
       {
         "description": "Returns list of all vesting payment contracts in reverse",
         "type": "object",
-        "required": ["list_vesting_contracts_reverse"],
+        "required": [
+          "list_vesting_contracts_reverse"
+        ],
         "properties": {
           "list_vesting_contracts_reverse": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_before": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -402,22 +468,32 @@
       {
         "description": "Returns list of all vesting payment contracts by who instantiated them",
         "type": "object",
-        "required": ["list_vesting_contracts_by_instantiator"],
+        "required": [
+          "list_vesting_contracts_by_instantiator"
+        ],
         "properties": {
           "list_vesting_contracts_by_instantiator": {
             "type": "object",
-            "required": ["instantiator"],
+            "required": [
+              "instantiator"
+            ],
             "properties": {
               "instantiator": {
                 "type": "string"
               },
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -428,22 +504,32 @@
       {
         "description": "Returns list of all vesting payment contracts by who instantiated them in reverse",
         "type": "object",
-        "required": ["list_vesting_contracts_by_instantiator_reverse"],
+        "required": [
+          "list_vesting_contracts_by_instantiator_reverse"
+        ],
         "properties": {
           "list_vesting_contracts_by_instantiator_reverse": {
             "type": "object",
-            "required": ["instantiator"],
+            "required": [
+              "instantiator"
+            ],
             "properties": {
               "instantiator": {
                 "type": "string"
               },
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_before": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -454,14 +540,21 @@
       {
         "description": "Returns list of all vesting payment contracts by recipient",
         "type": "object",
-        "required": ["list_vesting_contracts_by_recipient"],
+        "required": [
+          "list_vesting_contracts_by_recipient"
+        ],
         "properties": {
           "list_vesting_contracts_by_recipient": {
             "type": "object",
-            "required": ["recipient"],
+            "required": [
+              "recipient"
+            ],
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
@@ -469,7 +562,10 @@
                 "type": "string"
               },
               "start_after": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -480,14 +576,21 @@
       {
         "description": "Returns list of all vesting payment contracts by recipient in reverse",
         "type": "object",
-        "required": ["list_vesting_contracts_by_recipient_reverse"],
+        "required": [
+          "list_vesting_contracts_by_recipient_reverse"
+        ],
         "properties": {
           "list_vesting_contracts_by_recipient_reverse": {
             "type": "object",
-            "required": ["recipient"],
+            "required": [
+              "recipient"
+            ],
             "properties": {
               "limit": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "format": "uint32",
                 "minimum": 0.0
               },
@@ -495,7 +598,10 @@
                 "type": "string"
               },
               "start_before": {
-                "type": ["string", "null"]
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -506,7 +612,9 @@
       {
         "description": "Returns info about the contract ownership, if set",
         "type": "object",
-        "required": ["ownership"],
+        "required": [
+          "ownership"
+        ],
         "properties": {
           "ownership": {
             "type": "object",
@@ -518,7 +626,9 @@
       {
         "description": "Returns the code ID currently being used to instantiate vesting contracts.",
         "type": "object",
-        "required": ["code_id"],
+        "required": [
+          "code_id"
+        ],
         "properties": {
           "code_id": {
             "type": "object",
@@ -549,7 +659,11 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": ["contract", "instantiator", "recipient"],
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
           "properties": {
             "contract": {
               "type": "string"
@@ -575,7 +689,11 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": ["contract", "instantiator", "recipient"],
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
           "properties": {
             "contract": {
               "type": "string"
@@ -601,7 +719,11 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": ["contract", "instantiator", "recipient"],
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
           "properties": {
             "contract": {
               "type": "string"
@@ -627,7 +749,11 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": ["contract", "instantiator", "recipient"],
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
           "properties": {
             "contract": {
               "type": "string"
@@ -653,7 +779,11 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": ["contract", "instantiator", "recipient"],
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
           "properties": {
             "contract": {
               "type": "string"
@@ -679,7 +809,11 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": ["contract", "instantiator", "recipient"],
+          "required": [
+            "contract",
+            "instantiator",
+            "recipient"
+          ],
           "properties": {
             "contract": {
               "type": "string"
@@ -747,7 +881,9 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": ["at_height"],
+              "required": [
+                "at_height"
+              ],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -760,7 +896,9 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": ["at_time"],
+              "required": [
+                "at_time"
+              ],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -771,7 +909,9 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": ["never"],
+              "required": [
+                "never"
+              ],
               "properties": {
                 "never": {
                   "type": "object",

--- a/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
+++ b/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
@@ -1,20 +1,15 @@
 {
   "contract_name": "cw-payroll-factory",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "vesting_code_id"
-    ],
+    "required": ["vesting_code_id"],
     "properties": {
       "owner": {
-        "type": [
-          "string",
-          "null"
-        ]
+        "type": ["string", "null"]
       },
       "vesting_code_id": {
         "type": "integer",
@@ -31,9 +26,7 @@
       {
         "description": "Instantiates a new vesting contract that is funded by a cw20 token.",
         "type": "object",
-        "required": [
-          "receive"
-        ],
+        "required": ["receive"],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -44,16 +37,11 @@
       {
         "description": "Instantiates a new vesting contract that is funded by a native token.",
         "type": "object",
-        "required": [
-          "instantiate_native_payroll_contract"
-        ],
+        "required": ["instantiate_native_payroll_contract"],
         "properties": {
           "instantiate_native_payroll_contract": {
             "type": "object",
-            "required": [
-              "instantiate_msg",
-              "label"
-            ],
+            "required": ["instantiate_msg", "label"],
             "properties": {
               "instantiate_msg": {
                 "$ref": "#/definitions/InstantiateMsg"
@@ -70,15 +58,11 @@
       {
         "description": "Callable only by the current owner. Updates the code ID used while instantiating vesting contracts.",
         "type": "object",
-        "required": [
-          "update_code_id"
-        ],
+        "required": ["update_code_id"],
         "properties": {
           "update_code_id": {
             "type": "object",
-            "required": [
-              "vesting_code_id"
-            ],
+            "required": ["vesting_code_id"],
             "properties": {
               "vesting_code_id": {
                 "type": "integer",
@@ -94,9 +78,7 @@
       {
         "description": "Update the contract's ownership. The `action` to be provided can be either to propose transferring ownership to an account, accept a pending ownership transfer, or renounce the ownership permanently.",
         "type": "object",
-        "required": [
-          "update_ownership"
-        ],
+        "required": ["update_ownership"],
         "properties": {
           "update_ownership": {
             "$ref": "#/definitions/Action"
@@ -112,15 +94,11 @@
           {
             "description": "Propose to transfer the contract's ownership to another account, optionally with an expiry time.\n\nCan only be called by the contract's current owner.\n\nAny existing pending ownership transfer is overwritten.",
             "type": "object",
-            "required": [
-              "transfer_ownership"
-            ],
+            "required": ["transfer_ownership"],
             "properties": {
               "transfer_ownership": {
                 "type": "object",
-                "required": [
-                  "new_owner"
-                ],
+                "required": ["new_owner"],
                 "properties": {
                   "expiry": {
                     "anyOf": [
@@ -144,16 +122,12 @@
           {
             "description": "Accept the pending ownership transfer.\n\nCan only be called by the pending owner.",
             "type": "string",
-            "enum": [
-              "accept_ownership"
-            ]
+            "enum": ["accept_ownership"]
           },
           {
             "description": "Give up the contract's ownership and the possibility of appointing a new owner.\n\nCan only be invoked by the contract's current owner.\n\nAny existing pending ownership transfer is canceled.",
             "type": "string",
-            "enum": [
-              "renounce_ownership"
-            ]
+            "enum": ["renounce_ownership"]
           }
         ]
       },
@@ -164,11 +138,7 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": [
-          "amount",
-          "msg",
-          "sender"
-        ],
+        "required": ["amount", "msg", "sender"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -188,9 +158,7 @@
           {
             "description": "AtHeight will expire when `env.block.height` >= height",
             "type": "object",
-            "required": [
-              "at_height"
-            ],
+            "required": ["at_height"],
             "properties": {
               "at_height": {
                 "type": "integer",
@@ -203,9 +171,7 @@
           {
             "description": "AtTime will expire when `env.block.time` >= time",
             "type": "object",
-            "required": [
-              "at_time"
-            ],
+            "required": ["at_time"],
             "properties": {
               "at_time": {
                 "$ref": "#/definitions/Timestamp"
@@ -216,9 +182,7 @@
           {
             "description": "Never will never expire. Used to express the empty variant",
             "type": "object",
-            "required": [
-              "never"
-            ],
+            "required": ["never"],
             "properties": {
               "never": {
                 "type": "object",
@@ -251,17 +215,11 @@
           },
           "description": {
             "description": "A description for the payment to provide more context.",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "owner": {
             "description": "The optional owner address of the contract. If an owner is specified, the owner may cancel the vesting contract at any time and withdraw unvested funds.",
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "recipient": {
             "description": "The receiver address of the vesting tokens.",
@@ -318,16 +276,12 @@
           {
             "description": "Vests linearally from `0` to `total`.",
             "type": "string",
-            "enum": [
-              "saturating_linear"
-            ]
+            "enum": ["saturating_linear"]
           },
           {
             "description": "Vests by linearally interpolating between the provided (seconds, amount) points. The first amount must be zero and the last amount the total vesting amount. `seconds` are seconds since the vest start time.\n\nThere is a problem in the underlying Curve library that doesn't allow zero start values, so the first value of `seconds` must be > 1. To start at a particular time (if you need that level of percision), subtract one from the true start time, and make the first `seconds` value `1`.\n\n<https://github.com/cosmorama/wynddao/pull/4>",
             "type": "object",
-            "required": [
-              "piecewise_linear"
-            ],
+            "required": ["piecewise_linear"],
             "properties": {
               "piecewise_linear": {
                 "type": "array",
@@ -374,9 +328,7 @@
           {
             "description": "A native (bank module) asset.",
             "type": "object",
-            "required": [
-              "native"
-            ],
+            "required": ["native"],
             "properties": {
               "native": {
                 "type": "string"
@@ -387,9 +339,7 @@
           {
             "description": "A cw20 asset.",
             "type": "object",
-            "required": [
-              "cw20"
-            ],
+            "required": ["cw20"],
             "properties": {
               "cw20": {
                 "type": "string"
@@ -408,26 +358,18 @@
       {
         "description": "Returns list of all vesting payment contracts",
         "type": "object",
-        "required": [
-          "list_vesting_contracts"
-        ],
+        "required": ["list_vesting_contracts"],
         "properties": {
           "list_vesting_contracts": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -438,26 +380,18 @@
       {
         "description": "Returns list of all vesting payment contracts in reverse",
         "type": "object",
-        "required": [
-          "list_vesting_contracts_reverse"
-        ],
+        "required": ["list_vesting_contracts_reverse"],
         "properties": {
           "list_vesting_contracts_reverse": {
             "type": "object",
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_before": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -468,32 +402,22 @@
       {
         "description": "Returns list of all vesting payment contracts by who instantiated them",
         "type": "object",
-        "required": [
-          "list_vesting_contracts_by_instantiator"
-        ],
+        "required": ["list_vesting_contracts_by_instantiator"],
         "properties": {
           "list_vesting_contracts_by_instantiator": {
             "type": "object",
-            "required": [
-              "instantiator"
-            ],
+            "required": ["instantiator"],
             "properties": {
               "instantiator": {
                 "type": "string"
               },
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -504,32 +428,22 @@
       {
         "description": "Returns list of all vesting payment contracts by who instantiated them in reverse",
         "type": "object",
-        "required": [
-          "list_vesting_contracts_by_instantiator_reverse"
-        ],
+        "required": ["list_vesting_contracts_by_instantiator_reverse"],
         "properties": {
           "list_vesting_contracts_by_instantiator_reverse": {
             "type": "object",
-            "required": [
-              "instantiator"
-            ],
+            "required": ["instantiator"],
             "properties": {
               "instantiator": {
                 "type": "string"
               },
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
               "start_before": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -540,21 +454,14 @@
       {
         "description": "Returns list of all vesting payment contracts by recipient",
         "type": "object",
-        "required": [
-          "list_vesting_contracts_by_recipient"
-        ],
+        "required": ["list_vesting_contracts_by_recipient"],
         "properties": {
           "list_vesting_contracts_by_recipient": {
             "type": "object",
-            "required": [
-              "recipient"
-            ],
+            "required": ["recipient"],
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
@@ -562,10 +469,7 @@
                 "type": "string"
               },
               "start_after": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -576,21 +480,14 @@
       {
         "description": "Returns list of all vesting payment contracts by recipient in reverse",
         "type": "object",
-        "required": [
-          "list_vesting_contracts_by_recipient_reverse"
-        ],
+        "required": ["list_vesting_contracts_by_recipient_reverse"],
         "properties": {
           "list_vesting_contracts_by_recipient_reverse": {
             "type": "object",
-            "required": [
-              "recipient"
-            ],
+            "required": ["recipient"],
             "properties": {
               "limit": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
+                "type": ["integer", "null"],
                 "format": "uint32",
                 "minimum": 0.0
               },
@@ -598,10 +495,7 @@
                 "type": "string"
               },
               "start_before": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+                "type": ["string", "null"]
               }
             },
             "additionalProperties": false
@@ -612,9 +506,7 @@
       {
         "description": "Returns info about the contract ownership, if set",
         "type": "object",
-        "required": [
-          "ownership"
-        ],
+        "required": ["ownership"],
         "properties": {
           "ownership": {
             "type": "object",
@@ -626,9 +518,7 @@
       {
         "description": "Returns the code ID currently being used to instantiate vesting contracts.",
         "type": "object",
-        "required": [
-          "code_id"
-        ],
+        "required": ["code_id"],
         "properties": {
           "code_id": {
             "type": "object",
@@ -659,11 +549,7 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": [
-            "contract",
-            "instantiator",
-            "recipient"
-          ],
+          "required": ["contract", "instantiator", "recipient"],
           "properties": {
             "contract": {
               "type": "string"
@@ -689,11 +575,7 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": [
-            "contract",
-            "instantiator",
-            "recipient"
-          ],
+          "required": ["contract", "instantiator", "recipient"],
           "properties": {
             "contract": {
               "type": "string"
@@ -719,11 +601,7 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": [
-            "contract",
-            "instantiator",
-            "recipient"
-          ],
+          "required": ["contract", "instantiator", "recipient"],
           "properties": {
             "contract": {
               "type": "string"
@@ -749,11 +627,7 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": [
-            "contract",
-            "instantiator",
-            "recipient"
-          ],
+          "required": ["contract", "instantiator", "recipient"],
           "properties": {
             "contract": {
               "type": "string"
@@ -779,11 +653,7 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": [
-            "contract",
-            "instantiator",
-            "recipient"
-          ],
+          "required": ["contract", "instantiator", "recipient"],
           "properties": {
             "contract": {
               "type": "string"
@@ -809,11 +679,7 @@
       "definitions": {
         "VestingContract": {
           "type": "object",
-          "required": [
-            "contract",
-            "instantiator",
-            "recipient"
-          ],
+          "required": ["contract", "instantiator", "recipient"],
           "properties": {
             "contract": {
               "type": "string"
@@ -881,9 +747,7 @@
             {
               "description": "AtHeight will expire when `env.block.height` >= height",
               "type": "object",
-              "required": [
-                "at_height"
-              ],
+              "required": ["at_height"],
               "properties": {
                 "at_height": {
                   "type": "integer",
@@ -896,9 +760,7 @@
             {
               "description": "AtTime will expire when `env.block.time` >= time",
               "type": "object",
-              "required": [
-                "at_time"
-              ],
+              "required": ["at_time"],
               "properties": {
                 "at_time": {
                   "$ref": "#/definitions/Timestamp"
@@ -909,9 +771,7 @@
             {
               "description": "Never will never expire. Used to express the empty variant",
               "type": "object",
-              "required": [
-                "never"
-              ],
+              "required": ["never"],
               "properties": {
                 "never": {
                   "type": "object",

--- a/contracts/external/cw-token-swap/schema/cw-token-swap.json
+++ b/contracts/external/cw-token-swap/schema/cw-token-swap.json
@@ -6,7 +6,10 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": ["counterparty_one", "counterparty_two"],
+    "required": [
+      "counterparty_one",
+      "counterparty_two"
+    ],
     "properties": {
       "counterparty_one": {
         "$ref": "#/definitions/Counterparty"
@@ -20,7 +23,10 @@
       "Counterparty": {
         "description": "Information about a counterparty in this escrow transaction and their promised funds.",
         "type": "object",
-        "required": ["address", "promise"],
+        "required": [
+          "address",
+          "promise"
+        ],
         "properties": {
           "address": {
             "description": "The address of the counterparty.",
@@ -43,11 +49,16 @@
           {
             "description": "A native token.",
             "type": "object",
-            "required": ["native"],
+            "required": [
+              "native"
+            ],
             "properties": {
               "native": {
                 "type": "object",
-                "required": ["amount", "denom"],
+                "required": [
+                  "amount",
+                  "denom"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Uint128"
@@ -64,11 +75,16 @@
           {
             "description": "A cw20 token.",
             "type": "object",
-            "required": ["cw20"],
+            "required": [
+              "cw20"
+            ],
             "properties": {
               "cw20": {
                 "type": "object",
-                "required": ["amount", "contract_addr"],
+                "required": [
+                  "amount",
+                  "contract_addr"
+                ],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Uint128"
@@ -97,7 +113,9 @@
       {
         "description": "Used to provide cw20 tokens to satisfy a funds promise.",
         "type": "object",
-        "required": ["receive"],
+        "required": [
+          "receive"
+        ],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -108,7 +126,9 @@
       {
         "description": "Provides native tokens to satisfy a funds promise.",
         "type": "object",
-        "required": ["fund"],
+        "required": [
+          "fund"
+        ],
         "properties": {
           "fund": {
             "type": "object",
@@ -120,7 +140,9 @@
       {
         "description": "Withdraws provided funds. Only allowed if the other counterparty has yet to provide their promised funds.",
         "type": "object",
-        "required": ["withdraw"],
+        "required": [
+          "withdraw"
+        ],
         "properties": {
           "withdraw": {
             "type": "object",
@@ -138,7 +160,11 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": ["amount", "msg", "sender"],
+        "required": [
+          "amount",
+          "msg",
+          "sender"
+        ],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -164,7 +190,9 @@
     "oneOf": [
       {
         "type": "object",
-        "required": ["status"],
+        "required": [
+          "status"
+        ],
         "properties": {
           "status": {
             "type": "object",
@@ -187,7 +215,10 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "StatusResponse",
       "type": "object",
-      "required": ["counterparty_one", "counterparty_two"],
+      "required": [
+        "counterparty_one",
+        "counterparty_two"
+      ],
       "properties": {
         "counterparty_one": {
           "$ref": "#/definitions/CheckedCounterparty"
@@ -204,7 +235,11 @@
         },
         "CheckedCounterparty": {
           "type": "object",
-          "required": ["address", "promise", "provided"],
+          "required": [
+            "address",
+            "promise",
+            "provided"
+          ],
           "properties": {
             "address": {
               "$ref": "#/definitions/Addr"
@@ -222,11 +257,16 @@
           "oneOf": [
             {
               "type": "object",
-              "required": ["native"],
+              "required": [
+                "native"
+              ],
               "properties": {
                 "native": {
                   "type": "object",
-                  "required": ["amount", "denom"],
+                  "required": [
+                    "amount",
+                    "denom"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Uint128"
@@ -242,11 +282,16 @@
             },
             {
               "type": "object",
-              "required": ["cw20"],
+              "required": [
+                "cw20"
+              ],
               "properties": {
                 "cw20": {
                   "type": "object",
-                  "required": ["amount", "contract_addr"],
+                  "required": [
+                    "amount",
+                    "contract_addr"
+                  ],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Uint128"

--- a/contracts/external/cw-token-swap/schema/cw-token-swap.json
+++ b/contracts/external/cw-token-swap/schema/cw-token-swap.json
@@ -1,15 +1,12 @@
 {
   "contract_name": "cw-token-swap",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "InstantiateMsg",
     "type": "object",
-    "required": [
-      "counterparty_one",
-      "counterparty_two"
-    ],
+    "required": ["counterparty_one", "counterparty_two"],
     "properties": {
       "counterparty_one": {
         "$ref": "#/definitions/Counterparty"
@@ -23,10 +20,7 @@
       "Counterparty": {
         "description": "Information about a counterparty in this escrow transaction and their promised funds.",
         "type": "object",
-        "required": [
-          "address",
-          "promise"
-        ],
+        "required": ["address", "promise"],
         "properties": {
           "address": {
             "description": "The address of the counterparty.",
@@ -49,16 +43,11 @@
           {
             "description": "A native token.",
             "type": "object",
-            "required": [
-              "native"
-            ],
+            "required": ["native"],
             "properties": {
               "native": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "denom"
-                ],
+                "required": ["amount", "denom"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Uint128"
@@ -75,16 +64,11 @@
           {
             "description": "A cw20 token.",
             "type": "object",
-            "required": [
-              "cw20"
-            ],
+            "required": ["cw20"],
             "properties": {
               "cw20": {
                 "type": "object",
-                "required": [
-                  "amount",
-                  "contract_addr"
-                ],
+                "required": ["amount", "contract_addr"],
                 "properties": {
                   "amount": {
                     "$ref": "#/definitions/Uint128"
@@ -113,9 +97,7 @@
       {
         "description": "Used to provide cw20 tokens to satisfy a funds promise.",
         "type": "object",
-        "required": [
-          "receive"
-        ],
+        "required": ["receive"],
         "properties": {
           "receive": {
             "$ref": "#/definitions/Cw20ReceiveMsg"
@@ -126,9 +108,7 @@
       {
         "description": "Provides native tokens to satisfy a funds promise.",
         "type": "object",
-        "required": [
-          "fund"
-        ],
+        "required": ["fund"],
         "properties": {
           "fund": {
             "type": "object",
@@ -140,9 +120,7 @@
       {
         "description": "Withdraws provided funds. Only allowed if the other counterparty has yet to provide their promised funds.",
         "type": "object",
-        "required": [
-          "withdraw"
-        ],
+        "required": ["withdraw"],
         "properties": {
           "withdraw": {
             "type": "object",
@@ -160,11 +138,7 @@
       "Cw20ReceiveMsg": {
         "description": "Cw20ReceiveMsg should be de/serialized under `Receive()` variant in a ExecuteMsg",
         "type": "object",
-        "required": [
-          "amount",
-          "msg",
-          "sender"
-        ],
+        "required": ["amount", "msg", "sender"],
         "properties": {
           "amount": {
             "$ref": "#/definitions/Uint128"
@@ -190,9 +164,7 @@
     "oneOf": [
       {
         "type": "object",
-        "required": [
-          "status"
-        ],
+        "required": ["status"],
         "properties": {
           "status": {
             "type": "object",
@@ -215,10 +187,7 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "StatusResponse",
       "type": "object",
-      "required": [
-        "counterparty_one",
-        "counterparty_two"
-      ],
+      "required": ["counterparty_one", "counterparty_two"],
       "properties": {
         "counterparty_one": {
           "$ref": "#/definitions/CheckedCounterparty"
@@ -235,11 +204,7 @@
         },
         "CheckedCounterparty": {
           "type": "object",
-          "required": [
-            "address",
-            "promise",
-            "provided"
-          ],
+          "required": ["address", "promise", "provided"],
           "properties": {
             "address": {
               "$ref": "#/definitions/Addr"
@@ -257,16 +222,11 @@
           "oneOf": [
             {
               "type": "object",
-              "required": [
-                "native"
-              ],
+              "required": ["native"],
               "properties": {
                 "native": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "denom"
-                  ],
+                  "required": ["amount", "denom"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Uint128"
@@ -282,16 +242,11 @@
             },
             {
               "type": "object",
-              "required": [
-                "cw20"
-              ],
+              "required": ["cw20"],
               "properties": {
                 "cw20": {
                   "type": "object",
-                  "required": [
-                    "amount",
-                    "contract_addr"
-                  ],
+                  "required": ["amount", "contract_addr"],
                   "properties": {
                     "amount": {
                       "$ref": "#/definitions/Uint128"

--- a/contracts/external/cw-tokenfactory-issuer/schema/cw-tokenfactory-issuer.json
+++ b/contracts/external/cw-tokenfactory-issuer/schema/cw-tokenfactory-issuer.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-tokenfactory-issuer",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-vesting/schema/cw-vesting.json
+++ b/contracts/external/cw-vesting/schema/cw-vesting.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-vesting",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw721-roles/schema/cw721-roles.json
+++ b/contracts/external/cw721-roles/schema/cw721-roles.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw721-roles",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/dao-migrator/schema/dao-migrator.json
+++ b/contracts/external/dao-migrator/schema/dao-migrator.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-migrator",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-approval-single",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
+++ b/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-approver",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-multiple",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
+++ b/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-single",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
+++ b/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-condorcet",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
+++ b/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-multiple",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
+++ b/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-single",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/staking/cw20-stake-external-rewards/schema/cw20-stake-external-rewards.json
+++ b/contracts/staking/cw20-stake-external-rewards/schema/cw20-stake-external-rewards.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw20-stake-external-rewards",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/staking/cw20-stake-reward-distributor/schema/cw20-stake-reward-distributor.json
+++ b/contracts/staking/cw20-stake-reward-distributor/schema/cw20-stake-reward-distributor.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw20-stake-reward-distributor",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/staking/cw20-stake/schema/cw20-stake.json
+++ b/contracts/staking/cw20-stake/schema/cw20-stake.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw20-stake",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw20-staked/schema/dao-voting-cw20-staked.json
+++ b/contracts/voting/dao-voting-cw20-staked/schema/dao-voting-cw20-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw20-staked",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw4/schema/dao-voting-cw4.json
+++ b/contracts/voting/dao-voting-cw4/schema/dao-voting-cw4.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw4",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw721-roles/schema/dao-voting-cw721-roles.json
+++ b/contracts/voting/dao-voting-cw721-roles/schema/dao-voting-cw721-roles.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw721-roles",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw721-staked/schema/dao-voting-cw721-staked.json
+++ b/contracts/voting/dao-voting-cw721-staked/schema/dao-voting-cw721-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw721-staked",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-onft-staked/schema/dao-voting-onft-staked.json
+++ b/contracts/voting/dao-voting-onft-staked/schema/dao-voting-onft-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-onft-staked",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-token-staked/schema/dao-voting-token-staked.json
+++ b/contracts/voting/dao-voting-token-staked/schema/dao-voting-token-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-token-staked",
-  "contract_version": "2.5.0",
+  "contract_version": "2.5.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
the reward distribution contract currently suffers a bug where reward distribution intervals are delayed each time a voting power change occurs.

this is due to the fact that integer division is used to make it so that only increments of the linear emission rate duration are distributed. when a voting power change occurs before one interval has passed, it calculates 0 new rewards distributed and updates the last updated timestamp, which effectively restarts the interval timer.

for example, if you distribute 100 tokens per hour:
- at minute 0, timer starts counting
- at minute 30, member stakes more tokens, and timer restarts
- at minute 60, nothing happens
- at minute 90, first distribution occurs

this PR fixes it so that it uses decimal math when counting the intervals that have passed since the last update in order to update the rewards distributed.

this also adds a force withdraw execution message to allow the contract owner to recover locked funds, since the delayed funds are likely stuck in the contract.

## recover delayed/locked rewards

i think the ideal way to remedy this is:

- pause all distributions
- withdraw all undistributed funds from the distributions
- upgrade the contract to fix the partial-interval distribution and add the force withdraw message
- calculate the missed rewards by looking at what's left over in the contract and then looping through everyone's pending rewards and subtracting those from the left over amounts
- force withdraw that unaccounted for amount, leaving all pending rewards that were successfully distributed intact
- restart the distributions and fund them again

this way the state should be reset to account for the pending rewards that were allegedly distributed, and you can manually withdraw any funds beyond that amount before restarting and refunding.