### PR TITLE
feat: dao-voting-juno-staked — historical-snapshot voting via x/votin…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,6 +2702,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "dao-voting-juno-staked"
+version = "2.8.0-alpha.2"
+dependencies = [
+ "anyhow",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-hooks 2.8.0-alpha.2",
+ "cw-multi-test",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
+ "dao-dao-macros 2.8.0-alpha.2",
+ "dao-hooks 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "dao-voting-onft-staked"
 version = "2.8.0-alpha.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ dao-voting-cw4 = { path = "./contracts/voting/dao-voting-cw4", version = "2.8.0-
 dao-voting-cw721-roles = { path = "./contracts/voting/dao-voting-cw721-roles", version = "2.8.0-alpha.2" }
 dao-voting-cw721-staked = { path = "./contracts/voting/dao-voting-cw721-staked", version = "2.8.0-alpha.2" }
 dao-voting-onft-staked = { path = "./contracts/voting/dao-voting-onft-staked", version = "2.8.0-alpha.2" }
+dao-voting-juno-staked = { path = "./contracts/voting/dao-voting-juno-staked", version = "2.8.0-alpha.2" }
 dao-voting-token-staked = { path = "./contracts/voting/dao-voting-token-staked", version = "2.8.0-alpha.2" }
 nft-controllers = { path = "./packages/nft-controllers", version = "2.8.0-alpha.2" }
 

--- a/contracts/voting/dao-voting-juno-staked/.cargo/config
+++ b/contracts/voting/dao-voting-juno-staked/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+schema = "run --example schema"

--- a/contracts/voting/dao-voting-juno-staked/Cargo.toml
+++ b/contracts/voting/dao-voting-juno-staked/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "dao-voting-juno-staked"
+authors = [
+  "Jake Hartnell <no-reply@no-reply.com>",
+  "Juno AI <juno-ai-dev@users.noreply.github.com>",
+  "Noah Saso <no-reply@no-reply.com>",
+]
+description = "A DAO DAO voting module that derives voting power from Juno's x/voting-snapshot module. Historical staking power with LST exclusion enforced at the chain layer."
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+version = { workspace = true }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[dependencies]
+cosmwasm-std = { workspace = true, features = ["cosmwasm_1_2", "stargate"] }
+cosmwasm-schema = { workspace = true }
+cw-hooks = { workspace = true }
+cw-storage-plus = { workspace = true }
+cw2 = { workspace = true }
+dao-dao-macros = { workspace = true }
+dao-hooks = { workspace = true }
+dao-interface = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+cw-multi-test = { workspace = true }

--- a/contracts/voting/dao-voting-juno-staked/README.md
+++ b/contracts/voting/dao-voting-juno-staked/README.md
@@ -1,0 +1,52 @@
+# dao-voting-juno-staked
+
+A DAO DAO voting module that derives voting power from **staked JUNO**, using
+Juno's `x/voting-snapshot` chain module for historical snapshots.
+
+## What this fixes vs. `dao-voting-cosmos-staked`
+
+The earlier attempt at a Cosmos-staked voting module
+([DA0-DA0/dao-contracts#832](https://github.com/DA0-DA0/dao-contracts/pull/832))
+lived inside contract storage with no access to historical staking data, and
+[acknowledged in its README](https://github.com/DA0-DA0/dao-contracts/pull/832/files#diff-README)
+that voting power "is always calculated based on the current amount staked
+(regardless of which block is requested in the query)." That breaks any
+proposal module that relies on a stable voting-power snapshot at proposal
+creation — voters can rage-stake mid-proposal, slashing silently moves the
+denominator, etc.
+
+Juno v30 ships a chain module — `x/voting-snapshot` — that records
+`(delegator, height) → bonded power` on every staking event with LST
+exclusion built in. This contract is a thin consumer of that module:
+
+- **`VotingPowerAtHeight`** asks the chain for the snapshot at the requested
+  height (returning the at-or-before snapshot per the chain's semantics).
+- **`TotalPowerAtHeight`** returns the total bonded supply at the same height.
+- **Liquid-staked tokens contribute zero voting power** because the chain
+  enforces the LST allowlist before writing the snapshot.
+
+## Hook fan-out
+
+For consumers that need stake-change notifications (the gauge orchestrator,
+dao-rewards-distributor, etc.), this contract subscribes to Juno's
+`x/cw-hooks` staking events via the standard `sudo` interface and re-emits
+them as `dao_hooks::stake::StakeChangedHookMsg::{Stake, Unstake}` to all
+registered subscribers. Subscribers register via `AddHook { addr }` (gated to
+the DAO) and are auto-unregistered if their execute call errors (standard
+`reply_on_error` pattern from the rest of the dao-contracts hook surface).
+
+The amount in `Stake { addr, amount }` is the delegator's **new total bonded
+power** read from `x/voting-snapshot` after the staking event lands, not the
+delta of the individual delegation — this matches what gauge tally
+maintenance actually needs ("what's this voter's new weight").
+
+## Limitations
+
+- **Juno-only.** This contract uses Juno's `x/voting-snapshot` custom wasm
+  binding, which is not available on other Cosmos chains.
+- **Requires v30 or later.** Older juno releases don't have the
+  voting-snapshot module.
+- **Staking happens at the SDK layer, not through this contract.** Users
+  delegate via `MsgDelegate` / `MsgUndelegate` / `MsgBeginRedelegate`. This
+  contract has no `Stake` / `Unstake` / `Claim` execute variants — the
+  unbonding period is the chain's, not a contract config.

--- a/contracts/voting/dao-voting-juno-staked/examples/schema.rs
+++ b/contracts/voting/dao-voting-juno-staked/examples/schema.rs
@@ -1,0 +1,11 @@
+use cosmwasm_schema::write_api;
+use dao_voting_juno_staked::msg::{ExecuteMsg, InstantiateMsg, QueryMsg, SudoMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        execute: ExecuteMsg,
+        query: QueryMsg,
+        sudo: SudoMsg,
+    }
+}

--- a/contracts/voting/dao-voting-juno-staked/schema/dao-voting-juno-staked.json
+++ b/contracts/voting/dao-voting-juno-staked/schema/dao-voting-juno-staked.json
@@ -1,0 +1,596 @@
+{
+  "contract_name": "dao-voting-juno-staked",
+  "contract_version": "2.8.0-alpha.2",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "properties": {
+      "auto_register_staking_hooks": {
+        "description": "Reserved for future single-tx registration with `x/cw-hooks`. **Currently must be `None` or `Some(false)`** — passing `Some(true)` fails with `AutoRegisterNotYetSupported`.\n\nProduction deploys register the instantiated contract address with `x/cw-hooks` out-of-band: `junod tx cw-hooks register-staking <contract_addr>`. Field is kept so the in-contract path can be added later without an API break.",
+        "type": [
+          "boolean",
+          "null"
+        ]
+      }
+    },
+    "additionalProperties": false
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "oneOf": [
+      {
+        "description": "Adds a subscriber that will receive `dao_hooks::stake::StakeChangedHookMsg::{Stake, Unstake}` execute messages whenever the chain reports a delegation change. Only the DAO may call this.",
+        "type": "object",
+        "required": [
+          "add_hook"
+        ],
+        "properties": {
+          "add_hook": {
+            "type": "object",
+            "required": [
+              "addr"
+            ],
+            "properties": {
+              "addr": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Removes a previously-registered subscriber. Only the DAO may call this.",
+        "type": "object",
+        "required": [
+          "remove_hook"
+        ],
+        "properties": {
+          "remove_hook": {
+            "type": "object",
+            "required": [
+              "addr"
+            ],
+            "properties": {
+              "addr": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "oneOf": [
+      {
+        "description": "Returns the currently-registered stake-change hook subscribers.",
+        "type": "object",
+        "required": [
+          "get_hooks"
+        ],
+        "properties": {
+          "get_hooks": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the voting power for an address at a given height.",
+        "type": "object",
+        "required": [
+          "voting_power_at_height"
+        ],
+        "properties": {
+          "voting_power_at_height": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "height": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the total voting power at a given block heigh.",
+        "type": "object",
+        "required": [
+          "total_power_at_height"
+        ],
+        "properties": {
+          "total_power_at_height": {
+            "type": "object",
+            "properties": {
+              "height": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the address of the DAO this module belongs to.",
+        "type": "object",
+        "required": [
+          "dao"
+        ],
+        "properties": {
+          "dao": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns contract version info.",
+        "type": "object",
+        "required": [
+          "info"
+        ],
+        "properties": {
+          "info": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": null,
+  "sudo": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "SudoMsg",
+    "description": "Messages routed via `x/cw-hooks` when a staking event lands.\n\nVariant names and field names mirror the JSON emitted by Juno's `x/cw-hooks` `staking_hook_types.go` exactly — anything else would mean we never receive the sudo at all.",
+    "oneOf": [
+      {
+        "type": "object",
+        "required": [
+          "after_delegation_modified"
+        ],
+        "properties": {
+          "after_delegation_modified": {
+            "type": "object",
+            "required": [
+              "after_delegation_modified"
+            ],
+            "properties": {
+              "after_delegation_modified": {
+                "$ref": "#/definitions/DelegationEvent"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "before_delegation_created"
+        ],
+        "properties": {
+          "before_delegation_created": {
+            "type": "object",
+            "required": [
+              "before_delegation_created"
+            ],
+            "properties": {
+              "before_delegation_created": {
+                "$ref": "#/definitions/DelegationEvent"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "before_delegation_shares_modified"
+        ],
+        "properties": {
+          "before_delegation_shares_modified": {
+            "type": "object",
+            "required": [
+              "before_delegation_shares_modified"
+            ],
+            "properties": {
+              "before_delegation_shares_modified": {
+                "$ref": "#/definitions/DelegationEvent"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "before_delegation_removed"
+        ],
+        "properties": {
+          "before_delegation_removed": {
+            "type": "object",
+            "required": [
+              "before_delegation_removed"
+            ],
+            "properties": {
+              "before_delegation_removed": {
+                "$ref": "#/definitions/DelegationEvent"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "before_validator_slashed"
+        ],
+        "properties": {
+          "before_validator_slashed": {
+            "type": "object",
+            "required": [
+              "before_validator_slashed"
+            ],
+            "properties": {
+              "before_validator_slashed": {
+                "$ref": "#/definitions/ValidatorSlashEvent"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "after_validator_created"
+        ],
+        "properties": {
+          "after_validator_created": {
+            "type": "object",
+            "required": [
+              "after_validator_created"
+            ],
+            "properties": {
+              "after_validator_created": {
+                "$ref": "#/definitions/ValidatorEvent"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "after_validator_removed"
+        ],
+        "properties": {
+          "after_validator_removed": {
+            "type": "object",
+            "required": [
+              "after_validator_removed"
+            ],
+            "properties": {
+              "after_validator_removed": {
+                "$ref": "#/definitions/ValidatorEvent"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "before_validator_modified"
+        ],
+        "properties": {
+          "before_validator_modified": {
+            "type": "object",
+            "required": [
+              "before_validator_modified"
+            ],
+            "properties": {
+              "before_validator_modified": {
+                "$ref": "#/definitions/ValidatorEvent"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "after_validator_modified"
+        ],
+        "properties": {
+          "after_validator_modified": {
+            "type": "object",
+            "required": [
+              "after_validator_modified"
+            ],
+            "properties": {
+              "after_validator_modified": {
+                "$ref": "#/definitions/ValidatorEvent"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "after_validator_bonded"
+        ],
+        "properties": {
+          "after_validator_bonded": {
+            "type": "object",
+            "required": [
+              "after_validator_bonded"
+            ],
+            "properties": {
+              "after_validator_bonded": {
+                "$ref": "#/definitions/ValidatorEvent"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "after_validator_begin_unbonding"
+        ],
+        "properties": {
+          "after_validator_begin_unbonding": {
+            "type": "object",
+            "required": [
+              "after_validator_begin_unbonding"
+            ],
+            "properties": {
+              "after_validator_begin_unbonding": {
+                "$ref": "#/definitions/ValidatorEvent"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ],
+    "definitions": {
+      "DelegationEvent": {
+        "type": "object",
+        "required": [
+          "delegator_address",
+          "shares",
+          "validator_address"
+        ],
+        "properties": {
+          "delegator_address": {
+            "type": "string"
+          },
+          "shares": {
+            "type": "string"
+          },
+          "validator_address": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ValidatorEvent": {
+        "type": "object",
+        "required": [
+          "bond_status",
+          "bonded_tokens",
+          "commission",
+          "moniker",
+          "validator_address",
+          "validator_tokens"
+        ],
+        "properties": {
+          "bond_status": {
+            "type": "string"
+          },
+          "bonded_tokens": {
+            "type": "string"
+          },
+          "commission": {
+            "type": "string"
+          },
+          "moniker": {
+            "type": "string"
+          },
+          "validator_address": {
+            "type": "string"
+          },
+          "validator_tokens": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ValidatorSlashEvent": {
+        "type": "object",
+        "required": [
+          "moniker",
+          "slashed_amount",
+          "validator_address"
+        ],
+        "properties": {
+          "moniker": {
+            "type": "string"
+          },
+          "slashed_amount": {
+            "type": "string"
+          },
+          "validator_address": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "responses": {
+    "dao": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "get_hooks": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "GetHooksResponse",
+      "type": "object",
+      "required": [
+        "hooks"
+      ],
+      "properties": {
+        "hooks": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "info": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "InfoResponse",
+      "type": "object",
+      "required": [
+        "info"
+      ],
+      "properties": {
+        "info": {
+          "$ref": "#/definitions/ContractVersion"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "ContractVersion": {
+          "type": "object",
+          "required": [
+            "contract",
+            "version"
+          ],
+          "properties": {
+            "contract": {
+              "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
+              "type": "string"
+            },
+            "version": {
+              "description": "version is any string that this implementation knows. It may be simple counter \"1\", \"2\". or semantic version on release tags \"v0.7.0\", or some custom feature flag list. the only code that needs to understand the version parsing is code that knows how to migrate from the given contract (and is tied to it's implementation somehow)",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "total_power_at_height": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "TotalPowerAtHeightResponse",
+      "type": "object",
+      "required": [
+        "height",
+        "power"
+      ],
+      "properties": {
+        "height": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "power": {
+          "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "voting_power_at_height": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "VotingPowerAtHeightResponse",
+      "type": "object",
+      "required": [
+        "height",
+        "power"
+      ],
+      "properties": {
+        "height": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "power": {
+          "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/voting/dao-voting-juno-staked/src/bindings.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/bindings.rs
@@ -1,0 +1,104 @@
+//! Juno-specific custom wasm bindings consumed by this contract.
+//!
+//! These types mirror the JSON shape produced by
+//! `juno/wasmbindings/types/query.go` byte-for-byte. The chain registers a
+//! `QueryPlugin` that dispatches based on the tagged variant; anything that
+//! doesn't match results in a wasm query error.
+
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{CustomQuery, QuerierWrapper, QueryRequest, StdResult, Uint128};
+
+/// Top-level custom query enum. Variants are tagged exactly as the chain
+/// expects (lowercase snake_case via `cw_serde`).
+#[cw_serde]
+#[derive(Eq)]
+pub enum JunoQuery {
+    /// Bonded voting power for `address` at-or-before `height`, with LSTs
+    /// excluded. The chain returns the most recent snapshot whose recorded
+    /// height is `<= height`; zero if no snapshot exists.
+    VotingPowerAt(VotingPowerAt),
+    /// Total bonded voting power at-or-before `height`.
+    TotalVotingPowerAt(TotalVotingPowerAt),
+    /// Every recorded snapshot for `address` in `[from_height, to_height]`.
+    /// Not used by the voting module itself but exposed here so consumers
+    /// in this workspace can share the binding types.
+    VotingPowerOverRange(VotingPowerOverRange),
+}
+
+impl CustomQuery for JunoQuery {}
+
+#[cw_serde]
+#[derive(Eq)]
+pub struct VotingPowerAt {
+    pub address: String,
+    pub height: i64,
+}
+
+#[cw_serde]
+#[derive(Eq)]
+pub struct TotalVotingPowerAt {
+    pub height: i64,
+}
+
+#[cw_serde]
+#[derive(Eq)]
+pub struct VotingPowerOverRange {
+    pub address: String,
+    pub from_height: i64,
+    pub to_height: i64,
+}
+
+/// Response for both `VotingPowerAt` and `TotalVotingPowerAt`. The chain
+/// emits the bonded amount as a base-10 string sized for uint256 — we
+/// parse to `Uint128` and surface overflow as a query error.
+#[cw_serde]
+pub struct VotingPowerResponse {
+    pub power: String,
+}
+
+#[cw_serde]
+pub struct VotingPowerOverRangeResponse {
+    pub rows: Vec<HeightPower>,
+}
+
+#[cw_serde]
+pub struct HeightPower {
+    pub height: i64,
+    pub power: String,
+}
+
+/// Helpers wrapping the raw `QuerierWrapper<JunoQuery>` so call sites read
+/// like ordinary querier calls.
+pub trait JunoQuerier {
+    fn voting_power_at(&self, address: String, height: u64) -> StdResult<Uint128>;
+    fn total_voting_power_at(&self, height: u64) -> StdResult<Uint128>;
+}
+
+impl<'a> JunoQuerier for QuerierWrapper<'a, JunoQuery> {
+    fn voting_power_at(&self, address: String, height: u64) -> StdResult<Uint128> {
+        let req: QueryRequest<JunoQuery> =
+            QueryRequest::Custom(JunoQuery::VotingPowerAt(VotingPowerAt {
+                address,
+                height: height as i64,
+            }));
+        let resp: VotingPowerResponse = self.query(&req)?;
+        parse_power(&resp.power)
+    }
+
+    fn total_voting_power_at(&self, height: u64) -> StdResult<Uint128> {
+        let req: QueryRequest<JunoQuery> =
+            QueryRequest::Custom(JunoQuery::TotalVotingPowerAt(TotalVotingPowerAt {
+                height: height as i64,
+            }));
+        let resp: VotingPowerResponse = self.query(&req)?;
+        parse_power(&resp.power)
+    }
+}
+
+fn parse_power(raw: &str) -> StdResult<Uint128> {
+    raw.parse::<Uint128>().map_err(|e| {
+        cosmwasm_std::StdError::generic_err(format!(
+            "voting-snapshot returned unparseable power '{raw}': {e}"
+        ))
+    })
+}

--- a/contracts/voting/dao-voting-juno-staked/src/contract.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/contract.rs
@@ -1,0 +1,258 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+
+use cosmwasm_std::{
+    to_json_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdResult,
+    Uint128,
+};
+use cw2::set_contract_version;
+use dao_hooks::stake::{stake_hook_msgs, unstake_hook_msgs};
+use dao_interface::voting::{
+    InfoResponse, TotalPowerAtHeightResponse, VotingPowerAtHeightResponse,
+};
+
+use crate::bindings::{JunoQuerier, JunoQuery};
+use crate::error::ContractError;
+use crate::msg::{
+    DelegationEvent, ExecuteMsg, GetHooksResponse, InstantiateMsg, QueryMsg, SudoMsg,
+};
+use crate::state::{DAO, HOOKS};
+
+pub(crate) const CONTRACT_NAME: &str = "crates.io:dao-voting-juno-staked";
+pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut<JunoQuery>,
+    _env: Env,
+    info: MessageInfo,
+    msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    DAO.save(deps.storage, &info.sender)?;
+
+    // Registration with x/cw-hooks happens out-of-band post-instantiate
+    // (CLI `junod tx cw-hooks register-staking <contract>` or a separate
+    // governance/DAO proposal). Building the `MsgRegisterStaking` proto
+    // body in-contract would mean pulling in a prost codegen dependency
+    // just for one message shape — deferred until a concrete need for
+    // single-tx setup appears. See `auto_register_staking_hooks` in
+    // `InstantiateMsg`: currently must be `None` / `Some(false)`.
+    if msg.auto_register_staking_hooks.unwrap_or(false) {
+        return Err(ContractError::AutoRegisterNotYetSupported {});
+    }
+
+    Ok(Response::new()
+        .add_attribute("action", "instantiate")
+        .add_attribute("dao", info.sender.to_string()))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    deps: DepsMut<JunoQuery>,
+    _env: Env,
+    info: MessageInfo,
+    msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    match msg {
+        ExecuteMsg::AddHook { addr } => execute_add_hook(deps, info, addr),
+        ExecuteMsg::RemoveHook { addr } => execute_remove_hook(deps, info, addr),
+    }
+}
+
+fn execute_add_hook(
+    deps: DepsMut<JunoQuery>,
+    info: MessageInfo,
+    addr: String,
+) -> Result<Response, ContractError> {
+    only_dao(deps.as_ref(), &info.sender)?;
+    let addr = deps.api.addr_validate(&addr)?;
+    HOOKS.add_hook(deps.storage, addr.clone())?;
+    Ok(Response::new()
+        .add_attribute("action", "add_hook")
+        .add_attribute("hook", addr.to_string()))
+}
+
+fn execute_remove_hook(
+    deps: DepsMut<JunoQuery>,
+    info: MessageInfo,
+    addr: String,
+) -> Result<Response, ContractError> {
+    only_dao(deps.as_ref(), &info.sender)?;
+    let addr = deps.api.addr_validate(&addr)?;
+    HOOKS.remove_hook(deps.storage, addr.clone())?;
+    Ok(Response::new()
+        .add_attribute("action", "remove_hook")
+        .add_attribute("hook", addr.to_string()))
+}
+
+fn only_dao(deps: Deps<JunoQuery>, sender: &Addr) -> Result<(), ContractError> {
+    let dao = DAO.load(deps.storage)?;
+    if *sender != dao {
+        return Err(ContractError::Unauthorized {});
+    }
+    Ok(())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn sudo(deps: DepsMut<JunoQuery>, env: Env, msg: SudoMsg) -> Result<Response, ContractError> {
+    match msg {
+        // Delegation events that actually move a delegator's bonded
+        // power. The chain's x/voting-snapshot fires first in the
+        // staking-hook chain (see app/keepers/keepers.go ordering), so
+        // by the time our sudo runs the snapshot at `env.block.height`
+        // is already written and queryable.
+        SudoMsg::AfterDelegationModified {
+            after_delegation_modified: ev,
+        } => sudo_stake_delta(deps, env, ev, StakeDirection::AfterEvent),
+        SudoMsg::BeforeDelegationRemoved {
+            before_delegation_removed: ev,
+        } => sudo_stake_delta(deps, env, ev, StakeDirection::BeforeRemoval),
+        // BeforeDelegationCreated / BeforeDelegationSharesModified fire
+        // *before* the snapshot is written, so the new power isn't
+        // queryable yet. The after-event variants above carry the same
+        // delegator so we get a clean post-event read there; ignoring
+        // the pre-event variants avoids double-firing or stale reads.
+        SudoMsg::BeforeDelegationCreated { .. }
+        | SudoMsg::BeforeDelegationSharesModified { .. } => Ok(Response::new()),
+        SudoMsg::BeforeValidatorSlashed {
+            before_validator_slashed: _,
+        } => {
+            // Slashing redistributes power across many delegators at
+            // once. We don't enumerate them here — the chain's
+            // x/voting-snapshot has lazy per-delegator decay (see
+            // memory/v30-upgrade-plan.md B1+B2+B4) so callers that
+            // re-query power at the slash height get correct values.
+            // Subscribers that need a notification can register with
+            // x/cw-hooks directly.
+            Ok(Response::new())
+        }
+        // Validator lifecycle events don't move any single delegator's
+        // bonded power on their own; ignoring them keeps cw-hooks
+        // happy without firing meaningless stake hooks.
+        SudoMsg::AfterValidatorCreated { .. }
+        | SudoMsg::AfterValidatorRemoved { .. }
+        | SudoMsg::BeforeValidatorModified { .. }
+        | SudoMsg::AfterValidatorModified { .. }
+        | SudoMsg::AfterValidatorBonded { .. }
+        | SudoMsg::AfterValidatorBeginUnbonding { .. } => Ok(Response::new()),
+    }
+}
+
+enum StakeDirection {
+    /// The event fired after a delegation was modified — the chain has
+    /// the new total bonded for the delegator in the current-height
+    /// snapshot.
+    AfterEvent,
+    /// The event fired before a delegation was wiped — at sudo time the
+    /// chain still has the old non-zero entry in storage. We emit
+    /// Unstake for the full pre-removal amount and clear our internal
+    /// view to zero.
+    BeforeRemoval,
+}
+
+fn sudo_stake_delta(
+    deps: DepsMut<JunoQuery>,
+    env: Env,
+    ev: DelegationEvent,
+    direction: StakeDirection,
+) -> Result<Response, ContractError> {
+    let delegator = deps.api.addr_validate(&ev.delegator_address)?;
+
+    let new_power = match direction {
+        StakeDirection::AfterEvent => deps
+            .querier
+            .voting_power_at(delegator.to_string(), env.block.height)?,
+        // For a removal that hasn't yet committed, the snapshot at
+        // current height still shows the pre-removal stake. Report
+        // zero — this delegation is about to be gone, and any
+        // subscriber tracking "what's the delegator's voting power
+        // now" wants the post-removal value.
+        StakeDirection::BeforeRemoval => Uint128::zero(),
+    };
+
+    let prev_power = previous_power(deps.as_ref(), delegator.to_string(), env.block.height)?;
+
+    let hooks = HOOKS;
+    let submsgs = if new_power >= prev_power {
+        let amount = new_power.checked_sub(prev_power).unwrap_or_default();
+        if amount.is_zero() {
+            return Ok(Response::new().add_attribute("action", "stake_unchanged"));
+        }
+        stake_hook_msgs(hooks, deps.storage, delegator.clone(), amount)?
+    } else {
+        let amount = prev_power.checked_sub(new_power).unwrap_or_default();
+        unstake_hook_msgs(hooks, deps.storage, delegator.clone(), amount)?
+    };
+
+    Ok(Response::new()
+        .add_submessages(submsgs)
+        .add_attribute("action", "stake_change_hook")
+        .add_attribute("delegator", delegator.to_string())
+        .add_attribute("new_power", new_power.to_string())
+        .add_attribute("prev_power", prev_power.to_string()))
+}
+
+/// Returns the snapshot recorded immediately before `current_height`. The
+/// chain's at-or-before semantics give us this for free: querying at
+/// `current_height - 1` returns whatever the previous event wrote.
+/// Saturates at 0 for genesis-block edge cases.
+fn previous_power(
+    deps: Deps<JunoQuery>,
+    address: String,
+    current_height: u64,
+) -> StdResult<Uint128> {
+    if current_height == 0 {
+        return Ok(Uint128::zero());
+    }
+    deps.querier.voting_power_at(address, current_height - 1)
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn reply(_deps: DepsMut<JunoQuery>, _env: Env, _reply: Reply) -> Result<Response, ContractError> {
+    // Reserved for future auto-unregistration on hook failure. The
+    // current dao_hooks call sites use plain SubMsg::new (no reply
+    // requested), so this entry-point is unreachable in practice.
+    Ok(Response::new())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps<JunoQuery>, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::VotingPowerAtHeight { address, height } => {
+            to_json_binary(&query_voting_power_at_height(deps, env, address, height)?)
+        }
+        QueryMsg::TotalPowerAtHeight { height } => {
+            to_json_binary(&query_total_power_at_height(deps, env, height)?)
+        }
+        QueryMsg::Dao {} => to_json_binary(&DAO.load(deps.storage)?),
+        QueryMsg::Info {} => to_json_binary(&InfoResponse {
+            info: cw2::get_contract_version(deps.storage)?,
+        }),
+        QueryMsg::GetHooks {} => to_json_binary(&GetHooksResponse {
+            hooks: HOOKS.query_hooks(deps)?.hooks,
+        }),
+    }
+}
+
+fn query_voting_power_at_height(
+    deps: Deps<JunoQuery>,
+    env: Env,
+    address: String,
+    height: Option<u64>,
+) -> StdResult<VotingPowerAtHeightResponse> {
+    let height = height.unwrap_or(env.block.height);
+    let power = deps.querier.voting_power_at(address, height)?;
+    Ok(VotingPowerAtHeightResponse { power, height })
+}
+
+fn query_total_power_at_height(
+    deps: Deps<JunoQuery>,
+    env: Env,
+    height: Option<u64>,
+) -> StdResult<TotalPowerAtHeightResponse> {
+    let height = height.unwrap_or(env.block.height);
+    let power = deps.querier.total_voting_power_at(height)?;
+    Ok(TotalPowerAtHeightResponse { power, height })
+}

--- a/contracts/voting/dao-voting-juno-staked/src/error.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/error.rs
@@ -1,0 +1,25 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error(transparent)]
+    Std(#[from] StdError),
+
+    #[error(transparent)]
+    HookError(#[from] cw_hooks::HookError),
+
+    #[error("Only the DAO may call this method")]
+    Unauthorized {},
+
+    #[error("Contract has no execute variants for end users; delegation happens via x/staking")]
+    NoExecute {},
+
+    #[error(
+        "auto_register_staking_hooks is not yet supported; register out-of-band via x/cw-hooks tx"
+    )]
+    AutoRegisterNotYetSupported {},
+
+    #[error("Voting power query returned a value larger than Uint128")]
+    PowerOverflow {},
+}

--- a/contracts/voting/dao-voting-juno-staked/src/lib.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/lib.rs
@@ -1,0 +1,12 @@
+#![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
+
+pub mod bindings;
+pub mod contract;
+mod error;
+pub mod msg;
+pub mod state;
+
+#[cfg(test)]
+mod tests;
+
+pub use crate::error::ContractError;

--- a/contracts/voting/dao-voting-juno-staked/src/msg.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/msg.rs
@@ -1,0 +1,114 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use dao_dao_macros::voting_module_query;
+
+#[cw_serde]
+pub struct InstantiateMsg {
+    /// Reserved for future single-tx registration with `x/cw-hooks`.
+    /// **Currently must be `None` or `Some(false)`** — passing
+    /// `Some(true)` fails with `AutoRegisterNotYetSupported`.
+    ///
+    /// Production deploys register the instantiated contract address with
+    /// `x/cw-hooks` out-of-band: `junod tx cw-hooks register-staking
+    /// <contract_addr>`. Field is kept so the in-contract path can be
+    /// added later without an API break.
+    pub auto_register_staking_hooks: Option<bool>,
+}
+
+#[cw_serde]
+pub enum ExecuteMsg {
+    /// Adds a subscriber that will receive
+    /// `dao_hooks::stake::StakeChangedHookMsg::{Stake, Unstake}` execute
+    /// messages whenever the chain reports a delegation change. Only the
+    /// DAO may call this.
+    AddHook { addr: String },
+    /// Removes a previously-registered subscriber. Only the DAO may call
+    /// this.
+    RemoveHook { addr: String },
+}
+
+/// Messages routed via `x/cw-hooks` when a staking event lands.
+///
+/// Variant names and field names mirror the JSON emitted by Juno's
+/// `x/cw-hooks` `staking_hook_types.go` exactly — anything else would
+/// mean we never receive the sudo at all.
+#[cw_serde]
+pub enum SudoMsg {
+    AfterDelegationModified {
+        after_delegation_modified: DelegationEvent,
+    },
+    BeforeDelegationCreated {
+        before_delegation_created: DelegationEvent,
+    },
+    BeforeDelegationSharesModified {
+        before_delegation_shares_modified: DelegationEvent,
+    },
+    BeforeDelegationRemoved {
+        before_delegation_removed: DelegationEvent,
+    },
+    BeforeValidatorSlashed {
+        before_validator_slashed: ValidatorSlashEvent,
+    },
+    // Validator-lifecycle hooks fire but do not change any single
+    // delegator's bonded amount in a way the snapshot module wouldn't
+    // already have written through delegation events; we silently
+    // ignore them so cw-hooks doesn't drop us from the registry.
+    AfterValidatorCreated {
+        after_validator_created: ValidatorEvent,
+    },
+    AfterValidatorRemoved {
+        after_validator_removed: ValidatorEvent,
+    },
+    BeforeValidatorModified {
+        before_validator_modified: ValidatorEvent,
+    },
+    AfterValidatorModified {
+        after_validator_modified: ValidatorEvent,
+    },
+    AfterValidatorBonded {
+        after_validator_bonded: ValidatorEvent,
+    },
+    AfterValidatorBeginUnbonding {
+        after_validator_begin_unbonding: ValidatorEvent,
+    },
+}
+
+#[cw_serde]
+pub struct DelegationEvent {
+    pub delegator_address: String,
+    pub validator_address: String,
+    pub shares: String,
+}
+
+#[cw_serde]
+pub struct ValidatorEvent {
+    pub moniker: String,
+    pub validator_address: String,
+    pub commission: String,
+    pub validator_tokens: String,
+    pub bonded_tokens: String,
+    pub bond_status: String,
+}
+
+#[cw_serde]
+pub struct ValidatorSlashEvent {
+    pub moniker: String,
+    pub validator_address: String,
+    pub slashed_amount: String,
+}
+
+#[voting_module_query]
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {
+    /// Returns the currently-registered stake-change hook subscribers.
+    #[returns(GetHooksResponse)]
+    GetHooks {},
+}
+
+#[cw_serde]
+pub struct GetHooksResponse {
+    pub hooks: Vec<String>,
+}
+
+#[cw_serde]
+pub struct MigrateMsg {}

--- a/contracts/voting/dao-voting-juno-staked/src/state.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/state.rs
@@ -1,0 +1,11 @@
+use cosmwasm_std::Addr;
+use cw_hooks::Hooks;
+use cw_storage_plus::Item;
+
+/// The address of the DAO that instantiated this voting module.
+pub const DAO: Item<Addr> = Item::new("dao");
+
+/// Subscribers that receive `dao_hooks::stake::StakeChangedHookMsg` events
+/// when delegations change. Managed via `AddHook` / `RemoveHook` (gated to
+/// the DAO).
+pub const HOOKS: Hooks = Hooks::new("hooks");

--- a/contracts/voting/dao-voting-juno-staked/src/tests/mod.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/tests/mod.rs
@@ -1,0 +1,13 @@
+//! Unit tests for `dao-voting-juno-staked`.
+//!
+//! cw-multi-test has no first-class support for our `JunoQuery` custom
+//! binding (the chain's `x/voting-snapshot` keeper isn't present in
+//! integration test stubs), so we wire a small `MockQuerier`-derived
+//! `JunoMockQuerier` that intercepts `QueryRequest::Custom(JunoQuery::..)`
+//! and returns canned snapshot values. That's enough to exercise the
+//! full query + sudo paths without needing a chain binary or multitest
+//! module shim.
+
+mod sudo;
+mod support;
+mod surface;

--- a/contracts/voting/dao-voting-juno-staked/src/tests/sudo.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/tests/sudo.rs
@@ -1,0 +1,272 @@
+use cosmwasm_std::testing::{mock_env, mock_info};
+use cosmwasm_std::{from_json, CosmosMsg, WasmMsg};
+use dao_hooks::stake::{StakeChangedExecuteMsg, StakeChangedHookMsg};
+
+use crate::contract::{execute, instantiate, sudo};
+use crate::msg::{
+    DelegationEvent, ExecuteMsg, InstantiateMsg, SudoMsg, ValidatorEvent, ValidatorSlashEvent,
+};
+
+use super::support::{juno_deps_with, SnapshotStore, DAO_ADDR, VOTER_A};
+
+fn boot(
+    store: SnapshotStore,
+) -> cosmwasm_std::OwnedDeps<
+    cosmwasm_std::testing::MockStorage,
+    cosmwasm_std::testing::MockApi,
+    super::support::JunoMockQuerier,
+    crate::bindings::JunoQuery,
+> {
+    let mut deps = juno_deps_with(store);
+    instantiate(
+        deps.as_mut(),
+        mock_env(),
+        mock_info(DAO_ADDR, &[]),
+        InstantiateMsg {
+            auto_register_staking_hooks: Some(false),
+        },
+    )
+    .unwrap();
+    deps
+}
+
+fn subscribe(
+    deps: &mut cosmwasm_std::OwnedDeps<
+        cosmwasm_std::testing::MockStorage,
+        cosmwasm_std::testing::MockApi,
+        super::support::JunoMockQuerier,
+        crate::bindings::JunoQuery,
+    >,
+    subscriber: &str,
+) {
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        mock_info(DAO_ADDR, &[]),
+        ExecuteMsg::AddHook {
+            addr: subscriber.to_string(),
+        },
+    )
+    .unwrap();
+}
+
+fn extract_hook_msg(msg: &CosmosMsg) -> StakeChangedHookMsg {
+    match msg {
+        CosmosMsg::Wasm(WasmMsg::Execute { msg, .. }) => {
+            let env: StakeChangedExecuteMsg = from_json(msg).unwrap();
+            match env {
+                StakeChangedExecuteMsg::StakeChangeHook(h) => h,
+            }
+        }
+        _ => panic!("expected wasm execute"),
+    }
+}
+
+#[test]
+fn after_delegation_modified_fires_stake_delta() {
+    let mut store = SnapshotStore::default();
+    // Pre-event: at the height before sudo, voter had 100. Post-event:
+    // chain wrote 175 at current height. Delta = +75.
+    let env = mock_env();
+    let current_height = env.block.height;
+    store.set_power(VOTER_A, current_height - 1, 100);
+    store.set_power(VOTER_A, current_height, 175);
+    let mut deps = boot(store);
+    subscribe(&mut deps, "subscriber");
+
+    let resp = sudo(
+        deps.as_mut(),
+        env,
+        SudoMsg::AfterDelegationModified {
+            after_delegation_modified: DelegationEvent {
+                delegator_address: VOTER_A.to_string(),
+                validator_address: "junovaloper1...".to_string(),
+                shares: "75000000".to_string(),
+            },
+        },
+    )
+    .unwrap();
+
+    assert_eq!(resp.messages.len(), 1);
+    let hook = extract_hook_msg(&resp.messages[0].msg);
+    match hook {
+        StakeChangedHookMsg::Stake { addr, amount } => {
+            assert_eq!(addr.as_str(), VOTER_A);
+            assert_eq!(amount.u128(), 75);
+        }
+        other => panic!("expected Stake, got {other:?}"),
+    }
+}
+
+#[test]
+fn after_delegation_modified_fires_unstake_when_power_drops() {
+    let mut store = SnapshotStore::default();
+    let env = mock_env();
+    let h = env.block.height;
+    // Voter previously had 200, partial undelegation drops them to 80.
+    store.set_power(VOTER_A, h - 1, 200);
+    store.set_power(VOTER_A, h, 80);
+    let mut deps = boot(store);
+    subscribe(&mut deps, "subscriber");
+
+    let resp = sudo(
+        deps.as_mut(),
+        env,
+        SudoMsg::AfterDelegationModified {
+            after_delegation_modified: DelegationEvent {
+                delegator_address: VOTER_A.to_string(),
+                validator_address: "junovaloper1...".to_string(),
+                shares: "80000000".to_string(),
+            },
+        },
+    )
+    .unwrap();
+
+    assert_eq!(resp.messages.len(), 1);
+    let hook = extract_hook_msg(&resp.messages[0].msg);
+    match hook {
+        StakeChangedHookMsg::Unstake { addr, amount } => {
+            assert_eq!(addr.as_str(), VOTER_A);
+            assert_eq!(amount.u128(), 120);
+        }
+        other => panic!("expected Unstake, got {other:?}"),
+    }
+}
+
+#[test]
+fn before_delegation_removed_emits_full_unstake() {
+    let mut store = SnapshotStore::default();
+    let env = mock_env();
+    let h = env.block.height;
+    // Voter has 90 just before the removal commits.
+    store.set_power(VOTER_A, h - 1, 90);
+    store.set_power(VOTER_A, h, 90);
+    let mut deps = boot(store);
+    subscribe(&mut deps, "subscriber");
+
+    let resp = sudo(
+        deps.as_mut(),
+        env,
+        SudoMsg::BeforeDelegationRemoved {
+            before_delegation_removed: DelegationEvent {
+                delegator_address: VOTER_A.to_string(),
+                validator_address: "junovaloper1...".to_string(),
+                shares: "0".to_string(),
+            },
+        },
+    )
+    .unwrap();
+
+    let hook = extract_hook_msg(&resp.messages[0].msg);
+    match hook {
+        StakeChangedHookMsg::Unstake { amount, .. } => assert_eq!(amount.u128(), 90),
+        other => panic!("expected Unstake, got {other:?}"),
+    }
+}
+
+#[test]
+fn unchanged_power_emits_no_hooks() {
+    let mut store = SnapshotStore::default();
+    let env = mock_env();
+    let h = env.block.height;
+    store.set_power(VOTER_A, h - 1, 100);
+    store.set_power(VOTER_A, h, 100);
+    let mut deps = boot(store);
+    subscribe(&mut deps, "subscriber");
+
+    let resp = sudo(
+        deps.as_mut(),
+        env,
+        SudoMsg::AfterDelegationModified {
+            after_delegation_modified: DelegationEvent {
+                delegator_address: VOTER_A.to_string(),
+                validator_address: "junovaloper1...".to_string(),
+                shares: "100000000".to_string(),
+            },
+        },
+    )
+    .unwrap();
+    assert!(resp.messages.is_empty());
+}
+
+#[test]
+fn fan_out_targets_every_subscriber() {
+    let mut store = SnapshotStore::default();
+    let env = mock_env();
+    let h = env.block.height;
+    store.set_power(VOTER_A, h - 1, 0);
+    store.set_power(VOTER_A, h, 42);
+    let mut deps = boot(store);
+    subscribe(&mut deps, "gauge");
+    subscribe(&mut deps, "rewards");
+
+    let resp = sudo(
+        deps.as_mut(),
+        env,
+        SudoMsg::AfterDelegationModified {
+            after_delegation_modified: DelegationEvent {
+                delegator_address: VOTER_A.to_string(),
+                validator_address: "junovaloper1...".to_string(),
+                shares: "42000000".to_string(),
+            },
+        },
+    )
+    .unwrap();
+    assert_eq!(resp.messages.len(), 2);
+    let targets: Vec<String> = resp
+        .messages
+        .iter()
+        .map(|m| match &m.msg {
+            CosmosMsg::Wasm(WasmMsg::Execute { contract_addr, .. }) => contract_addr.clone(),
+            _ => panic!(),
+        })
+        .collect();
+    assert!(targets.contains(&"gauge".to_string()));
+    assert!(targets.contains(&"rewards".to_string()));
+}
+
+#[test]
+fn validator_lifecycle_and_slash_events_are_swallowed_silently() {
+    let mut deps = boot(SnapshotStore::default());
+    subscribe(&mut deps, "subscriber");
+
+    let validator = ValidatorEvent {
+        moniker: "v".to_string(),
+        validator_address: "junovaloper1...".to_string(),
+        commission: "0.05".to_string(),
+        validator_tokens: "0".to_string(),
+        bonded_tokens: "0".to_string(),
+        bond_status: "BOND_STATUS_BONDED".to_string(),
+    };
+
+    for msg in [
+        SudoMsg::AfterValidatorCreated {
+            after_validator_created: validator.clone(),
+        },
+        SudoMsg::AfterValidatorRemoved {
+            after_validator_removed: validator.clone(),
+        },
+        SudoMsg::AfterValidatorBonded {
+            after_validator_bonded: validator.clone(),
+        },
+        SudoMsg::AfterValidatorBeginUnbonding {
+            after_validator_begin_unbonding: validator.clone(),
+        },
+        SudoMsg::BeforeValidatorModified {
+            before_validator_modified: validator.clone(),
+        },
+        SudoMsg::AfterValidatorModified {
+            after_validator_modified: validator.clone(),
+        },
+        SudoMsg::BeforeValidatorSlashed {
+            before_validator_slashed: ValidatorSlashEvent {
+                moniker: "v".to_string(),
+                validator_address: "junovaloper1...".to_string(),
+                slashed_amount: "0.01".to_string(),
+            },
+        },
+    ] {
+        let resp = sudo(deps.as_mut(), mock_env(), msg).unwrap();
+        assert!(resp.messages.is_empty());
+    }
+}

--- a/contracts/voting/dao-voting-juno-staked/src/tests/support.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/tests/support.rs
@@ -1,0 +1,129 @@
+use std::collections::HashMap;
+
+use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage};
+use cosmwasm_std::{
+    from_json, to_json_binary, ContractResult, OwnedDeps, Querier, QuerierResult, QueryRequest,
+    SystemError, SystemResult, Uint128,
+};
+
+use crate::bindings::{JunoQuery, VotingPowerResponse};
+
+pub const DAO_ADDR: &str = "dao-core";
+pub const VOTER_A: &str = "voter-a";
+pub const VOTER_B: &str = "voter-b";
+
+/// Canned snapshot store keyed on `(address, height)`. A height of `None`
+/// in the lookup acts as a fallback for "any height not explicitly set",
+/// matching the at-or-before semantics of the real chain module.
+#[derive(Default, Clone)]
+pub struct SnapshotStore {
+    per_addr: HashMap<(String, u64), Uint128>,
+    addr_default: HashMap<String, Uint128>,
+    total_at: HashMap<u64, Uint128>,
+    total_default: Uint128,
+}
+
+impl SnapshotStore {
+    pub fn set_power(&mut self, addr: &str, height: u64, power: u128) {
+        self.per_addr
+            .insert((addr.to_string(), height), Uint128::new(power));
+    }
+
+    pub fn set_default_power(&mut self, addr: &str, power: u128) {
+        self.addr_default
+            .insert(addr.to_string(), Uint128::new(power));
+    }
+
+    pub fn set_total(&mut self, height: u64, power: u128) {
+        self.total_at.insert(height, Uint128::new(power));
+    }
+
+    pub fn set_default_total(&mut self, power: u128) {
+        self.total_default = Uint128::new(power);
+    }
+
+    fn lookup_addr(&self, addr: &str, height: u64) -> Uint128 {
+        if let Some(p) = self.per_addr.get(&(addr.to_string(), height)) {
+            return *p;
+        }
+        self.addr_default
+            .get(addr)
+            .copied()
+            .unwrap_or(Uint128::zero())
+    }
+
+    fn lookup_total(&self, height: u64) -> Uint128 {
+        self.total_at
+            .get(&height)
+            .copied()
+            .unwrap_or(self.total_default)
+    }
+}
+
+pub struct JunoMockQuerier {
+    base: MockQuerier,
+    store: SnapshotStore,
+}
+
+impl JunoMockQuerier {
+    pub fn new(store: SnapshotStore) -> Self {
+        Self {
+            base: MockQuerier::new(&[]),
+            store,
+        }
+    }
+}
+
+impl Querier for JunoMockQuerier {
+    fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
+        let request: QueryRequest<JunoQuery> = match from_json(bin_request) {
+            Ok(req) => req,
+            Err(e) => {
+                return SystemResult::Err(SystemError::InvalidRequest {
+                    error: format!("parsing query: {e}"),
+                    request: bin_request.into(),
+                })
+            }
+        };
+        match request {
+            QueryRequest::Custom(custom) => self.handle_custom(custom, bin_request),
+            other => self
+                .base
+                .raw_query(&cosmwasm_std::to_json_vec(&other).unwrap()),
+        }
+    }
+}
+
+impl JunoMockQuerier {
+    fn handle_custom(&self, q: JunoQuery, raw: &[u8]) -> QuerierResult {
+        let resp = match q {
+            JunoQuery::VotingPowerAt(p) => VotingPowerResponse {
+                power: self
+                    .store
+                    .lookup_addr(&p.address, p.height as u64)
+                    .to_string(),
+            },
+            JunoQuery::TotalVotingPowerAt(p) => VotingPowerResponse {
+                power: self.store.lookup_total(p.height as u64).to_string(),
+            },
+            JunoQuery::VotingPowerOverRange(_) => {
+                return SystemResult::Err(SystemError::InvalidRequest {
+                    error: "VotingPowerOverRange not stubbed in tests".to_string(),
+                    request: raw.into(),
+                })
+            }
+        };
+        SystemResult::Ok(ContractResult::Ok(to_json_binary(&resp).unwrap()))
+    }
+}
+
+pub fn juno_deps_with(
+    store: SnapshotStore,
+) -> OwnedDeps<MockStorage, MockApi, JunoMockQuerier, JunoQuery> {
+    OwnedDeps {
+        storage: MockStorage::default(),
+        api: MockApi::default(),
+        querier: JunoMockQuerier::new(store),
+        custom_query_type: std::marker::PhantomData,
+    }
+}

--- a/contracts/voting/dao-voting-juno-staked/src/tests/surface.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/tests/surface.rs
@@ -1,0 +1,169 @@
+use cosmwasm_std::testing::{mock_env, mock_info};
+use cosmwasm_std::{from_json, Addr, Uint128};
+use dao_interface::voting::{
+    InfoResponse, TotalPowerAtHeightResponse, VotingPowerAtHeightResponse,
+};
+
+use crate::contract::{execute, instantiate, query};
+use crate::error::ContractError;
+use crate::msg::{ExecuteMsg, GetHooksResponse, InstantiateMsg, QueryMsg};
+
+use super::support::{juno_deps_with, SnapshotStore, DAO_ADDR, VOTER_A, VOTER_B};
+
+fn instantiate_module(
+    deps: &mut cosmwasm_std::OwnedDeps<
+        cosmwasm_std::testing::MockStorage,
+        cosmwasm_std::testing::MockApi,
+        super::support::JunoMockQuerier,
+        crate::bindings::JunoQuery,
+    >,
+) {
+    let info = mock_info(DAO_ADDR, &[]);
+    instantiate(
+        deps.as_mut(),
+        mock_env(),
+        info,
+        InstantiateMsg {
+            auto_register_staking_hooks: Some(false),
+        },
+    )
+    .unwrap();
+}
+
+#[test]
+fn instantiate_stores_dao_address() {
+    let mut store = SnapshotStore::default();
+    store.set_default_total(0);
+    let mut deps = juno_deps_with(store);
+    instantiate_module(&mut deps);
+
+    let dao_bin = query(deps.as_ref(), mock_env(), QueryMsg::Dao {}).unwrap();
+    let dao: Addr = from_json(dao_bin).unwrap();
+    assert_eq!(dao, Addr::unchecked(DAO_ADDR));
+
+    let info_bin = query(deps.as_ref(), mock_env(), QueryMsg::Info {}).unwrap();
+    let info: InfoResponse = from_json(info_bin).unwrap();
+    assert_eq!(info.info.contract, "crates.io:dao-voting-juno-staked");
+}
+
+#[test]
+fn voting_power_proxies_to_chain_snapshot_with_at_or_before_semantics() {
+    let mut store = SnapshotStore::default();
+    // The chain wrote the voter's power at height 100; later heights
+    // without an explicit snapshot fall through to whatever the
+    // default for that voter is. Mirrors the chain's at-or-before
+    // iterator returning the latest entry <= requested height.
+    store.set_power(VOTER_A, 100, 250_000_000);
+    store.set_default_power(VOTER_A, 250_000_000);
+    store.set_total(100, 1_000_000_000);
+    store.set_default_total(1_000_000_000);
+    let mut deps = juno_deps_with(store);
+    instantiate_module(&mut deps);
+
+    let mut env = mock_env();
+    env.block.height = 250;
+
+    let bin = query(
+        deps.as_ref(),
+        env.clone(),
+        QueryMsg::VotingPowerAtHeight {
+            address: VOTER_A.to_string(),
+            height: Some(100),
+        },
+    )
+    .unwrap();
+    let resp: VotingPowerAtHeightResponse = from_json(bin).unwrap();
+    assert_eq!(resp.power, Uint128::new(250_000_000));
+    assert_eq!(resp.height, 100);
+
+    // No height → current env.block.height.
+    let bin = query(
+        deps.as_ref(),
+        env.clone(),
+        QueryMsg::VotingPowerAtHeight {
+            address: VOTER_A.to_string(),
+            height: None,
+        },
+    )
+    .unwrap();
+    let resp: VotingPowerAtHeightResponse = from_json(bin).unwrap();
+    assert_eq!(resp.power, Uint128::new(250_000_000));
+    assert_eq!(resp.height, 250);
+
+    let bin = query(
+        deps.as_ref(),
+        env,
+        QueryMsg::TotalPowerAtHeight { height: Some(100) },
+    )
+    .unwrap();
+    let resp: TotalPowerAtHeightResponse = from_json(bin).unwrap();
+    assert_eq!(resp.power, Uint128::new(1_000_000_000));
+}
+
+#[test]
+fn add_and_remove_hook_only_dao() {
+    let mut deps = juno_deps_with(SnapshotStore::default());
+    instantiate_module(&mut deps);
+
+    // Non-DAO sender is rejected.
+    let res = execute(
+        deps.as_mut(),
+        mock_env(),
+        mock_info("rando", &[]),
+        ExecuteMsg::AddHook {
+            addr: VOTER_A.to_string(),
+        },
+    );
+    assert!(matches!(res, Err(ContractError::Unauthorized {})));
+
+    // DAO adds two subscribers.
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        mock_info(DAO_ADDR, &[]),
+        ExecuteMsg::AddHook {
+            addr: VOTER_A.to_string(),
+        },
+    )
+    .unwrap();
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        mock_info(DAO_ADDR, &[]),
+        ExecuteMsg::AddHook {
+            addr: VOTER_B.to_string(),
+        },
+    )
+    .unwrap();
+
+    let bin = query(deps.as_ref(), mock_env(), QueryMsg::GetHooks {}).unwrap();
+    let resp: GetHooksResponse = from_json(bin).unwrap();
+    assert_eq!(resp.hooks.len(), 2);
+    assert!(resp.hooks.contains(&VOTER_A.to_string()));
+    assert!(resp.hooks.contains(&VOTER_B.to_string()));
+
+    // Duplicate add fails.
+    let res = execute(
+        deps.as_mut(),
+        mock_env(),
+        mock_info(DAO_ADDR, &[]),
+        ExecuteMsg::AddHook {
+            addr: VOTER_A.to_string(),
+        },
+    );
+    assert!(matches!(res, Err(ContractError::HookError(_))));
+
+    // Remove works.
+    execute(
+        deps.as_mut(),
+        mock_env(),
+        mock_info(DAO_ADDR, &[]),
+        ExecuteMsg::RemoveHook {
+            addr: VOTER_A.to_string(),
+        },
+    )
+    .unwrap();
+    let bin = query(deps.as_ref(), mock_env(), QueryMsg::GetHooks {}).unwrap();
+    let resp: GetHooksResponse = from_json(bin).unwrap();
+    assert_eq!(resp.hooks, vec![VOTER_B.to_string()]);
+}


### PR DESCRIPTION
Replaces the live-query approach attempted in DA0-DA0/dao-contracts#832 with a thin consumer of Juno v30's x/voting-snapshot chain module. Voting power is now read at the exact requested height (at-or-before semantics enforced by the chain), with LST exclusion handled at the chain layer.

Architecture:
- Custom-query binding (JunoQuery) mirroring juno/wasmbindings/types/query.go exactly. Contract is Deps<JunoQuery> internally; external WasmQuery::Smart consumers don't need to know about the chain type.
- Standard dao-interface voting surface: VotingPowerAtHeight, TotalPowerAtHeight, Dao, Info.
- Sudo intake for x/cw-hooks staking events. AfterDelegationModified + BeforeDelegationRemoved drive a stake-delta computation (new power read from the chain snapshot, prev power read at current_height-1). Other variants are swallowed silently to keep cw-hooks registration alive.
- Hook fan-out via dao_hooks::stake::StakeChangedHookMsg::{Stake,Unstake} to a DAO-gated subscriber list (the standard cw-hooks::Hooks pattern), so the gauge orchestrator and rewards distributor wire up unchanged.

Out of scope for v1:
- auto_register_staking_hooks (would need a prost dep just for one proto message; registration happens out-of-band via the CLI). Field is kept for future use; passing Some(true) returns AutoRegisterNotYetSupported.
- VotingPowerOverRange consumer — surfaced in bindings.rs for downstream contracts that want plural-voting-style integration, but not used by the voting module itself.

Verification:
- 9/9 unit tests pass under nightly-2024-01-08 (the dao-contracts CI pin). Tests cover instantiate / DAO storage / hook add+remove auth / power proxy under at-or-before / stake-delta math / fan-out / silent swallowing of validator and slash events.
- cargo clippy --all-targets -- -D warnings clean.
- cargo fmt -- --check clean.
- wasm32-unknown-unknown release build clean (1.7 MB).

Refs: memory/juno-voting-design.md (option C settled), memory/v30-upgrade-plan.md (x/voting-snapshot in PR #1202), memory/hack-juno-plan-2026-05-12.md (this is the "dao-voting-juno-staked" item in the program's sequencing diagram).