### PR TITLE
Fix Rujira tokenfactory format (v2.7.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,12 +271,12 @@ dependencies = [
  "cw-admin-factory",
  "cw-utils 1.0.3",
  "cw20 1.1.2",
- "cw20-stake 2.7.0",
- "dao-dao-core 2.7.0",
- "dao-interface 2.7.0",
- "dao-pre-propose-single 2.7.0",
- "dao-proposal-single 2.7.0",
- "dao-voting 2.7.0",
+ "cw20-stake 2.7.1",
+ "dao-dao-core 2.7.1",
+ "dao-interface 2.7.1",
+ "dao-pre-propose-single 2.7.1",
+ "dao-proposal-single 2.7.1",
+ "dao-voting 2.7.1",
  "dao-voting-cw20-staked",
  "env_logger",
  "serde",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "btsg-ft-factory"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -304,11 +304,11 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "dao-dao-core 2.7.0",
- "dao-interface 2.7.0",
- "dao-proposal-single 2.7.0",
+ "dao-dao-core 2.7.1",
+ "dao-interface 2.7.1",
+ "dao-proposal-single 2.7.1",
  "dao-testing",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "dao-voting-token-staked",
  "osmosis-std-derive",
  "prost 0.12.3",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "cw-admin-factory"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "bech32",
  "cosmwasm-schema",
@@ -698,11 +698,11 @@ dependencies = [
  "cw2 1.1.2",
  "cw20-base 1.1.2",
  "cw4 1.1.2",
- "dao-interface 2.7.0",
- "dao-proposal-single 2.7.0",
+ "dao-interface 2.7.1",
+ "dao-proposal-single 2.7.1",
  "dao-testing",
- "dao-voting 2.7.0",
- "dao-voting-cw4 2.7.0",
+ "dao-voting 2.7.1",
+ "dao-voting-cw4 2.7.1",
  "osmosis-test-tube",
  "thiserror",
 ]
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "cw-denom"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -844,20 +844,20 @@ dependencies = [
 
 [[package]]
 name = "cw-fund-distributor"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-paginate-storage 2.7.0",
+ "cw-paginate-storage 2.7.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.7.0",
- "dao-dao-core 2.7.0",
- "dao-interface 2.7.0",
+ "cw20-stake 2.7.1",
+ "dao-dao-core 2.7.1",
+ "dao-interface 2.7.1",
  "dao-testing",
  "dao-voting-cw20-staked",
  "thiserror",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "cw-hooks"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "cw-paginate-storage"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
@@ -966,11 +966,11 @@ dependencies = [
 
 [[package]]
 name = "cw-payroll-factory"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.7.0",
+ "cw-denom 2.7.1",
  "cw-multi-test",
  "cw-ownable",
  "cw-payroll-factory",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "cw-snapshot-vector-map"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.2.0",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "cw-stake-tracker"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "cw-token-swap"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "cw-tokenfactory-issuer"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1100,7 +1100,7 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-tokenfactory-types",
  "cw2 1.1.2",
- "dao-interface 2.7.0",
+ "dao-interface 2.7.1",
  "osmosis-std",
  "osmosis-test-tube",
  "prost 0.12.3",
@@ -1113,11 +1113,11 @@ dependencies = [
 
 [[package]]
 name = "cw-tokenfactory-types"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "dao-interface 2.7.0",
+ "dao-interface 2.7.1",
  "osmosis-std",
  "osmosis-std-derive",
  "prost 0.12.3",
@@ -1184,12 +1184,12 @@ dependencies = [
 
 [[package]]
 name = "cw-vesting"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.7.0",
+ "cw-denom 2.7.1",
  "cw-multi-test",
  "cw-ownable",
  "cw-stake-tracker",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "cw-wormhole"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1375,16 +1375,16 @@ dependencies = [
 
 [[package]]
 name = "cw20-stake"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-hooks 2.7.0",
+ "cw-hooks 2.7.1",
  "cw-multi-test",
  "cw-ownable",
- "cw-paginate-storage 2.7.0",
+ "cw-paginate-storage 2.7.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 0.13.4",
  "cw-utils 1.0.3",
@@ -1392,16 +1392,16 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw20-stake 0.2.6",
- "cw20-stake 2.7.0",
- "dao-hooks 2.7.0",
+ "cw20-stake 2.7.1",
+ "dao-hooks 2.7.1",
  "dao-testing",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "thiserror",
 ]
 
 [[package]]
 name = "cw20-stake-external-rewards"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1415,9 +1415,9 @@ dependencies = [
  "cw20 0.13.4",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.7.0",
+ "cw20-stake 2.7.1",
  "cw20-stake-external-rewards",
- "dao-hooks 2.7.0",
+ "dao-hooks 2.7.1",
  "dao-testing",
  "stake-cw20-external-rewards",
  "thiserror",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-stake-reward-distributor"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1436,7 +1436,7 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.7.0",
+ "cw20-stake 2.7.1",
  "cw20-stake-reward-distributor",
  "dao-testing",
  "stake-cw20-reward-distributor",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-roles"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1666,7 +1666,7 @@ dependencies = [
 
 [[package]]
 name = "dao-cw721-extensions"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1696,13 +1696,13 @@ dependencies = [
 
 [[package]]
 name = "dao-dao-core"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-core",
  "cw-multi-test",
- "cw-paginate-storage 2.7.0",
+ "cw-paginate-storage 2.7.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1710,9 +1710,9 @@ dependencies = [
  "cw20-base 1.1.2",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
- "dao-dao-core 2.7.0",
- "dao-dao-macros 2.7.0",
- "dao-interface 2.7.0",
+ "dao-dao-core 2.7.1",
+ "dao-dao-macros 2.7.1",
+ "dao-interface 2.7.1",
  "dao-proposal-sudo",
  "dao-testing",
  "dao-voting-cw20-balance",
@@ -1733,13 +1733,13 @@ dependencies = [
 
 [[package]]
 name = "dao-dao-macros"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-hooks 2.7.0",
- "dao-interface 2.7.0",
- "dao-voting 2.7.0",
+ "cw-hooks 2.7.1",
+ "dao-interface 2.7.1",
+ "dao-voting 2.7.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1761,14 +1761,14 @@ dependencies = [
 
 [[package]]
 name = "dao-hooks"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-hooks 2.7.0",
+ "cw-hooks 2.7.1",
  "cw4 1.1.2",
- "dao-pre-propose-base 2.7.0",
- "dao-voting 2.7.0",
+ "dao-pre-propose-base 2.7.1",
+ "dao-voting 2.7.1",
 ]
 
 [[package]]
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "dao-interface"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "dao-migrator"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1818,31 +1818,31 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw20-stake 0.2.6",
- "cw20-stake 2.7.0",
+ "cw20-stake 2.7.1",
  "cw20-staked-balance-voting",
  "cw4 0.13.4",
  "cw4-voting",
- "dao-dao-core 2.7.0",
- "dao-interface 2.7.0",
+ "dao-dao-core 2.7.1",
+ "dao-interface 2.7.1",
  "dao-migrator",
- "dao-proposal-single 2.7.0",
+ "dao-proposal-single 2.7.1",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.7.0",
+ "dao-voting-cw4 2.7.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-pre-propose-approval-multiple"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.7.0",
+ "cw-denom 2.7.1",
  "cw-multi-test",
- "cw-paginate-storage 2.7.0",
+ "cw-paginate-storage 2.7.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1850,15 +1850,15 @@ dependencies = [
  "cw20-base 1.1.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
- "dao-dao-core 2.7.0",
- "dao-hooks 2.7.0",
- "dao-interface 2.7.0",
- "dao-pre-propose-base 2.7.0",
- "dao-proposal-multiple 2.7.0",
+ "dao-dao-core 2.7.1",
+ "dao-hooks 2.7.1",
+ "dao-interface 2.7.1",
+ "dao-pre-propose-base 2.7.1",
+ "dao-proposal-multiple 2.7.1",
  "dao-testing",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.7.0",
+ "dao-voting-cw4 2.7.1",
  "thiserror",
 ]
 
@@ -1881,13 +1881,13 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-approval-single"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.7.0",
+ "cw-denom 2.7.1",
  "cw-multi-test",
- "cw-paginate-storage 2.7.0",
+ "cw-paginate-storage 2.7.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1896,30 +1896,30 @@ dependencies = [
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "dao-dao-core 2.4.1",
- "dao-dao-core 2.7.0",
- "dao-hooks 2.7.0",
+ "dao-dao-core 2.7.1",
+ "dao-hooks 2.7.1",
  "dao-interface 2.4.1",
- "dao-interface 2.7.0",
+ "dao-interface 2.7.1",
  "dao-pre-propose-approval-single 2.4.1",
- "dao-pre-propose-base 2.7.0",
+ "dao-pre-propose-base 2.7.1",
  "dao-proposal-single 2.4.1",
- "dao-proposal-single 2.7.0",
+ "dao-proposal-single 2.7.1",
  "dao-testing",
  "dao-voting 2.4.1",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "dao-voting-cw20-staked",
  "dao-voting-cw4 2.4.1",
- "dao-voting-cw4 2.7.0",
+ "dao-voting-cw4 2.7.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-pre-propose-approver"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.7.0",
+ "cw-denom 2.7.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -1927,18 +1927,18 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw4-group 1.1.2",
- "dao-dao-core 2.7.0",
- "dao-hooks 2.7.0",
- "dao-interface 2.7.0",
+ "dao-dao-core 2.7.1",
+ "dao-hooks 2.7.1",
+ "dao-interface 2.7.1",
  "dao-pre-propose-approval-multiple",
- "dao-pre-propose-approval-single 2.7.0",
- "dao-pre-propose-base 2.7.0",
- "dao-proposal-multiple 2.7.0",
- "dao-proposal-single 2.7.0",
+ "dao-pre-propose-approval-single 2.7.1",
+ "dao-pre-propose-base 2.7.1",
+ "dao-proposal-multiple 2.7.1",
+ "dao-proposal-single 2.7.1",
  "dao-testing",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.7.0",
+ "dao-voting-cw4 2.7.1",
 ]
 
 [[package]]
@@ -1962,18 +1962,18 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-base"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.7.0",
- "cw-hooks 2.7.0",
+ "cw-denom 2.7.1",
+ "cw-hooks 2.7.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "dao-interface 2.7.0",
- "dao-voting 2.7.0",
+ "dao-interface 2.7.1",
+ "dao-voting 2.7.1",
  "semver",
  "serde",
  "thiserror",
@@ -1994,11 +1994,11 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-multiple"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.7.0",
+ "cw-denom 2.7.1",
  "cw-multi-test",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -2007,20 +2007,20 @@ dependencies = [
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "dao-dao-core 2.4.1",
- "dao-dao-core 2.7.0",
- "dao-hooks 2.7.0",
+ "dao-dao-core 2.7.1",
+ "dao-hooks 2.7.1",
  "dao-interface 2.4.1",
- "dao-interface 2.7.0",
- "dao-pre-propose-base 2.7.0",
+ "dao-interface 2.7.1",
+ "dao-pre-propose-base 2.7.1",
  "dao-pre-propose-multiple 2.4.1",
  "dao-proposal-multiple 2.4.1",
- "dao-proposal-multiple 2.7.0",
+ "dao-proposal-multiple 2.7.1",
  "dao-testing",
  "dao-voting 2.4.1",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "dao-voting-cw20-staked",
  "dao-voting-cw4 2.4.1",
- "dao-voting-cw4 2.7.0",
+ "dao-voting-cw4 2.7.1",
 ]
 
 [[package]]
@@ -2038,12 +2038,12 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-single"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.7.0",
- "cw-hooks 2.7.0",
+ "cw-denom 2.7.1",
+ "cw-hooks 2.7.1",
  "cw-multi-test",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -2052,25 +2052,25 @@ dependencies = [
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "dao-dao-core 2.4.1",
- "dao-dao-core 2.7.0",
- "dao-hooks 2.7.0",
+ "dao-dao-core 2.7.1",
+ "dao-hooks 2.7.1",
  "dao-interface 2.4.1",
- "dao-interface 2.7.0",
- "dao-pre-propose-base 2.7.0",
+ "dao-interface 2.7.1",
+ "dao-pre-propose-base 2.7.1",
  "dao-pre-propose-single 2.4.1",
  "dao-proposal-single 2.4.1",
- "dao-proposal-single 2.7.0",
+ "dao-proposal-single 2.7.1",
  "dao-testing",
  "dao-voting 2.4.1",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "dao-voting-cw20-staked",
  "dao-voting-cw4 2.4.1",
- "dao-voting-cw4 2.7.0",
+ "dao-voting-cw4 2.7.1",
 ]
 
 [[package]]
 name = "dao-proposal-condorcet"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2081,34 +2081,34 @@ dependencies = [
  "cw2 1.1.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
- "dao-dao-core 2.7.0",
- "dao-dao-macros 2.7.0",
- "dao-interface 2.7.0",
+ "dao-dao-core 2.7.1",
+ "dao-dao-macros 2.7.1",
+ "dao-interface 2.7.1",
  "dao-testing",
- "dao-voting 2.7.0",
- "dao-voting-cw4 2.7.0",
+ "dao-voting 2.7.1",
+ "dao-voting-cw4 2.7.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-proposal-hook-counter"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-hooks 2.7.0",
+ "cw-hooks 2.7.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "dao-dao-core 2.7.0",
- "dao-hooks 2.7.0",
- "dao-interface 2.7.0",
- "dao-proposal-single 2.7.0",
+ "dao-dao-core 2.7.1",
+ "dao-hooks 2.7.1",
+ "dao-interface 2.7.1",
+ "dao-proposal-single 2.7.1",
  "dao-testing",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "dao-voting-cw20-balance",
  "thiserror",
 ]
@@ -2138,35 +2138,35 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-multiple"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.7.0",
- "cw-hooks 2.7.0",
+ "cw-denom 2.7.1",
+ "cw-hooks 2.7.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.7.0",
+ "cw20-stake 2.7.1",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
- "dao-dao-macros 2.7.0",
- "dao-hooks 2.7.0",
- "dao-interface 2.7.0",
- "dao-pre-propose-base 2.7.0",
- "dao-pre-propose-multiple 2.7.0",
- "dao-proposal-multiple 2.7.0",
+ "dao-dao-macros 2.7.1",
+ "dao-hooks 2.7.1",
+ "dao-interface 2.7.1",
+ "dao-pre-propose-base 2.7.1",
+ "dao-pre-propose-multiple 2.7.1",
+ "dao-proposal-multiple 2.7.1",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.7.0",
+ "dao-voting-cw4 2.7.1",
  "dao-voting-cw721-staked",
  "dao-voting-token-staked",
  "rand",
@@ -2199,14 +2199,14 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-single"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-core",
- "cw-denom 2.7.0",
- "cw-hooks 2.7.0",
+ "cw-denom 2.7.1",
+ "cw-hooks 2.7.1",
  "cw-multi-test",
  "cw-proposal-single",
  "cw-storage-plus 1.2.0",
@@ -2215,23 +2215,23 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.7.0",
+ "cw20-stake 2.7.1",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
- "dao-dao-core 2.7.0",
- "dao-dao-macros 2.7.0",
- "dao-hooks 2.7.0",
- "dao-interface 2.7.0",
- "dao-pre-propose-base 2.7.0",
- "dao-pre-propose-single 2.7.0",
- "dao-proposal-single 2.7.0",
+ "dao-dao-core 2.7.1",
+ "dao-dao-macros 2.7.1",
+ "dao-hooks 2.7.1",
+ "dao-interface 2.7.1",
+ "dao-pre-propose-base 2.7.1",
+ "dao-pre-propose-single 2.7.1",
+ "dao-proposal-single 2.7.1",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.7.0",
+ "dao-voting-cw4 2.7.1",
  "dao-voting-cw721-staked",
  "dao-voting-token-staked",
  "thiserror",
@@ -2239,21 +2239,21 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-sudo"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
- "dao-dao-macros 2.7.0",
- "dao-interface 2.7.0",
+ "dao-dao-macros 2.7.1",
+ "dao-interface 2.7.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-rewards-distributor"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2266,17 +2266,17 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.7.0",
+ "cw20-stake 2.7.1",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
- "dao-hooks 2.7.0",
- "dao-interface 2.7.0",
+ "dao-hooks 2.7.1",
+ "dao-interface 2.7.1",
  "dao-rewards-distributor",
  "dao-testing",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.7.0",
+ "dao-voting-cw4 2.7.1",
  "dao-voting-cw721-staked",
  "dao-voting-token-staked",
  "semver",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "dao-test-custom-factory"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2297,22 +2297,22 @@ dependencies = [
  "cw2 1.1.2",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
- "dao-dao-macros 2.7.0",
- "dao-interface 2.7.0",
- "dao-voting 2.7.0",
+ "dao-dao-macros 2.7.1",
+ "dao-interface 2.7.1",
+ "dao-voting 2.7.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-testing"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "btsg-ft-factory",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-admin-factory",
  "cw-core",
- "cw-hooks 2.7.0",
+ "cw-hooks 2.7.1",
  "cw-multi-test",
  "cw-payroll-factory",
  "cw-proposal-single",
@@ -2324,7 +2324,7 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw20-stake 0.2.6",
- "cw20-stake 2.7.0",
+ "cw20-stake 2.7.1",
  "cw20-stake-external-rewards",
  "cw20-stake-reward-distributor",
  "cw4 1.1.2",
@@ -2333,33 +2333,33 @@ dependencies = [
  "cw721-base 0.18.0",
  "cw721-roles",
  "dao-dao-core 2.4.1",
- "dao-dao-core 2.7.0",
+ "dao-dao-core 2.7.1",
  "dao-interface 2.4.1",
- "dao-interface 2.7.0",
+ "dao-interface 2.7.1",
  "dao-migrator",
  "dao-pre-propose-approval-single 2.4.1",
- "dao-pre-propose-approval-single 2.7.0",
+ "dao-pre-propose-approval-single 2.7.1",
  "dao-pre-propose-approver",
  "dao-pre-propose-multiple 2.4.1",
- "dao-pre-propose-multiple 2.7.0",
+ "dao-pre-propose-multiple 2.7.1",
  "dao-pre-propose-single 2.4.1",
- "dao-pre-propose-single 2.7.0",
+ "dao-pre-propose-single 2.7.1",
  "dao-proposal-condorcet",
  "dao-proposal-hook-counter",
  "dao-proposal-multiple 2.4.1",
- "dao-proposal-multiple 2.7.0",
+ "dao-proposal-multiple 2.7.1",
  "dao-proposal-single 2.4.1",
- "dao-proposal-single 2.7.0",
+ "dao-proposal-single 2.7.1",
  "dao-proposal-sudo",
  "dao-rewards-distributor",
  "dao-test-custom-factory",
  "dao-voting 0.1.0",
  "dao-voting 2.4.1",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
  "dao-voting-cw4 2.4.1",
- "dao-voting-cw4 2.7.0",
+ "dao-voting-cw4 2.7.1",
  "dao-voting-cw721-roles",
  "dao-voting-cw721-staked",
  "dao-voting-onft-staked",
@@ -2376,14 +2376,14 @@ dependencies = [
 
 [[package]]
 name = "dao-vote-delegation"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
  "cw-multi-test",
- "cw-paginate-storage 2.7.0",
+ "cw-paginate-storage 2.7.1",
  "cw-snapshot-vector-map",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -2391,19 +2391,19 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.7.0",
+ "cw20-stake 2.7.1",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
- "dao-hooks 2.7.0",
- "dao-interface 2.7.0",
- "dao-proposal-multiple 2.7.0",
- "dao-proposal-single 2.7.0",
+ "dao-hooks 2.7.1",
+ "dao-interface 2.7.1",
+ "dao-proposal-multiple 2.7.1",
+ "dao-proposal-single 2.7.1",
  "dao-proposal-sudo",
  "dao-testing",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.7.0",
+ "dao-voting-cw4 2.7.1",
  "dao-voting-cw721-staked",
  "dao-voting-token-staked",
  "semver",
@@ -2441,22 +2441,22 @@ dependencies = [
 
 [[package]]
 name = "dao-voting"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.7.0",
+ "cw-denom 2.7.1",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw20 1.1.2",
- "dao-dao-macros 2.7.0",
- "dao-interface 2.7.0",
+ "dao-dao-macros 2.7.1",
+ "dao-interface 2.7.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw20-balance"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2466,15 +2466,15 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "dao-dao-macros 2.7.0",
- "dao-interface 2.7.0",
+ "dao-dao-macros 2.7.1",
+ "dao-interface 2.7.1",
  "dao-testing",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw20-staked"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2484,11 +2484,11 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.7.0",
- "dao-dao-macros 2.7.0",
- "dao-interface 2.7.0",
+ "cw20-stake 2.7.1",
+ "dao-dao-macros 2.7.1",
+ "dao-interface 2.7.1",
  "dao-testing",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "thiserror",
 ]
 
@@ -2512,7 +2512,7 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-cw4"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2522,16 +2522,16 @@ dependencies = [
  "cw2 1.1.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
- "dao-dao-macros 2.7.0",
- "dao-interface 2.7.0",
+ "dao-dao-macros 2.7.1",
+ "dao-interface 2.7.1",
  "dao-testing",
- "dao-voting-cw4 2.7.0",
+ "dao-voting-cw4 2.7.1",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw721-roles"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2546,21 +2546,21 @@ dependencies = [
  "cw721-base 0.18.0",
  "cw721-roles",
  "dao-cw721-extensions",
- "dao-dao-macros 2.7.0",
- "dao-interface 2.7.0",
+ "dao-dao-macros 2.7.1",
+ "dao-interface 2.7.1",
  "dao-testing",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw721-staked"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-hooks 2.7.0",
+ "cw-hooks 2.7.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -2568,14 +2568,14 @@ dependencies = [
  "cw721 0.18.0",
  "cw721-base 0.18.0",
  "cw721-controllers",
- "dao-dao-macros 2.7.0",
- "dao-hooks 2.7.0",
- "dao-interface 2.7.0",
+ "dao-dao-macros 2.7.1",
+ "dao-hooks 2.7.1",
+ "dao-interface 2.7.1",
  "dao-proposal-hook-counter",
- "dao-proposal-single 2.7.0",
+ "dao-proposal-single 2.7.1",
  "dao-test-custom-factory",
  "dao-testing",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "nft-controllers",
  "osmosis-std",
  "osmosis-test-tube",
@@ -2585,26 +2585,26 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-onft-staked"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-hooks 2.7.0",
+ "cw-hooks 2.7.1",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw721-controllers",
- "dao-dao-macros 2.7.0",
- "dao-hooks 2.7.0",
- "dao-interface 2.7.0",
+ "dao-dao-macros 2.7.1",
+ "dao-hooks 2.7.1",
+ "dao-interface 2.7.1",
  "dao-proposal-hook-counter",
- "dao-proposal-single 2.7.0",
+ "dao-proposal-single 2.7.1",
  "dao-test-custom-factory",
  "dao-testing",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "nft-controllers",
  "omniflix-std",
  "osmosis-test-tube",
@@ -2616,27 +2616,27 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-token-staked"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-hooks 2.7.0",
+ "cw-hooks 2.7.1",
  "cw-multi-test",
  "cw-ownable",
  "cw-storage-plus 1.2.0",
  "cw-tokenfactory-issuer",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "dao-dao-macros 2.7.0",
- "dao-hooks 2.7.0",
- "dao-interface 2.7.0",
+ "dao-dao-macros 2.7.1",
+ "dao-hooks 2.7.1",
+ "dao-interface 2.7.1",
  "dao-proposal-hook-counter",
- "dao-proposal-single 2.7.0",
+ "dao-proposal-single 2.7.1",
  "dao-test-custom-factory",
  "dao-testing",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "osmosis-std",
  "osmosis-test-tube",
  "serde",
@@ -3324,16 +3324,16 @@ dependencies = [
  "cw-vesting",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.7.0",
+ "cw20-stake 2.7.1",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
  "cw721-roles",
- "dao-dao-core 2.7.0",
- "dao-interface 2.7.0",
- "dao-pre-propose-single 2.7.0",
- "dao-proposal-single 2.7.0",
+ "dao-dao-core 2.7.1",
+ "dao-interface 2.7.1",
+ "dao-pre-propose-single 2.7.1",
+ "dao-proposal-single 2.7.1",
  "dao-test-custom-factory",
- "dao-voting 2.7.0",
+ "dao-voting 2.7.1",
  "dao-voting-cw20-staked",
  "dao-voting-cw721-staked",
  "env_logger",
@@ -3527,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "nft-controllers"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/DA0-DA0/dao-contracts"
-version = "2.7.0"
+version = "2.7.1"
 
 [profile.release]
 codegen-units = 1
@@ -86,54 +86,54 @@ wynd-utils = "0.4"
 # optional owner.
 cw-ownable = "0.5"
 
-btsg-ft-factory = { path = "./contracts/external/btsg-ft-factory", version = "2.7.0" }
-cw-admin-factory = { path = "./contracts/external/cw-admin-factory", version = "2.7.0" }
-cw-denom = { path = "./packages/cw-denom", version = "2.7.0" }
-cw-fund-distributor = { path = "./contracts/distribution/cw-fund-distributor", version = "2.7.0" }
-cw-hooks = { path = "./packages/cw-hooks", version = "2.7.0" }
-cw-paginate-storage = { path = "./packages/cw-paginate-storage", version = "2.7.0" }
-cw-payroll-factory = { path = "./contracts/external/cw-payroll-factory", version = "2.7.0" }
-cw-snapshot-vector-map = { path = "./packages/cw-snapshot-vector-map", version = "2.7.0" }
-cw-stake-tracker = { path = "./packages/cw-stake-tracker", version = "2.7.0" }
-cw-token-swap = { path = "./contracts/external/cw-token-swap", version = "2.7.0" }
-cw-tokenfactory-issuer = { path = "./contracts/external/cw-tokenfactory-issuer", version = "2.7.0", default-features = false }
-cw-tokenfactory-types = { path = "./packages/cw-tokenfactory-types", version = "2.7.0", default-features = false }
-cw-vesting = { path = "./contracts/external/cw-vesting", version = "2.7.0" }
-cw-wormhole = { path = "./packages/cw-wormhole", version = "2.7.0" }
-cw20-stake = { path = "./contracts/staking/cw20-stake", version = "2.7.0" }
-cw20-stake-external-rewards = { path = "./contracts/staking/cw20-stake-external-rewards", version = "2.7.0" }
-cw20-stake-reward-distributor = { path = "./contracts/staking/cw20-stake-reward-distributor", version = "2.7.0" }
-cw721-roles = { path = "./contracts/external/cw721-roles", version = "2.7.0" }
-dao-cw721-extensions = { path = "./packages/dao-cw721-extensions", version = "2.7.0" }
-dao-dao-core = { path = "./contracts/dao-dao-core", version = "2.7.0" }
-dao-dao-macros = { path = "./packages/dao-dao-macros", version = "2.7.0" }
-dao-hooks = { path = "./packages/dao-hooks", version = "2.7.0" }
-dao-interface = { path = "./packages/dao-interface", version = "2.7.0" }
-dao-pre-propose-approval-multiple = { path = "./contracts/pre-propose/dao-pre-propose-approval-multiple", version = "2.7.0" }
-dao-migrator = { path = "./contracts/external/dao-migrator", version = "2.7.0" }
-dao-pre-propose-approval-single = { path = "./contracts/pre-propose/dao-pre-propose-approval-single", version = "2.7.0" }
-dao-pre-propose-approver = { path = "./contracts/pre-propose/dao-pre-propose-approver", version = "2.7.0" }
-dao-pre-propose-base = { path = "./packages/dao-pre-propose-base", version = "2.7.0" }
-dao-pre-propose-multiple = { path = "./contracts/pre-propose/dao-pre-propose-multiple", version = "2.7.0" }
-dao-pre-propose-single = { path = "./contracts/pre-propose/dao-pre-propose-single", version = "2.7.0" }
-dao-proposal-condorcet = { path = "./contracts/proposal/dao-proposal-condorcet", version = "2.7.0" }
-dao-proposal-hook-counter = { path = "./contracts/test/dao-proposal-hook-counter", version = "2.7.0" }
-dao-proposal-multiple = { path = "./contracts/proposal/dao-proposal-multiple", version = "2.7.0" }
-dao-proposal-single = { path = "./contracts/proposal/dao-proposal-single", version = "2.7.0" }
-dao-proposal-sudo = { path = "./contracts/test/dao-proposal-sudo", version = "2.7.0" }
-dao-rewards-distributor = { path = "./contracts/distribution/dao-rewards-distributor", version = "2.7.0" }
-dao-test-custom-factory = { path = "./contracts/test/dao-test-custom-factory", version = "2.7.0" }
-dao-testing = { path = "./packages/dao-testing", version = "2.7.0" }
-dao-vote-delegation = { path = "./contracts/delegation/dao-vote-delegation", version = "2.7.0" }
-dao-voting = { path = "./packages/dao-voting", version = "2.7.0" }
-dao-voting-cw20-balance = { path = "./contracts/test/dao-voting-cw20-balance", version = "2.7.0" }
-dao-voting-cw20-staked = { path = "./contracts/voting/dao-voting-cw20-staked", version = "2.7.0" }
-dao-voting-cw4 = { path = "./contracts/voting/dao-voting-cw4", version = "2.7.0" }
-dao-voting-cw721-roles = { path = "./contracts/voting/dao-voting-cw721-roles", version = "2.7.0" }
-dao-voting-cw721-staked = { path = "./contracts/voting/dao-voting-cw721-staked", version = "2.7.0" }
-dao-voting-onft-staked = { path = "./contracts/voting/dao-voting-onft-staked", version = "2.7.0" }
-dao-voting-token-staked = { path = "./contracts/voting/dao-voting-token-staked", version = "2.7.0" }
-nft-controllers = { path = "./packages/nft-controllers", version = "2.7.0" }
+btsg-ft-factory = { path = "./contracts/external/btsg-ft-factory", version = "2.7.1" }
+cw-admin-factory = { path = "./contracts/external/cw-admin-factory", version = "2.7.1" }
+cw-denom = { path = "./packages/cw-denom", version = "2.7.1" }
+cw-fund-distributor = { path = "./contracts/distribution/cw-fund-distributor", version = "2.7.1" }
+cw-hooks = { path = "./packages/cw-hooks", version = "2.7.1" }
+cw-paginate-storage = { path = "./packages/cw-paginate-storage", version = "2.7.1" }
+cw-payroll-factory = { path = "./contracts/external/cw-payroll-factory", version = "2.7.1" }
+cw-snapshot-vector-map = { path = "./packages/cw-snapshot-vector-map", version = "2.7.1" }
+cw-stake-tracker = { path = "./packages/cw-stake-tracker", version = "2.7.1" }
+cw-token-swap = { path = "./contracts/external/cw-token-swap", version = "2.7.1" }
+cw-tokenfactory-issuer = { path = "./contracts/external/cw-tokenfactory-issuer", version = "2.7.1", default-features = false }
+cw-tokenfactory-types = { path = "./packages/cw-tokenfactory-types", version = "2.7.1", default-features = false }
+cw-vesting = { path = "./contracts/external/cw-vesting", version = "2.7.1" }
+cw-wormhole = { path = "./packages/cw-wormhole", version = "2.7.1" }
+cw20-stake = { path = "./contracts/staking/cw20-stake", version = "2.7.1" }
+cw20-stake-external-rewards = { path = "./contracts/staking/cw20-stake-external-rewards", version = "2.7.1" }
+cw20-stake-reward-distributor = { path = "./contracts/staking/cw20-stake-reward-distributor", version = "2.7.1" }
+cw721-roles = { path = "./contracts/external/cw721-roles", version = "2.7.1" }
+dao-cw721-extensions = { path = "./packages/dao-cw721-extensions", version = "2.7.1" }
+dao-dao-core = { path = "./contracts/dao-dao-core", version = "2.7.1" }
+dao-dao-macros = { path = "./packages/dao-dao-macros", version = "2.7.1" }
+dao-hooks = { path = "./packages/dao-hooks", version = "2.7.1" }
+dao-interface = { path = "./packages/dao-interface", version = "2.7.1" }
+dao-pre-propose-approval-multiple = { path = "./contracts/pre-propose/dao-pre-propose-approval-multiple", version = "2.7.1" }
+dao-migrator = { path = "./contracts/external/dao-migrator", version = "2.7.1" }
+dao-pre-propose-approval-single = { path = "./contracts/pre-propose/dao-pre-propose-approval-single", version = "2.7.1" }
+dao-pre-propose-approver = { path = "./contracts/pre-propose/dao-pre-propose-approver", version = "2.7.1" }
+dao-pre-propose-base = { path = "./packages/dao-pre-propose-base", version = "2.7.1" }
+dao-pre-propose-multiple = { path = "./contracts/pre-propose/dao-pre-propose-multiple", version = "2.7.1" }
+dao-pre-propose-single = { path = "./contracts/pre-propose/dao-pre-propose-single", version = "2.7.1" }
+dao-proposal-condorcet = { path = "./contracts/proposal/dao-proposal-condorcet", version = "2.7.1" }
+dao-proposal-hook-counter = { path = "./contracts/test/dao-proposal-hook-counter", version = "2.7.1" }
+dao-proposal-multiple = { path = "./contracts/proposal/dao-proposal-multiple", version = "2.7.1" }
+dao-proposal-single = { path = "./contracts/proposal/dao-proposal-single", version = "2.7.1" }
+dao-proposal-sudo = { path = "./contracts/test/dao-proposal-sudo", version = "2.7.1" }
+dao-rewards-distributor = { path = "./contracts/distribution/dao-rewards-distributor", version = "2.7.1" }
+dao-test-custom-factory = { path = "./contracts/test/dao-test-custom-factory", version = "2.7.1" }
+dao-testing = { path = "./packages/dao-testing", version = "2.7.1" }
+dao-vote-delegation = { path = "./contracts/delegation/dao-vote-delegation", version = "2.7.1" }
+dao-voting = { path = "./packages/dao-voting", version = "2.7.1" }
+dao-voting-cw20-balance = { path = "./contracts/test/dao-voting-cw20-balance", version = "2.7.1" }
+dao-voting-cw20-staked = { path = "./contracts/voting/dao-voting-cw20-staked", version = "2.7.1" }
+dao-voting-cw4 = { path = "./contracts/voting/dao-voting-cw4", version = "2.7.1" }
+dao-voting-cw721-roles = { path = "./contracts/voting/dao-voting-cw721-roles", version = "2.7.1" }
+dao-voting-cw721-staked = { path = "./contracts/voting/dao-voting-cw721-staked", version = "2.7.1" }
+dao-voting-onft-staked = { path = "./contracts/voting/dao-voting-onft-staked", version = "2.7.1" }
+dao-voting-token-staked = { path = "./contracts/voting/dao-voting-token-staked", version = "2.7.1" }
+nft-controllers = { path = "./packages/nft-controllers", version = "2.7.1" }
 
 # v1 dependencies. used for state migrations.
 cw-core-v1 = { package = "cw-core", version = "0.1.0" }

--- a/contracts/dao-dao-core/schema/dao-dao-core.json
+++ b/contracts/dao-dao-core/schema/dao-dao-core.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-dao-core",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/delegation/dao-vote-delegation/schema/dao-vote-delegation.json
+++ b/contracts/delegation/dao-vote-delegation/schema/dao-vote-delegation.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-vote-delegation",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/distribution/cw-fund-distributor/schema/cw-fund-distributor.json
+++ b/contracts/distribution/cw-fund-distributor/schema/cw-fund-distributor.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-fund-distributor",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
+++ b/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-rewards-distributor",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/btsg-ft-factory/schema/btsg-ft-factory.json
+++ b/contracts/external/btsg-ft-factory/schema/btsg-ft-factory.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "btsg-ft-factory",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
+++ b/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-admin-factory",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
+++ b/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-payroll-factory",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-token-swap/schema/cw-token-swap.json
+++ b/contracts/external/cw-token-swap/schema/cw-token-swap.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-token-swap",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-tokenfactory-issuer/schema/cw-tokenfactory-issuer.json
+++ b/contracts/external/cw-tokenfactory-issuer/schema/cw-tokenfactory-issuer.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-tokenfactory-issuer",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-tokenfactory-issuer/schema/cw-tokenfactory-issuer.json
+++ b/contracts/external/cw-tokenfactory-issuer/schema/cw-tokenfactory-issuer.json
@@ -8,7 +8,7 @@
     "description": "The message used to create a new instance of this smart contract.",
     "oneOf": [
       {
-        "description": "`NewToken` will create a new token when instantiate the contract. Newly created token will have full denom as `factory/<contract_address>/<subdenom>`. It will be attached to the contract setup the beforesend listener automatically.",
+        "description": "`NewToken` will create a new token when instantiate the contract. Newly created token will have full denom as `factory/<contract_address>/<subdenom>` (typical), `x/<contract_address>/<subdenom>` (Thorchain), or whatever the chain uses. It will be attached to the contract setup the beforesend listener automatically.",
         "type": "object",
         "required": [
           "new_token"
@@ -21,7 +21,7 @@
             ],
             "properties": {
               "subdenom": {
-                "description": "component of fulldenom (`factory/<contract_address>/<subdenom>`).",
+                "description": "Component of fulldenom.",
                 "type": "string"
               }
             },
@@ -986,7 +986,7 @@
     "denom": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "DenomResponse",
-      "description": "Returns the full denomination for the Token Factory token. For example: `factory/{contract address}/{subdenom}`",
+      "description": "Returns the full denomination for the Token Factory token. For example: `factory/{contract address}/{subdenom}` (typical), `x/{subdenom}` (Thorchain), or whatever the chain uses for its denom format.",
       "type": "object",
       "required": [
         "denom"

--- a/contracts/external/cw-tokenfactory-issuer/src/msg.rs
+++ b/contracts/external/cw-tokenfactory-issuer/src/msg.rs
@@ -7,17 +7,20 @@ pub use dao_interface::token::{DenomUnit, Metadata};
 /// The message used to create a new instance of this smart contract.
 #[cw_serde]
 pub enum InstantiateMsg {
-    /// `NewToken` will create a new token when instantiate the contract.
-    /// Newly created token will have full denom as `factory/<contract_address>/<subdenom>`.
-    /// It will be attached to the contract setup the beforesend listener automatically.
+    /// `NewToken` will create a new token when instantiate the contract. Newly
+    /// created token will have full denom as
+    /// `factory/<contract_address>/<subdenom>` (typical),
+    /// `x/<contract_address>/<subdenom>` (Thorchain), or whatever the chain
+    /// uses. It will be attached to the contract setup the beforesend listener
+    /// automatically.
     #[cfg(not(feature = "thorchain_tokenfactory"))]
     NewToken {
-        /// component of fulldenom (`factory/<contract_address>/<subdenom>`).
+        /// Component of fulldenom.
         subdenom: String,
     },
     #[cfg(feature = "thorchain_tokenfactory")]
     NewToken {
-        /// component of fulldenom (`factory/<contract_address>/<subdenom>`).
+        /// Component of fulldenom.
         subdenom: String,
         metadata: Metadata,
     },
@@ -203,7 +206,8 @@ pub struct IsFrozenResponse {
 }
 
 /// Returns the full denomination for the Token Factory token. For example:
-/// `factory/{contract address}/{subdenom}`
+/// `factory/{contract address}/{subdenom}` (typical), `x/{subdenom}`
+/// (Thorchain), or whatever the chain uses for its denom format.
 #[cw_serde]
 pub struct DenomResponse {
     pub denom: String,

--- a/contracts/external/cw-vesting/schema/cw-vesting.json
+++ b/contracts/external/cw-vesting/schema/cw-vesting.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-vesting",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw721-roles/schema/cw721-roles.json
+++ b/contracts/external/cw721-roles/schema/cw721-roles.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw721-roles",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/dao-migrator/schema/dao-migrator.json
+++ b/contracts/external/dao-migrator/schema/dao-migrator.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-migrator",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-approval-multiple/schema/dao-pre-propose-approval-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-multiple/schema/dao-pre-propose-approval-multiple.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-approval-multiple",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-approval-single",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
+++ b/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-approver",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-multiple",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
+++ b/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-single",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
+++ b/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-condorcet",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
+++ b/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-multiple",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
+++ b/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-single",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/staking/cw20-stake-external-rewards/schema/cw20-stake-external-rewards.json
+++ b/contracts/staking/cw20-stake-external-rewards/schema/cw20-stake-external-rewards.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw20-stake-external-rewards",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/staking/cw20-stake-reward-distributor/schema/cw20-stake-reward-distributor.json
+++ b/contracts/staking/cw20-stake-reward-distributor/schema/cw20-stake-reward-distributor.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw20-stake-reward-distributor",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/staking/cw20-stake/schema/cw20-stake.json
+++ b/contracts/staking/cw20-stake/schema/cw20-stake.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw20-stake",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/test/dao-test-custom-factory/src/contract.rs
+++ b/contracts/test/dao-test-custom-factory/src/contract.rs
@@ -356,7 +356,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
             let issuer_addr = parse_reply_instantiate_data(msg)?.contract_address;
 
             // Format the denom
-            let denom = format!("factory/{}/{}", &issuer_addr, token.subdenom);
+            let denom = format!("factory/{}/{}", issuer_addr, token.subdenom);
 
             let initial_supply = token
                 .initial_balances

--- a/contracts/voting/dao-voting-cw20-staked/schema/dao-voting-cw20-staked.json
+++ b/contracts/voting/dao-voting-cw20-staked/schema/dao-voting-cw20-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw20-staked",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw4/schema/dao-voting-cw4.json
+++ b/contracts/voting/dao-voting-cw4/schema/dao-voting-cw4.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw4",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw721-roles/schema/dao-voting-cw721-roles.json
+++ b/contracts/voting/dao-voting-cw721-roles/schema/dao-voting-cw721-roles.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw721-roles",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw721-staked/schema/dao-voting-cw721-staked.json
+++ b/contracts/voting/dao-voting-cw721-staked/schema/dao-voting-cw721-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw721-staked",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-onft-staked/schema/dao-voting-onft-staked.json
+++ b/contracts/voting/dao-voting-onft-staked/schema/dao-voting-onft-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-onft-staked",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-token-staked/schema/dao-voting-token-staked.json
+++ b/contracts/voting/dao-voting-token-staked/schema/dao-voting-token-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-token-staked",
-  "contract_version": "2.7.0",
+  "contract_version": "2.7.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-token-staked/schema/dao-voting-token-staked.json
+++ b/contracts/voting/dao-voting-token-staked/schema/dao-voting-token-staked.json
@@ -254,7 +254,7 @@
             ]
           },
           "subdenom": {
-            "description": "The subdenom of the token to create, will also be used as an alias for the denom. The Token Factory denom will have the format of factory/{contract_address}/{subdenom}",
+            "description": "The subdenom of the token to create, will also be used as an alias for the denom. The Token Factory denom will have the format of `factory/{contract_address}/{subdenom}` (typical), `x/{contract_address}/{subdenom}` (Thorchain), or whatever the chain uses.",
             "type": "string"
           },
           "token_issuer_code_id": {

--- a/contracts/voting/dao-voting-token-staked/src/contract.rs
+++ b/contracts/voting/dao-voting-token-staked/src/contract.rs
@@ -117,6 +117,7 @@ pub fn instantiate(
             // Save new token info for use in reply
             TOKEN_INSTANTIATION_INFO.save(deps.storage, &msg.token_info)?;
 
+            // Metadata must be set on creation for Thorchain.
             #[cfg(feature = "thorchain_tokenfactory")]
             let msg = if let Some(metadata) = &token.metadata {
                 // If the salt is not provided, use a default salt so that
@@ -138,7 +139,12 @@ pub fn instantiate(
                     &token_issuer_salt.clone().unwrap(),
                 )?)?;
 
-                let denom = format!("factory/{}/{}", &issuer_addr, token.subdenom);
+                // Thorchain does not insert the contract address automatically,
+                // leaving it up to the caller to avoid collisions. To allow
+                // DAOs to use the same denom/ticker, we insert the contract
+                // address into the subdenom to ensure uniqueness.
+                let subdenom = format!("{}/{}", issuer_addr, subdenom);
+                let denom = format!("x/{}", subdenom);
 
                 // The first denom_unit must be the same as the tf and base
                 // denom. It must have an exponent of 0. This the smallest
@@ -147,6 +153,8 @@ pub fn instantiate(
                 let mut denom_units = vec![DenomUnit {
                     denom: denom.clone(),
                     exponent: 0,
+                    // Use provided subdenom, not the one with the issuer
+                    // address.
                     aliases: vec![token.subdenom.clone()],
                 }];
 
@@ -652,8 +660,15 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractEr
                     // Load the DAO address
                     let dao = DAO.load(deps.storage)?;
 
-                    // Format the denom and save it
-                    let denom = format!("factory/{}/{}", &issuer_addr, token.subdenom);
+                    // Format the denom and save it. Thorchain uses x/denom
+                    // format, and we inserted the issuer address into the
+                    // subdenom to ensure uniqueness. Other chains use
+                    // factory/issuer_addr/subdenom format, with the issuer
+                    // address automatically inserted.
+                    #[cfg(feature = "thorchain_tokenfactory")]
+                    let denom = format!("x/{}/{}", issuer_addr, token.subdenom);
+                    #[cfg(not(feature = "thorchain_tokenfactory"))]
+                    let denom = format!("factory/{}/{}", issuer_addr, token.subdenom);
 
                     DENOM.save(deps.storage, &denom)?;
 

--- a/packages/cw-tokenfactory-types/src/msg.rs
+++ b/packages/cw-tokenfactory-types/src/msg.rs
@@ -175,7 +175,7 @@ mod tokenfactory_msg {
 #[cfg(feature = "thorchain_tokenfactory")]
 mod tokenfactory_msg {
     use crate::cosmos::{Coin, DenomUnit as ThorchainDenomUnit, Metadata as ThorchainMetadata};
-    use crate::thorchain::{MsgBurnTokens, MsgChangeDenomAdmin, MsgCreateDenom, MsgMintTokens};
+    use crate::thorchain::{MsgBurnTokens, MsgCreateDenom, MsgMintTokens, MsgSetDenomAdmin};
 
     pub use crate::thorchain::MsgCreateDenomResponse;
     pub use dao_interface::token::Metadata;
@@ -235,12 +235,8 @@ mod tokenfactory_msg {
         }
     }
 
-    pub fn msg_change_admin(
-        sender: String,
-        denom: String,
-        new_admin: String,
-    ) -> MsgChangeDenomAdmin {
-        MsgChangeDenomAdmin {
+    pub fn msg_change_admin(sender: String, denom: String, new_admin: String) -> MsgSetDenomAdmin {
+        MsgSetDenomAdmin {
             sender,
             denom,
             new_admin,

--- a/packages/cw-tokenfactory-types/src/thorchain.rs
+++ b/packages/cw-tokenfactory-types/src/thorchain.rs
@@ -116,8 +116,8 @@ pub struct MsgBurnTokens {
 #[proto_message(type_url = "/thorchain.denom.v1.MsgBurnTokensResponse")]
 pub struct MsgBurnTokensResponse {}
 
-/// MsgChangeAdmin is the sdk.Msg type for allowing an admin account to reassign
-/// adminship of a denom to a new account
+/// MsgSetDenomAdmin is the sdk.Msg type for allowing an admin account to
+/// reassign adminship of a denom to a new account
 #[derive(
     Clone,
     PartialEq,
@@ -128,8 +128,8 @@ pub struct MsgBurnTokensResponse {}
     ::schemars::JsonSchema,
     CosmwasmExt,
 )]
-#[proto_message(type_url = "/thorchain.denom.v1.MsgChangeDenomAdmin")]
-pub struct MsgChangeDenomAdmin {
+#[proto_message(type_url = "/thorchain.denom.v1.MsgSetDenomAdmin")]
+pub struct MsgSetDenomAdmin {
     #[prost(string, tag = "1")]
     pub sender: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
@@ -138,8 +138,8 @@ pub struct MsgChangeDenomAdmin {
     pub new_admin: ::prost::alloc::string::String,
 }
 
-// MsgChangeAdminResponse defines the response structure for an executed
-// MsgChangeAdmin message.
+// MsgSetDenomAdminResponse defines the response structure for an executed
+// MsgSetDenomAdmin message.
 #[derive(
     Clone,
     PartialEq,
@@ -150,5 +150,5 @@ pub struct MsgChangeDenomAdmin {
     ::schemars::JsonSchema,
     CosmwasmExt,
 )]
-#[proto_message(type_url = "/thorchain.denom.v1.MsgChangeDenomAdminResponse")]
-pub struct MsgChangeDenomAdminResponse {}
+#[proto_message(type_url = "/thorchain.denom.v1.MsgSetDenomAdminResponse")]
+pub struct MsgSetDenomAdminResponse {}

--- a/packages/dao-interface/src/token.rs
+++ b/packages/dao-interface/src/token.rs
@@ -35,9 +35,11 @@ pub struct NewTokenInfo {
     /// Optionally instantiate the cw-tokenfactory-issuer contract with
     /// instantiate2 using this salt.
     pub token_issuer_salt: Option<Binary>,
-    /// The subdenom of the token to create, will also be used as an alias
-    /// for the denom. The Token Factory denom will have the format of
-    /// factory/{contract_address}/{subdenom}
+    /// The subdenom of the token to create, will also be used as an alias for
+    /// the denom. The Token Factory denom will have the format of
+    /// `factory/{contract_address}/{subdenom}` (typical),
+    /// `x/{contract_address}/{subdenom}` (Thorchain), or whatever the chain
+    /// uses.
     pub subdenom: String,
     /// Optional metadata for the token, this can additionally be set later.
     pub metadata: Option<NewDenomMetadata>,


### PR DESCRIPTION
Thorchain/Rujira uses x/denom instead of factory/creator_address/denom when creating new token factory tokens. They force the caller to resolve naming collisions instead of enforcing that the creator address is part of the denom.

This PR:
- makes it so that the token staking voting module inserts its contract address in the denom when creating to allow DAOs to use any denom/ticker they want
- fixes the token staking voting module denom format for Thorchain
- fixes an incorrectly named tokenfactory message
- updates versions to v2.7.1