### PR TITLE
fix release github CI

### DIFF
--- a/.github/workflows/release-contracts.yml
+++ b/.github/workflows/release-contracts.yml
@@ -14,9 +14,12 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    container: cosmwasm/optimizer:0.16.0
+    container: cosmwasm/optimizer:0.16.1
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install bash
+        run: apk add --no-cache bash
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main


### PR DESCRIPTION
Bumps the optimizer version in the contract release CI and installs bash which the disk space freer step needs.