### PR TITLE
feat(cw-vesting): add migrate entry point

### DIFF
--- a/contracts/external/cw-vesting/src/contract.rs
+++ b/contracts/external/cw-vesting/src/contract.rs
@@ -15,7 +15,7 @@ use cw_ownable::OwnershipError;
 use cw_utils::{must_pay, nonpayable};
 
 use crate::error::ContractError;
-use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, ReceiveMsg};
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, ReceiveMsg};
 use crate::state::{PAYMENT, UNBONDING_DURATION_SECONDS};
 use crate::vesting::{Status, VestInit};
 
@@ -481,4 +481,11 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::TotalToVest {} => to_json_binary(&PAYMENT.get_vest(deps.storage)?.total()),
         QueryMsg::VestDuration {} => to_json_binary(&PAYMENT.duration(deps.storage)?),
     }
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    // Set contract to version to latest
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::default())
 }

--- a/contracts/external/cw-vesting/src/contract.rs
+++ b/contracts/external/cw-vesting/src/contract.rs
@@ -19,8 +19,8 @@ use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, ReceiveMsg};
 use crate::state::{PAYMENT, UNBONDING_DURATION_SECONDS};
 use crate::vesting::{Status, VestInit};
 
-const CONTRACT_NAME: &str = "crates.io:cw-vesting";
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const CONTRACT_NAME: &str = "crates.io:cw-vesting";
+pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(

--- a/contracts/external/cw-vesting/src/lib.rs
+++ b/contracts/external/cw-vesting/src/lib.rs
@@ -16,6 +16,8 @@ pub use cw_ownable::Ownership;
 pub use cw_stake_tracker::StakeTrackerQuery;
 
 #[cfg(test)]
+mod migrate_tests;
+#[cfg(test)]
 mod suite_tests;
 #[cfg(test)]
 mod tests;

--- a/contracts/external/cw-vesting/src/migrate_tests.rs
+++ b/contracts/external/cw-vesting/src/migrate_tests.rs
@@ -1,0 +1,14 @@
+use cosmwasm_std::testing::{mock_dependencies, mock_env};
+
+use crate::contract::{migrate, CONTRACT_NAME, CONTRACT_VERSION};
+use crate::msg::MigrateMsg;
+
+#[test]
+pub fn test_migrate_update_version() {
+    let mut deps = mock_dependencies();
+    cw2::set_contract_version(&mut deps.storage, "my-contract", "old-version").unwrap();
+    migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+    let version = cw2::get_contract_version(&deps.storage).unwrap();
+    assert_eq!(version.version, CONTRACT_VERSION);
+    assert_eq!(version.contract, CONTRACT_NAME);
+}

--- a/contracts/external/cw-vesting/src/msg.rs
+++ b/contracts/external/cw-vesting/src/msg.rs
@@ -234,3 +234,6 @@ pub enum QueryMsg {
     #[returns(::cosmwasm_std::Uint128)]
     Stake(StakeTrackerQuery),
 }
+
+#[cw_serde]
+pub struct MigrateMsg {}


### PR DESCRIPTION
## Summary

Add basic `migrate` entry point to the cw-vesting contract to enable contract upgrades.

## Changes

- **msg.rs**: Add empty `MigrateMsg` struct with `#[cw_serde]`
- **contract.rs**: Add `migrate` entry point that updates contract version using `cw2::set_contract_version`
- **lib.rs**: Register new migrate_tests module
- **migrate_tests.rs**: Add unit test verifying version update during migration

## Pattern

Follows the established simple migration pattern used by:
- `cw-token-swap`
- `cw-admin-factory`

## Testing

- ✅ `cargo check -p cw-vesting` passes
- ✅ Migration test verifies contract version is updated correctly

---
*This PR was reviewed and created by an AI agent.*