### PR TITLE
fixed unsafe force withdraw to support native and cw20 tokens

### DIFF
--- a/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
+++ b/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
@@ -235,11 +235,25 @@
           "unsafe_force_withdraw": {
             "type": "object",
             "required": [
-              "amount"
+              "amount",
+              "denom"
             ],
             "properties": {
               "amount": {
-                "$ref": "#/definitions/Coin"
+                "description": "amount to withdraw",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/Uint128"
+                  }
+                ]
+              },
+              "denom": {
+                "description": "denom to withdraw",
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/UncheckedDenom"
+                  }
+                ]
               }
             },
             "additionalProperties": false
@@ -320,21 +334,6 @@
       "Binary": {
         "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
         "type": "string"
-      },
-      "Coin": {
-        "type": "object",
-        "required": [
-          "amount",
-          "denom"
-        ],
-        "properties": {
-          "amount": {
-            "$ref": "#/definitions/Uint128"
-          },
-          "denom": {
-            "type": "string"
-          }
-        }
       },
       "CreateMsg": {
         "type": "object",

--- a/contracts/distribution/dao-rewards-distributor/src/msg.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/msg.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Coin, Uint128};
+use cosmwasm_std::Uint128;
 use cw20::{Cw20ReceiveMsg, Denom, UncheckedDenom};
 use cw4::MemberChangedHookMsg;
 use cw_ownable::cw_ownable_execute;
@@ -62,7 +62,12 @@ pub enum ExecuteMsg {
     Withdraw { id: u64 },
     /// forcibly withdraw funds from the contract. this is unsafe and should
     /// only be used to recover funds that are stuck in the contract.
-    UnsafeForceWithdraw { amount: Coin },
+    UnsafeForceWithdraw {
+        /// amount to withdraw
+        amount: Uint128,
+        /// denom to withdraw
+        denom: UncheckedDenom,
+    },
 }
 
 #[cw_serde]

--- a/contracts/distribution/dao-rewards-distributor/src/testing/suite.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/testing/suite.rs
@@ -975,8 +975,11 @@ impl Suite {
             .unwrap();
     }
 
-    pub fn unsafe_force_withdraw(&mut self, amount: Coin) {
-        let msg = ExecuteMsg::UnsafeForceWithdraw { amount };
+    pub fn unsafe_force_withdraw(&mut self, amount: impl Into<Uint128>, denom: UncheckedDenom) {
+        let msg = ExecuteMsg::UnsafeForceWithdraw {
+            amount: amount.into(),
+            denom,
+        };
         self.base
             .app
             .execute_contract(
@@ -988,8 +991,15 @@ impl Suite {
             .unwrap();
     }
 
-    pub fn unsafe_force_withdraw_unauthorized(&mut self, amount: Coin) -> ContractError {
-        let msg = ExecuteMsg::UnsafeForceWithdraw { amount };
+    pub fn unsafe_force_withdraw_unauthorized(
+        &mut self,
+        amount: impl Into<Uint128>,
+        denom: UncheckedDenom,
+    ) -> ContractError {
+        let msg = ExecuteMsg::UnsafeForceWithdraw {
+            amount: amount.into(),
+            denom,
+        };
         self.base
             .app
             .execute_contract(

--- a/contracts/distribution/dao-rewards-distributor/src/testing/tests.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/testing/tests.rs
@@ -2997,7 +2997,10 @@ fn test_unsafe_force_withdraw() {
         suite.get_balance_native(suite.distribution_contract.clone(), &suite.reward_denom);
 
     // non-owner cannot force withdraw
-    let err = suite.unsafe_force_withdraw_unauthorized(coin(100, &suite.reward_denom));
+    let err = suite.unsafe_force_withdraw_unauthorized(
+        100u128,
+        UncheckedDenom::Native(suite.reward_denom.clone()),
+    );
     assert_eq!(err, ContractError::Ownable(OwnershipError::NotOwner));
 
     let after_balance =
@@ -3009,7 +3012,7 @@ fn test_unsafe_force_withdraw() {
     assert_eq!(owner_balance, 0);
 
     // owner can force withdraw
-    suite.unsafe_force_withdraw(coin(100, &suite.reward_denom));
+    suite.unsafe_force_withdraw(100u128, UncheckedDenom::Native(suite.reward_denom.clone()));
 
     // owner has balance
     let owner_balance = suite.get_balance_native(OWNER, &suite.reward_denom);


### PR DESCRIPTION
whoops, dumb oversight

unsafe force withdraw only worked for native tokens. now it supports cw20s as well.