### PR TITLE
clean up RBAM action log storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,12 +292,12 @@ dependencies = [
  "cw-admin-factory",
  "cw-utils 1.0.3",
  "cw20 1.1.2",
- "cw20-stake 2.8.0-alpha.1",
- "dao-dao-core 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
- "dao-pre-propose-single 2.8.0-alpha.1",
- "dao-proposal-single 2.8.0-alpha.1",
- "dao-voting 2.8.0-alpha.1",
+ "cw20-stake 2.8.0-alpha.2",
+ "dao-dao-core 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
+ "dao-pre-propose-single 2.8.0-alpha.2",
+ "dao-proposal-single 2.8.0-alpha.2",
+ "dao-voting 2.8.0-alpha.2",
  "dao-voting-cw20-staked",
  "env_logger",
  "serde",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "btsg-ft-factory"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -325,11 +325,11 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "dao-dao-core 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
- "dao-proposal-single 2.8.0-alpha.1",
+ "dao-dao-core 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
+ "dao-proposal-single 2.8.0-alpha.2",
  "dao-testing",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "dao-voting-token-staked",
  "osmosis-std-derive",
  "prost 0.12.3",
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "cw-admin-factory"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "bech32",
  "cosmwasm-schema",
@@ -723,11 +723,11 @@ dependencies = [
  "cw2 1.1.2",
  "cw20-base 1.1.2",
  "cw4 1.1.2",
- "dao-interface 2.8.0-alpha.1",
- "dao-proposal-single 2.8.0-alpha.1",
+ "dao-interface 2.8.0-alpha.2",
+ "dao-proposal-single 2.8.0-alpha.2",
  "dao-testing",
- "dao-voting 2.8.0-alpha.1",
- "dao-voting-cw4 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
+ "dao-voting-cw4 2.8.0-alpha.2",
  "osmosis-test-tube",
  "thiserror",
 ]
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "cw-denom"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "cw-filter"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -881,7 +881,7 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "dao-interface 2.8.0-alpha.1",
+ "dao-interface 2.8.0-alpha.2",
  "dao-testing",
  "prost 0.12.3",
  "prost-reflect",
@@ -894,20 +894,20 @@ dependencies = [
 
 [[package]]
 name = "cw-fund-distributor"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-paginate-storage 2.8.0-alpha.1",
+ "cw-paginate-storage 2.8.0-alpha.2",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.8.0-alpha.1",
- "dao-dao-core 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
+ "cw20-stake 2.8.0-alpha.2",
+ "dao-dao-core 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
  "dao-testing",
  "dao-voting-cw20-staked",
  "thiserror",
@@ -927,7 +927,7 @@ dependencies = [
 
 [[package]]
 name = "cw-hooks"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "cw-jsonfilter"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "base64 0.22.1",
  "cw-protobuf-registry",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "cw-paginate-storage"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
@@ -1028,11 +1028,11 @@ dependencies = [
 
 [[package]]
 name = "cw-payroll-factory"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.8.0-alpha.1",
+ "cw-denom 2.8.0-alpha.2",
  "cw-multi-test",
  "cw-ownable",
  "cw-payroll-factory",
@@ -1074,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "cw-protobuf-registry"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "base64 0.22.1",
  "cosmwasm-schema",
@@ -1085,7 +1085,7 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "dao-interface 2.8.0-alpha.1",
+ "dao-interface 2.8.0-alpha.2",
  "dao-testing",
  "prost 0.12.3",
  "prost-reflect",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "cw-snapshot-vector-map"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.2.0",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "cw-stake-tracker"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "cw-token-swap"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1177,7 +1177,7 @@ dependencies = [
 
 [[package]]
 name = "cw-tokenfactory-issuer"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1186,7 +1186,7 @@ dependencies = [
  "cw-storage-plus 1.2.0",
  "cw-tokenfactory-types",
  "cw2 1.1.2",
- "dao-interface 2.8.0-alpha.1",
+ "dao-interface 2.8.0-alpha.2",
  "osmosis-std",
  "osmosis-test-tube",
  "prost 0.12.3",
@@ -1198,11 +1198,11 @@ dependencies = [
 
 [[package]]
 name = "cw-tokenfactory-types"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "dao-interface 2.8.0-alpha.1",
+ "dao-interface 2.8.0-alpha.2",
  "osmosis-std",
  "osmosis-std-derive",
  "prost 0.12.3",
@@ -1268,12 +1268,12 @@ dependencies = [
 
 [[package]]
 name = "cw-vesting"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.8.0-alpha.1",
+ "cw-denom 2.8.0-alpha.2",
  "cw-multi-test",
  "cw-ownable",
  "cw-stake-tracker",
@@ -1292,7 +1292,7 @@ dependencies = [
 
 [[package]]
 name = "cw-wormhole"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1459,16 +1459,16 @@ dependencies = [
 
 [[package]]
 name = "cw20-stake"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-hooks 2.8.0-alpha.1",
+ "cw-hooks 2.8.0-alpha.2",
  "cw-multi-test",
  "cw-ownable",
- "cw-paginate-storage 2.8.0-alpha.1",
+ "cw-paginate-storage 2.8.0-alpha.2",
  "cw-storage-plus 1.2.0",
  "cw-utils 0.13.4",
  "cw-utils 1.0.3",
@@ -1476,16 +1476,16 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw20-stake 0.2.6",
- "cw20-stake 2.8.0-alpha.1",
- "dao-hooks 2.8.0-alpha.1",
+ "cw20-stake 2.8.0-alpha.2",
+ "dao-hooks 2.8.0-alpha.2",
  "dao-testing",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "thiserror",
 ]
 
 [[package]]
 name = "cw20-stake-external-rewards"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1499,9 +1499,9 @@ dependencies = [
  "cw20 0.13.4",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.8.0-alpha.1",
+ "cw20-stake 2.8.0-alpha.2",
  "cw20-stake-external-rewards",
- "dao-hooks 2.8.0-alpha.1",
+ "dao-hooks 2.8.0-alpha.2",
  "dao-testing",
  "stake-cw20-external-rewards",
  "thiserror",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "cw20-stake-reward-distributor"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1520,7 +1520,7 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.8.0-alpha.1",
+ "cw20-stake 2.8.0-alpha.2",
  "cw20-stake-reward-distributor",
  "dao-testing",
  "stake-cw20-reward-distributor",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "cw721-roles"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "dao-cw721-extensions"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1780,13 +1780,13 @@ dependencies = [
 
 [[package]]
 name = "dao-dao-core"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-core",
  "cw-multi-test",
- "cw-paginate-storage 2.8.0-alpha.1",
+ "cw-paginate-storage 2.8.0-alpha.2",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1794,9 +1794,9 @@ dependencies = [
  "cw20-base 1.1.2",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
- "dao-dao-core 2.8.0-alpha.1",
- "dao-dao-macros 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
+ "dao-dao-core 2.8.0-alpha.2",
+ "dao-dao-macros 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
  "dao-proposal-sudo",
  "dao-testing",
  "dao-voting-cw20-balance",
@@ -1817,13 +1817,13 @@ dependencies = [
 
 [[package]]
 name = "dao-dao-macros"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-hooks 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
- "dao-voting 2.8.0-alpha.1",
+ "cw-hooks 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
+ "dao-voting 2.8.0-alpha.2",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1845,14 +1845,14 @@ dependencies = [
 
 [[package]]
 name = "dao-hooks"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-hooks 2.8.0-alpha.1",
+ "cw-hooks 2.8.0-alpha.2",
  "cw4 1.1.2",
- "dao-pre-propose-base 2.8.0-alpha.1",
- "dao-voting 2.8.0-alpha.1",
+ "dao-pre-propose-base 2.8.0-alpha.2",
+ "dao-voting 2.8.0-alpha.2",
 ]
 
 [[package]]
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "dao-interface"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "dao-migrator"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1903,31 +1903,31 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw20-stake 0.2.6",
- "cw20-stake 2.8.0-alpha.1",
+ "cw20-stake 2.8.0-alpha.2",
  "cw20-staked-balance-voting",
  "cw4 0.13.4",
  "cw4-voting",
- "dao-dao-core 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
+ "dao-dao-core 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
  "dao-migrator",
- "dao-proposal-single 2.8.0-alpha.1",
+ "dao-proposal-single 2.8.0-alpha.2",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.8.0-alpha.1",
+ "dao-voting-cw4 2.8.0-alpha.2",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-pre-propose-approval-multiple"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.8.0-alpha.1",
+ "cw-denom 2.8.0-alpha.2",
  "cw-multi-test",
- "cw-paginate-storage 2.8.0-alpha.1",
+ "cw-paginate-storage 2.8.0-alpha.2",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1935,15 +1935,15 @@ dependencies = [
  "cw20-base 1.1.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
- "dao-dao-core 2.8.0-alpha.1",
- "dao-hooks 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
- "dao-pre-propose-base 2.8.0-alpha.1",
- "dao-proposal-multiple 2.8.0-alpha.1",
+ "dao-dao-core 2.8.0-alpha.2",
+ "dao-hooks 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
+ "dao-pre-propose-base 2.8.0-alpha.2",
+ "dao-proposal-multiple 2.8.0-alpha.2",
  "dao-testing",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.8.0-alpha.1",
+ "dao-voting-cw4 2.8.0-alpha.2",
  "thiserror",
 ]
 
@@ -1966,13 +1966,13 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-approval-single"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.8.0-alpha.1",
+ "cw-denom 2.8.0-alpha.2",
  "cw-multi-test",
- "cw-paginate-storage 2.8.0-alpha.1",
+ "cw-paginate-storage 2.8.0-alpha.2",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -1981,30 +1981,30 @@ dependencies = [
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "dao-dao-core 2.4.1",
- "dao-dao-core 2.8.0-alpha.1",
- "dao-hooks 2.8.0-alpha.1",
+ "dao-dao-core 2.8.0-alpha.2",
+ "dao-hooks 2.8.0-alpha.2",
  "dao-interface 2.4.1",
- "dao-interface 2.8.0-alpha.1",
+ "dao-interface 2.8.0-alpha.2",
  "dao-pre-propose-approval-single 2.4.1",
- "dao-pre-propose-base 2.8.0-alpha.1",
+ "dao-pre-propose-base 2.8.0-alpha.2",
  "dao-proposal-single 2.4.1",
- "dao-proposal-single 2.8.0-alpha.1",
+ "dao-proposal-single 2.8.0-alpha.2",
  "dao-testing",
  "dao-voting 2.4.1",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "dao-voting-cw20-staked",
  "dao-voting-cw4 2.4.1",
- "dao-voting-cw4 2.8.0-alpha.1",
+ "dao-voting-cw4 2.8.0-alpha.2",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-pre-propose-approver"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.8.0-alpha.1",
+ "cw-denom 2.8.0-alpha.2",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -2012,18 +2012,18 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw4-group 1.1.2",
- "dao-dao-core 2.8.0-alpha.1",
- "dao-hooks 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
+ "dao-dao-core 2.8.0-alpha.2",
+ "dao-hooks 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
  "dao-pre-propose-approval-multiple",
- "dao-pre-propose-approval-single 2.8.0-alpha.1",
- "dao-pre-propose-base 2.8.0-alpha.1",
- "dao-proposal-multiple 2.8.0-alpha.1",
- "dao-proposal-single 2.8.0-alpha.1",
+ "dao-pre-propose-approval-single 2.8.0-alpha.2",
+ "dao-pre-propose-base 2.8.0-alpha.2",
+ "dao-proposal-multiple 2.8.0-alpha.2",
+ "dao-proposal-single 2.8.0-alpha.2",
  "dao-testing",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.8.0-alpha.1",
+ "dao-voting-cw4 2.8.0-alpha.2",
 ]
 
 [[package]]
@@ -2047,18 +2047,18 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-base"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.8.0-alpha.1",
- "cw-hooks 2.8.0-alpha.1",
+ "cw-denom 2.8.0-alpha.2",
+ "cw-hooks 2.8.0-alpha.2",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "dao-interface 2.8.0-alpha.1",
- "dao-voting 2.8.0-alpha.1",
+ "dao-interface 2.8.0-alpha.2",
+ "dao-voting 2.8.0-alpha.2",
  "semver",
  "serde",
  "thiserror",
@@ -2079,11 +2079,11 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-multiple"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.8.0-alpha.1",
+ "cw-denom 2.8.0-alpha.2",
  "cw-multi-test",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -2092,20 +2092,20 @@ dependencies = [
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "dao-dao-core 2.4.1",
- "dao-dao-core 2.8.0-alpha.1",
- "dao-hooks 2.8.0-alpha.1",
+ "dao-dao-core 2.8.0-alpha.2",
+ "dao-hooks 2.8.0-alpha.2",
  "dao-interface 2.4.1",
- "dao-interface 2.8.0-alpha.1",
- "dao-pre-propose-base 2.8.0-alpha.1",
+ "dao-interface 2.8.0-alpha.2",
+ "dao-pre-propose-base 2.8.0-alpha.2",
  "dao-pre-propose-multiple 2.4.1",
  "dao-proposal-multiple 2.4.1",
- "dao-proposal-multiple 2.8.0-alpha.1",
+ "dao-proposal-multiple 2.8.0-alpha.2",
  "dao-testing",
  "dao-voting 2.4.1",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "dao-voting-cw20-staked",
  "dao-voting-cw4 2.4.1",
- "dao-voting-cw4 2.8.0-alpha.1",
+ "dao-voting-cw4 2.8.0-alpha.2",
 ]
 
 [[package]]
@@ -2123,12 +2123,12 @@ dependencies = [
 
 [[package]]
 name = "dao-pre-propose-single"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.8.0-alpha.1",
- "cw-hooks 2.8.0-alpha.1",
+ "cw-denom 2.8.0-alpha.2",
+ "cw-hooks 2.8.0-alpha.2",
  "cw-multi-test",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
@@ -2137,25 +2137,25 @@ dependencies = [
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "dao-dao-core 2.4.1",
- "dao-dao-core 2.8.0-alpha.1",
- "dao-hooks 2.8.0-alpha.1",
+ "dao-dao-core 2.8.0-alpha.2",
+ "dao-hooks 2.8.0-alpha.2",
  "dao-interface 2.4.1",
- "dao-interface 2.8.0-alpha.1",
- "dao-pre-propose-base 2.8.0-alpha.1",
+ "dao-interface 2.8.0-alpha.2",
+ "dao-pre-propose-base 2.8.0-alpha.2",
  "dao-pre-propose-single 2.4.1",
  "dao-proposal-single 2.4.1",
- "dao-proposal-single 2.8.0-alpha.1",
+ "dao-proposal-single 2.8.0-alpha.2",
  "dao-testing",
  "dao-voting 2.4.1",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "dao-voting-cw20-staked",
  "dao-voting-cw4 2.4.1",
- "dao-voting-cw4 2.8.0-alpha.1",
+ "dao-voting-cw4 2.8.0-alpha.2",
 ]
 
 [[package]]
 name = "dao-proposal-condorcet"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2166,34 +2166,34 @@ dependencies = [
  "cw2 1.1.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
- "dao-dao-core 2.8.0-alpha.1",
- "dao-dao-macros 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
+ "dao-dao-core 2.8.0-alpha.2",
+ "dao-dao-macros 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
  "dao-testing",
- "dao-voting 2.8.0-alpha.1",
- "dao-voting-cw4 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
+ "dao-voting-cw4 2.8.0-alpha.2",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-proposal-hook-counter"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-hooks 2.8.0-alpha.1",
+ "cw-hooks 2.8.0-alpha.2",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "dao-dao-core 2.8.0-alpha.1",
- "dao-hooks 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
- "dao-proposal-single 2.8.0-alpha.1",
+ "dao-dao-core 2.8.0-alpha.2",
+ "dao-hooks 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
+ "dao-proposal-single 2.8.0-alpha.2",
  "dao-testing",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "dao-voting-cw20-balance",
  "thiserror",
 ]
@@ -2223,35 +2223,35 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-multiple"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.8.0-alpha.1",
- "cw-hooks 2.8.0-alpha.1",
+ "cw-denom 2.8.0-alpha.2",
+ "cw-hooks 2.8.0-alpha.2",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.8.0-alpha.1",
+ "cw20-stake 2.8.0-alpha.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
- "dao-dao-macros 2.8.0-alpha.1",
- "dao-hooks 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
- "dao-pre-propose-base 2.8.0-alpha.1",
- "dao-pre-propose-multiple 2.8.0-alpha.1",
- "dao-proposal-multiple 2.8.0-alpha.1",
+ "dao-dao-macros 2.8.0-alpha.2",
+ "dao-hooks 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
+ "dao-pre-propose-base 2.8.0-alpha.2",
+ "dao-pre-propose-multiple 2.8.0-alpha.2",
+ "dao-proposal-multiple 2.8.0-alpha.2",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.8.0-alpha.1",
+ "dao-voting-cw4 2.8.0-alpha.2",
  "dao-voting-cw721-staked",
  "dao-voting-token-staked",
  "rand",
@@ -2284,14 +2284,14 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-single"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-core",
- "cw-denom 2.8.0-alpha.1",
- "cw-hooks 2.8.0-alpha.1",
+ "cw-denom 2.8.0-alpha.2",
+ "cw-hooks 2.8.0-alpha.2",
  "cw-multi-test",
  "cw-proposal-single",
  "cw-storage-plus 1.2.0",
@@ -2300,23 +2300,23 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.8.0-alpha.1",
+ "cw20-stake 2.8.0-alpha.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
- "dao-dao-core 2.8.0-alpha.1",
- "dao-dao-macros 2.8.0-alpha.1",
- "dao-hooks 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
- "dao-pre-propose-base 2.8.0-alpha.1",
- "dao-pre-propose-single 2.8.0-alpha.1",
- "dao-proposal-single 2.8.0-alpha.1",
+ "dao-dao-core 2.8.0-alpha.2",
+ "dao-dao-macros 2.8.0-alpha.2",
+ "dao-hooks 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
+ "dao-pre-propose-base 2.8.0-alpha.2",
+ "dao-pre-propose-single 2.8.0-alpha.2",
+ "dao-proposal-single 2.8.0-alpha.2",
  "dao-testing",
  "dao-voting 0.1.0",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.8.0-alpha.1",
+ "dao-voting-cw4 2.8.0-alpha.2",
  "dao-voting-cw721-staked",
  "dao-voting-token-staked",
  "thiserror",
@@ -2324,21 +2324,21 @@ dependencies = [
 
 [[package]]
 name = "dao-proposal-sudo"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw2 1.1.2",
- "dao-dao-macros 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
+ "dao-dao-macros 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-rbam"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "chrono",
  "cosmwasm-schema",
@@ -2352,7 +2352,7 @@ dependencies = [
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw4 1.1.2",
- "dao-interface 2.8.0-alpha.1",
+ "dao-interface 2.8.0-alpha.2",
  "dao-rbam",
  "dao-testing",
  "osmosis-std",
@@ -2368,7 +2368,7 @@ dependencies = [
 
 [[package]]
 name = "dao-rewards-distributor"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2381,17 +2381,17 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.8.0-alpha.1",
+ "cw20-stake 2.8.0-alpha.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
- "dao-hooks 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
+ "dao-hooks 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
  "dao-rewards-distributor",
  "dao-testing",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.8.0-alpha.1",
+ "dao-voting-cw4 2.8.0-alpha.2",
  "dao-voting-cw721-staked",
  "dao-voting-token-staked",
  "semver",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "dao-test-custom-factory"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2412,15 +2412,15 @@ dependencies = [
  "cw2 1.1.2",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
- "dao-dao-macros 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
- "dao-voting 2.8.0-alpha.1",
+ "dao-dao-macros 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
+ "dao-voting 2.8.0-alpha.2",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-testing"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "btsg-ft-factory",
  "cosmwasm-schema",
@@ -2428,7 +2428,7 @@ dependencies = [
  "cw-admin-factory",
  "cw-core",
  "cw-filter",
- "cw-hooks 2.8.0-alpha.1",
+ "cw-hooks 2.8.0-alpha.2",
  "cw-multi-test",
  "cw-payroll-factory",
  "cw-proposal-single",
@@ -2441,7 +2441,7 @@ dependencies = [
  "cw20 1.1.2",
  "cw20-base 1.1.2",
  "cw20-stake 0.2.6",
- "cw20-stake 2.8.0-alpha.1",
+ "cw20-stake 2.8.0-alpha.2",
  "cw20-stake-external-rewards",
  "cw20-stake-reward-distributor",
  "cw4 1.1.2",
@@ -2450,34 +2450,34 @@ dependencies = [
  "cw721-base 0.18.0",
  "cw721-roles",
  "dao-dao-core 2.4.1",
- "dao-dao-core 2.8.0-alpha.1",
+ "dao-dao-core 2.8.0-alpha.2",
  "dao-interface 2.4.1",
- "dao-interface 2.8.0-alpha.1",
+ "dao-interface 2.8.0-alpha.2",
  "dao-migrator",
  "dao-pre-propose-approval-single 2.4.1",
- "dao-pre-propose-approval-single 2.8.0-alpha.1",
+ "dao-pre-propose-approval-single 2.8.0-alpha.2",
  "dao-pre-propose-approver",
  "dao-pre-propose-multiple 2.4.1",
- "dao-pre-propose-multiple 2.8.0-alpha.1",
+ "dao-pre-propose-multiple 2.8.0-alpha.2",
  "dao-pre-propose-single 2.4.1",
- "dao-pre-propose-single 2.8.0-alpha.1",
+ "dao-pre-propose-single 2.8.0-alpha.2",
  "dao-proposal-condorcet",
  "dao-proposal-hook-counter",
  "dao-proposal-multiple 2.4.1",
- "dao-proposal-multiple 2.8.0-alpha.1",
+ "dao-proposal-multiple 2.8.0-alpha.2",
  "dao-proposal-single 2.4.1",
- "dao-proposal-single 2.8.0-alpha.1",
+ "dao-proposal-single 2.8.0-alpha.2",
  "dao-proposal-sudo",
  "dao-rbam",
  "dao-rewards-distributor",
  "dao-test-custom-factory",
  "dao-voting 0.1.0",
  "dao-voting 2.4.1",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "dao-voting-cw20-balance",
  "dao-voting-cw20-staked",
  "dao-voting-cw4 2.4.1",
- "dao-voting-cw4 2.8.0-alpha.1",
+ "dao-voting-cw4 2.8.0-alpha.2",
  "dao-voting-cw721-roles",
  "dao-voting-cw721-staked",
  "dao-voting-onft-staked",
@@ -2494,14 +2494,14 @@ dependencies = [
 
 [[package]]
 name = "dao-vote-delegation"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
  "cw-multi-test",
- "cw-paginate-storage 2.8.0-alpha.1",
+ "cw-paginate-storage 2.8.0-alpha.2",
  "cw-snapshot-vector-map",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -2509,19 +2509,19 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.8.0-alpha.1",
+ "cw20-stake 2.8.0-alpha.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
  "cw721-base 0.18.0",
- "dao-hooks 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
- "dao-proposal-multiple 2.8.0-alpha.1",
- "dao-proposal-single 2.8.0-alpha.1",
+ "dao-hooks 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
+ "dao-proposal-multiple 2.8.0-alpha.2",
+ "dao-proposal-single 2.8.0-alpha.2",
  "dao-proposal-sudo",
  "dao-testing",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "dao-voting-cw20-staked",
- "dao-voting-cw4 2.8.0-alpha.1",
+ "dao-voting-cw4 2.8.0-alpha.2",
  "dao-voting-cw721-staked",
  "dao-voting-token-staked",
  "semver",
@@ -2559,22 +2559,22 @@ dependencies = [
 
 [[package]]
 name = "dao-voting"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw-denom 2.8.0-alpha.1",
+ "cw-denom 2.8.0-alpha.2",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw20 1.1.2",
- "dao-dao-macros 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
+ "dao-dao-macros 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw20-balance"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2584,15 +2584,15 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "dao-dao-macros 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
+ "dao-dao-macros 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
  "dao-testing",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw20-staked"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2602,11 +2602,11 @@ dependencies = [
  "cw2 1.1.2",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.8.0-alpha.1",
- "dao-dao-macros 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
+ "cw20-stake 2.8.0-alpha.2",
+ "dao-dao-macros 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
  "dao-testing",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "thiserror",
 ]
 
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-cw4"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -2640,16 +2640,16 @@ dependencies = [
  "cw2 1.1.2",
  "cw4 1.1.2",
  "cw4-group 1.1.2",
- "dao-dao-macros 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
+ "dao-dao-macros 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
  "dao-testing",
- "dao-voting-cw4 2.8.0-alpha.1",
+ "dao-voting-cw4 2.8.0-alpha.2",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw721-roles"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -2664,21 +2664,21 @@ dependencies = [
  "cw721-base 0.18.0",
  "cw721-roles",
  "dao-cw721-extensions",
- "dao-dao-macros 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
+ "dao-dao-macros 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
  "dao-testing",
  "thiserror",
 ]
 
 [[package]]
 name = "dao-voting-cw721-staked"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-hooks 2.8.0-alpha.1",
+ "cw-hooks 2.8.0-alpha.2",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
@@ -2686,14 +2686,14 @@ dependencies = [
  "cw721 0.18.0",
  "cw721-base 0.18.0",
  "cw721-controllers",
- "dao-dao-macros 2.8.0-alpha.1",
- "dao-hooks 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
+ "dao-dao-macros 2.8.0-alpha.2",
+ "dao-hooks 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
  "dao-proposal-hook-counter",
- "dao-proposal-single 2.8.0-alpha.1",
+ "dao-proposal-single 2.8.0-alpha.2",
  "dao-test-custom-factory",
  "dao-testing",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "nft-controllers",
  "osmosis-std",
  "osmosis-test-tube",
@@ -2703,26 +2703,26 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-onft-staked"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-hooks 2.8.0-alpha.1",
+ "cw-hooks 2.8.0-alpha.2",
  "cw-multi-test",
  "cw-storage-plus 1.2.0",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
  "cw721-controllers",
- "dao-dao-macros 2.8.0-alpha.1",
- "dao-hooks 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
+ "dao-dao-macros 2.8.0-alpha.2",
+ "dao-hooks 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
  "dao-proposal-hook-counter",
- "dao-proposal-single 2.8.0-alpha.1",
+ "dao-proposal-single 2.8.0-alpha.2",
  "dao-test-custom-factory",
  "dao-testing",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "nft-controllers",
  "omniflix-std",
  "osmosis-test-tube",
@@ -2733,27 +2733,27 @@ dependencies = [
 
 [[package]]
 name = "dao-voting-token-staked"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-controllers 1.1.2",
- "cw-hooks 2.8.0-alpha.1",
+ "cw-hooks 2.8.0-alpha.2",
  "cw-multi-test",
  "cw-ownable",
  "cw-storage-plus 1.2.0",
  "cw-tokenfactory-issuer",
  "cw-utils 1.0.3",
  "cw2 1.1.2",
- "dao-dao-macros 2.8.0-alpha.1",
- "dao-hooks 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
+ "dao-dao-macros 2.8.0-alpha.2",
+ "dao-hooks 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
  "dao-proposal-hook-counter",
- "dao-proposal-single 2.8.0-alpha.1",
+ "dao-proposal-single 2.8.0-alpha.2",
  "dao-test-custom-factory",
  "dao-testing",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "osmosis-std",
  "osmosis-test-tube",
  "serde",
@@ -3465,16 +3465,16 @@ dependencies = [
  "cw-vesting",
  "cw20 1.1.2",
  "cw20-base 1.1.2",
- "cw20-stake 2.8.0-alpha.1",
+ "cw20-stake 2.8.0-alpha.2",
  "cw721 0.18.0",
  "cw721-base 0.18.0",
  "cw721-roles",
- "dao-dao-core 2.8.0-alpha.1",
- "dao-interface 2.8.0-alpha.1",
- "dao-pre-propose-single 2.8.0-alpha.1",
- "dao-proposal-single 2.8.0-alpha.1",
+ "dao-dao-core 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
+ "dao-pre-propose-single 2.8.0-alpha.2",
+ "dao-proposal-single 2.8.0-alpha.2",
  "dao-test-custom-factory",
- "dao-voting 2.8.0-alpha.1",
+ "dao-voting 2.8.0-alpha.2",
  "dao-voting-cw20-staked",
  "dao-voting-cw721-staked",
  "env_logger",
@@ -3668,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "nft-controllers"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/DA0-DA0/dao-contracts"
-version = "2.8.0-alpha.1"
+version = "2.8.0-alpha.2"
 
 [profile.release]
 codegen-units = 1
@@ -92,58 +92,58 @@ wynd-utils = "0.4"
 # optional owner.
 cw-ownable = "0.5"
 
-btsg-ft-factory = { path = "./contracts/external/btsg-ft-factory", version = "2.8.0-alpha.1" }
-cw-admin-factory = { path = "./contracts/external/cw-admin-factory", version = "2.8.0-alpha.1" }
-cw-denom = { path = "./packages/cw-denom", version = "2.8.0-alpha.1" }
-cw-fund-distributor = { path = "./contracts/distribution/cw-fund-distributor", version = "2.8.0-alpha.1" }
-cw-hooks = { path = "./packages/cw-hooks", version = "2.8.0-alpha.1" }
-cw-filter = { path = "./contracts/external/cw-filter", version = "2.8.0-alpha.1" }
-cw-jsonfilter = { path = "./packages/cw-jsonfilter", version = "2.8.0-alpha.1" }
-cw-paginate-storage = { path = "./packages/cw-paginate-storage", version = "2.8.0-alpha.1" }
-cw-payroll-factory = { path = "./contracts/external/cw-payroll-factory", version = "2.8.0-alpha.1" }
-cw-protobuf-registry = { path = "./contracts/external/cw-protobuf-registry", version = "2.8.0-alpha.1" }
-cw-snapshot-vector-map = { path = "./packages/cw-snapshot-vector-map", version = "2.8.0-alpha.1" }
-cw-stake-tracker = { path = "./packages/cw-stake-tracker", version = "2.8.0-alpha.1" }
-cw-token-swap = { path = "./contracts/external/cw-token-swap", version = "2.8.0-alpha.1" }
-cw-tokenfactory-issuer = { path = "./contracts/external/cw-tokenfactory-issuer", version = "2.8.0-alpha.1", default-features = false }
-cw-tokenfactory-types = { path = "./packages/cw-tokenfactory-types", version = "2.8.0-alpha.1", default-features = false }
-cw-vesting = { path = "./contracts/external/cw-vesting", version = "2.8.0-alpha.1" }
-cw-wormhole = { path = "./packages/cw-wormhole", version = "2.8.0-alpha.1" }
-cw20-stake = { path = "./contracts/staking/cw20-stake", version = "2.8.0-alpha.1" }
-cw20-stake-external-rewards = { path = "./contracts/staking/cw20-stake-external-rewards", version = "2.8.0-alpha.1" }
-cw20-stake-reward-distributor = { path = "./contracts/staking/cw20-stake-reward-distributor", version = "2.8.0-alpha.1" }
-cw721-roles = { path = "./contracts/external/cw721-roles", version = "2.8.0-alpha.1" }
-dao-cw721-extensions = { path = "./packages/dao-cw721-extensions", version = "2.8.0-alpha.1" }
-dao-dao-core = { path = "./contracts/dao-dao-core", version = "2.8.0-alpha.1" }
-dao-dao-macros = { path = "./packages/dao-dao-macros", version = "2.8.0-alpha.1" }
-dao-hooks = { path = "./packages/dao-hooks", version = "2.8.0-alpha.1" }
-dao-interface = { path = "./packages/dao-interface", version = "2.8.0-alpha.1" }
-dao-pre-propose-approval-multiple = { path = "./contracts/pre-propose/dao-pre-propose-approval-multiple", version = "2.8.0-alpha.1" }
-dao-migrator = { path = "./contracts/external/dao-migrator", version = "2.8.0-alpha.1" }
-dao-pre-propose-approval-single = { path = "./contracts/pre-propose/dao-pre-propose-approval-single", version = "2.8.0-alpha.1" }
-dao-pre-propose-approver = { path = "./contracts/pre-propose/dao-pre-propose-approver", version = "2.8.0-alpha.1" }
-dao-pre-propose-base = { path = "./packages/dao-pre-propose-base", version = "2.8.0-alpha.1" }
-dao-pre-propose-multiple = { path = "./contracts/pre-propose/dao-pre-propose-multiple", version = "2.8.0-alpha.1" }
-dao-pre-propose-single = { path = "./contracts/pre-propose/dao-pre-propose-single", version = "2.8.0-alpha.1" }
-dao-proposal-condorcet = { path = "./contracts/proposal/dao-proposal-condorcet", version = "2.8.0-alpha.1" }
-dao-proposal-hook-counter = { path = "./contracts/test/dao-proposal-hook-counter", version = "2.8.0-alpha.1" }
-dao-proposal-multiple = { path = "./contracts/proposal/dao-proposal-multiple", version = "2.8.0-alpha.1" }
-dao-proposal-single = { path = "./contracts/proposal/dao-proposal-single", version = "2.8.0-alpha.1" }
-dao-proposal-sudo = { path = "./contracts/test/dao-proposal-sudo", version = "2.8.0-alpha.1" }
-dao-rbam = { path = "./contracts/external/dao-rbam", version = "2.8.0-alpha.1" }
-dao-rewards-distributor = { path = "./contracts/distribution/dao-rewards-distributor", version = "2.8.0-alpha.1" }
-dao-test-custom-factory = { path = "./contracts/test/dao-test-custom-factory", version = "2.8.0-alpha.1" }
-dao-testing = { path = "./packages/dao-testing", version = "2.8.0-alpha.1" }
-dao-vote-delegation = { path = "./contracts/delegation/dao-vote-delegation", version = "2.8.0-alpha.1" }
-dao-voting = { path = "./packages/dao-voting", version = "2.8.0-alpha.1" }
-dao-voting-cw20-balance = { path = "./contracts/test/dao-voting-cw20-balance", version = "2.8.0-alpha.1" }
-dao-voting-cw20-staked = { path = "./contracts/voting/dao-voting-cw20-staked", version = "2.8.0-alpha.1" }
-dao-voting-cw4 = { path = "./contracts/voting/dao-voting-cw4", version = "2.8.0-alpha.1" }
-dao-voting-cw721-roles = { path = "./contracts/voting/dao-voting-cw721-roles", version = "2.8.0-alpha.1" }
-dao-voting-cw721-staked = { path = "./contracts/voting/dao-voting-cw721-staked", version = "2.8.0-alpha.1" }
-dao-voting-onft-staked = { path = "./contracts/voting/dao-voting-onft-staked", version = "2.8.0-alpha.1" }
-dao-voting-token-staked = { path = "./contracts/voting/dao-voting-token-staked", version = "2.8.0-alpha.1" }
-nft-controllers = { path = "./packages/nft-controllers", version = "2.8.0-alpha.1" }
+btsg-ft-factory = { path = "./contracts/external/btsg-ft-factory", version = "2.8.0-alpha.2" }
+cw-admin-factory = { path = "./contracts/external/cw-admin-factory", version = "2.8.0-alpha.2" }
+cw-denom = { path = "./packages/cw-denom", version = "2.8.0-alpha.2" }
+cw-fund-distributor = { path = "./contracts/distribution/cw-fund-distributor", version = "2.8.0-alpha.2" }
+cw-hooks = { path = "./packages/cw-hooks", version = "2.8.0-alpha.2" }
+cw-filter = { path = "./contracts/external/cw-filter", version = "2.8.0-alpha.2" }
+cw-jsonfilter = { path = "./packages/cw-jsonfilter", version = "2.8.0-alpha.2" }
+cw-paginate-storage = { path = "./packages/cw-paginate-storage", version = "2.8.0-alpha.2" }
+cw-payroll-factory = { path = "./contracts/external/cw-payroll-factory", version = "2.8.0-alpha.2" }
+cw-protobuf-registry = { path = "./contracts/external/cw-protobuf-registry", version = "2.8.0-alpha.2" }
+cw-snapshot-vector-map = { path = "./packages/cw-snapshot-vector-map", version = "2.8.0-alpha.2" }
+cw-stake-tracker = { path = "./packages/cw-stake-tracker", version = "2.8.0-alpha.2" }
+cw-token-swap = { path = "./contracts/external/cw-token-swap", version = "2.8.0-alpha.2" }
+cw-tokenfactory-issuer = { path = "./contracts/external/cw-tokenfactory-issuer", version = "2.8.0-alpha.2", default-features = false }
+cw-tokenfactory-types = { path = "./packages/cw-tokenfactory-types", version = "2.8.0-alpha.2", default-features = false }
+cw-vesting = { path = "./contracts/external/cw-vesting", version = "2.8.0-alpha.2" }
+cw-wormhole = { path = "./packages/cw-wormhole", version = "2.8.0-alpha.2" }
+cw20-stake = { path = "./contracts/staking/cw20-stake", version = "2.8.0-alpha.2" }
+cw20-stake-external-rewards = { path = "./contracts/staking/cw20-stake-external-rewards", version = "2.8.0-alpha.2" }
+cw20-stake-reward-distributor = { path = "./contracts/staking/cw20-stake-reward-distributor", version = "2.8.0-alpha.2" }
+cw721-roles = { path = "./contracts/external/cw721-roles", version = "2.8.0-alpha.2" }
+dao-cw721-extensions = { path = "./packages/dao-cw721-extensions", version = "2.8.0-alpha.2" }
+dao-dao-core = { path = "./contracts/dao-dao-core", version = "2.8.0-alpha.2" }
+dao-dao-macros = { path = "./packages/dao-dao-macros", version = "2.8.0-alpha.2" }
+dao-hooks = { path = "./packages/dao-hooks", version = "2.8.0-alpha.2" }
+dao-interface = { path = "./packages/dao-interface", version = "2.8.0-alpha.2" }
+dao-pre-propose-approval-multiple = { path = "./contracts/pre-propose/dao-pre-propose-approval-multiple", version = "2.8.0-alpha.2" }
+dao-migrator = { path = "./contracts/external/dao-migrator", version = "2.8.0-alpha.2" }
+dao-pre-propose-approval-single = { path = "./contracts/pre-propose/dao-pre-propose-approval-single", version = "2.8.0-alpha.2" }
+dao-pre-propose-approver = { path = "./contracts/pre-propose/dao-pre-propose-approver", version = "2.8.0-alpha.2" }
+dao-pre-propose-base = { path = "./packages/dao-pre-propose-base", version = "2.8.0-alpha.2" }
+dao-pre-propose-multiple = { path = "./contracts/pre-propose/dao-pre-propose-multiple", version = "2.8.0-alpha.2" }
+dao-pre-propose-single = { path = "./contracts/pre-propose/dao-pre-propose-single", version = "2.8.0-alpha.2" }
+dao-proposal-condorcet = { path = "./contracts/proposal/dao-proposal-condorcet", version = "2.8.0-alpha.2" }
+dao-proposal-hook-counter = { path = "./contracts/test/dao-proposal-hook-counter", version = "2.8.0-alpha.2" }
+dao-proposal-multiple = { path = "./contracts/proposal/dao-proposal-multiple", version = "2.8.0-alpha.2" }
+dao-proposal-single = { path = "./contracts/proposal/dao-proposal-single", version = "2.8.0-alpha.2" }
+dao-proposal-sudo = { path = "./contracts/test/dao-proposal-sudo", version = "2.8.0-alpha.2" }
+dao-rbam = { path = "./contracts/external/dao-rbam", version = "2.8.0-alpha.2" }
+dao-rewards-distributor = { path = "./contracts/distribution/dao-rewards-distributor", version = "2.8.0-alpha.2" }
+dao-test-custom-factory = { path = "./contracts/test/dao-test-custom-factory", version = "2.8.0-alpha.2" }
+dao-testing = { path = "./packages/dao-testing", version = "2.8.0-alpha.2" }
+dao-vote-delegation = { path = "./contracts/delegation/dao-vote-delegation", version = "2.8.0-alpha.2" }
+dao-voting = { path = "./packages/dao-voting", version = "2.8.0-alpha.2" }
+dao-voting-cw20-balance = { path = "./contracts/test/dao-voting-cw20-balance", version = "2.8.0-alpha.2" }
+dao-voting-cw20-staked = { path = "./contracts/voting/dao-voting-cw20-staked", version = "2.8.0-alpha.2" }
+dao-voting-cw4 = { path = "./contracts/voting/dao-voting-cw4", version = "2.8.0-alpha.2" }
+dao-voting-cw721-roles = { path = "./contracts/voting/dao-voting-cw721-roles", version = "2.8.0-alpha.2" }
+dao-voting-cw721-staked = { path = "./contracts/voting/dao-voting-cw721-staked", version = "2.8.0-alpha.2" }
+dao-voting-onft-staked = { path = "./contracts/voting/dao-voting-onft-staked", version = "2.8.0-alpha.2" }
+dao-voting-token-staked = { path = "./contracts/voting/dao-voting-token-staked", version = "2.8.0-alpha.2" }
+nft-controllers = { path = "./packages/nft-controllers", version = "2.8.0-alpha.2" }
 
 # v1 dependencies. used for state migrations.
 cw-core-v1 = { package = "cw-core", version = "0.1.0" }

--- a/contracts/dao-dao-core/schema/dao-dao-core.json
+++ b/contracts/dao-dao-core/schema/dao-dao-core.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-dao-core",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/delegation/dao-vote-delegation/schema/dao-vote-delegation.json
+++ b/contracts/delegation/dao-vote-delegation/schema/dao-vote-delegation.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-vote-delegation",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/distribution/cw-fund-distributor/schema/cw-fund-distributor.json
+++ b/contracts/distribution/cw-fund-distributor/schema/cw-fund-distributor.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-fund-distributor",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
+++ b/contracts/distribution/dao-rewards-distributor/schema/dao-rewards-distributor.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-rewards-distributor",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/btsg-ft-factory/schema/btsg-ft-factory.json
+++ b/contracts/external/btsg-ft-factory/schema/btsg-ft-factory.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "btsg-ft-factory",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
+++ b/contracts/external/cw-admin-factory/schema/cw-admin-factory.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-admin-factory",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-filter/schema/cw-filter.json
+++ b/contracts/external/cw-filter/schema/cw-filter.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-filter",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
+++ b/contracts/external/cw-payroll-factory/schema/cw-payroll-factory.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-payroll-factory",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-protobuf-registry/schema/cw-protobuf-registry.json
+++ b/contracts/external/cw-protobuf-registry/schema/cw-protobuf-registry.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-protobuf-registry",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-token-swap/schema/cw-token-swap.json
+++ b/contracts/external/cw-token-swap/schema/cw-token-swap.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-token-swap",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-tokenfactory-issuer/schema/cw-tokenfactory-issuer.json
+++ b/contracts/external/cw-tokenfactory-issuer/schema/cw-tokenfactory-issuer.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-tokenfactory-issuer",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw-vesting/schema/cw-vesting.json
+++ b/contracts/external/cw-vesting/schema/cw-vesting.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw-vesting",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/cw721-roles/schema/cw721-roles.json
+++ b/contracts/external/cw721-roles/schema/cw721-roles.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw721-roles",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/dao-migrator/schema/dao-migrator.json
+++ b/contracts/external/dao-migrator/schema/dao-migrator.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-migrator",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/dao-rbam/schema/dao-rbam.json
+++ b/contracts/external/dao-rbam/schema/dao-rbam.json
@@ -2303,14 +2303,9 @@
           "action": {
             "type": "object",
             "required": [
-              "addr",
               "id"
             ],
             "properties": {
-              "addr": {
-                "description": "The address of the action.",
-                "type": "string"
-              },
               "id": {
                 "description": "The action ID.",
                 "type": "integer",
@@ -2398,23 +2393,13 @@
                 "minimum": 0.0
               },
               "start_after": {
-                "description": "The (addr, action_id) to start after. If not provided, the query will start from the beginning.",
+                "description": "The action_id to start after. If not provided, the query will start from the beginning.",
                 "type": [
-                  "array",
+                  "integer",
                   "null"
                 ],
-                "items": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  }
-                ],
-                "maxItems": 2,
-                "minItems": 2
+                "format": "uint64",
+                "minimum": 0.0
               }
             },
             "additionalProperties": false
@@ -2457,23 +2442,13 @@
                 ]
               },
               "start_after": {
-                "description": "The (addr, action_id) to start after. If not provided, the query will start from the beginning.",
+                "description": "The action_id to start after. If not provided, the query will start from the beginning.",
                 "type": [
-                  "array",
+                  "integer",
                   "null"
                 ],
-                "items": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "integer",
-                    "format": "uint64",
-                    "minimum": 0.0
-                  }
-                ],
-                "maxItems": 2,
-                "minItems": 2
+                "format": "uint64",
+                "minimum": 0.0
               }
             },
             "additionalProperties": false

--- a/contracts/external/dao-rbam/schema/dao-rbam.json
+++ b/contracts/external/dao-rbam/schema/dao-rbam.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-rbam",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/external/dao-rbam/src/action.rs
+++ b/contracts/external/dao-rbam/src/action.rs
@@ -51,7 +51,7 @@ impl Action {
             tx_index: env.transaction.as_ref().map(|tx| tx.index),
         };
 
-        LOG.save(deps.storage, (addr, action.id), &action)?;
+        LOG.save(deps.storage, action.id, &action)?;
 
         Ok(action)
     }

--- a/contracts/external/dao-rbam/src/contract.rs
+++ b/contracts/external/dao-rbam/src/contract.rs
@@ -699,7 +699,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             start_after,
             limit,
         )?),
-        QueryMsg::Action { addr, id } => to_json_binary(&query_get_action(deps, addr, id)?),
+        QueryMsg::Action { id } => to_json_binary(&query_get_action(deps, id)?),
         QueryMsg::ListActions {
             start_after,
             limit,
@@ -943,9 +943,8 @@ fn query_list_assignments_by_address(
     Ok(ListRolesForAddressResponse { role_ids })
 }
 
-fn query_get_action(deps: Deps, addr: String, action_id: u64) -> StdResult<ActionResponse> {
-    let addr = deps.api.addr_validate(&addr)?;
-    let action = LOG.load(deps.storage, (addr, action_id)).map_err(|_| {
+fn query_get_action(deps: Deps, action_id: u64) -> StdResult<ActionResponse> {
+    let action = LOG.load(deps.storage, action_id).map_err(|_| {
         StdError::generic_err(ContractError::ActionNotFound { id: action_id }.to_string())
     })?;
     Ok(ActionResponse { action })
@@ -966,8 +965,6 @@ fn query_list_actions(
     };
 
     let actions: Vec<Action> = LOG
-        .idx
-        .action_id
         .range(deps.storage, min, max, order)
         .take(limit)
         .collect::<StdResult<Vec<_>>>()?
@@ -981,18 +978,12 @@ fn query_list_actions(
 fn query_list_actions_by_role(
     deps: Deps,
     role_id: u64,
-    start_after: Option<(String, u64)>,
+    start_after: Option<u64>,
     limit: Option<u32>,
     reverse: Option<bool>,
 ) -> StdResult<ListActionsResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after
-        .map(|(addr, action_id)| {
-            deps.api
-                .addr_validate(&addr)
-                .map(|addr| Bound::exclusive((addr, action_id)))
-        })
-        .transpose()?;
+    let start = start_after.map(Bound::exclusive);
     let (min, max, order) = if reverse.unwrap_or(false) {
         (None, start, Order::Descending)
     } else {
@@ -1014,18 +1005,12 @@ fn query_list_actions_by_role(
 fn query_list_actions_by_authorization(
     deps: Deps,
     authorization_id: u64,
-    start_after: Option<(String, u64)>,
+    start_after: Option<u64>,
     limit: Option<u32>,
     reverse: Option<bool>,
 ) -> StdResult<ListActionsResponse> {
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
-    let start = start_after
-        .map(|(addr, authorization_id)| {
-            deps.api
-                .addr_validate(&addr)
-                .map(|addr| Bound::exclusive((addr, authorization_id)))
-        })
-        .transpose()?;
+    let start = start_after.map(Bound::exclusive);
     let (min, max, order) = if reverse.unwrap_or(false) {
         (None, start, Order::Descending)
     } else {
@@ -1061,6 +1046,8 @@ fn query_list_actions_by_address(
     };
 
     let actions: Vec<Action> = LOG
+        .idx
+        .address
         .prefix(addr)
         .range(deps.storage, min, max, order)
         .take(limit)

--- a/contracts/external/dao-rbam/src/msg.rs
+++ b/contracts/external/dao-rbam/src/msg.rs
@@ -273,8 +273,6 @@ pub enum QueryMsg {
     // Action/Log queries
     #[returns(ActionResponse)]
     Action {
-        /// The address of the action.
-        addr: String,
         /// The action ID.
         id: u64,
     },
@@ -294,9 +292,9 @@ pub enum QueryMsg {
     ListActionsByRole {
         /// The role to list actions for.
         role_id: u64,
-        /// The (addr, action_id) to start after. If not provided, the query
-        /// will start from the beginning.
-        start_after: Option<(String, u64)>,
+        /// The action_id to start after. If not provided, the query will start
+        /// from the beginning.
+        start_after: Option<u64>,
         /// The maximum number of actions to return. Defaults to 10, max is 100.
         limit: Option<u32>,
         /// Whether to reverse the order of the results. Defaults to false. If
@@ -308,9 +306,9 @@ pub enum QueryMsg {
     ListActionsByAuthorization {
         /// The authorization to list actions for.
         authorization_id: u64,
-        /// The (addr, action_id) to start after. If not provided, the query
-        /// will start from the beginning.
-        start_after: Option<(String, u64)>,
+        /// The action_id to start after. If not provided, the query will start
+        /// from the beginning.
+        start_after: Option<u64>,
         /// The maximum number of actions to return. Defaults to 10, max is 100.
         limit: Option<u32>,
         /// Whether to reverse the order of the results. Defaults to false. If

--- a/contracts/external/dao-rbam/src/state.rs
+++ b/contracts/external/dao-rbam/src/state.rs
@@ -1,8 +1,6 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Binary};
-use cw_storage_plus::{
-    Index, IndexList, IndexedMap, Item, KeyDeserialize, Map, MultiIndex, UniqueIndex,
-};
+use cw_storage_plus::{Index, IndexList, IndexedMap, Item, KeyDeserialize, Map, MultiIndex};
 
 use crate::{
     action::Action,
@@ -77,20 +75,21 @@ pub const ASSIGNMENTS: IndexedMap<AssignmentPair, Addr, AssignmentsIndexes<'_>> 
     },
 );
 
-/// Map (address, action_id) -> action. Secondary indexes on action_id, role_id,
-/// and authorization_id to look up/iterate over all actions by role and by
+/// Map action_id -> action. Secondary indexes on address, role_id, and
+/// authorization_id to look up/iterate over all actions by address, role, and
 /// authorization. This supports the following queries:
 /// - get a specific action by ID (map lookup)
 /// - list all actions (range query)
-/// - list all actions performed by a specific address (prefixed range query)
+/// - list all actions performed by a specific address (secondary index range
+///   query)
 /// - list all actions performed by a specific role (secondary index range
 ///   query)
 /// - list all actions performed by a specific authorization (secondary index
 ///   range query)
-pub const LOG: IndexedMap<LogPairKey, Action, LogIndexes<'_>> = IndexedMap::new(
+pub const LOG: IndexedMap<u64, Action, LogIndexes<'_>> = IndexedMap::new(
     "log",
     LogIndexes {
-        action_id: UniqueIndex::new(|a| a.id, "log__action_id"),
+        address: MultiIndex::new(|_pk, a| a.addr.clone(), "log", "log__address"),
         role_id: MultiIndex::new(|_pk, a| a.role_id, "log", "log__role_id"),
         authorization_id: MultiIndex::new(
             |_pk, a| a.authorization_id,
@@ -126,20 +125,16 @@ impl IndexList<Addr> for AssignmentsIndexes<'_> {
     }
 }
 
-/// A pair of (address, action_id), the key for the LOG map.
-pub type LogPairKey = (Addr, u64);
-
-/// Secondary indexes for log to look up/iterate over all actions by role and by
-/// authorization.
+/// Secondary indexes for log to look up/iterate over all actions by address,
+/// role, and authorization.
 pub struct LogIndexes<'a> {
-    pub action_id: UniqueIndex<'a, u64, Action, LogPairKey>,
-    pub role_id: MultiIndex<'a, u64, Action, LogPairKey>,
-    pub authorization_id: MultiIndex<'a, u64, Action, LogPairKey>,
+    pub address: MultiIndex<'a, Addr, Action, u64>,
+    pub role_id: MultiIndex<'a, u64, Action, u64>,
+    pub authorization_id: MultiIndex<'a, u64, Action, u64>,
 }
 impl IndexList<Action> for LogIndexes<'_> {
     fn get_indexes(&self) -> Box<dyn Iterator<Item = &dyn Index<Action>> + '_> {
-        let v: Vec<&dyn Index<Action>> =
-            vec![&self.action_id, &self.role_id, &self.authorization_id];
+        let v: Vec<&dyn Index<Action>> = vec![&self.address, &self.role_id, &self.authorization_id];
         Box::new(v.into_iter())
     }
 }

--- a/contracts/external/dao-rbam/src/testing/suite.rs
+++ b/contracts/external/dao-rbam/src/testing/suite.rs
@@ -343,22 +343,19 @@ impl Suite {
             .unwrap()
     }
 
-    pub fn get_action(&mut self, addr: String, id: u64) -> ActionResponse {
+    pub fn get_action(&mut self, id: u64) -> ActionResponse {
         self.base
             .app
             .wrap()
-            .query_wasm_smart(self.rbam_addr.clone(), &QueryMsg::Action { addr, id })
+            .query_wasm_smart(self.rbam_addr.clone(), &QueryMsg::Action { id })
             .unwrap()
     }
 
-    pub fn get_action_err(&mut self, addr: String, id: u64) -> StdError {
+    pub fn get_action_err(&mut self, id: u64) -> StdError {
         self.base
             .app
             .wrap()
-            .query_wasm_smart::<ActionResponse>(
-                self.rbam_addr.clone(),
-                &QueryMsg::Action { addr, id },
-            )
+            .query_wasm_smart::<ActionResponse>(self.rbam_addr.clone(), &QueryMsg::Action { id })
             .unwrap_err()
     }
 
@@ -385,7 +382,7 @@ impl Suite {
     pub fn list_actions_by_role(
         &mut self,
         role_id: u64,
-        start_after: Option<(String, u64)>,
+        start_after: Option<u64>,
         limit: Option<u32>,
         reverse: Option<bool>,
     ) -> ListActionsResponse {
@@ -407,7 +404,7 @@ impl Suite {
     pub fn list_actions_by_authorization(
         &mut self,
         authorization_id: u64,
-        start_after: Option<(String, u64)>,
+        start_after: Option<u64>,
         limit: Option<u32>,
         reverse: Option<bool>,
     ) -> ListActionsResponse {

--- a/contracts/external/dao-rbam/src/testing/tests.rs
+++ b/contracts/external/dao-rbam/src/testing/tests.rs
@@ -920,7 +920,7 @@ fn test_action_execution() {
     assert_eq!(actions[0].authorization_id, authorization_id);
     assert_eq!(actions[0].msg, action_msg);
 
-    let action = suite.get_action(ADDR0.to_string(), actions[0].id).action;
+    let action = suite.get_action(actions[0].id).action;
     assert_eq!(action.role_id, role_id);
     assert_eq!(action.authorization_id, authorization_id);
     assert_eq!(action.msg, action_msg);
@@ -930,7 +930,7 @@ fn test_action_execution() {
     assert_eq!(config.name, "new_name");
     assert_eq!(config.description, "new_description");
 
-    let err = suite.get_action_err(ADDR0.to_string(), 100);
+    let err = suite.get_action_err(100);
     assert!(err.to_string().contains(
         ContractError::ActionNotFound { id: 100 }
             .to_string()
@@ -2149,15 +2149,8 @@ fn test_comprehensive_list_queries_with_filtering() {
     let mut role2_actions = suite.list_actions_by_role(role_id2, None, None, None);
     assert_eq!(role2_actions.actions.len(), 2);
 
-    let role2_actions_start_after = suite.list_actions_by_role(
-        role_id2,
-        Some((
-            role2_actions.actions[0].addr.to_string(),
-            role2_actions.actions[0].id,
-        )),
-        None,
-        None,
-    );
+    let role2_actions_start_after =
+        suite.list_actions_by_role(role_id2, Some(role2_actions.actions[0].id), None, None);
     assert_eq!(role2_actions_start_after.actions.len(), 1);
     assert_eq!(
         role2_actions_start_after.actions[0].id,
@@ -2179,10 +2172,7 @@ fn test_comprehensive_list_queries_with_filtering() {
 
     let auth3_actions_start_after = suite.list_actions_by_authorization(
         authorization_id3,
-        Some((
-            auth3_actions.actions[0].addr.to_string(),
-            auth3_actions.actions[0].id,
-        )),
+        Some(auth3_actions.actions[0].id),
         None,
         None,
     );

--- a/contracts/pre-propose/dao-pre-propose-approval-multiple/schema/dao-pre-propose-approval-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-multiple/schema/dao-pre-propose-approval-multiple.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-approval-multiple",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
+++ b/contracts/pre-propose/dao-pre-propose-approval-single/schema/dao-pre-propose-approval-single.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-approval-single",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
+++ b/contracts/pre-propose/dao-pre-propose-approver/schema/dao-pre-propose-approver.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-approver",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
+++ b/contracts/pre-propose/dao-pre-propose-multiple/schema/dao-pre-propose-multiple.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-multiple",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
+++ b/contracts/pre-propose/dao-pre-propose-single/schema/dao-pre-propose-single.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-pre-propose-single",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
+++ b/contracts/proposal/dao-proposal-condorcet/schema/dao-proposal-condorcet.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-condorcet",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
+++ b/contracts/proposal/dao-proposal-multiple/schema/dao-proposal-multiple.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-multiple",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
+++ b/contracts/proposal/dao-proposal-single/schema/dao-proposal-single.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-proposal-single",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/staking/cw20-stake-external-rewards/schema/cw20-stake-external-rewards.json
+++ b/contracts/staking/cw20-stake-external-rewards/schema/cw20-stake-external-rewards.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw20-stake-external-rewards",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/staking/cw20-stake-reward-distributor/schema/cw20-stake-reward-distributor.json
+++ b/contracts/staking/cw20-stake-reward-distributor/schema/cw20-stake-reward-distributor.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw20-stake-reward-distributor",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/staking/cw20-stake/schema/cw20-stake.json
+++ b/contracts/staking/cw20-stake/schema/cw20-stake.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "cw20-stake",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw20-staked/schema/dao-voting-cw20-staked.json
+++ b/contracts/voting/dao-voting-cw20-staked/schema/dao-voting-cw20-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw20-staked",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw4/schema/dao-voting-cw4.json
+++ b/contracts/voting/dao-voting-cw4/schema/dao-voting-cw4.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw4",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw721-roles/schema/dao-voting-cw721-roles.json
+++ b/contracts/voting/dao-voting-cw721-roles/schema/dao-voting-cw721-roles.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw721-roles",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-cw721-staked/schema/dao-voting-cw721-staked.json
+++ b/contracts/voting/dao-voting-cw721-staked/schema/dao-voting-cw721-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-cw721-staked",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-onft-staked/schema/dao-voting-onft-staked.json
+++ b/contracts/voting/dao-voting-onft-staked/schema/dao-voting-onft-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-onft-staked",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/contracts/voting/dao-voting-token-staked/schema/dao-voting-token-staked.json
+++ b/contracts/voting/dao-voting-token-staked/schema/dao-voting-token-staked.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "dao-voting-token-staked",
-  "contract_version": "2.8.0-alpha.1",
+  "contract_version": "2.8.0-alpha.2",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
This cleans up an unnecessary design decision made in a previous version of the contract in which action IDs were unique to addresses. Now since they are globally unique, we can simplify the action log state map to just map `action_id` to `action`, and simplify the queries as a result.