### PR TITLE
vote delegations review

### DIFF
--- a/contracts/delegation/dao-vote-delegation/README.md
+++ b/contracts/delegation/dao-vote-delegation/README.md
@@ -84,6 +84,7 @@ state. However, when querying information from the past, we need to match the
 delayed update behavior of voting power queries.
 
 More concretely:
+
 - when registering/unregistering a delegate, delegating/undelegating, or
   handling voting power change hooks, we need to access the account's latest
   voting power (by querying `latest_height + 1`), even if it was updated in the
@@ -102,3 +103,64 @@ More concretely:
   total unvoted delegated VP when they cast a vote, or when a vote cast hook is
   triggered for a delegator, we need to use historical queries that match the
   behavior of the voting module's voting power queries, i.e. delayed by 1 block.
+
+## Limitations
+
+### Voting Module Compatibility
+
+The delegation module expects the voting power module to realize voting power
+changes on the block following a change. In DAO DAO's voting power contracts,
+this is accomplished by using CosmWasm's `SnapshotMap` storage type.
+
+More concretely: staking tokens on block `n` will not reflect the change in
+voting power until block `n+1`. Querying voting power at height `n` will return
+the voting power as it was at the beginning of block `n`, before any
+transactions occurred, after any changes from `n-1`. Querying `n+1` is the first
+block where the voting power changes from `n` will be reflected.
+
+If custom voting power modules are used, the voting module must ensure that the
+1-block delay is respected, or else proposal vote tallies will be incorrect.
+
+### Voting Power Granularity
+
+Because voting power is floored when multiplying by delegation percentages, the
+granularity of delegation is restricted to the unit size used by the voting
+power module.
+
+For example, if a DAO is using the `cw4-group` voting power module—a
+multisig-like structure with static membership weights—and a member has a weight
+of `1`, then they can only delegate all their voting power to a single delegate.
+Delegating any less than 100% will be floored to 0 and effectively nullify the
+delegation. The DAO can remedy this by increasing the order of magnitude of
+voting power weights, giving members a weight of 1,000 (or more) instead of 1,
+for example.
+
+This is particularly problematic for NFT-based DAOs, since 1 NFT corresponds
+with 1 voting power unit: the number of NFTs a member has staked will determine
+how many delegations they can have and the percentages that can be used.
+
+For token-based DAOs, this isn't really an issue, since tokens usually have
+divisible units with a precision of at least 6 decimal places, meaning 1 token
+in a user's wallet is actually 1,000,000 token units.
+
+### Delegation Limits
+
+Because all math is done on-chain, the block gas limit configured by the chain
+determines the maximum number of delegations a user can have. When a delegator's
+voting power changes, or a delegator's vote overrides their delegates' votes on
+a proposal, the computation needed to update all the relevant state depends on
+the number of delegations. This is unavoidable, unless the computation were to
+be moved off-chain.
+
+### Delegates Cannot Delegate
+
+Delegates cannot delegate their voting power to other delegates. This is
+technically possible to implement, though it would be more complex and approach
+computation limits must faster, so it was not included in this first version.
+
+### Delegation Expiration Defined in Blocks
+
+Automatic delegation expiry must be configured in blocks because proposals
+freeze members' voting power at the block when the proposal was created, and
+historical queries don't have access to timestamps associated with past blocks
+(only the current one).

--- a/contracts/delegation/dao-vote-delegation/schema/dao-vote-delegation.json
+++ b/contracts/delegation/dao-vote-delegation/schema/dao-vote-delegation.json
@@ -32,8 +32,8 @@
         "format": "uint64",
         "minimum": 0.0
       },
-      "no_sync_proposal_modules": {
-        "description": "Whether or not to sync proposal modules initially. If there are too many, the instantiation will run out of gas, so this should be disabled and `SyncProposalModules` called manually.\n\nDefaults to false.",
+      "sync_proposal_modules": {
+        "description": "Whether or not to sync proposal modules initially. If there are too many, the instantiation will run out of gas, so this should be disabled and `SyncProposalModules` called manually.\n\nDefaults to `true`.",
         "type": [
           "boolean",
           "null"

--- a/contracts/delegation/dao-vote-delegation/schema/dao-vote-delegation.json
+++ b/contracts/delegation/dao-vote-delegation/schema/dao-vote-delegation.json
@@ -795,13 +795,13 @@
         "additionalProperties": false
       },
       {
-        "description": "Returns the VP that should be removed from a delegate's vote tally on a specific proposal when a delegator overrides their vote. The `proposal_height` field is the height at which the proposal was created. The `delegated_vp` field is the amount of VP delegated by the delegator to the delegate for this proposal. This query takes into account the configured VP cap and should be used by proposal modules when a delegator overrides a delegate's vote to compute ballot VP updates.",
+        "description": "Returns the VP that should be removed from a delegate's effective UDVP (and vote tally if already voted) on a specific proposal when a delegator casts a vote (potentially overriding the delegate's vote). The `proposal_height` field is the height at which the proposal was created. The `delegated_vp` field is the amount of VP delegated by the delegator to the delegate for this proposal. This query takes into account the configured VP cap and should be used by proposal modules when a delegator overrides a delegate's vote to compute ballot VP updates.",
         "type": "object",
         "required": [
-          "less_vote_power_without_delegation"
+          "delegated_vote_power_reduction"
         ],
         "properties": {
-          "less_vote_power_without_delegation": {
+          "delegated_vote_power_reduction": {
             "type": "object",
             "required": [
               "delegate",
@@ -976,6 +976,12 @@
       },
       "additionalProperties": false
     },
+    "delegated_vote_power_reduction": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Uint128",
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
     "delegates": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "DelegatesResponse",
@@ -1129,12 +1135,6 @@
           "additionalProperties": false
         }
       }
-    },
-    "less_vote_power_without_delegation": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "Uint128",
-      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
-      "type": "string"
     },
     "proposal_modules": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/delegation/dao-vote-delegation/schema/dao-vote-delegation.json
+++ b/contracts/delegation/dao-vote-delegation/schema/dao-vote-delegation.json
@@ -798,10 +798,10 @@
         "description": "Returns the VP that should be removed from a delegate's effective UDVP (and vote tally if already voted) on a specific proposal when a delegator casts a vote (potentially overriding the delegate's vote). The `proposal_height` field is the height at which the proposal was created. The `delegated_vp` field is the amount of VP delegated by the delegator to the delegate for this proposal. This query takes into account the configured VP cap and should be used by proposal modules when a delegator overrides a delegate's vote to compute ballot VP updates.",
         "type": "object",
         "required": [
-          "delegated_vote_power_reduction"
+          "effective_unvoted_delegated_voting_power_reduction"
         ],
         "properties": {
-          "delegated_vote_power_reduction": {
+          "effective_unvoted_delegated_voting_power_reduction": {
             "type": "object",
             "required": [
               "delegate",
@@ -976,12 +976,6 @@
       },
       "additionalProperties": false
     },
-    "delegated_vote_power_reduction": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "title": "Uint128",
-      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
-      "type": "string"
-    },
     "delegates": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "DelegatesResponse",
@@ -1101,6 +1095,12 @@
           "additionalProperties": false
         }
       }
+    },
+    "effective_unvoted_delegated_voting_power_reduction": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Uint128",
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
     },
     "info": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/delegation/dao-vote-delegation/schema/dao-vote-delegation.json
+++ b/contracts/delegation/dao-vote-delegation/schema/dao-vote-delegation.json
@@ -32,8 +32,8 @@
         "format": "uint64",
         "minimum": 0.0
       },
-      "sync_proposal_modules": {
-        "description": "Whether or not to sync proposal modules initially. If there are too many, the instantiation will run out of gas, so this should be disabled and `SyncProposalModules` called manually.\n\nDefaults to `true`.",
+      "no_sync_proposal_modules": {
+        "description": "Whether or not to sync proposal modules initially. If there are too many, the instantiation will run out of gas, so this should be disabled and `SyncProposalModules` called manually.\n\nDefaults to `false`.",
         "type": [
           "boolean",
           "null"

--- a/contracts/delegation/dao-vote-delegation/schema/dao-vote-delegation.json
+++ b/contracts/delegation/dao-vote-delegation/schema/dao-vote-delegation.json
@@ -757,7 +757,7 @@
         "additionalProperties": false
       },
       {
-        "description": "Returns the VP delegated to a delegate that has not yet been used in votes cast by delegators in a specific proposal. This updates immediately via vote hooks (instead of being delayed 1 block like other historical queries), making it safe to vote multiple times in the same block. Proposal modules are responsible for maintaining the effective VP cap when a delegator overrides a delegate's vote.",
+        "description": "Returns the VP delegated to a delegate that has not yet been used in votes cast by delegators in a specific proposal. This updates immediately via vote hooks (instead of being delayed 1 block like other historical queries), making it safe to vote multiple times in the same block. Proposal modules are responsible for maintaining the effective VP cap when a delegator overrides a delegate's vote. The `proposal_height` field is the height at which the proposal was created.",
         "type": "object",
         "required": [
           "unvoted_delegated_voting_power"
@@ -767,7 +767,7 @@
             "type": "object",
             "required": [
               "delegate",
-              "height",
+              "proposal_height",
               "proposal_id",
               "proposal_module"
             ],
@@ -775,7 +775,49 @@
               "delegate": {
                 "type": "string"
               },
-              "height": {
+              "proposal_height": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "proposal_id": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "proposal_module": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the VP that should be removed from a delegate's vote tally on a specific proposal when a delegator overrides their vote. The `proposal_height` field is the height at which the proposal was created. The `delegated_vp` field is the amount of VP delegated by the delegator to the delegate for this proposal. This query takes into account the configured VP cap and should be used by proposal modules when a delegator overrides a delegate's vote to compute ballot VP updates.",
+        "type": "object",
+        "required": [
+          "less_vote_power_without_delegation"
+        ],
+        "properties": {
+          "less_vote_power_without_delegation": {
+            "type": "object",
+            "required": [
+              "delegate",
+              "delegated_vp",
+              "proposal_height",
+              "proposal_id",
+              "proposal_module"
+            ],
+            "properties": {
+              "delegate": {
+                "type": "string"
+              },
+              "delegated_vp": {
+                "$ref": "#/definitions/Uint128"
+              },
+              "proposal_height": {
                 "type": "integer",
                 "format": "uint64",
                 "minimum": 0.0
@@ -892,7 +934,13 @@
         },
         "additionalProperties": false
       }
-    ]
+    ],
+    "definitions": {
+      "Uint128": {
+        "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+        "type": "string"
+      }
+    }
   },
   "migrate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -1081,6 +1129,12 @@
           "additionalProperties": false
         }
       }
+    },
+    "less_vote_power_without_delegation": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Uint128",
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
     },
     "proposal_modules": {
       "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/delegation/dao-vote-delegation/src/contract.rs
+++ b/contracts/delegation/dao-vote-delegation/src/contract.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{ensure, Addr, Order};
+use cosmwasm_std::{ensure, Addr, Order, Uint128};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::{
     entry_point, to_json_binary, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Response,
@@ -520,13 +520,27 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             delegate,
             proposal_module,
             proposal_id,
-            height,
+            proposal_height,
         } => Ok(to_json_binary(&query_unvoted_delegated_vp(
             deps,
             delegate,
             proposal_module,
             proposal_id,
-            height,
+            proposal_height,
+        )?)?),
+        QueryMsg::LessVotePowerWithoutDelegation {
+            proposal_module,
+            proposal_id,
+            proposal_height,
+            delegate,
+            delegated_vp,
+        } => Ok(to_json_binary(&query_less_vote_power_without_delegation(
+            deps,
+            proposal_module,
+            proposal_id,
+            proposal_height,
+            delegate,
+            delegated_vp,
         )?)?),
         QueryMsg::ProposalModules { start_after, limit } => Ok(to_json_binary(
             &query_proposal_modules(deps, start_after, limit)?,
@@ -655,6 +669,61 @@ fn query_unvoted_delegated_vp(
     }
 
     Ok(UnvotedDelegatedVotingPowerResponse { total, effective })
+}
+
+fn query_less_vote_power_without_delegation(
+    deps: Deps,
+    proposal_module: String,
+    proposal_id: u64,
+    proposal_height: u64,
+    delegate: String,
+    delegated_vp: Uint128,
+) -> StdResult<Uint128> {
+    let udvp = query_unvoted_delegated_vp(
+        deps,
+        delegate,
+        proposal_module,
+        proposal_id,
+        proposal_height,
+    )?;
+
+    // compute the new effective UDVP after this voter's delegated VP is
+    // removed, respecting the configured cap. subtract the voter's delegated VP
+    // from the delegate's total UDVP, and cap the result at the delegate's
+    // effective UDVP, to ensure we properly take into account the configured VP
+    // cap (the effective UDVP is the total UDVP with the cap applied, so the
+    // effective UDVP can be used in place of the cap in this computation).
+    let new_effective_udvp = udvp.total.checked_sub(delegated_vp)?.min(udvp.effective);
+
+    // compute the amount of UDVP the delegate will lose due to this voter's
+    // delegated VP being removed (likely due to a vote override).
+    // new_effective_udvp is capped at udvp.effective, so this will never
+    // underflow, but use saturating_sub for vibes anyway.
+    //
+    // the delegate will lose none, part, or all of this voter's delegated VP
+    // based on how the delegate's total UDVP and voter's delegated VP compare
+    // to the configured cap:
+    //
+    // 1. if the delegate's total UDVP is less than or equal to the cap, the
+    //    delegate will lose all of this voter's delegated VP since the cap is
+    //    not exceeded.
+    //
+    //       IF total_udvp <= cap, THEN loss = voter_delegated
+    //
+    // 2. if the delegate's total UDVP is greater than the cap by a margin less
+    //    than this voter's delegated VP, the delegate will lose part of this
+    //    voter's delegated VP. specifically: the difference between the cap and
+    //    the delegate's total UDVP without the voter's delegated VP.
+    //
+    //       IF total_udvp - voter_delegated < cap AND total_udvp > cap, THEN
+    //       loss = cap - (total_udvp - voter_delegated)
+    //
+    // 3. if the delegate's total UDVP is greater than the cap by a margin
+    //    greater than or equal to this voter's delegated VP, the delegate will
+    //    not lose any VP since the cap is already low enough.
+    //
+    //       IF total_udvp - voter_delegated >= cap, THEN loss = 0
+    Ok(udvp.effective.saturating_sub(new_effective_udvp))
 }
 
 fn query_proposal_modules(

--- a/contracts/delegation/dao-vote-delegation/src/contract.rs
+++ b/contracts/delegation/dao-vote-delegation/src/contract.rs
@@ -147,7 +147,7 @@ pub fn execute(
         ExecuteMsg::MemberChangedHook(msg) => {
             execute_membership_changed(deps, env, info.sender, msg)
         }
-        ExecuteMsg::VoteHook(vote_hook) => execute_vote_hook(deps, env, info.sender, vote_hook),
+        ExecuteMsg::VoteHook(vote_hook) => execute_vote_hook(deps, info.sender, vote_hook),
     }
 }
 
@@ -296,9 +296,13 @@ fn execute_delegate(
     // ensure not delegating more than 100%
     if new_total_percent > Decimal::one() {
         return Err(ContractError::CannotDelegateMoreThan100Percent {
+            // multiply decimal (between 0 and 1) by 100 (which = 10,000%) to
+            // convert to a human-readable percentage out of 100%
             current: current_percent_delegated
                 .checked_mul(Decimal::percent(10_000))?
                 .to_string(),
+            // multiply decimal (between 0 and 1) by 100 (which = 10,000%) to
+            // convert to a human-readable percentage out of 100%
             attempt: new_total_percent
                 .checked_mul(Decimal::percent(10_000))?
                 .to_string(),
@@ -343,12 +347,19 @@ fn execute_undelegate(
     DELEGATION_ENTRIES.remove(deps.storage, (&delegator, &delegate));
 
     // update the total percent delegated by the delegator
-    PERCENT_DELEGATED.update(deps.storage, &delegator, |c| -> StdResult<_> {
-        // if delegation above exists, percent will exist. if for some reason it
-        // doesn't, it will surface in the checked_sub call below due to an overflow.
-        let current_percentage = c.unwrap_or_default();
-        Ok(current_percentage.checked_sub(delegation.percent)?)
-    })?;
+    PERCENT_DELEGATED.update(
+        deps.storage,
+        &delegator,
+        |current_percent| -> StdResult<_> {
+            // if delegation above exists, percent will exist. if for some
+            // reason it doesn't, it will surface in the checked_sub call below
+            // due to an underflow, in which case something is horribly wrong so
+            // we should error.
+            Ok(current_percent
+                .unwrap_or_default()
+                .checked_sub(delegation.percent)?)
+        },
+    )?;
 
     let vp = get_voting_power(
         deps.as_ref(),

--- a/contracts/delegation/dao-vote-delegation/src/contract.rs
+++ b/contracts/delegation/dao-vote-delegation/src/contract.rs
@@ -233,68 +233,55 @@ fn execute_delegate(
     }
 
     let config = CONFIG.load(deps.storage)?;
-
     let current_percent_delegated = PERCENT_DELEGATED
         .may_load(deps.storage, &delegator)?
         .unwrap_or_default();
-
     let existing_delegation_entry =
         DELEGATION_ENTRIES.may_load(deps.storage, (&delegator, &delegate))?;
 
-    // will be set below, differing based on whether this is a new delegation or
-    // an update to an existing one
-    let new_total_percent_delegated: Decimal;
-
     // update an existing delegation
-    if let Some((existing_id, existing_expiration)) = existing_delegation_entry {
-        let mut existing_delegation =
-            DELEGATIONS.load_item(deps.storage, &delegator, existing_id)?;
+    let (new_total_percent, new_entry) = if let Some((id, expiration)) = existing_delegation_entry {
+        let mut delegation = DELEGATIONS.load_item(deps.storage, &delegator, id)?;
 
         // remove existing percent and replace with new percent
-        new_total_percent_delegated = current_percent_delegated
-            .checked_sub(existing_delegation.percent)?
+        let new_total = current_percent_delegated
+            .checked_sub(delegation.percent)?
             .checked_add(percent)?;
 
         // remove current delegated VP based on existing percent
-        let current_delegated_vp = calculate_delegated_vp(vp, existing_delegation.percent);
-        remove_delegated_vp(
-            deps.storage,
-            &env,
-            &delegate,
-            current_delegated_vp,
-            existing_expiration,
-        )?;
+        let old_vp = calculate_delegated_vp(vp, delegation.percent);
+        remove_delegated_vp(deps.storage, &env, &delegate, old_vp, expiration)?;
 
         // remove the existing delegation entry before updating it
-        DELEGATIONS.remove(deps.storage, &delegator, existing_id, env.block.height)?;
+        DELEGATIONS.remove(deps.storage, &delegator, id, env.block.height)?;
 
-        existing_delegation.percent = percent;
-
-        let (new_delegation_entry, new_total) = DELEGATIONS.push(
+        // update the delegation and push it
+        delegation.percent = percent;
+        let (entry, total_count) = DELEGATIONS.push(
             deps.storage,
             &delegator,
-            &existing_delegation,
+            &delegation,
             env.block.height,
             config.delegation_validity_blocks,
         )?;
 
         // don't let them update if they are over the max, instead requiring
         // them to remove existing delegations before updating any
-        if new_total > config.max_delegations as usize {
+        if total_count > config.max_delegations as usize {
             return Err(ContractError::MaxDelegationsReached {
                 max: config.max_delegations,
-                current: new_total,
+                current: total_count,
             });
         }
 
-        DELEGATION_ENTRIES.save(deps.storage, (&delegator, &delegate), &new_delegation_entry)?;
+        (new_total, entry)
     }
     // create a new delegation
     else {
-        new_total_percent_delegated = current_percent_delegated.checked_add(percent)?;
+        let new_total = current_percent_delegated.checked_add(percent)?;
 
         // add new delegation
-        let (new_delegation_entry, new_total) = DELEGATIONS.push(
+        let (entry, total_count) = DELEGATIONS.push(
             deps.storage,
             &delegator,
             &Delegation {
@@ -306,29 +293,31 @@ fn execute_delegate(
         )?;
 
         // prevent new delegations if they are over the max
-        if new_total > config.max_delegations as usize {
+        if total_count > config.max_delegations as usize {
             return Err(ContractError::MaxDelegationsReached {
                 max: config.max_delegations,
-                current: new_total - 1,
+                current: total_count - 1,
             });
         }
 
-        DELEGATION_ENTRIES.save(deps.storage, (&delegator, &delegate), &new_delegation_entry)?;
-    }
+        (new_total, entry)
+    };
 
     // ensure not delegating more than 100%
-    if new_total_percent_delegated > Decimal::one() {
+    if new_total_percent > Decimal::one() {
         return Err(ContractError::CannotDelegateMoreThan100Percent {
             current: current_percent_delegated
                 .checked_mul(Decimal::percent(10_000))?
                 .to_string(),
-            attempt: new_total_percent_delegated
+            attempt: new_total_percent
                 .checked_mul(Decimal::percent(10_000))?
                 .to_string(),
         });
     }
 
-    PERCENT_DELEGATED.save(deps.storage, &delegator, &new_total_percent_delegated)?;
+    // final state updates applicable to both new and existing delegations
+    DELEGATION_ENTRIES.save(deps.storage, (&delegator, &delegate), &new_entry)?;
+    PERCENT_DELEGATED.save(deps.storage, &delegator, &new_total_percent)?;
 
     // calculate the new delegated VP and add to the delegate's total
     let new_delegated_vp = calculate_delegated_vp(vp, percent);

--- a/contracts/delegation/dao-vote-delegation/src/contract.rs
+++ b/contracts/delegation/dao-vote-delegation/src/contract.rs
@@ -528,13 +528,13 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             proposal_id,
             proposal_height,
         )?)?),
-        QueryMsg::LessVotePowerWithoutDelegation {
+        QueryMsg::DelegatedVotePowerReduction {
             proposal_module,
             proposal_id,
             proposal_height,
             delegate,
             delegated_vp,
-        } => Ok(to_json_binary(&query_less_vote_power_without_delegation(
+        } => Ok(to_json_binary(&query_delegated_vote_power_reduction(
             deps,
             proposal_module,
             proposal_id,
@@ -671,7 +671,7 @@ fn query_unvoted_delegated_vp(
     Ok(UnvotedDelegatedVotingPowerResponse { total, effective })
 }
 
-fn query_less_vote_power_without_delegation(
+fn query_delegated_vote_power_reduction(
     deps: Deps,
     proposal_module: String,
     proposal_id: u64,

--- a/contracts/delegation/dao-vote-delegation/src/contract.rs
+++ b/contracts/delegation/dao-vote-delegation/src/contract.rs
@@ -96,10 +96,10 @@ pub fn instantiate(
         }
     }
 
-    // sync proposal modules with no limit unless disabled. this should succeed
+    // sync proposal modules with no limit if not disabled. this should succeed
     // for most DAOs as the query will not run out of gas with only a few
     // proposal modules.
-    if msg.sync_proposal_modules.unwrap_or(true) {
+    if !msg.no_sync_proposal_modules.unwrap_or(false) {
         execute_sync_proposal_modules(deps, None, None)?;
     }
 

--- a/contracts/delegation/dao-vote-delegation/src/contract.rs
+++ b/contracts/delegation/dao-vote-delegation/src/contract.rs
@@ -528,20 +528,22 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
             proposal_id,
             proposal_height,
         )?)?),
-        QueryMsg::DelegatedVotePowerReduction {
+        QueryMsg::EffectiveUnvotedDelegatedVotingPowerReduction {
             proposal_module,
             proposal_id,
             proposal_height,
             delegate,
             delegated_vp,
-        } => Ok(to_json_binary(&query_delegated_vote_power_reduction(
-            deps,
-            proposal_module,
-            proposal_id,
-            proposal_height,
-            delegate,
-            delegated_vp,
-        )?)?),
+        } => Ok(to_json_binary(
+            &query_effective_unvoted_delegated_vote_power_reduction(
+                deps,
+                proposal_module,
+                proposal_id,
+                proposal_height,
+                delegate,
+                delegated_vp,
+            )?,
+        )?),
         QueryMsg::ProposalModules { start_after, limit } => Ok(to_json_binary(
             &query_proposal_modules(deps, start_after, limit)?,
         )?),
@@ -671,7 +673,7 @@ fn query_unvoted_delegated_vp(
     Ok(UnvotedDelegatedVotingPowerResponse { total, effective })
 }
 
-fn query_delegated_vote_power_reduction(
+fn query_effective_unvoted_delegated_vote_power_reduction(
     deps: Deps,
     proposal_module: String,
     proposal_id: u64,

--- a/contracts/delegation/dao-vote-delegation/src/contract.rs
+++ b/contracts/delegation/dao-vote-delegation/src/contract.rs
@@ -57,13 +57,11 @@ pub fn instantiate(
 ) -> Result<Response, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
-    let dao = msg
-        .dao
-        .map(|d| deps.api.addr_validate(&d))
-        .transpose()?
-        .unwrap_or(info.sender);
-
-    DAO.save(deps.storage, &dao)?;
+    let dao = match msg.dao {
+        Some(addr) => &deps.api.addr_validate(&addr)?,
+        None => &info.sender,
+    };
+    DAO.save(deps.storage, dao)?;
 
     if let Some(vp_cap_percent) = msg.vp_cap_percent {
         if vp_cap_percent <= Decimal::zero() || vp_cap_percent > Decimal::one() {
@@ -96,11 +94,11 @@ pub fn instantiate(
         }
     }
 
-    // sync proposal modules with no limit if not disabled. this should succeed
+    // sync proposal modules with no limit unless disabled. this should succeed
     // for most DAOs as the query will not run out of gas with only a few
     // proposal modules.
-    if !msg.no_sync_proposal_modules.unwrap_or(false) {
-        execute_sync_proposal_modules(deps, None, None)?;
+    if msg.sync_proposal_modules.unwrap_or(true) {
+        execute_sync_proposal_modules(deps, &info, None, None)?;
     }
 
     Ok(Response::new().add_attribute("dao", dao))
@@ -126,7 +124,7 @@ pub fn execute(
             execute_update_voting_power_hook_callers(deps, info.sender, add, remove)
         }
         ExecuteMsg::SyncProposalModules { start_after, limit } => {
-            execute_sync_proposal_modules(deps, start_after, limit)
+            execute_sync_proposal_modules(deps, &info, start_after, limit)
         }
         ExecuteMsg::UpdateConfig {
             vp_cap_percent,
@@ -402,10 +400,12 @@ fn execute_update_voting_power_hook_callers(
 
 fn execute_sync_proposal_modules(
     deps: DepsMut,
+    info: &MessageInfo,
     start_after: Option<String>,
     limit: Option<u32>,
 ) -> Result<Response, ContractError> {
-    // TODO: nonpayable?
+    nonpayable(info)?;
+
     let dao = DAO.load(deps.storage)?;
     let proposal_modules: Vec<ProposalModule> = deps.querier.query_wasm_smart(
         dao,

--- a/contracts/delegation/dao-vote-delegation/src/contract.rs
+++ b/contracts/delegation/dao-vote-delegation/src/contract.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{ensure, Addr, Order};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::{
     entry_point, to_json_binary, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Response,
-    StdResult, Uint128,
+    StdResult,
 };
 use cw2::{get_contract_version, set_contract_version};
 use cw_paginate_storage::paginate_map_keys;
@@ -46,6 +46,8 @@ pub const DEFAULT_LIMIT: u32 = 10;
 /// bound, so this defaults to 50.
 pub const DEFAULT_MAX_DELEGATIONS: u64 = 50;
 
+const MIN_DELEGATION_VALIDITY_BLOCKS: u64 = 2;
+
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
     deps: DepsMut,
@@ -70,10 +72,10 @@ pub fn instantiate(
     }
 
     if let Some(delegation_validity_blocks) = msg.delegation_validity_blocks {
-        if delegation_validity_blocks < 2 {
+        if delegation_validity_blocks < MIN_DELEGATION_VALIDITY_BLOCKS {
             return Err(ContractError::InvalidDelegationValidityBlocks {
                 provided: delegation_validity_blocks,
-                min: 2,
+                min: MIN_DELEGATION_VALIDITY_BLOCKS,
             });
         }
     }
@@ -318,10 +320,10 @@ fn execute_delegate(
     if new_total_percent_delegated > Decimal::one() {
         return Err(ContractError::CannotDelegateMoreThan100Percent {
             current: current_percent_delegated
-                .checked_mul(Decimal::from_atomics(100u128, 0).unwrap())?
+                .checked_mul(Decimal::percent(10_000))?
                 .to_string(),
             attempt: new_total_percent_delegated
-                .checked_mul(Decimal::from_atomics(100u128, 0).unwrap())?
+                .checked_mul(Decimal::percent(10_000))?
                 .to_string(),
         });
     }
@@ -356,14 +358,13 @@ fn execute_undelegate(
         .load(deps.storage, (&delegator, &delegate))
         .map_err(|_| ContractError::DelegationDoesNotExist {})?;
 
-    // if delegation exists above, percent will exist
-    let current_percent_delegated = PERCENT_DELEGATED.load(deps.storage, &delegator)?;
-
     // retrieve and remove delegation
     let (delegation, _) =
         DELEGATIONS.remove(deps.storage, &delegator, existing_id, env.block.height)?;
     DELEGATION_ENTRIES.remove(deps.storage, (&delegator, &delegate));
 
+    // if delegation exists above, percent will exist
+    let current_percent_delegated = PERCENT_DELEGATED.load(deps.storage, &delegator)?;
     // update delegator's percent delegated
     let new_percent_delegated = current_percent_delegated.checked_sub(delegation.percent)?;
     PERCENT_DELEGATED.save(deps.storage, &delegator, &new_percent_delegated)?;
@@ -477,10 +478,10 @@ fn execute_update_config(
         delegation_validity_blocks.maybe_update_result(|value| {
             // validate if defined
             if let Some(value) = value {
-                if value < 2 {
+                if value < MIN_DELEGATION_VALIDITY_BLOCKS {
                     return Err(ContractError::InvalidDelegationValidityBlocks {
                         provided: value,
-                        min: 2,
+                        min: MIN_DELEGATION_VALIDITY_BLOCKS,
                     });
                 }
             }
@@ -637,10 +638,7 @@ fn query_unvoted_delegated_vp(
 
     // if delegate not registered, they have no unvoted delegated VP.
     if !is_delegate_registered(deps, &delegate, Some(height))? {
-        return Ok(UnvotedDelegatedVotingPowerResponse {
-            total: Uint128::zero(),
-            effective: Uint128::zero(),
-        });
+        return Ok(UnvotedDelegatedVotingPowerResponse::default());
     }
 
     let proposal_module = deps.api.addr_validate(&proposal_module)?;
@@ -698,8 +696,7 @@ fn query_voting_power_hook_callers(
 }
 
 fn query_config(deps: Deps) -> StdResult<Config> {
-    let config = CONFIG.load(deps.storage)?;
-    Ok(config)
+    CONFIG.load(deps.storage)
 }
 
 fn query_voting_power_cap(

--- a/contracts/delegation/dao-vote-delegation/src/contract.rs
+++ b/contracts/delegation/dao-vote-delegation/src/contract.rs
@@ -1,9 +1,9 @@
+use cosmwasm_std::{ensure, Addr, Order};
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::{
     entry_point, to_json_binary, Binary, Decimal, Deps, DepsMut, Env, MessageInfo, Response,
     StdResult, Uint128,
 };
-use cosmwasm_std::{Addr, Order};
 use cw2::{get_contract_version, set_contract_version};
 use cw_paginate_storage::paginate_map_keys;
 use cw_storage_plus::Bound;
@@ -170,10 +170,10 @@ fn execute_register(deps: DepsMut, env: Env, delegate: Addr) -> Result<Response,
     }
 
     // ensure delegate has no delegations
-    let has_delegations = !DELEGATION_ENTRIES.prefix(&delegate).is_empty(deps.storage);
-    if has_delegations {
-        return Err(ContractError::CannotRegisterWithDelegations {});
-    }
+    ensure!(
+        DELEGATION_ENTRIES.prefix(&delegate).is_empty(deps.storage),
+        ContractError::CannotRegisterWithDelegations {}
+    );
 
     DELEGATES.save(deps.storage, delegate, &Delegate {}, env.block.height)?;
 

--- a/contracts/delegation/dao-vote-delegation/src/contract.rs
+++ b/contracts/delegation/dao-vote-delegation/src/contract.rs
@@ -265,28 +265,28 @@ fn execute_delegate(
             existing_expiration,
         )?;
 
-        // replace delegation with updated percent
-        let (_, total_minus_one) =
-            DELEGATIONS.remove(deps.storage, &delegator, existing_id, env.block.height)?;
-
-        // don't let them update if they are over the max, instead requiring
-        // them to remove existing delegations before updating any
-        if total_minus_one + 1 > config.max_delegations as usize {
-            return Err(ContractError::MaxDelegationsReached {
-                max: config.max_delegations,
-                current: total_minus_one + 1,
-            });
-        }
+        // remove the existing delegation entry before updating it
+        DELEGATIONS.remove(deps.storage, &delegator, existing_id, env.block.height)?;
 
         existing_delegation.percent = percent;
 
-        let (new_delegation_entry, _) = DELEGATIONS.push(
+        let (new_delegation_entry, new_total) = DELEGATIONS.push(
             deps.storage,
             &delegator,
             &existing_delegation,
             env.block.height,
             config.delegation_validity_blocks,
         )?;
+
+        // don't let them update if they are over the max, instead requiring
+        // them to remove existing delegations before updating any
+        if new_total > config.max_delegations as usize {
+            return Err(ContractError::MaxDelegationsReached {
+                max: config.max_delegations,
+                current: new_total,
+            });
+        }
+
         DELEGATION_ENTRIES.save(deps.storage, (&delegator, &delegate), &new_delegation_entry)?;
     }
     // create a new delegation
@@ -424,6 +424,7 @@ fn execute_sync_proposal_modules(
     start_after: Option<String>,
     limit: Option<u32>,
 ) -> Result<Response, ContractError> {
+    // TODO: nonpayable?
     let dao = DAO.load(deps.storage)?;
     let proposal_modules: Vec<ProposalModule> = deps.querier.query_wasm_smart(
         dao,

--- a/contracts/delegation/dao-vote-delegation/src/contract.rs
+++ b/contracts/delegation/dao-vote-delegation/src/contract.rs
@@ -56,12 +56,13 @@ pub fn instantiate(
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    nonpayable(&info)?;
 
     let dao = msg
         .dao
         .map(|d| deps.api.addr_validate(&d))
         .transpose()?
-        .unwrap_or(info.sender.clone());
+        .unwrap_or(info.sender);
     DAO.save(deps.storage, &dao)?;
 
     if let Some(vp_cap_percent) = msg.vp_cap_percent {
@@ -99,7 +100,7 @@ pub fn instantiate(
     // for most DAOs as the query will not run out of gas with only a few
     // proposal modules.
     if msg.sync_proposal_modules.unwrap_or(true) {
-        execute_sync_proposal_modules(deps, &info, None, None)?;
+        execute_sync_proposal_modules(deps, None, None)?;
     }
 
     Ok(Response::new().add_attribute("dao", dao))
@@ -125,7 +126,7 @@ pub fn execute(
             execute_update_voting_power_hook_callers(deps, info.sender, add, remove)
         }
         ExecuteMsg::SyncProposalModules { start_after, limit } => {
-            execute_sync_proposal_modules(deps, &info, start_after, limit)
+            execute_sync_proposal_modules(deps, start_after, limit)
         }
         ExecuteMsg::UpdateConfig {
             vp_cap_percent,
@@ -401,12 +402,9 @@ fn execute_update_voting_power_hook_callers(
 
 fn execute_sync_proposal_modules(
     deps: DepsMut,
-    info: &MessageInfo,
     start_after: Option<String>,
     limit: Option<u32>,
 ) -> Result<Response, ContractError> {
-    nonpayable(info)?;
-
     let dao = DAO.load(deps.storage)?;
     let proposal_modules: Vec<ProposalModule> = deps.querier.query_wasm_smart(
         dao,

--- a/contracts/delegation/dao-vote-delegation/src/contract.rs
+++ b/contracts/delegation/dao-vote-delegation/src/contract.rs
@@ -467,6 +467,8 @@ fn execute_update_config(
     })?;
 
     CONFIG.update(deps.storage, |mut config| -> Result<_, ContractError> {
+        // updating delegation validity blocks will only apply to new delegations.
+        // all existing delegations will keep their existing expiration until it expires.
         delegation_validity_blocks.maybe_update_result(|value| {
             // validate if defined
             if let Some(value) = value {

--- a/contracts/delegation/dao-vote-delegation/src/contract.rs
+++ b/contracts/delegation/dao-vote-delegation/src/contract.rs
@@ -19,8 +19,8 @@ use dao_voting::voting;
 use semver::Version;
 
 use crate::helpers::{
-    add_delegated_vp, ensure_setup, get_udvp, get_voting_power, is_delegate_registered,
-    remove_delegated_vp, unregister_delegate,
+    add_delegated_vp, ensure_max_delegations_not_reached, ensure_setup, get_udvp, get_voting_power,
+    is_delegate_registered, remove_delegated_vp, unregister_delegate,
 };
 use crate::hooks::{
     execute_membership_changed, execute_nft_stake_changed, execute_stake_changed, execute_vote_hook,
@@ -267,12 +267,7 @@ fn execute_delegate(
 
         // don't let them update if they are over the max, instead requiring
         // them to remove existing delegations before updating any
-        if total_count > config.max_delegations as usize {
-            return Err(ContractError::MaxDelegationsReached {
-                max: config.max_delegations,
-                current: total_count,
-            });
-        }
+        ensure_max_delegations_not_reached(config.max_delegations, total_count, total_count)?;
 
         (new_total, entry)
     }
@@ -293,12 +288,7 @@ fn execute_delegate(
         )?;
 
         // prevent new delegations if they are over the max
-        if total_count > config.max_delegations as usize {
-            return Err(ContractError::MaxDelegationsReached {
-                max: config.max_delegations,
-                current: total_count - 1,
-            });
-        }
+        ensure_max_delegations_not_reached(config.max_delegations, total_count - 1, total_count)?;
 
         (new_total, entry)
     };

--- a/contracts/delegation/dao-vote-delegation/src/contract.rs
+++ b/contracts/delegation/dao-vote-delegation/src/contract.rs
@@ -57,11 +57,12 @@ pub fn instantiate(
 ) -> Result<Response, ContractError> {
     set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
 
-    let dao = match msg.dao {
-        Some(addr) => &deps.api.addr_validate(&addr)?,
-        None => &info.sender,
-    };
-    DAO.save(deps.storage, dao)?;
+    let dao = msg
+        .dao
+        .map(|d| deps.api.addr_validate(&d))
+        .transpose()?
+        .unwrap_or(info.sender.clone());
+    DAO.save(deps.storage, &dao)?;
 
     if let Some(vp_cap_percent) = msg.vp_cap_percent {
         if vp_cap_percent <= Decimal::zero() || vp_cap_percent > Decimal::one() {

--- a/contracts/delegation/dao-vote-delegation/src/contract.rs
+++ b/contracts/delegation/dao-vote-delegation/src/contract.rs
@@ -352,11 +352,13 @@ fn execute_undelegate(
         DELEGATIONS.remove(deps.storage, &delegator, existing_id, env.block.height)?;
     DELEGATION_ENTRIES.remove(deps.storage, (&delegator, &delegate));
 
-    // if delegation exists above, percent will exist
-    let current_percent_delegated = PERCENT_DELEGATED.load(deps.storage, &delegator)?;
-    // update delegator's percent delegated
-    let new_percent_delegated = current_percent_delegated.checked_sub(delegation.percent)?;
-    PERCENT_DELEGATED.save(deps.storage, &delegator, &new_percent_delegated)?;
+    // update the total percent delegated by the delegator
+    PERCENT_DELEGATED.update(deps.storage, &delegator, |c| -> StdResult<_> {
+        // if delegation above exists, percent will exist. if for some reason it
+        // doesn't, it will surface in the checked_sub call below due to an overflow.
+        let current_percentage = c.unwrap_or_default();
+        Ok(current_percentage.checked_sub(delegation.percent)?)
+    })?;
 
     let vp = get_voting_power(
         deps.as_ref(),
@@ -369,12 +371,12 @@ fn execute_undelegate(
 
     // remove delegated VP from delegate's total delegated VP at the current
     // height.
-    let current_delegated_vp = calculate_delegated_vp(vp, delegation.percent);
+    let delegated_vp = calculate_delegated_vp(vp, delegation.percent);
     remove_delegated_vp(
         deps.storage,
         &env,
         &delegate,
-        current_delegated_vp,
+        delegated_vp,
         existing_expiration,
     )?;
 

--- a/contracts/delegation/dao-vote-delegation/src/helpers.rs
+++ b/contracts/delegation/dao-vote-delegation/src/helpers.rs
@@ -64,6 +64,19 @@ pub fn ensure_setup(deps: Deps) -> Result<(), ContractError> {
     Ok(())
 }
 
+/// Ensures that the max delegations limit has not been reached.
+pub fn ensure_max_delegations_not_reached(
+    max: u64,
+    old: usize,
+    new: usize,
+) -> Result<(), ContractError> {
+    if new > max as usize {
+        return Err(ContractError::MaxDelegationsReached { max, current: old });
+    }
+
+    Ok(())
+}
+
 /// Add delegated VP from a delegator to a delegate, potentially with a given
 /// expiration.
 pub fn add_delegated_vp(

--- a/contracts/delegation/dao-vote-delegation/src/helpers.rs
+++ b/contracts/delegation/dao-vote-delegation/src/helpers.rs
@@ -40,7 +40,7 @@ pub fn get_udvp(
     delegate: &Addr,
     proposal_module: &Addr,
     proposal_id: u64,
-    height: u64,
+    proposal_height: u64,
 ) -> StdResult<Uint128> {
     // if no unvoted delegated VP exists for the proposal, use the delegate's
     // total delegated VP at that height. UNVOTED_DELEGATED_VP gets set when one
@@ -48,7 +48,7 @@ pub fn get_udvp(
     match UNVOTED_DELEGATED_VP.may_load(deps.storage, (delegate, proposal_module, proposal_id))? {
         Some(vp) => Ok(vp),
         None => Ok(DELEGATED_VP
-            .load(deps.storage, delegate.clone(), height)?
+            .load(deps.storage, delegate.clone(), proposal_height)?
             .unwrap_or_default()),
     }
 }

--- a/contracts/delegation/dao-vote-delegation/src/hooks.rs
+++ b/contracts/delegation/dao-vote-delegation/src/hooks.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, DepsMut, Env, Response};
+use cosmwasm_std::{Addr, DepsMut, Env, Response, Uint128};
 use cw4::MemberChangedHookMsg;
 use cw_snapshot_vector_map::LoadedItem;
 use dao_hooks::{nft_stake::NftStakeChangedHookMsg, stake::StakeChangedHookMsg, vote::VoteHookMsg};
@@ -6,11 +6,11 @@ use dao_voting::delegation::calculate_delegated_vp;
 
 use crate::{
     helpers::{
-        add_delegated_vp, get_udvp, get_voting_power, is_delegate_registered, remove_delegated_vp,
+        add_delegated_vp, get_udvp, is_delegate_registered, remove_delegated_vp,
         unregister_delegate,
     },
     state::{
-        Delegation, CONFIG, DELEGATIONS, PROPOSAL_HOOK_CALLERS, UNVOTED_DELEGATED_VP,
+        Delegation, CONFIG, DAO, DELEGATIONS, PROPOSAL_HOOK_CALLERS, UNVOTED_DELEGATED_VP,
         VOTING_POWER_HOOK_CALLERS,
     },
     ContractError,
@@ -27,14 +27,11 @@ pub(crate) fn execute_stake_changed(
         return Err(ContractError::UnauthorizedHookCaller {});
     }
 
-    match msg {
-        StakeChangedHookMsg::Stake { addr, .. } => {
-            handle_voting_power_changed_hook(deps, &env, addr)
-        }
-        StakeChangedHookMsg::Unstake { addr, .. } => {
-            handle_voting_power_changed_hook(deps, &env, addr)
-        }
-    }
+    let addr = match msg {
+        StakeChangedHookMsg::Stake { addr, .. } | StakeChangedHookMsg::Unstake { addr, .. } => addr,
+    };
+
+    handle_voting_power_changed_hook(deps, &env, addr)
 }
 
 pub(crate) fn execute_membership_changed(
@@ -68,14 +65,12 @@ pub(crate) fn execute_nft_stake_changed(
         return Err(ContractError::UnauthorizedHookCaller {});
     }
 
-    match msg {
-        NftStakeChangedHookMsg::Stake { addr, .. } => {
-            handle_voting_power_changed_hook(deps, &env, addr)
-        }
-        NftStakeChangedHookMsg::Unstake { addr, .. } => {
-            handle_voting_power_changed_hook(deps, &env, addr)
-        }
-    }
+    let addr = match msg {
+        NftStakeChangedHookMsg::Stake { addr, .. }
+        | NftStakeChangedHookMsg::Unstake { addr, .. } => addr,
+    };
+
+    handle_voting_power_changed_hook(deps, &env, addr)
 }
 
 /// Perform necessary updates when a member's voting power changes.
@@ -92,74 +87,95 @@ pub(crate) fn handle_voting_power_changed_hook(
     env: &Env,
     addr: Addr,
 ) -> Result<Response, ContractError> {
-    let old_vp = get_voting_power(deps.as_ref(), &addr, env.block.height)?;
-    let new_vp = get_voting_power(
+    let dao = DAO.load(deps.storage)?;
+
+    let new_vp = dao_voting::voting::get_voting_power(
         deps.as_ref(),
-        &addr,
+        addr.clone(),
+        &dao,
         // use next block height since voting power takes effect at the start of
         // the next block. since the member changed their voting power in the
         // current block, we need to use the new value.
-        env.block.height + 1,
+        Some(env.block.height + 1),
     )?;
 
     // check latest state instead of historical height, since we need access to
     // immediate updates made earlier in the same block
-    if is_delegate_registered(deps.as_ref(), &addr, None)? {
-        let delegate = addr;
-
-        // unregister if no more voting power
-        if new_vp.is_zero() {
-            unregister_delegate(deps, &delegate, env.block.height)?;
-        }
+    match is_delegate_registered(deps.as_ref(), &addr, None)? {
+        true => handle_delegate_voting_power_changed_hook(deps, env.block.height, addr, new_vp),
+        // if not a delegate, check if they have any delegations, and update
+        // delegate VPs accordingly
+        false => handle_delegator_voting_power_changed_hook(deps, env, dao, addr, new_vp),
     }
-    // if not a delegate, check if they have any delegations, and update
-    // delegate VPs accordingly
-    else {
-        let delegator = addr;
+}
 
-        // need to get the latest delegations in case any were updated earlier
-        // in the same block
-        let delegations =
-            DELEGATIONS.load_all_latest(deps.storage, &delegator, env.block.height)?;
-
-        let config = CONFIG.load(deps.storage)?;
-
-        for LoadedItem {
-            item: Delegation { delegate, percent },
-            expiration,
-            ..
-        } in delegations
-        {
-            // remove the latest delegated VP from the delegate's total and
-            // replace it with the new delegated VP
-
-            // remove original delegated VP if nonzero
-            let current_delegated_vp = calculate_delegated_vp(old_vp, percent);
-            if !current_delegated_vp.is_zero() {
-                remove_delegated_vp(
-                    deps.storage,
-                    env,
-                    &delegate,
-                    current_delegated_vp,
-                    expiration,
-                )?;
-            }
-
-            // add new delegated VP if nonzero
-            let new_delegated_vp = calculate_delegated_vp(new_vp, percent);
-            if !new_delegated_vp.is_zero() {
-                add_delegated_vp(
-                    deps.storage,
-                    env,
-                    &delegate,
-                    new_delegated_vp,
-                    config.delegation_validity_blocks,
-                )?;
-            }
-        }
+fn handle_delegate_voting_power_changed_hook(
+    deps: DepsMut,
+    block_height: u64,
+    delegate: Addr,
+    new_vp: Uint128,
+) -> Result<Response, ContractError> {
+    // unregister if no more voting power
+    if new_vp.is_zero() {
+        unregister_delegate(deps, &delegate, block_height)?;
     }
 
-    Ok(Response::new().add_attribute("action", "voting_power_change_hook"))
+    Ok(Response::new()
+        .add_attribute("action", "voting_power_change_hook")
+        .add_attribute("member_type", "delegate"))
+}
+
+fn handle_delegator_voting_power_changed_hook(
+    deps: DepsMut,
+    env: &Env,
+    dao: Addr,
+    delegator: Addr,
+    new_vp: Uint128,
+) -> Result<Response, ContractError> {
+    // need to get the latest delegations in case any were updated earlier
+    // in the same block
+    let delegations = DELEGATIONS.load_all_latest(deps.storage, &delegator, env.block.height)?;
+
+    let config = CONFIG.load(deps.storage)?;
+    let old_vp = dao_voting::voting::get_voting_power(deps.as_ref(), delegator, &dao, None)?;
+
+    for LoadedItem {
+        item: Delegation { delegate, percent },
+        expiration,
+        ..
+    } in delegations
+    {
+        // remove the latest delegated VP from the delegate's total and
+        // replace it with the new delegated VP
+
+        // remove original delegated VP if nonzero
+        let current_delegated_vp = calculate_delegated_vp(old_vp, percent);
+        if !current_delegated_vp.is_zero() {
+            remove_delegated_vp(
+                deps.storage,
+                env,
+                &delegate,
+                current_delegated_vp,
+                expiration,
+            )?;
+        }
+
+        // add new delegated VP if nonzero
+        let new_delegated_vp = calculate_delegated_vp(new_vp, percent);
+        if !new_delegated_vp.is_zero() {
+            add_delegated_vp(
+                deps.storage,
+                env,
+                &delegate,
+                new_delegated_vp,
+                config.delegation_validity_blocks,
+            )?;
+        }
+    }
+
+    Ok(Response::new()
+        .add_attribute("action", "voting_power_change_hook")
+        .add_attribute("member_type", "delegator"))
 }
 
 pub fn execute_vote_hook(

--- a/contracts/delegation/dao-vote-delegation/src/hooks.rs
+++ b/contracts/delegation/dao-vote-delegation/src/hooks.rs
@@ -26,8 +26,11 @@ pub(crate) fn execute_stake_changed(
     }
 
     match msg {
-        StakeChangedHookMsg::Stake { addr, .. } | StakeChangedHookMsg::Unstake { addr, .. } => {
-            handle_voting_power_changed_hook(deps, &env, addr)
+        StakeChangedHookMsg::Stake { addr, amount } => {
+            handle_voting_power_changed_hook(deps, &env, addr, amount, true)
+        }
+        StakeChangedHookMsg::Unstake { addr, amount } => {
+            handle_voting_power_changed_hook(deps, &env, addr, amount, false)
         }
     }
 }
@@ -46,7 +49,19 @@ pub(crate) fn execute_membership_changed(
     // Get the members whose voting power changed and update their voting power.
     for member in msg.diffs {
         let addr = deps.api.addr_validate(&member.key)?;
-        handle_voting_power_changed_hook(deps.branch(), &env, addr)?;
+
+        // old is None when adding a new member
+        let old = member.old.unwrap_or_default();
+        // new is None when removing a member
+        let new = member.new.unwrap_or_default();
+        // compute the delta and whether the voting power increased or decreased
+        let (vp_delta, increased) = if new > old {
+            (new - old, true)
+        } else {
+            (old - new, false)
+        };
+
+        handle_voting_power_changed_hook(deps.branch(), &env, addr, vp_delta, increased)?;
     }
 
     Ok(Response::new().add_attribute("action", "voting_power_change_hook"))
@@ -64,18 +79,24 @@ pub(crate) fn execute_nft_stake_changed(
     }
 
     match msg {
-        NftStakeChangedHookMsg::Stake { addr, .. }
-        | NftStakeChangedHookMsg::Unstake { addr, .. } => {
-            handle_voting_power_changed_hook(deps, &env, addr)
+        NftStakeChangedHookMsg::Stake { addr, .. } => {
+            // NFTs are staked one at a time
+            handle_voting_power_changed_hook(deps, &env, addr, Uint128::one(), true)
+        }
+        NftStakeChangedHookMsg::Unstake { addr, token_ids } => {
+            // more than one NFT can be unstaked at once
+            handle_voting_power_changed_hook(deps, &env, addr, token_ids.len() as u128, false)
         }
     }
 }
 
 /// Perform necessary updates when a member's voting power changes.
-pub(crate) fn handle_voting_power_changed_hook(
+fn handle_voting_power_changed_hook(
     deps: DepsMut,
     env: &Env,
     addr: Addr,
+    vp_delta: impl Into<Uint128>,
+    increased: bool,
 ) -> Result<Response, ContractError> {
     let dao = DAO.load(deps.storage)?;
 
@@ -98,7 +119,14 @@ pub(crate) fn handle_voting_power_changed_hook(
     } else {
         // if not a delegate, check if they have any delegations, and update
         // delegate VPs accordingly
-        handle_delegator_voting_power_changed_hook(deps, env, dao, addr, new_vp)
+        handle_delegator_voting_power_changed_hook(
+            deps,
+            env,
+            addr,
+            new_vp,
+            vp_delta.into(),
+            increased,
+        )
     }
 }
 
@@ -123,24 +151,44 @@ fn handle_delegate_voting_power_changed_hook(
 /// handles the delegator voting power changed hook by updating their delegated
 /// VP for each delegate they are delegating to and each delegate's total
 /// delegated VP.
-/// TODO: fix bug when multiple voting power changes occur in the same block
 fn handle_delegator_voting_power_changed_hook(
     deps: DepsMut,
     env: &Env,
-    dao: Addr,
     delegator: Addr,
     new_vp: Uint128,
+    vp_delta: Uint128,
+    increased: bool,
 ) -> Result<Response, ContractError> {
     // need to get the latest delegations in case any were updated earlier in
     // the same block
     let delegations = DELEGATIONS.load_all_latest(deps.storage, &delegator, env.block.height)?;
 
-    let old_vp = dao_voting::voting::get_voting_power(
-        deps.as_ref(),
-        delegator,
-        &dao,
-        Some(env.block.height),
-    )?;
+    // compute old VP based on the new VP and the delta, since multiple voting
+    // power changes can occur in the same block and we can't reliably access
+    // the previous VP without storing intermediate state (which would require
+    // storing every single voting power change and never clearing them). we can
+    // only query voting power at the beginning of the current block (before any
+    // changes) or at the end of the current block/beginning of the next block
+    // thus far (i.e. the new voting power after this most recent change).
+    // however, what we really want is the voting power change between the
+    // previous update, which may or may not have been an earlier transaction in
+    // this same block, and this current update. thus, we use the delta from the
+    // current update and the final voting power after all changes thus far have
+    // been processed to compute the previously updated VP.
+    //
+    // also, we need the actual raw VPs instead of just the delta to ensure that
+    // rounding behavior remains consistent. everywhere delegated VP is
+    // calculated, the percent delegated is multiplied by the delegator's VP and
+    // floored to the nearest integer. thus, we need to calculate the floored
+    // delegated VP before and after and then find the delta, instead of finding
+    // the delta and applying the floor, since the floor of the delta may not
+    // match the difference between the floored VPs. we care about the delta
+    // between the floored VPs.
+    let old_vp = if increased {
+        new_vp.checked_sub(vp_delta)?
+    } else {
+        new_vp.checked_add(vp_delta)?
+    };
 
     for LoadedItem {
         item: Delegation { delegate, percent },

--- a/contracts/delegation/dao-vote-delegation/src/hooks.rs
+++ b/contracts/delegation/dao-vote-delegation/src/hooks.rs
@@ -5,13 +5,10 @@ use dao_hooks::{nft_stake::NftStakeChangedHookMsg, stake::StakeChangedHookMsg, v
 use dao_voting::delegation::calculate_delegated_vp;
 
 use crate::{
-    helpers::{
-        add_delegated_vp, get_udvp, is_delegate_registered, remove_delegated_vp,
-        unregister_delegate,
-    },
+    helpers::{get_udvp, is_delegate_registered, unregister_delegate},
     state::{
-        Delegation, CONFIG, DAO, DELEGATIONS, PROPOSAL_HOOK_CALLERS, UNVOTED_DELEGATED_VP,
-        VOTING_POWER_HOOK_CALLERS,
+        Delegation, CONFIG, DAO, DELEGATED_VP, DELEGATIONS, PROPOSAL_HOOK_CALLERS,
+        UNVOTED_DELEGATED_VP, VOTING_POWER_HOOK_CALLERS,
     },
     ContractError,
 };
@@ -156,31 +153,59 @@ fn handle_delegator_voting_power_changed_hook(
         ..
     } in delegations
     {
-        // remove the latest delegated VP from the delegate's total and
-        // replace it with the new delegated VP
-
-        // remove original delegated VP if nonzero
+        // for each delegation, we first find the current delegated VP and
+        // the new delegated VP
         let current_delegated_vp = calculate_delegated_vp(old_vp, percent);
-        if !current_delegated_vp.is_zero() {
-            remove_delegated_vp(
+        let new_delegated_vp = calculate_delegated_vp(new_vp, percent);
+
+        // first we update the next block's delegated VP for the delegate.
+        // for cases where current delegated VP is equal to new delegated VP,
+        // we don't need to do anything.
+        if new_delegated_vp > current_delegated_vp {
+            // if the new delegated VP is greater than the current delegated VP,
+            // we increment the delegated VP by the delta.
+            DELEGATED_VP.increment(
                 deps.storage,
-                env,
-                &delegate,
-                current_delegated_vp,
-                expiration,
+                delegate.clone(),
+                env.block.height + 1,
+                new_delegated_vp - current_delegated_vp,
+            )?;
+        } else if current_delegated_vp > new_delegated_vp {
+            // if the new delegated VP is lesser than the current delegated VP,
+            // we decrement the delegated VP by the delta.
+            DELEGATED_VP.decrement(
+                deps.storage,
+                delegate.clone(),
+                env.block.height + 1,
+                current_delegated_vp - new_delegated_vp,
             )?;
         }
 
-        // add new delegated VP if nonzero
-        let new_delegated_vp = calculate_delegated_vp(new_vp, percent);
-        if !new_delegated_vp.is_zero() {
-            add_delegated_vp(
-                deps.storage,
-                env,
-                &delegate,
-                new_delegated_vp,
-                config.delegation_validity_blocks,
-            )?;
+        // if original delegation had voting power and an expiration date,
+        // we undo the previous decrement at the end of the expiration period.
+        if current_delegated_vp.u128() > 0 {
+            if let Some(expire_in) = expiration {
+                DELEGATED_VP.increment(
+                    deps.storage,
+                    delegate.clone(),
+                    expire_in,
+                    current_delegated_vp,
+                )?;
+            }
+        }
+
+        // if the new delegation has voting power & global config specifies
+        // a delegation validity duration, we apply the decrement at the end
+        // of the expiration period.
+        if new_delegated_vp.u128() > 0 {
+            if let Some(config_expiration) = config.delegation_validity_blocks {
+                DELEGATED_VP.decrement(
+                    deps.storage,
+                    delegate.clone(),
+                    env.block.height + config_expiration,
+                    new_delegated_vp,
+                )?;
+            }
         }
     }
 

--- a/contracts/delegation/dao-vote-delegation/src/hooks.rs
+++ b/contracts/delegation/dao-vote-delegation/src/hooks.rs
@@ -27,11 +27,11 @@ pub(crate) fn execute_stake_changed(
         return Err(ContractError::UnauthorizedHookCaller {});
     }
 
-    let addr = match msg {
-        StakeChangedHookMsg::Stake { addr, .. } | StakeChangedHookMsg::Unstake { addr, .. } => addr,
-    };
-
-    handle_voting_power_changed_hook(deps, &env, addr)
+    match msg {
+        StakeChangedHookMsg::Stake { addr, .. } | StakeChangedHookMsg::Unstake { addr, .. } => {
+            handle_voting_power_changed_hook(deps, &env, addr)
+        }
+    }
 }
 
 pub(crate) fn execute_membership_changed(
@@ -65,12 +65,12 @@ pub(crate) fn execute_nft_stake_changed(
         return Err(ContractError::UnauthorizedHookCaller {});
     }
 
-    let addr = match msg {
+    match msg {
         NftStakeChangedHookMsg::Stake { addr, .. }
-        | NftStakeChangedHookMsg::Unstake { addr, .. } => addr,
-    };
-
-    handle_voting_power_changed_hook(deps, &env, addr)
+        | NftStakeChangedHookMsg::Unstake { addr, .. } => {
+            handle_voting_power_changed_hook(deps, &env, addr)
+        }
+    }
 }
 
 /// Perform necessary updates when a member's voting power changes.
@@ -99,16 +99,21 @@ pub(crate) fn handle_voting_power_changed_hook(
         Some(env.block.height + 1),
     )?;
 
+    // depending on whether the voting power hook was fired for a delegate or delegator,
+    // we need to handle the voting power change differently.
     // check latest state instead of historical height, since we need access to
     // immediate updates made earlier in the same block
-    match is_delegate_registered(deps.as_ref(), &addr, None)? {
-        true => handle_delegate_voting_power_changed_hook(deps, env.block.height, addr, new_vp),
+    if is_delegate_registered(deps.as_ref(), &addr, None)? {
+        handle_delegate_voting_power_changed_hook(deps, env.block.height, addr, new_vp)
+    } else {
         // if not a delegate, check if they have any delegations, and update
         // delegate VPs accordingly
-        false => handle_delegator_voting_power_changed_hook(deps, env, dao, addr, new_vp),
+        handle_delegator_voting_power_changed_hook(deps, env, dao, addr, new_vp)
     }
 }
 
+/// handles the delegate voting power changed hook by unregistering the delegate
+/// if they no longer have any voting power.
 fn handle_delegate_voting_power_changed_hook(
     deps: DepsMut,
     block_height: u64,
@@ -125,6 +130,7 @@ fn handle_delegate_voting_power_changed_hook(
         .add_attribute("member_type", "delegate"))
 }
 
+/// handles the delegator voting power changed hook by updating
 fn handle_delegator_voting_power_changed_hook(
     deps: DepsMut,
     env: &Env,
@@ -137,7 +143,12 @@ fn handle_delegator_voting_power_changed_hook(
     let delegations = DELEGATIONS.load_all_latest(deps.storage, &delegator, env.block.height)?;
 
     let config = CONFIG.load(deps.storage)?;
-    let old_vp = dao_voting::voting::get_voting_power(deps.as_ref(), delegator, &dao, None)?;
+    let old_vp = dao_voting::voting::get_voting_power(
+        deps.as_ref(),
+        delegator,
+        &dao,
+        Some(env.block.height),
+    )?;
 
     for LoadedItem {
         item: Delegation { delegate, percent },
@@ -194,7 +205,6 @@ pub fn execute_vote_hook(
             proposal_id,
             voter,
             power,
-            height,
             is_first_vote,
             ..
         } => {
@@ -202,37 +212,57 @@ pub fn execute_vote_hook(
             // delegates by subtracting this member's delegated VP. if not first
             // vote, this has already been done.
             if is_first_vote {
-                let delegator = deps.api.addr_validate(&voter)?;
-                let delegates = DELEGATIONS.load_all(deps.storage, &delegator, env.block.height)?;
-                for LoadedItem {
-                    item: Delegation { delegate, percent },
-                    ..
-                } in delegates
-                {
-                    let udvp = get_udvp(
-                        deps.as_ref(),
-                        &delegate,
-                        &proposal_module,
-                        proposal_id,
-                        height,
-                    )?;
-
-                    let delegated_vp = calculate_delegated_vp(power, percent);
-
-                    // remove the delegator's delegated VP from the delegate's
-                    // unvoted delegated VP for this proposal since this
-                    // delegator just voted.
-                    let new_udvp = udvp.checked_sub(delegated_vp)?;
-
-                    UNVOTED_DELEGATED_VP.save(
-                        deps.storage,
-                        (&delegate, &proposal_module, proposal_id),
-                        &new_udvp,
-                    )?;
-                }
+                handle_first_delegator_vote(
+                    deps,
+                    voter,
+                    env.block.height,
+                    power,
+                    proposal_id,
+                    &proposal_module,
+                )?;
             }
         }
     }
 
     Ok(Response::new().add_attribute("action", "vote_hook"))
+}
+
+fn handle_first_delegator_vote(
+    deps: DepsMut,
+    voter: String,
+    env_block_height: u64,
+    power: Uint128,
+    proposal_id: u64,
+    proposal_module: &Addr,
+) -> Result<(), ContractError> {
+    let delegator = deps.api.addr_validate(&voter)?;
+    let delegates = DELEGATIONS.load_all(deps.storage, &delegator, env_block_height)?;
+    for LoadedItem {
+        item: Delegation { delegate, percent },
+        ..
+    } in delegates
+    {
+        let udvp = get_udvp(
+            deps.as_ref(),
+            &delegate,
+            proposal_module,
+            proposal_id,
+            env_block_height,
+        )?;
+
+        let delegated_vp = calculate_delegated_vp(power, percent);
+
+        // remove the delegator's delegated VP from the delegate's
+        // unvoted delegated VP for this proposal since this
+        // delegator just voted.
+        let new_udvp = udvp.checked_sub(delegated_vp)?;
+
+        UNVOTED_DELEGATED_VP.save(
+            deps.storage,
+            (&delegate, proposal_module, proposal_id),
+            &new_udvp,
+        )?;
+    }
+
+    Ok(())
 }

--- a/contracts/delegation/dao-vote-delegation/src/hooks.rs
+++ b/contracts/delegation/dao-vote-delegation/src/hooks.rs
@@ -261,11 +261,11 @@ fn handle_first_delegator_vote(
     proposal_module: &Addr,
 ) -> Result<(), ContractError> {
     let delegator = deps.api.addr_validate(&voter)?;
-    let delegates = DELEGATIONS.load_all(deps.storage, &delegator, env_block_height)?;
+    let delegations = DELEGATIONS.load_all(deps.storage, &delegator, env_block_height)?;
     for LoadedItem {
         item: Delegation { delegate, percent },
         ..
-    } in delegates
+    } in delegations
     {
         let udvp = get_udvp(
             deps.as_ref(),

--- a/contracts/delegation/dao-vote-delegation/src/hooks.rs
+++ b/contracts/delegation/dao-vote-delegation/src/hooks.rs
@@ -153,6 +153,21 @@ fn handle_delegator_voting_power_changed_hook(
         let current_delegated_vp = calculate_delegated_vp(old_vp, percent);
         let new_delegated_vp = calculate_delegated_vp(new_vp, percent);
 
+        // if original delegation had voting power and an expiration date, we
+        // undo the previous decrement at the end of the expiration period,
+        // essentially undoing the expiration since we're about to restart the
+        // expiration period.
+        if !current_delegated_vp.is_zero() {
+            if let Some(expire_in) = expiration {
+                DELEGATED_VP.increment(
+                    deps.storage,
+                    delegate.clone(),
+                    expire_in,
+                    current_delegated_vp,
+                )?;
+            }
+        }
+
         // first we update the next block's delegated VP for the delegate
         match new_delegated_vp.cmp(&current_delegated_vp) {
             Ordering::Less => {
@@ -197,23 +212,10 @@ fn handle_delegator_voting_power_changed_hook(
             }
         }
 
-        // if original delegation had voting power and an expiration date, we
-        // undo the previous decrement at the end of the expiration period.
-        if current_delegated_vp.u128() > 0 {
-            if let Some(expire_in) = expiration {
-                DELEGATED_VP.increment(
-                    deps.storage,
-                    delegate.clone(),
-                    expire_in,
-                    current_delegated_vp,
-                )?;
-            }
-        }
-
         // if the new delegation has voting power and global config specifies a
         // delegation validity duration, we apply the decrement at the end of
         // the expiration period.
-        if new_delegated_vp.u128() > 0 {
+        if !new_delegated_vp.is_zero() {
             if let Some(config_expiration) = config.delegation_validity_blocks {
                 DELEGATED_VP.decrement(
                     deps.storage,

--- a/contracts/delegation/dao-vote-delegation/src/hooks.rs
+++ b/contracts/delegation/dao-vote-delegation/src/hooks.rs
@@ -72,14 +72,6 @@ pub(crate) fn execute_nft_stake_changed(
 }
 
 /// Perform necessary updates when a member's voting power changes.
-///
-/// For delegators:
-/// - update their delegated VP for each delegate
-/// - update each delegate's total delegated VP
-///
-/// For delegates:
-/// - unregister them if they have no voting power
-/// - TODO: re-register them if previously registered but had no voting power???
 pub(crate) fn handle_voting_power_changed_hook(
     deps: DepsMut,
     env: &Env,
@@ -129,6 +121,7 @@ fn handle_delegate_voting_power_changed_hook(
 }
 
 /// handles the delegator voting power changed hook by updating
+/// their delegated VP for each delegate they are delegating to.
 fn handle_delegator_voting_power_changed_hook(
     deps: DepsMut,
     env: &Env,

--- a/contracts/delegation/dao-vote-delegation/src/hooks.rs
+++ b/contracts/delegation/dao-vote-delegation/src/hooks.rs
@@ -3,6 +3,7 @@ use cw4::MemberChangedHookMsg;
 use cw_snapshot_vector_map::LoadedItem;
 use dao_hooks::{nft_stake::NftStakeChangedHookMsg, stake::StakeChangedHookMsg, vote::VoteHookMsg};
 use dao_voting::delegation::calculate_delegated_vp;
+use std::cmp::Ordering;
 
 use crate::{
     helpers::{get_udvp, is_delegate_registered, unregister_delegate},
@@ -158,27 +159,32 @@ fn handle_delegator_voting_power_changed_hook(
         let current_delegated_vp = calculate_delegated_vp(old_vp, percent);
         let new_delegated_vp = calculate_delegated_vp(new_vp, percent);
 
-        // first we update the next block's delegated VP for the delegate.
-        // for cases where current delegated VP is equal to new delegated VP,
-        // we don't need to do anything.
-        if new_delegated_vp > current_delegated_vp {
-            // if the new delegated VP is greater than the current delegated VP,
-            // we increment the delegated VP by the delta.
-            DELEGATED_VP.increment(
-                deps.storage,
-                delegate.clone(),
-                env.block.height + 1,
-                new_delegated_vp - current_delegated_vp,
-            )?;
-        } else if current_delegated_vp > new_delegated_vp {
-            // if the new delegated VP is lesser than the current delegated VP,
-            // we decrement the delegated VP by the delta.
-            DELEGATED_VP.decrement(
-                deps.storage,
-                delegate.clone(),
-                env.block.height + 1,
-                current_delegated_vp - new_delegated_vp,
-            )?;
+        // first we update the next block's delegated VP for the delegate
+        match new_delegated_vp.cmp(&current_delegated_vp) {
+            Ordering::Less => {
+                // if the new delegated VP is lesser than the current delegated VP,
+                // we decrement the delegated VP by the delta.
+                DELEGATED_VP.decrement(
+                    deps.storage,
+                    delegate.clone(),
+                    env.block.height + 1,
+                    current_delegated_vp - new_delegated_vp,
+                )?;
+            }
+            Ordering::Equal => {
+                // for cases where current delegated VP is equal to new delegated VP,
+                // we don't need to do anything.
+            }
+            Ordering::Greater => {
+                // if the new delegated VP is greater than the current delegated VP,
+                // we increment the delegated VP by the delta.
+                DELEGATED_VP.increment(
+                    deps.storage,
+                    delegate.clone(),
+                    env.block.height + 1,
+                    new_delegated_vp - current_delegated_vp,
+                )?;
+            }
         }
 
         // if original delegation had voting power and an expiration date,

--- a/contracts/delegation/dao-vote-delegation/src/hooks.rs
+++ b/contracts/delegation/dao-vote-delegation/src/hooks.rs
@@ -8,8 +8,8 @@ use std::cmp::Ordering;
 use crate::{
     helpers::{get_udvp, is_delegate_registered, unregister_delegate},
     state::{
-        Delegation, CONFIG, DAO, DELEGATED_VP, DELEGATIONS, PROPOSAL_HOOK_CALLERS,
-        UNVOTED_DELEGATED_VP, VOTING_POWER_HOOK_CALLERS,
+        Delegation, DAO, DELEGATED_VP, DELEGATIONS, PROPOSAL_HOOK_CALLERS, UNVOTED_DELEGATED_VP,
+        VOTING_POWER_HOOK_CALLERS,
     },
     ContractError,
 };
@@ -123,6 +123,7 @@ fn handle_delegate_voting_power_changed_hook(
 /// handles the delegator voting power changed hook by updating their delegated
 /// VP for each delegate they are delegating to and each delegate's total
 /// delegated VP.
+/// TODO: fix bug when multiple voting power changes occur in the same block
 fn handle_delegator_voting_power_changed_hook(
     deps: DepsMut,
     env: &Env,
@@ -134,7 +135,6 @@ fn handle_delegator_voting_power_changed_hook(
     // the same block
     let delegations = DELEGATIONS.load_all_latest(deps.storage, &delegator, env.block.height)?;
 
-    let config = CONFIG.load(deps.storage)?;
     let old_vp = dao_voting::voting::get_voting_power(
         deps.as_ref(),
         delegator,
@@ -148,29 +148,29 @@ fn handle_delegator_voting_power_changed_hook(
         ..
     } in delegations
     {
+        // if this delegation expires on the next block, do nothing since this
+        // update won't take effect until the next block anyway.
+        if expiration == Some(env.block.height + 1) {
+            continue;
+        }
+
         // for each delegation, we first find the current delegated VP and the
         // new delegated VP
         let current_delegated_vp = calculate_delegated_vp(old_vp, percent);
         let new_delegated_vp = calculate_delegated_vp(new_vp, percent);
 
-        // if original delegation had voting power and an expiration date, we
-        // undo the previous decrement at the end of the expiration period,
-        // essentially undoing the expiration since we're about to restart the
-        // expiration period.
-        if !current_delegated_vp.is_zero() {
-            if let Some(expire_in) = expiration {
-                DELEGATED_VP.increment(
-                    deps.storage,
-                    delegate.clone(),
-                    expire_in,
-                    current_delegated_vp,
-                )?;
-            }
-        }
-
-        // first we update the next block's delegated VP for the delegate
+        // update the next block's delegated VP for the delegate and perform the
+        // reverse on the expiration block if necessary.
         match new_delegated_vp.cmp(&current_delegated_vp) {
             Ordering::Less => {
+                let delta = current_delegated_vp - new_delegated_vp;
+
+                // perform the inverse of the change on the expiration block. do
+                // this increment before the decrement to avoid underflow.
+                if let Some(expiration) = expiration {
+                    DELEGATED_VP.increment(deps.storage, delegate.clone(), expiration, delta)?;
+                }
+
                 // if the new delegated VP is less than the current delegated
                 // VP, we decrement the delegated VP by the delta.
                 DELEGATED_VP.decrement(
@@ -185,7 +185,7 @@ fn handle_delegator_voting_power_changed_hook(
                     // block and update the total that will be reflected in
                     // historical queries starting from the next block.
                     env.block.height + 1,
-                    current_delegated_vp - new_delegated_vp,
+                    delta,
                 )?;
             }
             Ordering::Equal => {
@@ -193,6 +193,8 @@ fn handle_delegator_voting_power_changed_hook(
                 // delegated VP, we don't need to do anything.
             }
             Ordering::Greater => {
+                let delta = new_delegated_vp - current_delegated_vp;
+
                 // if the new delegated VP is greater than the current delegated
                 // VP, we increment the delegated VP by the delta.
                 DELEGATED_VP.increment(
@@ -207,22 +209,14 @@ fn handle_delegator_voting_power_changed_hook(
                     // block and update the total that will be reflected in
                     // historical queries starting from the next block.
                     env.block.height + 1,
-                    new_delegated_vp - current_delegated_vp,
+                    delta,
                 )?;
-            }
-        }
 
-        // if the new delegation has voting power and global config specifies a
-        // delegation validity duration, we apply the decrement at the end of
-        // the expiration period.
-        if !new_delegated_vp.is_zero() {
-            if let Some(config_expiration) = config.delegation_validity_blocks {
-                DELEGATED_VP.decrement(
-                    deps.storage,
-                    delegate.clone(),
-                    env.block.height + config_expiration,
-                    new_delegated_vp,
-                )?;
+                // perform the inverse of the change on the expiration block. do
+                // this decrement after the increment to avoid underflow.
+                if let Some(expiration) = expiration {
+                    DELEGATED_VP.decrement(deps.storage, delegate.clone(), expiration, delta)?;
+                }
             }
         }
     }

--- a/contracts/delegation/dao-vote-delegation/src/hooks.rs
+++ b/contracts/delegation/dao-vote-delegation/src/hooks.rs
@@ -89,12 +89,12 @@ pub(crate) fn handle_voting_power_changed_hook(
         Some(env.block.height + 1),
     )?;
 
-    // depending on whether the voting power hook was fired for a delegate or delegator,
-    // we need to handle the voting power change differently.
-    // check latest state instead of historical height, since we need access to
+    // depending on whether the voting power hook was fired for a delegate or
+    // delegator, we need to handle the voting power change differently. check
+    // latest state instead of historical height, since we need access to
     // immediate updates made earlier in the same block
     if is_delegate_registered(deps.as_ref(), &addr, None)? {
-        handle_delegate_voting_power_changed_hook(deps, env.block.height, addr, new_vp)
+        handle_delegate_voting_power_changed_hook(deps, env, addr, new_vp)
     } else {
         // if not a delegate, check if they have any delegations, and update
         // delegate VPs accordingly
@@ -106,13 +106,13 @@ pub(crate) fn handle_voting_power_changed_hook(
 /// if they no longer have any voting power.
 fn handle_delegate_voting_power_changed_hook(
     deps: DepsMut,
-    block_height: u64,
+    env: &Env,
     delegate: Addr,
     new_vp: Uint128,
 ) -> Result<Response, ContractError> {
     // unregister if no more voting power
     if new_vp.is_zero() {
-        unregister_delegate(deps, &delegate, block_height)?;
+        unregister_delegate(deps, &delegate, env.block.height)?;
     }
 
     Ok(Response::new()
@@ -120,8 +120,9 @@ fn handle_delegate_voting_power_changed_hook(
         .add_attribute("member_type", "delegate"))
 }
 
-/// handles the delegator voting power changed hook by updating
-/// their delegated VP for each delegate they are delegating to.
+/// handles the delegator voting power changed hook by updating their delegated
+/// VP for each delegate they are delegating to and each delegate's total
+/// delegated VP.
 fn handle_delegator_voting_power_changed_hook(
     deps: DepsMut,
     env: &Env,
@@ -129,8 +130,8 @@ fn handle_delegator_voting_power_changed_hook(
     delegator: Addr,
     new_vp: Uint128,
 ) -> Result<Response, ContractError> {
-    // need to get the latest delegations in case any were updated earlier
-    // in the same block
+    // need to get the latest delegations in case any were updated earlier in
+    // the same block
     let delegations = DELEGATIONS.load_all_latest(deps.storage, &delegator, env.block.height)?;
 
     let config = CONFIG.load(deps.storage)?;
@@ -147,41 +148,57 @@ fn handle_delegator_voting_power_changed_hook(
         ..
     } in delegations
     {
-        // for each delegation, we first find the current delegated VP and
-        // the new delegated VP
+        // for each delegation, we first find the current delegated VP and the
+        // new delegated VP
         let current_delegated_vp = calculate_delegated_vp(old_vp, percent);
         let new_delegated_vp = calculate_delegated_vp(new_vp, percent);
 
         // first we update the next block's delegated VP for the delegate
         match new_delegated_vp.cmp(&current_delegated_vp) {
             Ordering::Less => {
-                // if the new delegated VP is lesser than the current delegated VP,
-                // we decrement the delegated VP by the delta.
+                // if the new delegated VP is less than the current delegated
+                // VP, we decrement the delegated VP by the delta.
                 DELEGATED_VP.decrement(
                     deps.storage,
                     delegate.clone(),
+                    // update at next block height to match 1-block delay
+                    // behavior of voting power queries and delegation changes.
+                    // this matches the behavior of creating a new delegation,
+                    // which also starts on the following block. if future
+                    // delegations/undelegations/voting power changes occur in
+                    // this block, they will also load the state of the next
+                    // block and update the total that will be reflected in
+                    // historical queries starting from the next block.
                     env.block.height + 1,
                     current_delegated_vp - new_delegated_vp,
                 )?;
             }
             Ordering::Equal => {
-                // for cases where current delegated VP is equal to new delegated VP,
-                // we don't need to do anything.
+                // for cases where current delegated VP is equal to new
+                // delegated VP, we don't need to do anything.
             }
             Ordering::Greater => {
-                // if the new delegated VP is greater than the current delegated VP,
-                // we increment the delegated VP by the delta.
+                // if the new delegated VP is greater than the current delegated
+                // VP, we increment the delegated VP by the delta.
                 DELEGATED_VP.increment(
                     deps.storage,
                     delegate.clone(),
+                    // update at next block height to match 1-block delay
+                    // behavior of voting power queries and delegation changes.
+                    // this matches the behavior of creating a new delegation,
+                    // which also starts on the following block. if future
+                    // delegations/undelegations/voting power changes occur in
+                    // this block, they will also load the state of the next
+                    // block and update the total that will be reflected in
+                    // historical queries starting from the next block.
                     env.block.height + 1,
                     new_delegated_vp - current_delegated_vp,
                 )?;
             }
         }
 
-        // if original delegation had voting power and an expiration date,
-        // we undo the previous decrement at the end of the expiration period.
+        // if original delegation had voting power and an expiration date, we
+        // undo the previous decrement at the end of the expiration period.
         if current_delegated_vp.u128() > 0 {
             if let Some(expire_in) = expiration {
                 DELEGATED_VP.increment(
@@ -193,9 +210,9 @@ fn handle_delegator_voting_power_changed_hook(
             }
         }
 
-        // if the new delegation has voting power & global config specifies
-        // a delegation validity duration, we apply the decrement at the end
-        // of the expiration period.
+        // if the new delegation has voting power and global config specifies a
+        // delegation validity duration, we apply the decrement at the end of
+        // the expiration period.
         if new_delegated_vp.u128() > 0 {
             if let Some(config_expiration) = config.delegation_validity_blocks {
                 DELEGATED_VP.decrement(
@@ -213,9 +230,11 @@ fn handle_delegator_voting_power_changed_hook(
         .add_attribute("member_type", "delegator"))
 }
 
+// if first vote by a delegator, update the unvoted delegated VP for their
+// delegates, if any, by subtracting this member's delegated VP. if not first
+// vote, this has already been done.
 pub fn execute_vote_hook(
     deps: DepsMut,
-    env: Env,
     proposal_module: Addr,
     vote_hook: VoteHookMsg,
 ) -> Result<Response, ContractError> {
@@ -229,64 +248,51 @@ pub fn execute_vote_hook(
             proposal_id,
             voter,
             power,
+            height,
             is_first_vote,
             ..
         } => {
-            // if first vote, update the unvoted delegated VP for their
-            // delegates by subtracting this member's delegated VP. if not first
-            // vote, this has already been done.
-            if is_first_vote {
-                handle_first_delegator_vote(
-                    deps,
-                    voter,
-                    env.block.height,
-                    power,
-                    proposal_id,
+            // if not first vote, this has already been done.
+            if !is_first_vote {
+                return Ok(Response::new()
+                    .add_attribute("action", "vote_hook")
+                    .add_attribute("is_first_vote", "false"));
+            }
+
+            // update voting power for all delegates, if any. if this voter is a
+            // delegate themself, there will simply be no delegations.
+            let delegator = deps.api.addr_validate(&voter)?;
+            let delegations = DELEGATIONS.load_all(deps.storage, &delegator, height)?;
+            for LoadedItem {
+                item: Delegation { delegate, percent },
+                ..
+            } in delegations
+            {
+                let udvp = get_udvp(
+                    deps.as_ref(),
+                    &delegate,
                     &proposal_module,
+                    proposal_id,
+                    height,
+                )?;
+
+                let delegated_vp = calculate_delegated_vp(power, percent);
+
+                // remove the delegator's delegated VP from the delegate's
+                // unvoted delegated VP for this proposal since this
+                // delegator just voted.
+                let new_udvp = udvp.checked_sub(delegated_vp)?;
+
+                UNVOTED_DELEGATED_VP.save(
+                    deps.storage,
+                    (&delegate, &proposal_module, proposal_id),
+                    &new_udvp,
                 )?;
             }
         }
     }
 
-    Ok(Response::new().add_attribute("action", "vote_hook"))
-}
-
-fn handle_first_delegator_vote(
-    deps: DepsMut,
-    voter: String,
-    env_block_height: u64,
-    power: Uint128,
-    proposal_id: u64,
-    proposal_module: &Addr,
-) -> Result<(), ContractError> {
-    let delegator = deps.api.addr_validate(&voter)?;
-    let delegations = DELEGATIONS.load_all(deps.storage, &delegator, env_block_height)?;
-    for LoadedItem {
-        item: Delegation { delegate, percent },
-        ..
-    } in delegations
-    {
-        let udvp = get_udvp(
-            deps.as_ref(),
-            &delegate,
-            proposal_module,
-            proposal_id,
-            env_block_height,
-        )?;
-
-        let delegated_vp = calculate_delegated_vp(power, percent);
-
-        // remove the delegator's delegated VP from the delegate's
-        // unvoted delegated VP for this proposal since this
-        // delegator just voted.
-        let new_udvp = udvp.checked_sub(delegated_vp)?;
-
-        UNVOTED_DELEGATED_VP.save(
-            deps.storage,
-            (&delegate, proposal_module, proposal_id),
-            &new_udvp,
-        )?;
-    }
-
-    Ok(())
+    Ok(Response::new()
+        .add_attribute("action", "vote_hook")
+        .add_attribute("is_first_vote", "true"))
 }

--- a/contracts/delegation/dao-vote-delegation/src/msg.rs
+++ b/contracts/delegation/dao-vote-delegation/src/msg.rs
@@ -19,8 +19,8 @@ pub struct InstantiateMsg {
     /// many, the instantiation will run out of gas, so this should be disabled
     /// and `SyncProposalModules` called manually.
     ///
-    /// Defaults to false.
-    pub no_sync_proposal_modules: Option<bool>,
+    /// Defaults to `true`.
+    pub sync_proposal_modules: Option<bool>,
     /// the maximum percent of voting power that a single delegate can wield.
     /// they can be delegated any amount of voting power—this cap is only
     /// applied when casting votes.

--- a/contracts/delegation/dao-vote-delegation/src/msg.rs
+++ b/contracts/delegation/dao-vote-delegation/src/msg.rs
@@ -19,8 +19,8 @@ pub struct InstantiateMsg {
     /// many, the instantiation will run out of gas, so this should be disabled
     /// and `SyncProposalModules` called manually.
     ///
-    /// Defaults to `true`.
-    pub sync_proposal_modules: Option<bool>,
+    /// Defaults to `false`.
+    pub no_sync_proposal_modules: Option<bool>,
     /// the maximum percent of voting power that a single delegate can wield.
     /// they can be delegated any amount of voting power—this cap is only
     /// applied when casting votes.

--- a/contracts/delegation/dao-vote-delegation/src/testing/suite/base.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/suite/base.rs
@@ -294,8 +294,9 @@ impl DaoVoteDelegationTestingSuiteBase {
             .unwrap()
     }
 
-    /// get the delegated vote power reduction for a proposal
-    pub fn delegated_vote_power_reduction(
+    /// get the effective unvoted delegated voting power reduction for a
+    /// proposal
+    pub fn effective_unvoted_delegated_voting_power_reduction(
         &self,
         delegate: impl Into<String>,
         proposal_module: impl Into<String>,
@@ -306,7 +307,7 @@ impl DaoVoteDelegationTestingSuiteBase {
         self.querier()
             .query_wasm_smart(
                 &self.delegation_addr,
-                &crate::msg::QueryMsg::DelegatedVotePowerReduction {
+                &crate::msg::QueryMsg::EffectiveUnvotedDelegatedVotingPowerReduction {
                     delegate: delegate.into(),
                     proposal_module: proposal_module.into(),
                     proposal_id,
@@ -470,8 +471,8 @@ impl DaoVoteDelegationTestingSuiteBase {
         assert_eq!(udvp.effective, effective.into());
     }
 
-    /// assert the delegated vote power reduction on a proposal for a delegate
-    pub fn assert_delegated_vote_power_reduction(
+    /// assert the effective UDVP reduction on a proposal
+    pub fn assert_effective_udvp_reduction(
         &self,
         delegate: impl Into<String>,
         proposal_module: impl Into<String>,
@@ -480,7 +481,7 @@ impl DaoVoteDelegationTestingSuiteBase {
         delegated_vp: impl Into<Uint128>,
         expected: impl Into<Uint128>,
     ) {
-        let reduction = self.delegated_vote_power_reduction(
+        let reduction = self.effective_unvoted_delegated_voting_power_reduction(
             delegate,
             proposal_module,
             proposal_id,

--- a/contracts/delegation/dao-vote-delegation/src/testing/suite/base.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/suite/base.rs
@@ -288,7 +288,30 @@ impl DaoVoteDelegationTestingSuiteBase {
                     delegate: delegate.into(),
                     proposal_module: proposal_module.into(),
                     proposal_id,
-                    height: start_height,
+                    proposal_height: start_height,
+                },
+            )
+            .unwrap()
+    }
+
+    /// get the less vote power without delegation for a proposal
+    pub fn less_vote_power_without_delegation(
+        &self,
+        delegate: impl Into<String>,
+        proposal_module: impl Into<String>,
+        proposal_id: u64,
+        start_height: u64,
+        delegated_vp: impl Into<Uint128>,
+    ) -> Uint128 {
+        self.querier()
+            .query_wasm_smart(
+                &self.delegation_addr,
+                &crate::msg::QueryMsg::LessVotePowerWithoutDelegation {
+                    delegate: delegate.into(),
+                    proposal_module: proposal_module.into(),
+                    proposal_id,
+                    proposal_height: start_height,
+                    delegated_vp: delegated_vp.into(),
                 },
             )
             .unwrap()
@@ -445,6 +468,26 @@ impl DaoVoteDelegationTestingSuiteBase {
             start_height,
         );
         assert_eq!(udvp.effective, effective.into());
+    }
+
+    /// assert a delegate's less vote power without delegation on a proposal
+    pub fn assert_less_vote_power_without_delegation(
+        &self,
+        delegate: impl Into<String>,
+        proposal_module: impl Into<String>,
+        proposal_id: u64,
+        start_height: u64,
+        delegated_vp: impl Into<Uint128>,
+        expected: impl Into<Uint128>,
+    ) {
+        let less_vote_power = self.less_vote_power_without_delegation(
+            delegate,
+            proposal_module,
+            proposal_id,
+            start_height,
+            delegated_vp,
+        );
+        assert_eq!(less_vote_power, expected.into());
     }
 
     /// assert that the max delegations is set

--- a/contracts/delegation/dao-vote-delegation/src/testing/suite/base.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/suite/base.rs
@@ -294,8 +294,8 @@ impl DaoVoteDelegationTestingSuiteBase {
             .unwrap()
     }
 
-    /// get the less vote power without delegation for a proposal
-    pub fn less_vote_power_without_delegation(
+    /// get the delegated vote power reduction for a proposal
+    pub fn delegated_vote_power_reduction(
         &self,
         delegate: impl Into<String>,
         proposal_module: impl Into<String>,
@@ -306,7 +306,7 @@ impl DaoVoteDelegationTestingSuiteBase {
         self.querier()
             .query_wasm_smart(
                 &self.delegation_addr,
-                &crate::msg::QueryMsg::LessVotePowerWithoutDelegation {
+                &crate::msg::QueryMsg::DelegatedVotePowerReduction {
                     delegate: delegate.into(),
                     proposal_module: proposal_module.into(),
                     proposal_id,
@@ -470,8 +470,8 @@ impl DaoVoteDelegationTestingSuiteBase {
         assert_eq!(udvp.effective, effective.into());
     }
 
-    /// assert a delegate's less vote power without delegation on a proposal
-    pub fn assert_less_vote_power_without_delegation(
+    /// assert the delegated vote power reduction on a proposal for a delegate
+    pub fn assert_delegated_vote_power_reduction(
         &self,
         delegate: impl Into<String>,
         proposal_module: impl Into<String>,
@@ -480,14 +480,14 @@ impl DaoVoteDelegationTestingSuiteBase {
         delegated_vp: impl Into<Uint128>,
         expected: impl Into<Uint128>,
     ) {
-        let less_vote_power = self.less_vote_power_without_delegation(
+        let reduction = self.delegated_vote_power_reduction(
             delegate,
             proposal_module,
             proposal_id,
             start_height,
             delegated_vp,
         );
-        assert_eq!(less_vote_power, expected.into());
+        assert_eq!(reduction, expected.into());
     }
 
     /// assert that the max delegations is set

--- a/contracts/delegation/dao-vote-delegation/src/testing/suite/cw4.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/suite/cw4.rs
@@ -74,7 +74,7 @@ impl Cw4DaoVoteDelegationTestingSuite {
             &crate::msg::InstantiateMsg {
                 dao: None,
                 vp_hook_callers: Some(vec![group_addr]),
-                sync_proposal_modules: None,
+                no_sync_proposal_modules: None,
                 vp_cap_percent,
                 delegation_validity_blocks,
                 max_delegations,

--- a/contracts/delegation/dao-vote-delegation/src/testing/suite/cw4.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/suite/cw4.rs
@@ -74,7 +74,7 @@ impl Cw4DaoVoteDelegationTestingSuite {
             &crate::msg::InstantiateMsg {
                 dao: None,
                 vp_hook_callers: Some(vec![group_addr]),
-                no_sync_proposal_modules: None,
+                sync_proposal_modules: None,
                 vp_cap_percent,
                 delegation_validity_blocks,
                 max_delegations,

--- a/contracts/delegation/dao-vote-delegation/src/testing/suite/cw721.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/suite/cw721.rs
@@ -60,7 +60,7 @@ impl Cw721DaoVoteDelegationTestingSuite {
             &crate::msg::InstantiateMsg {
                 dao: None,
                 vp_hook_callers: Some(vec![voting_module_addr]),
-                sync_proposal_modules: None,
+                no_sync_proposal_modules: None,
                 vp_cap_percent,
                 delegation_validity_blocks,
                 max_delegations,

--- a/contracts/delegation/dao-vote-delegation/src/testing/suite/cw721.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/suite/cw721.rs
@@ -46,21 +46,6 @@ impl Cw721DaoVoteDelegationTestingSuite {
         Self { base, dao, members }
     }
 
-    pub fn with_vp_cap_percent(mut self, vp_cap_percent: Decimal) -> Self {
-        self.vp_cap_percent = Some(vp_cap_percent);
-        self
-    }
-
-    pub fn with_delegation_validity_blocks(mut self, delegation_validity_blocks: u64) -> Self {
-        self.delegation_validity_blocks = Some(delegation_validity_blocks);
-        self
-    }
-
-    pub fn with_max_delegations(mut self, max_delegations: u64) -> Self {
-        self.max_delegations = Some(max_delegations);
-        self
-    }
-
     pub fn build(mut self) -> Self {
         let code_id = self.delegation_code_id;
         let core_addr = self.dao.core_addr.clone();
@@ -125,5 +110,17 @@ impl Cw721DaoVoteDelegationTestingSuite {
 
             assert_eq!(delegation_module, Addr::unchecked(delegation_addr.clone()));
         });
+    }
+
+    /// unstake cw721
+    pub fn unstake(&mut self, staker: impl Into<String>, token_id: &str) {
+        let dao = self.dao.clone();
+        self.cw721().unstake(&dao, staker, token_id);
+    }
+
+    /// stake cw721
+    pub fn stake(&mut self, staker: impl Into<String>, token_id: &str) {
+        let dao = self.dao.clone();
+        self.cw721().stake(&dao, staker, token_id);
     }
 }

--- a/contracts/delegation/dao-vote-delegation/src/testing/suite/cw721.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/suite/cw721.rs
@@ -75,7 +75,7 @@ impl Cw721DaoVoteDelegationTestingSuite {
             &crate::msg::InstantiateMsg {
                 dao: None,
                 vp_hook_callers: Some(vec![voting_module_addr]),
-                no_sync_proposal_modules: None,
+                sync_proposal_modules: None,
                 vp_cap_percent,
                 delegation_validity_blocks,
                 max_delegations,

--- a/contracts/delegation/dao-vote-delegation/src/testing/suite/cw721.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/suite/cw721.rs
@@ -1,0 +1,129 @@
+use std::ops::{Deref, DerefMut};
+
+use cosmwasm_std::{Addr, Decimal};
+use dao_testing::{Cw721TestDao, DaoTestingSuite, InitialNft};
+
+use super::base::DaoVoteDelegationTestingSuiteBase;
+
+pub struct Cw721DaoVoteDelegationTestingSuite {
+    /// base testing suite that we're extending
+    pub base: DaoVoteDelegationTestingSuiteBase,
+
+    /// cw721 voting DAO
+    pub dao: Cw721TestDao,
+
+    /// members of the dao
+    pub members: Vec<InitialNft>,
+}
+
+// allow direct access to base testing suite methods
+impl Deref for Cw721DaoVoteDelegationTestingSuite {
+    type Target = DaoVoteDelegationTestingSuiteBase;
+
+    fn deref(&self) -> &Self::Target {
+        &self.base
+    }
+}
+
+// allow direct access to base testing suite methods
+impl DerefMut for Cw721DaoVoteDelegationTestingSuite {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.base
+    }
+}
+
+// CONSTRUCTOR
+impl Cw721DaoVoteDelegationTestingSuite {
+    pub fn new() -> Self {
+        let mut base = DaoVoteDelegationTestingSuiteBase::new();
+        let mut suite = base.cw721();
+
+        let dao = suite.dao();
+        let members = suite.initial_nfts.clone();
+
+        base.dao_core_addr = dao.core_addr.clone();
+
+        Self { base, dao, members }
+    }
+
+    pub fn with_vp_cap_percent(mut self, vp_cap_percent: Decimal) -> Self {
+        self.vp_cap_percent = Some(vp_cap_percent);
+        self
+    }
+
+    pub fn with_delegation_validity_blocks(mut self, delegation_validity_blocks: u64) -> Self {
+        self.delegation_validity_blocks = Some(delegation_validity_blocks);
+        self
+    }
+
+    pub fn with_max_delegations(mut self, max_delegations: u64) -> Self {
+        self.max_delegations = Some(max_delegations);
+        self
+    }
+
+    pub fn build(mut self) -> Self {
+        let code_id = self.delegation_code_id;
+        let core_addr = self.dao.core_addr.clone();
+        let vp_cap_percent = self.vp_cap_percent;
+        let delegation_validity_blocks = self.delegation_validity_blocks;
+        let max_delegations = self.max_delegations;
+        let voting_module_addr = self.dao.voting_module_addr.to_string();
+
+        self.delegation_addr = self.instantiate(
+            code_id,
+            &core_addr,
+            &crate::msg::InstantiateMsg {
+                dao: None,
+                vp_hook_callers: Some(vec![voting_module_addr]),
+                no_sync_proposal_modules: None,
+                vp_cap_percent,
+                delegation_validity_blocks,
+                max_delegations,
+            },
+            &[],
+            "delegation",
+            Some(core_addr.to_string()),
+        );
+
+        self.setup_delegation_module();
+
+        self
+    }
+
+    /// set up delegation module by adding necessary hooks and adding it to the
+    /// proposal modules
+    pub fn setup_delegation_module(&mut self) {
+        let dao = self.dao.clone();
+        let delegation_addr = self.delegation_addr.to_string();
+
+        // add voting power changed hook to cw721-group
+        self.execute_smart_ok(
+            &dao.core_addr,
+            &dao.voting_module_addr,
+            &dao_voting_cw721_staked::msg::ExecuteMsg::AddHook {
+                addr: delegation_addr.clone(),
+            },
+            &[],
+        );
+
+        // add vote hook to all proposal modules
+        self.add_vote_hook(&dao, &delegation_addr);
+
+        // set the delegation module for all proposal modules
+        self.set_delegation_module(&dao, &delegation_addr);
+
+        // ensure delegation modules are set
+        dao.proposal_modules.iter().for_each(|(_, module)| {
+            let delegation_module = self
+                .querier()
+                .query_wasm_smart::<Option<Addr>>(
+                    module,
+                    &dao_proposal_single::msg::QueryMsg::DelegationModule {},
+                )
+                .unwrap()
+                .unwrap();
+
+            assert_eq!(delegation_module, Addr::unchecked(delegation_addr.clone()));
+        });
+    }
+}

--- a/contracts/delegation/dao-vote-delegation/src/testing/suite/cw721.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/suite/cw721.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use cosmwasm_std::{Addr, Decimal};
+use cosmwasm_std::Addr;
 use dao_testing::{Cw721TestDao, DaoTestingSuite, InitialNft};
 
 use super::base::DaoVoteDelegationTestingSuiteBase;

--- a/contracts/delegation/dao-vote-delegation/src/testing/suite/mod.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/suite/mod.rs
@@ -1,3 +1,4 @@
 pub mod base;
 pub mod cw4;
+pub mod cw721;
 pub mod token;

--- a/contracts/delegation/dao-vote-delegation/src/testing/suite/token.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/suite/token.rs
@@ -76,7 +76,7 @@ impl TokenDaoVoteDelegationTestingSuite {
             &crate::msg::InstantiateMsg {
                 dao: None,
                 vp_hook_callers: Some(vec![voting_module_addr.to_string()]),
-                sync_proposal_modules: None,
+                no_sync_proposal_modules: None,
                 vp_cap_percent,
                 delegation_validity_blocks,
                 max_delegations,

--- a/contracts/delegation/dao-vote-delegation/src/testing/suite/token.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/suite/token.rs
@@ -76,7 +76,7 @@ impl TokenDaoVoteDelegationTestingSuite {
             &crate::msg::InstantiateMsg {
                 dao: None,
                 vp_hook_callers: Some(vec![voting_module_addr.to_string()]),
-                no_sync_proposal_modules: None,
+                sync_proposal_modules: None,
                 vp_cap_percent,
                 delegation_validity_blocks,
                 max_delegations,

--- a/contracts/delegation/dao-vote-delegation/src/testing/suite/token.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/suite/token.rs
@@ -139,6 +139,14 @@ impl TokenDaoVoteDelegationTestingSuite {
         );
     }
 
+    /// mint and stake tokens
+    pub fn mint_and_stake(&mut self, staker: impl Into<String>, amount: impl Into<u128>) {
+        let staker = staker.into();
+        let amount = amount.into();
+        self.mint(&staker, amount);
+        self.stake(&staker, amount);
+    }
+
     /// unstake tokens
     pub fn unstake(&mut self, staker: impl Into<String>, amount: impl Into<Uint128>) {
         let voting_module_addr = self.dao.voting_module_addr.clone();

--- a/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
@@ -918,7 +918,7 @@ fn test_vote_with_override() {
 
     // ensure ADDR0 delegate will lose all of ADDR1's 100% delegated voting
     // power on this proposal if they override their vote
-    suite.assert_delegated_vote_power_reduction(
+    suite.assert_effective_udvp_reduction(
         ADDR0,
         &proposal_module,
         id1,
@@ -954,7 +954,7 @@ fn test_vote_with_override() {
 
     // ensure ADDR3 delegate will lose all of ADDR4's 100% delegated voting
     // power on this proposal if they override their vote
-    suite.assert_delegated_vote_power_reduction(
+    suite.assert_effective_udvp_reduction(
         ADDR3,
         &proposal_module,
         id1,
@@ -990,7 +990,7 @@ fn test_vote_with_override() {
 
     // ensure ADDR0 delegate will lose all of ADDR2's 50% delegated voting power
     // on this proposal if they override their vote
-    suite.assert_delegated_vote_power_reduction(
+    suite.assert_effective_udvp_reduction(
         ADDR0,
         &proposal_module,
         id1,
@@ -1062,7 +1062,7 @@ fn test_vote_override_with_cap() {
     // if ADDR0 were to override the delegate's vote, the effective UDVP should
     // stay the same, since it's capped below the total UDVP and ADDR0's voting
     // power is only 1
-    suite.assert_delegated_vote_power_reduction(
+    suite.assert_effective_udvp_reduction(
         ADDR2,
         &proposal_module,
         id1,
@@ -1076,7 +1076,7 @@ fn test_vote_override_with_cap() {
     // UDVP is total UDVP minus ADDR3's VP, so the reduction is the difference
     // between the cap (which is the current effective UDVP) and the new value
     let new_effective_udvp = Uint128::from(total_udvp - suite.members[3].weight);
-    suite.assert_delegated_vote_power_reduction(
+    suite.assert_effective_udvp_reduction(
         ADDR2,
         &proposal_module,
         id1,
@@ -1123,7 +1123,7 @@ fn test_vote_override_with_cap() {
     // now if ADDR0 were to override the delegate's vote, the effective UDVP
     // should be reduced by the full amount of ADDR0's VP since the effective
     // UDVP is already below the cap
-    suite.assert_delegated_vote_power_reduction(
+    suite.assert_effective_udvp_reduction(
         ADDR2,
         &proposal_module,
         id1,

--- a/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
@@ -309,7 +309,7 @@ fn test_voting_power_updates() {
     // Verify delegate's effective voting power on the new proposal
     suite.assert_effective_udvp(
         ADDR0,
-        &proposal_module_2,
+        proposal_module_2,
         id_2,
         p_2.start_height,
         expected_vp_after_increase_2,
@@ -365,13 +365,13 @@ fn test_voting_power_updates() {
         suite.propose_single_choice(&dao, ADDR0, "test after expiration", vec![]);
 
     // Verify delegate has no effective voting power on this post-expiration proposal
-    suite.assert_effective_udvp(ADDR0, &proposal_module_4, id_4, p_4.start_height, 0u128);
+    suite.assert_effective_udvp(ADDR0, proposal_module_4, id_4, p_4.start_height, 0u128);
 
     // Verify that historical queries still show the correct voting power for proposals
     // created before expiration
     suite.assert_effective_udvp(
         ADDR0,
-        &proposal_module_3,
+        proposal_module_3,
         id_3,
         p_3.start_height,
         expected_final_vp,

--- a/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
@@ -7,6 +7,7 @@ use cw_utils::Duration;
 use dao_hooks::{nft_stake::NftStakeChangedHookMsg, stake::StakeChangedHookMsg, vote::VoteHookMsg};
 use dao_interface::helpers::OptionalUpdate;
 use dao_testing::{ADDR0, ADDR1, ADDR2, ADDR3, ADDR4};
+use dao_voting_token_staked::msg::ListStakersResponse;
 
 use crate::{
     contract::{CONTRACT_NAME, CONTRACT_VERSION, DEFAULT_MAX_DELEGATIONS},
@@ -14,7 +15,8 @@ use crate::{
 };
 
 use super::suite::{
-    cw4::Cw4DaoVoteDelegationTestingSuite, token::TokenDaoVoteDelegationTestingSuite,
+    cw4::Cw4DaoVoteDelegationTestingSuite, cw721::Cw721DaoVoteDelegationTestingSuite,
+    token::TokenDaoVoteDelegationTestingSuite,
 };
 
 pub fn dao_vote_delegation_contract() -> Box<dyn Contract<Empty>> {
@@ -535,6 +537,24 @@ fn test_max_delegations() {
 
     suite.assert_delegations_count(ADDR3, 1);
     suite.assert_delegation(ADDR3, ADDR1, Decimal::percent(25));
+}
+
+#[test]
+#[should_panic(expected = "unauthorized hook caller")]
+fn test_nft_stake_changed_hook_authorizes() {
+    let mut suite = Cw721DaoVoteDelegationTestingSuite::new().build();
+    let dao = suite.dao.clone();
+    let delegation_addr = suite.delegation_addr.clone();
+
+    suite.execute_smart_ok(
+        ADDR1,
+        delegation_addr,
+        &crate::msg::ExecuteMsg::NftStakeChangeHook(NftStakeChangedHookMsg::Stake {
+            addr: Addr::unchecked(ADDR3),
+            token_id: dao.x.cw721_addr.to_string(),
+        }),
+        &[],
+    );
 }
 
 #[test]

--- a/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
@@ -7,7 +7,6 @@ use cw_utils::Duration;
 use dao_hooks::{nft_stake::NftStakeChangedHookMsg, stake::StakeChangedHookMsg, vote::VoteHookMsg};
 use dao_interface::helpers::OptionalUpdate;
 use dao_testing::{ADDR0, ADDR1, ADDR2, ADDR3, ADDR4};
-use dao_voting_token_staked::msg::ListStakersResponse;
 
 use crate::{
     contract::{CONTRACT_NAME, CONTRACT_VERSION, DEFAULT_MAX_DELEGATIONS},

--- a/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
@@ -224,6 +224,161 @@ fn test_simple() {
 }
 
 #[test]
+fn test_voting_power_updates() {
+    // Create a token-based DAO for testing
+    let mut suite = TokenDaoVoteDelegationTestingSuite::new()
+        .with_delegation_validity_blocks(20) // Set a shorter expiration period for testing
+        .build();
+    let dao = suite.dao.clone();
+
+    // Register ADDR0 as a delegate
+    suite.register(ADDR0);
+
+    // Find the delegator's initial staked amount
+    let delegator = ADDR1;
+    let delegator_info = suite
+        .members
+        .iter()
+        .find(|m| m.address == delegator)
+        .expect("Delegator should exist in members");
+    let initial_staked = delegator_info.amount;
+
+    // Delegate 100% of ADDR1's voting power to ADDR0
+    let delegation_block = suite.block().height;
+    suite.delegate(delegator, ADDR0, Decimal::percent(100));
+
+    // Delegations take effect on the next block
+    suite.advance_block();
+
+    // Verify the initial delegation amount
+    suite.assert_delegate_total_delegated_vp(ADDR0, initial_staked);
+
+    // CASE 1: INCREASE voting power by minting and staking more tokens
+    let additional_stake = Uint128::from(500u128);
+    suite.mint_and_stake(delegator, additional_stake);
+    suite.advance_block();
+
+    // Verify the delegated voting power increases correctly
+    let expected_vp_after_increase = initial_staked + additional_stake;
+    suite.assert_delegate_total_delegated_vp(ADDR0, expected_vp_after_increase);
+
+    // CASE 2: DECREASE voting power by unstaking some tokens
+    let unstake_amount = Uint128::from(200u128);
+    suite.unstake(delegator, unstake_amount);
+    suite.advance_block();
+
+    // Verify the delegated voting power decreases correctly
+    let expected_vp_after_decrease = expected_vp_after_increase - unstake_amount;
+    suite.assert_delegate_total_delegated_vp(ADDR0, expected_vp_after_decrease);
+
+    // CASE 3: Verify with proposal creation that delegation is correctly applied
+    let (proposal_module, id, p) =
+        suite.propose_single_choice(&dao, ADDR0, "test voting power updates", vec![]);
+
+    // Verify delegate's effective voting power on the proposal
+    suite.assert_effective_udvp(
+        ADDR0,
+        &proposal_module,
+        id,
+        p.start_height,
+        expected_vp_after_decrease,
+    );
+
+    // CASE 4: INCREASE voting power again
+    let additional_stake_2 = Uint128::from(700u128);
+    suite.mint_and_stake(delegator, additional_stake_2);
+    suite.advance_block();
+
+    // Verify the delegated voting power increases correctly
+    let expected_vp_after_increase_2 = expected_vp_after_decrease + additional_stake_2;
+    suite.assert_delegate_total_delegated_vp(ADDR0, expected_vp_after_increase_2);
+
+    // Verify historical query still shows original voting power for earlier proposal
+    suite.assert_effective_udvp(
+        ADDR0,
+        &proposal_module,
+        id,
+        p.start_height,
+        expected_vp_after_decrease,
+    );
+
+    // Create a new proposal to check the updated voting power
+    let (proposal_module_2, id_2, p_2) =
+        suite.propose_single_choice(&dao, ADDR0, "test updated voting power", vec![]);
+
+    // Verify delegate's effective voting power on the new proposal
+    suite.assert_effective_udvp(
+        ADDR0,
+        &proposal_module_2,
+        id_2,
+        p_2.start_height,
+        expected_vp_after_increase_2,
+    );
+
+    // CASE 5: Multiple operations test - unstake then stake in same block
+    let unstake_amount_3 = Uint128::from(300u128);
+    let stake_amount_3 = Uint128::from(100u128);
+
+    suite.unstake(delegator, unstake_amount_3);
+    suite.mint_and_stake(delegator, stake_amount_3);
+    suite.advance_block();
+
+    // Verify the delegated voting power is correctly updated after both operations
+    let expected_final_vp = expected_vp_after_increase_2;
+
+    suite.assert_delegate_total_delegated_vp(ADDR0, expected_final_vp);
+
+    // CASE 6: Test automatic expiration
+    // Get original delegation expiration block
+    let expiry_height = delegation_block + 20; // Based on .with_delegation_validity_blocks(20)
+
+    // Advance to 1 block before expiration
+    let blocks_to_advance = expiry_height - suite.block().height - 1;
+    suite.advance_blocks(blocks_to_advance);
+
+    // Delegation should still be active
+    suite.assert_delegations_count(delegator, 1);
+    suite.assert_delegate_total_delegated_vp(ADDR0, expected_final_vp);
+
+    // Create a proposal just before expiration
+    let (proposal_module_3, id_3, p_3) =
+        suite.propose_single_choice(&dao, ADDR0, "test before expiration", vec![]);
+
+    // Verify delegate's effective voting power on this pre-expiration proposal
+    suite.assert_effective_udvp(
+        ADDR0,
+        &proposal_module_3,
+        id_3,
+        p_3.start_height,
+        expected_final_vp,
+    );
+
+    // Advance 1 more block so we hit expiration
+    suite.advance_block();
+
+    // Verify delegation is now expired
+    suite.assert_delegations_count(delegator, 0);
+    suite.assert_delegate_total_delegated_vp(ADDR0, 0u128);
+
+    // Create a proposal after expiration
+    let (proposal_module_4, id_4, p_4) =
+        suite.propose_single_choice(&dao, ADDR0, "test after expiration", vec![]);
+
+    // Verify delegate has no effective voting power on this post-expiration proposal
+    suite.assert_effective_udvp(ADDR0, &proposal_module_4, id_4, p_4.start_height, 0u128);
+
+    // Verify that historical queries still show the correct voting power for proposals
+    // created before expiration
+    suite.assert_effective_udvp(
+        ADDR0,
+        &proposal_module_3,
+        id_3,
+        p_3.start_height,
+        expected_final_vp,
+    );
+}
+
+#[test]
 fn test_vp_cap_update() {
     let mut suite = Cw4DaoVoteDelegationTestingSuite::new()
         .with_vp_cap_percent(Decimal::percent(50))
@@ -1616,8 +1771,7 @@ fn test_gas_limits() {
         Uint128::from(initial_staked)
             .mul_floor(percent_delegated)
             // add personal voting power
-            .checked_add(Uint128::from(initial_staked))
-            .unwrap()
+            .strict_add(Uint128::from(initial_staked))
             // multiply by number of delegates
             .checked_mul(Uint128::from(delegates))
             .unwrap(),

--- a/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
@@ -539,24 +539,6 @@ fn test_max_delegations() {
 }
 
 #[test]
-#[should_panic(expected = "unauthorized hook caller")]
-fn test_nft_stake_changed_hook_authorizes() {
-    let mut suite = Cw721DaoVoteDelegationTestingSuite::new().build();
-    let dao = suite.dao.clone();
-    let delegation_addr = suite.delegation_addr.clone();
-
-    suite.execute_smart_ok(
-        ADDR1,
-        delegation_addr,
-        &crate::msg::ExecuteMsg::NftStakeChangeHook(NftStakeChangedHookMsg::Stake {
-            addr: Addr::unchecked(ADDR3),
-            token_id: dao.x.cw721_addr.to_string(),
-        }),
-        &[],
-    );
-}
-
-#[test]
 fn test_update_hook_callers() {
     let mut suite = Cw4DaoVoteDelegationTestingSuite::new().build();
     let dao = suite.dao.clone();
@@ -732,6 +714,58 @@ fn test_vote_with_override() {
         dao_voting::voting::Vote::Yes,
         suite.members[0].weight + suite.members[2].weight,
     );
+}
+
+#[test]
+fn test_cw721_hook_handling() {
+    let mut suite = Cw721DaoVoteDelegationTestingSuite::new().build();
+    let dao = suite.dao.clone();
+
+    // start with ADDR2 unstaking their token
+    suite.unstake(ADDR2, "2");
+
+    // register ADDR0 as delegate
+    suite.register(ADDR0);
+
+    // addr3 and addr4 delegate to addr0
+    suite.delegate(ADDR3, ADDR0, Decimal::percent(100));
+    suite.delegate(ADDR4, ADDR0, Decimal::percent(100));
+
+    suite.advance_block();
+
+    // first prop
+    let (proposal_module, id1, p1) =
+        suite.propose_single_choice(&dao, ADDR3, "test proposal", vec![]);
+
+    suite.assert_effective_udvp(ADDR0, &proposal_module, id1, p1.start_height, 2u128);
+
+    // addr3 decides to unstake their cw721, which should decrease the effective
+    // udvp of addr0
+    suite.unstake(ADDR3, "3");
+
+    suite.advance_block();
+    suite.advance_block();
+
+    // second prop
+    let (proposal_module, id2, p2) =
+        suite.propose_single_choice(&dao, ADDR0, "test proposal 2", vec![]);
+
+    // assert that addr0's effective udvp is now 1
+    suite.assert_effective_udvp(ADDR0, &proposal_module, id2, p2.start_height, 1u128);
+
+    // addr3 stakes again, having not undelegated their voting power from addr0.
+    // this should increase the effective udvp of addr0.
+    suite.stake(ADDR3, "3");
+
+    suite.advance_block();
+    suite.advance_block();
+
+    // propose a proposal
+    let (proposal_module, id3, p3) =
+        suite.propose_single_choice(&dao, ADDR0, "test proposal 3", vec![]);
+
+    // assert that addr3's stake is now reflected in addr0's effective udvp again
+    suite.assert_effective_udvp(ADDR0, &proposal_module, id3, p3.start_height, 2u128);
 }
 
 #[test]
@@ -1101,16 +1135,17 @@ fn test_unauthorized_membership_changed_hook_caller() {
 
 #[test]
 #[should_panic(expected = "unauthorized hook caller")]
-fn test_unauthorized_nft_stake_changed_hook_caller() {
-    let mut suite = Cw4DaoVoteDelegationTestingSuite::new().build();
+fn test_cw721_stake_changed_hook_authorizes() {
+    let mut suite = Cw721DaoVoteDelegationTestingSuite::new().build();
+    let dao = suite.dao.clone();
     let delegation_addr = suite.delegation_addr.clone();
 
     suite.execute_smart_ok(
-        "not_registered_hook_caller",
-        &delegation_addr,
+        ADDR1,
+        delegation_addr,
         &crate::msg::ExecuteMsg::NftStakeChangeHook(NftStakeChangedHookMsg::Stake {
-            addr: Addr::unchecked("not_registered_hook_caller"),
-            token_id: "t_id".to_string(),
+            addr: Addr::unchecked(ADDR3),
+            token_id: dao.x.cw721_addr.to_string(),
         }),
         &[],
     );

--- a/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
@@ -694,6 +694,115 @@ fn test_max_delegations() {
 }
 
 #[test]
+fn test_different_daos_delegations_query() {
+    let mut token_dao_suite = TokenDaoVoteDelegationTestingSuite::new().build();
+
+    let mut cw4_dao_suite = Cw4DaoVoteDelegationTestingSuite::new().build();
+
+    let mut cw721_dao_suite = Cw721DaoVoteDelegationTestingSuite::new().build();
+
+    let token_dao_block = token_dao_suite.block().height;
+    let cw4_dao_block = cw4_dao_suite.block().height;
+    let cw721_dao_block = cw721_dao_suite.block().height;
+
+    assert_eq!(token_dao_block, 1);
+    assert_eq!(cw4_dao_block, 1);
+    assert_eq!(cw721_dao_block, 1);
+
+    // register a delegate to all daos
+    cw4_dao_suite.register(ADDR0);
+    token_dao_suite.register(ADDR0);
+    cw721_dao_suite.register(ADDR0);
+
+    // have a member delegate to the delegate in all daos
+    cw4_dao_suite.delegate(ADDR1, ADDR0, Decimal::percent(100));
+    token_dao_suite.delegate(ADDR1, ADDR0, Decimal::percent(100));
+    cw721_dao_suite.delegate(ADDR1, ADDR0, Decimal::percent(100));
+
+    // skip some blocks
+    cw4_dao_suite.advance_blocks(2);
+    token_dao_suite.advance_blocks(2);
+    cw721_dao_suite.advance_blocks(2);
+
+    let cw4_delegations = cw4_dao_suite
+        .delegations(ADDR1.to_string(), Some(1), None, None)
+        .delegations;
+    let token_delegations = token_dao_suite
+        .delegations(ADDR1.to_string(), Some(1), None, None)
+        .delegations;
+    let cw721_delegations = cw721_dao_suite
+        .delegations(ADDR1.to_string(), Some(1), None, None)
+        .delegations;
+
+    assert!(cw4_delegations.is_empty());
+    assert!(token_delegations.is_empty());
+    assert!(cw721_delegations.is_empty());
+
+    let cw4_delegations = cw4_dao_suite
+        .delegations(ADDR1.to_string(), Some(2), None, None)
+        .delegations;
+    let token_delegations = token_dao_suite
+        .delegations(ADDR1.to_string(), Some(2), None, None)
+        .delegations;
+    let cw721_delegations = cw721_dao_suite
+        .delegations(ADDR1.to_string(), Some(2), None, None)
+        .delegations;
+
+    assert_eq!(cw4_delegations.len(), 1);
+    assert_eq!(token_delegations.len(), 1);
+    assert_eq!(cw721_delegations.len(), 1);
+}
+
+#[test]
+fn test_token_dao_update_expiration_period() {
+    let mut suite = TokenDaoVoteDelegationTestingSuite::new()
+        .with_delegation_validity_blocks(5)
+        .build();
+
+    // register a delegate
+    suite.register(ADDR0);
+
+    // delegate to ADDR0 at block 1, expiring at block 1 + 5 = 6
+    suite.delegate(ADDR3, ADDR0, Decimal::percent(100));
+
+    // block height: 2
+    suite.advance_block();
+    suite.assert_delegations_count(ADDR3, 1);
+
+    // block height: 3
+    suite.advance_block();
+    suite.assert_delegations_count(ADDR3, 1);
+
+    // at block 5 the delegation should still be valid
+    let block_5_delegations = suite.delegations(ADDR3, Some(5), None, None);
+    assert_eq!(block_5_delegations.delegations.len(), 1);
+
+    // at block 6 the delegation should be expired
+    let block_6_delegations = suite.delegations(ADDR3, Some(6), None, None);
+    assert_eq!(block_6_delegations.delegations.len(), 0);
+
+    // dao updates the config and shortens the delegation validity blocks to 2
+    suite.update_delegation_validity_blocks(Some(2));
+
+    // delegate to ADDR0 at block 3. subject to new delegation expiration cfg,
+    // this should expire at block 3 + 2 = 5
+    suite.delegate(ADDR3, ADDR0, Decimal::percent(100));
+
+    suite.assert_delegations_count(ADDR3, 1);
+
+    // advance to block 4, there should still be an active delegation
+    suite.advance_block();
+    suite.assert_delegations_count(ADDR3, 1);
+
+    // at blocks 5, 6... the delegation should be expired
+    suite.advance_block();
+    suite.assert_delegations_count(ADDR3, 0);
+
+    suite.advance_block();
+    suite.assert_delegations_count(ADDR3, 0);
+}
+
+#[test]
 fn test_update_hook_callers() {
     let mut suite = Cw4DaoVoteDelegationTestingSuite::new().build();
     let dao = suite.dao.clone();

--- a/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
@@ -4,6 +4,7 @@ use cosmwasm_std::{
 };
 use cw_multi_test::{Contract, ContractWrapper};
 use cw_utils::Duration;
+use dao_hooks::{nft_stake::NftStakeChangedHookMsg, stake::StakeChangedHookMsg, vote::VoteHookMsg};
 use dao_interface::helpers::OptionalUpdate;
 use dao_testing::{ADDR0, ADDR1, ADDR2, ADDR3, ADDR4};
 
@@ -1044,6 +1045,76 @@ fn test_unauthorized_update_voting_power_hook_callers() {
             add: None,
             remove: None,
         },
+        &[],
+    );
+}
+
+#[test]
+#[should_panic(expected = "unauthorized hook caller")]
+fn test_unauthorized_stake_changed_hook_caller() {
+    let mut suite = Cw4DaoVoteDelegationTestingSuite::new().build();
+    let delegation_addr = suite.delegation_addr.clone();
+
+    suite.execute_smart_ok(
+        "not_registered_hook_caller",
+        &delegation_addr,
+        &crate::msg::ExecuteMsg::StakeChangeHook(StakeChangedHookMsg::Stake {
+            addr: Addr::unchecked("not_registered_hook_caller"),
+            amount: Uint128::one(),
+        }),
+        &[],
+    );
+}
+
+#[test]
+#[should_panic(expected = "unauthorized hook caller")]
+fn test_unauthorized_membership_changed_hook_caller() {
+    let mut suite = Cw4DaoVoteDelegationTestingSuite::new().build();
+    let delegation_addr = suite.delegation_addr.clone();
+
+    suite.execute_smart_ok(
+        "not_registered_hook_caller",
+        &delegation_addr,
+        &crate::msg::ExecuteMsg::MemberChangedHook(cw4::MemberChangedHookMsg { diffs: vec![] }),
+        &[],
+    );
+}
+
+#[test]
+#[should_panic(expected = "unauthorized hook caller")]
+fn test_unauthorized_nft_stake_changed_hook_caller() {
+    let mut suite = Cw4DaoVoteDelegationTestingSuite::new().build();
+    let delegation_addr = suite.delegation_addr.clone();
+
+    suite.execute_smart_ok(
+        "not_registered_hook_caller",
+        &delegation_addr,
+        &crate::msg::ExecuteMsg::NftStakeChangeHook(NftStakeChangedHookMsg::Stake {
+            addr: Addr::unchecked("not_registered_hook_caller"),
+            token_id: "t_id".to_string(),
+        }),
+        &[],
+    );
+}
+
+#[test]
+#[should_panic(expected = "unauthorized hook caller")]
+fn test_unauthorized_execute_vote_hook_caller() {
+    let mut suite = Cw4DaoVoteDelegationTestingSuite::new().build();
+    let delegation_addr = suite.delegation_addr.clone();
+
+    suite.execute_smart_ok(
+        "not_registered_hook_caller",
+        &delegation_addr,
+        &crate::msg::ExecuteMsg::VoteHook(VoteHookMsg::NewVote {
+            proposal_id: 1,
+            voter: "voter".to_string(),
+            vote: "vote".to_string(),
+            power: Uint128::one(),
+            individual_power: Uint128::one(),
+            height: 1,
+            is_first_vote: false,
+        }),
         &[],
     );
 }

--- a/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
@@ -918,7 +918,7 @@ fn test_vote_with_override() {
 
     // ensure ADDR0 delegate will lose all of ADDR1's 100% delegated voting
     // power on this proposal if they override their vote
-    suite.assert_less_vote_power_without_delegation(
+    suite.assert_delegated_vote_power_reduction(
         ADDR0,
         &proposal_module,
         id1,
@@ -954,7 +954,7 @@ fn test_vote_with_override() {
 
     // ensure ADDR3 delegate will lose all of ADDR4's 100% delegated voting
     // power on this proposal if they override their vote
-    suite.assert_less_vote_power_without_delegation(
+    suite.assert_delegated_vote_power_reduction(
         ADDR3,
         &proposal_module,
         id1,
@@ -990,7 +990,7 @@ fn test_vote_with_override() {
 
     // ensure ADDR0 delegate will lose all of ADDR2's 50% delegated voting power
     // on this proposal if they override their vote
-    suite.assert_less_vote_power_without_delegation(
+    suite.assert_delegated_vote_power_reduction(
         ADDR0,
         &proposal_module,
         id1,
@@ -1010,6 +1010,147 @@ fn test_vote_with_override() {
         id1,
         dao_voting::voting::Vote::Yes,
         suite.members[0].weight + suite.members[2].weight,
+    );
+}
+
+#[test]
+fn test_vote_override_with_cap() {
+    let vp_cap_percent = Decimal::percent(20);
+    let mut suite = Cw4DaoVoteDelegationTestingSuite::new()
+        .with_vp_cap_percent(vp_cap_percent)
+        .build();
+    let dao = suite.dao.clone();
+
+    let delegation_cap = suite
+        .total_voting_power(&dao.core_addr)
+        .mul_floor(vp_cap_percent);
+
+    suite.register(ADDR2);
+
+    // delegate all of ADDR3's and ADDR0's voting power to ADDR2
+    suite.delegate(ADDR3, ADDR2, Decimal::percent(100));
+    suite.delegate(ADDR0, ADDR2, Decimal::percent(100));
+    suite.advance_block();
+
+    let total_udvp = suite.members[3].weight + suite.members[0].weight;
+
+    // propose a proposal
+    let (proposal_module, id1, p1) =
+        suite.propose_single_choice(&dao, ADDR2, "test proposal", vec![]);
+
+    // delegate casts vote with all their VP and delegator's VP capped at 20%
+    suite.vote_single_choice(&dao, ADDR2, id1, dao_voting::voting::Vote::Yes);
+    suite.assert_single_choice_votes_count(
+        &proposal_module,
+        id1,
+        dao_voting::voting::Vote::Yes,
+        Uint128::from(suite.members[2].weight) + delegation_cap,
+    );
+
+    // ADDR2 has 100% of ADDR3's and ADDR0's voting power
+    suite.assert_total_udvp(ADDR2, &proposal_module, id1, p1.start_height, total_udvp);
+    // but cap is less so effective UDVP is capped
+    assert!(delegation_cap < total_udvp.into());
+    suite.assert_effective_udvp(
+        ADDR2,
+        &proposal_module,
+        id1,
+        p1.start_height,
+        delegation_cap,
+    );
+
+    // if ADDR0 were to override the delegate's vote, the effective UDVP should
+    // stay the same, since it's capped below the total UDVP and ADDR0's voting
+    // power is only 1
+    suite.assert_delegated_vote_power_reduction(
+        ADDR2,
+        &proposal_module,
+        id1,
+        p1.start_height,
+        suite.members[0].weight,
+        0u128,
+    );
+
+    // if ADDR3 were to override the delegate's vote, the effective UDVP will
+    // reduce by part of ADDR3's VP since the cap is applied: the new effective
+    // UDVP is total UDVP minus ADDR3's VP, so the reduction is the difference
+    // between the cap (which is the current effective UDVP) and the new value
+    let new_effective_udvp = Uint128::from(total_udvp - suite.members[3].weight);
+    suite.assert_delegated_vote_power_reduction(
+        ADDR2,
+        &proposal_module,
+        id1,
+        p1.start_height,
+        suite.members[3].weight,
+        delegation_cap - new_effective_udvp,
+    );
+
+    // ADDR3 cast a vote, bringing the effective UDVP below the cap
+    suite.vote_single_choice(&dao, ADDR3, id1, dao_voting::voting::Vote::No);
+    // effective UDVP should be reduced by the full amount of ADDR3's VP
+    suite.assert_effective_udvp(
+        ADDR2,
+        &proposal_module,
+        id1,
+        p1.start_height,
+        new_effective_udvp,
+    );
+    // since effective UDVP is below the cap, it should match the total UDVP
+    suite.assert_total_udvp(
+        ADDR2,
+        &proposal_module,
+        id1,
+        p1.start_height,
+        new_effective_udvp,
+    );
+
+    // since ADDR3 voted and reduced ADDR2's effective UDVP, the vote counts
+    // should reflect that. YES should have ADDR2's individual VP and new
+    // effective UDVP after the ADDR3 reduction, and NO should have ADDR3's VP
+    suite.assert_single_choice_votes_count(
+        &proposal_module,
+        id1,
+        dao_voting::voting::Vote::Yes,
+        Uint128::from(suite.members[2].weight) + new_effective_udvp,
+    );
+    suite.assert_single_choice_votes_count(
+        &proposal_module,
+        id1,
+        dao_voting::voting::Vote::No,
+        suite.members[3].weight,
+    );
+
+    // now if ADDR0 were to override the delegate's vote, the effective UDVP
+    // should be reduced by the full amount of ADDR0's VP since the effective
+    // UDVP is already below the cap
+    suite.assert_delegated_vote_power_reduction(
+        ADDR2,
+        &proposal_module,
+        id1,
+        p1.start_height,
+        suite.members[0].weight,
+        suite.members[0].weight,
+    );
+
+    // ADDR0 votes yes in agreement with the delegate's vote
+    suite.vote_single_choice(&dao, ADDR0, id1, dao_voting::voting::Vote::Yes);
+    // UDVP should be reduced entirely to 0 since both delegators voted
+    suite.assert_effective_udvp(ADDR2, &proposal_module, id1, p1.start_height, 0u128);
+    suite.assert_total_udvp(ADDR2, &proposal_module, id1, p1.start_height, 0u128);
+    // vote counts should not change since the delegator's vote matched the
+    // delegate's vote
+    assert_eq!(new_effective_udvp, Uint128::from(suite.members[0].weight));
+    suite.assert_single_choice_votes_count(
+        &proposal_module,
+        id1,
+        dao_voting::voting::Vote::Yes,
+        suite.members[2].weight + suite.members[0].weight,
+    );
+    suite.assert_single_choice_votes_count(
+        &proposal_module,
+        id1,
+        dao_voting::voting::Vote::No,
+        suite.members[3].weight,
     );
 }
 

--- a/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
@@ -916,6 +916,17 @@ fn test_vote_with_override() {
         suite.members[0].weight + suite.members[1].weight + suite.members[2].weight / 2,
     );
 
+    // ensure ADDR0 delegate will lose all of ADDR1's 100% delegated voting
+    // power on this proposal if they override their vote
+    suite.assert_less_vote_power_without_delegation(
+        ADDR0,
+        &proposal_module,
+        id1,
+        p1.start_height,
+        suite.members[1].weight,
+        suite.members[1].weight,
+    );
+
     // ADDR1 overrides ADDR0's vote
     suite.vote_single_choice(&dao, ADDR1, id1, dao_voting::voting::Vote::No);
     // ADDR0's unvoted delegated voting power should no longer include ADDR1's
@@ -941,6 +952,17 @@ fn test_vote_with_override() {
         suite.members[1].weight,
     );
 
+    // ensure ADDR3 delegate will lose all of ADDR4's 100% delegated voting
+    // power on this proposal if they override their vote
+    suite.assert_less_vote_power_without_delegation(
+        ADDR3,
+        &proposal_module,
+        id1,
+        p1.start_height,
+        suite.members[4].weight,
+        suite.members[4].weight,
+    );
+
     // ADDR4 votes before their delegate ADDR3 does
     suite.vote_single_choice(&dao, ADDR4, id1, dao_voting::voting::Vote::Abstain);
     // ADDR3 unvoted delegated voting power should not include ADDR4's voting
@@ -964,6 +986,17 @@ fn test_vote_with_override() {
         id1,
         dao_voting::voting::Vote::No,
         suite.members[1].weight + suite.members[3].weight,
+    );
+
+    // ensure ADDR0 delegate will lose all of ADDR2's 50% delegated voting power
+    // on this proposal if they override their vote
+    suite.assert_less_vote_power_without_delegation(
+        ADDR0,
+        &proposal_module,
+        id1,
+        p1.start_height,
+        suite.members[2].weight / 2,
+        suite.members[2].weight / 2,
     );
 
     // ADDR2 overrides ADDR0's vote

--- a/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
@@ -721,8 +721,7 @@ fn test_cw721_hook_handling() {
     let mut suite = Cw721DaoVoteDelegationTestingSuite::new().build();
     let dao = suite.dao.clone();
 
-    // start with ADDR2 unstaking their token
-    suite.unstake(ADDR2, "2");
+    let tid_3 = suite.members[3].token_id.to_string();
 
     // register ADDR0 as delegate
     suite.register(ADDR0);
@@ -737,11 +736,11 @@ fn test_cw721_hook_handling() {
     let (proposal_module, id1, p1) =
         suite.propose_single_choice(&dao, ADDR3, "test proposal", vec![]);
 
-    suite.assert_effective_udvp(ADDR0, &proposal_module, id1, p1.start_height, 2u128);
+    suite.assert_effective_udvp(ADDR0, proposal_module, id1, p1.start_height, 2u128);
 
     // addr3 decides to unstake their cw721, which should decrease the effective
     // udvp of addr0
-    suite.unstake(ADDR3, "3");
+    suite.unstake(ADDR3, &tid_3);
 
     suite.advance_block();
     suite.advance_block();
@@ -751,11 +750,11 @@ fn test_cw721_hook_handling() {
         suite.propose_single_choice(&dao, ADDR0, "test proposal 2", vec![]);
 
     // assert that addr0's effective udvp is now 1
-    suite.assert_effective_udvp(ADDR0, &proposal_module, id2, p2.start_height, 1u128);
+    suite.assert_effective_udvp(ADDR0, proposal_module, id2, p2.start_height, 1u128);
 
     // addr3 stakes again, having not undelegated their voting power from addr0.
     // this should increase the effective udvp of addr0.
-    suite.stake(ADDR3, "3");
+    suite.stake(ADDR3, &tid_3);
 
     suite.advance_block();
     suite.advance_block();
@@ -765,7 +764,7 @@ fn test_cw721_hook_handling() {
         suite.propose_single_choice(&dao, ADDR0, "test proposal 3", vec![]);
 
     // assert that addr3's stake is now reflected in addr0's effective udvp again
-    suite.assert_effective_udvp(ADDR0, &proposal_module, id3, p3.start_height, 2u128);
+    suite.assert_effective_udvp(ADDR0, proposal_module, id3, p3.start_height, 2u128);
 }
 
 #[test]

--- a/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
+++ b/contracts/delegation/dao-vote-delegation/src/testing/tests.rs
@@ -324,7 +324,7 @@ fn test_voting_power_updates() {
     suite.advance_block();
 
     // Verify the delegated voting power is correctly updated after both operations
-    let expected_final_vp = expected_vp_after_increase_2;
+    let expected_final_vp = expected_vp_after_increase_2 - unstake_amount_3 + stake_amount_3;
 
     suite.assert_delegate_total_delegated_vp(ADDR0, expected_final_vp);
 

--- a/contracts/external/cw-payroll-factory/src/contract.rs
+++ b/contracts/external/cw-payroll-factory/src/contract.rs
@@ -9,7 +9,6 @@ use cosmwasm_std::{Addr, Coin};
 use cw2::set_contract_version;
 use cw20::Cw20ExecuteMsg;
 use cw20::Cw20ReceiveMsg;
-use cw_denom::CheckedDenom;
 use cw_storage_plus::Bound;
 use cw_utils::{nonpayable, parse_reply_instantiate_data};
 use cw_vesting::msg::{
@@ -17,6 +16,7 @@ use cw_vesting::msg::{
     ReceiveMsg as PayrollReceiveMsg,
 };
 use cw_vesting::vesting::Vest;
+use cw_vesting::CheckedDenom;
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, ReceiveMsg};

--- a/contracts/proposal/dao-proposal-multiple/src/contract.rs
+++ b/contracts/proposal/dao-proposal-multiple/src/contract.rs
@@ -469,7 +469,7 @@ pub fn execute_vote(
             &env.contract.address,
             proposal_id,
             prop.start_height,
-            &vote_power,
+            &vote_power.individual,
             BALLOTS,
             &mut |vote, power| prop.votes.remove_vote(*vote, power),
         )?;

--- a/contracts/proposal/dao-proposal-single/src/contract.rs
+++ b/contracts/proposal/dao-proposal-single/src/contract.rs
@@ -576,7 +576,7 @@ pub fn execute_vote(
             &env.contract.address,
             proposal_id,
             prop.start_height,
-            &vote_power,
+            &vote_power.individual,
             BALLOTS,
             &mut |vote, power| {
                 prop.votes.remove_vote(*vote, power);

--- a/contracts/proposal/dao-proposal-single/src/testing/tests.rs
+++ b/contracts/proposal/dao-proposal-single/src/testing/tests.rs
@@ -4315,3 +4315,91 @@ fn test_instantiation_stores_delegation_module_addr() {
     let delegation_module = query_delegation_module(&app, &proposal_module).unwrap();
     assert_eq!(delegation_module.to_string(), CREATOR_ADDR.to_string());
 }
+
+#[test]
+fn test_update_delegation_module_validates_addr() {
+    let CommonTest {
+        mut app,
+        proposal_module,
+        gov_token,
+        core_addr,
+        ..
+    } = setup_test(vec![]);
+
+    // make a proposal to update the delegation module
+    mint_cw20s(&mut app, &gov_token, &core_addr, CREATOR_ADDR, 10_000_000);
+    let proposal_id = make_proposal(
+        &mut app,
+        &proposal_module,
+        CREATOR_ADDR,
+        vec![WasmMsg::Execute {
+            contract_addr: proposal_module.to_string(),
+            msg: to_json_binary(&ExecuteMsg::UpdateDelegationModule {
+                module: "".to_string(),
+            })
+            .unwrap(),
+            funds: vec![],
+        }
+        .into()],
+        None,
+    );
+
+    vote_on_proposal(
+        &mut app,
+        &proposal_module,
+        CREATOR_ADDR,
+        proposal_id,
+        Vote::Yes,
+    );
+
+    execute_proposal(&mut app, &proposal_module, CREATOR_ADDR, proposal_id);
+
+    let proposal = query_proposal(&app, &proposal_module, proposal_id);
+
+    // proposal should fail to execute
+    assert_eq!(proposal.proposal.status, Status::ExecutionFailed);
+}
+
+#[test]
+fn test_update_delegation_module() {
+    let CommonTest {
+        mut app,
+        proposal_module,
+        gov_token,
+        core_addr,
+        ..
+    } = setup_test(vec![]);
+
+    let delegation_module = "new_delegation_module".to_string();
+
+    // make a proposal to update the delegation module
+    mint_cw20s(&mut app, &gov_token, &core_addr, CREATOR_ADDR, 10_000_000);
+    let proposal_id = make_proposal(
+        &mut app,
+        &proposal_module,
+        CREATOR_ADDR,
+        vec![WasmMsg::Execute {
+            contract_addr: proposal_module.to_string(),
+            msg: to_json_binary(&ExecuteMsg::UpdateDelegationModule {
+                module: delegation_module.to_string(),
+            })
+            .unwrap(),
+            funds: vec![],
+        }
+        .into()],
+        None,
+    );
+
+    vote_on_proposal(
+        &mut app,
+        &proposal_module,
+        CREATOR_ADDR,
+        proposal_id,
+        Vote::Yes,
+    );
+    execute_proposal(&mut app, &proposal_module, CREATOR_ADDR, proposal_id);
+
+    let new_delegation_module = query_delegation_module(&app, &proposal_module).unwrap();
+
+    assert_eq!(delegation_module, new_delegation_module);
+}

--- a/packages/dao-testing/src/suite/base.rs
+++ b/packages/dao-testing/src/suite/base.rs
@@ -675,6 +675,17 @@ impl DaoTestingSuiteBase {
         self.app.block_info()
     }
 
+    /// get the total voting power of the DAO
+    pub fn total_voting_power(&self, core_addr: impl Into<String>) -> Uint128 {
+        self.querier()
+            .query_wasm_smart::<dao_interface::voting::TotalPowerAtHeightResponse>(
+                Addr::unchecked(core_addr.into()),
+                &dao_interface::msg::QueryMsg::TotalPowerAtHeight { height: None },
+            )
+            .unwrap()
+            .power
+    }
+
     /// get a single choice proposal
     pub fn get_single_choice_proposal(
         &self,

--- a/packages/dao-testing/src/suite/cw4_suite.rs
+++ b/packages/dao-testing/src/suite/cw4_suite.rs
@@ -104,6 +104,11 @@ impl DaoTestingSuite<Cw4DaoExtra> for DaoTestingSuiteCw4<'_> {
 
         Cw4DaoExtra { group_addr }
     }
+
+    fn dao_setup(&mut self, _dao: &mut TestDao<Cw4DaoExtra>) {
+        // advancing block for consistency with other dao types
+        self.advance_block();
+    }
 }
 
 #[cfg(test)]

--- a/packages/dao-voting/src/delegation.rs
+++ b/packages/dao-voting/src/delegation.rs
@@ -50,15 +50,16 @@ pub enum QueryMsg {
         proposal_id: u64,
         proposal_height: u64,
     },
-    /// Returns the VP that should be removed from a delegate's vote tally on a
-    /// specific proposal when a delegator overrides their vote. The
+    /// Returns the VP that should be removed from a delegate's effective UDVP
+    /// (and vote tally if already voted) on a specific proposal when a
+    /// delegator casts a vote (potentially overriding the delegate's vote). The
     /// `proposal_height` field is the height at which the proposal was created.
     /// The `delegated_vp` field is the amount of VP delegated by the delegator
     /// to the delegate for this proposal. This query takes into account the
     /// configured VP cap and should be used by proposal modules when a
     /// delegator overrides a delegate's vote to compute ballot VP updates.
     #[returns(Uint128)]
-    LessVotePowerWithoutDelegation {
+    DelegatedVotePowerReduction {
         proposal_module: String,
         proposal_id: u64,
         proposal_height: u64,
@@ -254,9 +255,9 @@ pub fn handle_delegate_vote_override<Vote: Serialize + DeserializeOwned>(
                 // delegator's vote override. this loss should be equal to the
                 // delegated VP or less if the delegated VP is already being
                 // capped due to the delegation module config.
-                let diff: Uint128 = deps.querier.query_wasm_smart(
+                let reduction: Uint128 = deps.querier.query_wasm_smart(
                     delegation_module,
-                    &QueryMsg::LessVotePowerWithoutDelegation {
+                    &QueryMsg::DelegatedVotePowerReduction {
                         proposal_module: proposal_module.to_string(),
                         proposal_id,
                         proposal_height,
@@ -265,14 +266,13 @@ pub fn handle_delegate_vote_override<Vote: Serialize + DeserializeOwned>(
                     },
                 )?;
 
-                // if the delegate's effective VP is less without the
-                // delegator's vote, update ballot total and vote tally by
-                // removing the lost delegated VP only. this diff method makes
-                // sure to preserve the delegate's individual VP even if they
-                // lose all delegated VP due to delegators overriding votes.
-                if !diff.is_zero() {
-                    delegate_ballot.power -= diff;
-                    remove_vote(&delegate_ballot.vote, diff)?;
+                // if the delegate's effective VP must be reduced, update ballot
+                // total and vote tally. this diff method makes sure to preserve
+                // the delegate's individual VP even if they lose all delegated
+                // VP due to delegators overriding votes.
+                if !reduction.is_zero() {
+                    delegate_ballot.power -= reduction;
+                    remove_vote(&delegate_ballot.vote, reduction)?;
                     ballots.save(deps.storage, (proposal_id, &delegate), &delegate_ballot)?;
                 }
             }

--- a/packages/dao-voting/src/delegation.rs
+++ b/packages/dao-voting/src/delegation.rs
@@ -7,7 +7,7 @@ use cosmwasm_std::{Addr, Decimal, DepsMut, StdResult, Uint128};
 use cw_storage_plus::Map;
 use dao_interface::voting::InfoResponse;
 
-use crate::{proposal::Ballot, voting::VotingPowerWithDelegation};
+use crate::proposal::Ballot;
 
 #[cw_serde]
 #[derive(QueryResponses)]
@@ -41,13 +41,29 @@ pub enum QueryMsg {
     /// immediately via vote hooks (instead of being delayed 1 block like other
     /// historical queries), making it safe to vote multiple times in the same
     /// block. Proposal modules are responsible for maintaining the effective VP
-    /// cap when a delegator overrides a delegate's vote.
+    /// cap when a delegator overrides a delegate's vote. The `proposal_height`
+    /// field is the height at which the proposal was created.
     #[returns(UnvotedDelegatedVotingPowerResponse)]
     UnvotedDelegatedVotingPower {
         delegate: String,
         proposal_module: String,
         proposal_id: u64,
-        height: u64,
+        proposal_height: u64,
+    },
+    /// Returns the VP that should be removed from a delegate's vote tally on a
+    /// specific proposal when a delegator overrides their vote. The
+    /// `proposal_height` field is the height at which the proposal was created.
+    /// The `delegated_vp` field is the amount of VP delegated by the delegator
+    /// to the delegate for this proposal. This query takes into account the
+    /// configured VP cap and should be used by proposal modules when a
+    /// delegator overrides a delegate's vote to compute ballot VP updates.
+    #[returns(Uint128)]
+    LessVotePowerWithoutDelegation {
+        proposal_module: String,
+        proposal_id: u64,
+        proposal_height: u64,
+        delegate: String,
+        delegated_vp: Uint128,
     },
     /// Returns the proposal modules synced from the DAO.
     #[returns(Vec<Addr>)]
@@ -181,14 +197,14 @@ pub fn calculate_delegated_vp(vp: Uint128, percent: Decimal) -> Uint128 {
 // DELEGATE VOTE OVERRIDE: if this is the first time this member voted, override
 // their delegates' votes with the delegator's vote.
 //
-// subtract the delegator's VP from the vote tally of all of their delegates who
-// already voted on this proposal, in order to override their vote with the
-// delegator's preference.
+// subtract the delegator's respective delegated VP  amounts from the vote tally
+// of all of their delegates who already voted on this proposal in order to
+// override their vote with the delegator's preference.
 //
 // we must load all delegations and update each. if this partially fails, the
 // vote tallies will be incorrect, so the entire vote transaction should fail.
-// we need to prevent this from happening by limiting the number of delegations
-// a member can have in order to ensure votes can always be cast.
+// we need to prevent this from running out of gas by limiting the number of
+// delegations a member can have in order to ensure votes can always be cast.
 #[allow(clippy::too_many_arguments)]
 pub fn handle_delegate_vote_override<Vote: Serialize + DeserializeOwned>(
     deps: DepsMut,
@@ -196,8 +212,8 @@ pub fn handle_delegate_vote_override<Vote: Serialize + DeserializeOwned>(
     delegation_module: &Option<Addr>,
     proposal_module: &Addr,
     proposal_id: u64,
-    proposal_start_height: u64,
-    vote_power: &VotingPowerWithDelegation,
+    proposal_height: u64,
+    individual_vote_power: &Uint128,
     ballots: Map<(u64, &Addr), Ballot<Vote>>,
     remove_vote: &mut impl FnMut(&Vote, Uint128) -> StdResult<()>,
 ) -> StdResult<()> {
@@ -208,7 +224,7 @@ pub fn handle_delegate_vote_override<Vote: Serialize + DeserializeOwned>(
                 delegation_module,
                 &QueryMsg::Delegations {
                     delegator: delegator.to_string(),
-                    height: Some(proposal_start_height),
+                    height: Some(proposal_height),
                     offset: None,
                     limit: None,
                 },
@@ -232,59 +248,31 @@ pub fn handle_delegate_vote_override<Vote: Serialize + DeserializeOwned>(
             if let Some(mut delegate_ballot) =
                 ballots.may_load(deps.storage, (proposal_id, &delegate))?
             {
-                // get the delegate's current unvoted delegated VP. since we are
-                // currently overriding this delegate's vote, this UDVP response
-                // will not yet take into account the loss of this current
-                // voter's delegated VP, so we have to do math below to remove
-                // this voter's VP from the delegate's effective VP. the vote
-                // hook at the end of the proposal module's vote function will
-                // update this UDVP in the delegation module for future votes.
-                //
-                // NOTE: this UDVP query reflects updates immediately, instead
-                // of waiting 1 block to take effect like other historical
-                // queries, so this will reflect the updated UDVP from the vote
-                // hooks within the same block, making it safe to vote twice in
-                // the same block.
-                let prev_udvp: UnvotedDelegatedVotingPowerResponse =
-                    deps.querier.query_wasm_smart(
-                        delegation_module,
-                        &QueryMsg::UnvotedDelegatedVotingPower {
-                            delegate: delegate.to_string(),
-                            proposal_module: proposal_module.to_string(),
-                            proposal_id,
-                            height: proposal_start_height,
-                        },
-                    )?;
+                let delegated_vp = calculate_delegated_vp(*individual_vote_power, percent);
 
-                let voter_delegated_vp = calculate_delegated_vp(vote_power.individual, percent);
+                // get the amount of VP the delegate should lose due to this
+                // delegator's vote override. this loss should be equal to the
+                // delegated VP or less if the delegated VP is already being
+                // capped due to the delegation module config.
+                let diff: Uint128 = deps.querier.query_wasm_smart(
+                    delegation_module,
+                    &QueryMsg::LessVotePowerWithoutDelegation {
+                        proposal_module: proposal_module.to_string(),
+                        proposal_id,
+                        proposal_height,
+                        delegate: delegate.to_string(),
+                        delegated_vp,
+                    },
+                )?;
 
-                // subtract this voter's delegated VP from the delegate's total
-                // VP, and cap the result at the delegate's effective VP, to
-                // ensure we properly take into account the configured VP cap.
-                // if the delegate has been delegated in total more than this
-                // voter's delegated VP above the cap, they will not lose any
-                // VP. they will lose part or all of this voter's delegated VP
-                // based on how their total VP ranks relative to the configured
-                // cap.
-                let new_effective_delegated = prev_udvp
-                    .total
-                    .checked_sub(voter_delegated_vp)?
-                    .min(prev_udvp.effective);
-
-                // if the new effective VP is less than the previous effective
-                // VP, update the delegate's ballot and tally.
-                if new_effective_delegated < prev_udvp.effective {
-                    // how much VP the delegate is losing based on this voter's
-                    // VP and the cap.
-                    let diff = prev_udvp.effective - new_effective_delegated;
-
-                    // update ballot total and vote tally by removing the lost
-                    // delegated VP only. this makes sure to fully preserve the
-                    // delegate's personal VP even if they lose all delegated VP
-                    // due to delegators overriding votes.
+                // if the delegate's effective VP is less without the
+                // delegator's vote, update ballot total and vote tally by
+                // removing the lost delegated VP only. this diff method makes
+                // sure to preserve the delegate's individual VP even if they
+                // lose all delegated VP due to delegators overriding votes.
+                if !diff.is_zero() {
                     delegate_ballot.power -= diff;
                     remove_vote(&delegate_ballot.vote, diff)?;
-
                     ballots.save(deps.storage, (proposal_id, &delegate), &delegate_ballot)?;
                 }
             }

--- a/packages/dao-voting/src/delegation.rs
+++ b/packages/dao-voting/src/delegation.rs
@@ -59,7 +59,7 @@ pub enum QueryMsg {
     /// configured VP cap and should be used by proposal modules when a
     /// delegator overrides a delegate's vote to compute ballot VP updates.
     #[returns(Uint128)]
-    DelegatedVotePowerReduction {
+    EffectiveUnvotedDelegatedVotingPowerReduction {
         proposal_module: String,
         proposal_id: u64,
         proposal_height: u64,
@@ -257,7 +257,7 @@ pub fn handle_delegate_vote_override<Vote: Serialize + DeserializeOwned>(
                 // capped due to the delegation module config.
                 let reduction: Uint128 = deps.querier.query_wasm_smart(
                     delegation_module,
-                    &QueryMsg::DelegatedVotePowerReduction {
+                    &QueryMsg::EffectiveUnvotedDelegatedVotingPowerReduction {
                         proposal_module: proposal_module.to_string(),
                         proposal_id,
                         proposal_height,

--- a/packages/dao-voting/src/voting.rs
+++ b/packages/dao-voting/src/voting.rs
@@ -247,10 +247,10 @@ pub fn get_voting_power_with_delegation(
     address: &Addr,
     proposal_id: u64,
     // the proposal start_height at which voting power should be queried
-    height: u64,
+    proposal_height: u64,
 ) -> StdResult<VotingPowerWithDelegation> {
     // get individual voting power from voting module
-    let individual = get_voting_power(deps, address.clone(), dao, Some(height))?;
+    let individual = get_voting_power(deps, address.clone(), dao, Some(proposal_height))?;
 
     // get effective VP delegated to this address from other members of the DAO
     // that has not yet been used to vote on the given proposal. if this query
@@ -265,7 +265,7 @@ pub fn get_voting_power_with_delegation(
                     delegate: address.to_string(),
                     proposal_module: proposal_module.to_string(),
                     proposal_id,
-                    height,
+                    proposal_height,
                 },
             )
         })


### PR DESCRIPTION
# DAO Vote delegation followups

This pr is a part of an extensive review of #888 and mostly contains cosmetic changes and small optimizations.

The summary of proposed changes is as follows:
 
## `contract.rs`

### Instantiation

Instantiate message `no_sync_proposal_modules` field was changed into `sync_proposal_modules` in order to avoid the double-negative condition (`if !msg.no_sync_proposal_modules.unwrap_or(false)`). This is the only proposed api change.

Instantiation now also asserts that no funds were sent along with the message to be consistent with the execution handlers - otherwise, `execute_sync_proposal_modules` would be checked to be nonpayable via executemsg, but not via instantiation.

### `execute_delegate`

Makes use of a new helper `ensure_max_delegations_not_reached` to check for max_delegations limit.
Moves some calls that apply to both new/existing delegations to be outside the if/else check.

### `execute_undelegate`

Updates the percentage via `.update` instead of loading and saving in separate calls.

## `hooks.rs`

### `execute_stake_changed` + `execute_nft_stake_changed`

Cleans up the match statements.

### `handle_voting_power_changed_hook`

Removes the `get_voting_power` helper which internally loads the `DAO` address and uses the `dao_voting::voting::get_voting_power` directly to avoid loading `DAO` twice.
It was quite an involved hook handler so it now branches into either `handle_delegator_voting_power_changed_hook` or `handle_delegate_voting_power_changed_hook` depending on `is_delegate_registered` response.

### `handle_delegator_voting_power_changed_hook`

Probably the only significant logical change in this pr so deserves some attention.
Previously delegator voting power changed handler did two things: remove original delegated VP if nonzero and add new delegated VP if nonzero. Internally, this logic could result in up to four storage updates to the `DELEGATED_VP` wormhole kv-store.

The proposal here is that now, instead of clearing the existing state and writing a new one, handler does the following (for the next block wormhole entry):
1. calculate the delegated vp delta
2. if new vp is less than old vp, decrement the vp by the delta
3. if new vp is greater than old vp, increment the vp by the delta
4. if vp is unchanged, noop

After that:
1. if original delegation had voting power and an expiration date, that entry is undone
2. if the new delegation has voting power & global config specifies a delegation validity duration, the expiration entry is created

This results in up to three storage updates in the worst case while achieving the same functionality.

### Testing

Adds`/suite/cw721.rs` testing suite to enable cw721 staking dao testing.
Adds more unit tests for unauthorized hook callers and cw721 hook handlers.
Under dao-prop-single, adds vote-delegation related unit tests.