### PR TITLE
remove dao-testing dependency on cw-fund-distributor and don't publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,6 @@ version = "2.6.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-fund-distributor",
  "cw-multi-test",
  "cw-paginate-storage 2.6.0",
  "cw-storage-plus 1.2.0",
@@ -2304,7 +2303,6 @@ dependencies = [
  "cosmwasm-std",
  "cw-admin-factory",
  "cw-core",
- "cw-fund-distributor",
  "cw-hooks 2.6.0",
  "cw-multi-test",
  "cw-payroll-factory",

--- a/contracts/distribution/cw-fund-distributor/Cargo.toml
+++ b/contracts/distribution/cw-fund-distributor/Cargo.toml
@@ -30,7 +30,6 @@ dao-interface = { workspace = true }
 cw-paginate-storage = { workspace = true }
 
 [dev-dependencies]
-cw-fund-distributor = { workspace = true }
 dao-dao-core = { workspace = true, features = ["library"] }
 dao-testing = { workspace = true }
 cw-multi-test = { workspace = true }

--- a/contracts/distribution/cw-fund-distributor/src/testing/adversarial_tests.rs
+++ b/contracts/distribution/cw-fund-distributor/src/testing/adversarial_tests.rs
@@ -5,9 +5,10 @@ use cw20::{BalanceResponse, Cw20Coin};
 use cw_multi_test::{next_block, App, BankSudo, Executor, SudoMsg};
 use cw_utils::Duration;
 use dao_testing::contracts::{
-    cw20_base_contract, cw20_stake_contract, cw_fund_distributor_contract,
-    dao_voting_cw20_staked_contract,
+    cw20_base_contract, cw20_stake_contract, dao_voting_cw20_staked_contract,
 };
+
+use super::cw_fund_distributor_contract;
 
 const CREATOR_ADDR: &str = "creator";
 const FEE_DENOM: &str = "ujuno";

--- a/contracts/distribution/cw-fund-distributor/src/testing/mod.rs
+++ b/contracts/distribution/cw-fund-distributor/src/testing/mod.rs
@@ -1,2 +1,15 @@
+use cosmwasm_std::Empty;
+use cw_multi_test::{Contract, ContractWrapper};
+
 mod adversarial_tests;
 mod tests;
+
+pub fn cw_fund_distributor_contract() -> Box<dyn Contract<Empty>> {
+    let contract = ContractWrapper::new(
+        crate::contract::execute,
+        crate::contract::instantiate,
+        crate::contract::query,
+    )
+    .with_migrate(crate::contract::migrate);
+    Box::new(contract)
+}

--- a/contracts/distribution/cw-fund-distributor/src/testing/tests.rs
+++ b/contracts/distribution/cw-fund-distributor/src/testing/tests.rs
@@ -2,19 +2,20 @@ use crate::msg::{
     CW20EntitlementResponse, CW20Response, DenomResponse, ExecuteMsg, InstantiateMsg, MigrateMsg,
     NativeEntitlementResponse, QueryMsg, TotalPowerResponse, VotingContractResponse,
 };
+use crate::ContractError;
 use cosmwasm_std::{to_json_binary, Addr, Binary, Coin, Uint128, WasmMsg};
 use cw20::Cw20Coin;
-use cw_fund_distributor::ContractError;
 use cw_multi_test::{next_block, App, BankSudo, Executor, SudoMsg};
 use dao_testing::contracts::{
-    cw20_base_contract, cw20_stake_contract, cw_fund_distributor_contract,
-    dao_voting_cw20_staked_contract,
+    cw20_base_contract, cw20_stake_contract, dao_voting_cw20_staked_contract,
 };
 
 use crate::msg::ExecuteMsg::{ClaimAll, ClaimCW20, ClaimNatives};
 use crate::msg::QueryMsg::TotalPower;
 use cosmwasm_std::StdError::GenericErr;
 use cw_utils::Duration;
+
+use super::cw_fund_distributor_contract;
 
 const CREATOR_ADDR: &str = "creator";
 const FEE_DENOM: &str = "ujuno";

--- a/packages/dao-testing/Cargo.toml
+++ b/packages/dao-testing/Cargo.toml
@@ -42,7 +42,6 @@ serde_json = { workspace = true }
 
 btsg-ft-factory = { workspace = true }
 cw-admin-factory = { workspace = true }
-cw-fund-distributor = { workspace = true }
 cw-hooks = { workspace = true }
 cw-payroll-factory = { workspace = true }
 cw-token-swap = { workspace = true }

--- a/packages/dao-testing/src/contracts/latest.rs
+++ b/packages/dao-testing/src/contracts/latest.rs
@@ -244,16 +244,6 @@ pub fn dao_test_custom_factory_contract() -> Box<dyn Contract<Empty>> {
     Box::new(contract)
 }
 
-pub fn cw_fund_distributor_contract() -> Box<dyn Contract<Empty>> {
-    let contract = ContractWrapper::new(
-        cw_fund_distributor::contract::execute,
-        cw_fund_distributor::contract::instantiate,
-        cw_fund_distributor::contract::query,
-    )
-    .with_migrate(cw_fund_distributor::contract::migrate);
-    Box::new(contract)
-}
-
 pub fn dao_rewards_distributor_contract() -> Box<dyn Contract<Empty>> {
     let contract = ContractWrapper::new(
         dao_rewards_distributor::contract::execute,

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -204,11 +204,6 @@ cd contracts/external/cw-admin-factory
 cargo hack publish --no-dev-deps --allow-dirty
 cd "$START_DIR"
 
-# TODO: uncomment once cleaned up and audited
-# cd contracts/distribution/cw-fund-distributor
-# cargo hack publish --no-dev-deps --allow-dirty
-# cd "$START_DIR"
-
 cd contracts/distribution/dao-rewards-distributor
 cargo hack publish --no-dev-deps --allow-dirty
 cd "$START_DIR"


### PR DESCRIPTION
`dao-rewards-distributor` is audited and can fully replicate `cw-fund-distributor` functionality with an immediate distribution, so we're not going to publish `cw-fund-distributor`. this removes `dao-testing`'s dependence on `cw-fund-distributor` so it can be published.