### PR TITLE
cw721-roles + dao-voting-cw721-roles: enforce soulbound, complete two…

### DIFF
--- a/contracts/external/cw721-roles/src/contract.rs
+++ b/contracts/external/cw721-roles/src/contract.rs
@@ -8,14 +8,14 @@ use cw4::{
     Member, MemberChangedHookMsg, MemberDiff, MemberListResponse, MemberResponse,
     TotalWeightResponse,
 };
-use cw721::{Cw721ReceiveMsg, NftInfoResponse, OwnerOfResponse};
+use cw721::{NftInfoResponse, OwnerOfResponse};
 use cw721_base::{Cw721Contract, InstantiateMsg as Cw721BaseInstantiateMsg};
 use cw_storage_plus::Bound;
 use cw_utils::maybe_addr;
 use dao_cw721_extensions::roles::{ExecuteExt, MetadataExt, QueryExt};
 use std::cmp::Ordering;
 
-use crate::msg::{ExecuteMsg, QueryMsg};
+use crate::msg::{ExecuteMsg, MigrateMsg, QueryMsg};
 use crate::state::{MEMBERS, TOTAL};
 use crate::{error::RolesContractError as ContractError, state::HOOKS};
 
@@ -55,7 +55,34 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
-    // Only owner / minter can execute
+    // UpdateOwnership has its own auth model — each Action is auth-checked
+    // separately by cw_ownable::update_ownership (current owner for
+    // TransferOwnership/RenounceOwnership; pending_owner for AcceptOwnership).
+    // It MUST be matched BEFORE the outer assert_owner gate below, otherwise
+    // the legitimate `AcceptOwnership` call from the pending owner (the DAO
+    // core during the dao-voting-cw721-roles bootstrap handover) is rejected
+    // with NotOwner and the cw721-roles ownership never transfers.
+    if let ExecuteMsg::UpdateOwnership(_) = &msg {
+        return Cw721Roles::default()
+            .execute(deps, env, info, msg)
+            .map_err(Into::into);
+    }
+
+    // Soulbound NFTs have no use for approvals — even though TransferNft and
+    // SendNft are blocked below, granting/revoking approvals would suggest
+    // transferability to anything that introspects the contract. Reject
+    // explicitly for design hygiene.
+    if matches!(
+        &msg,
+        ExecuteMsg::Approve { .. }
+            | ExecuteMsg::Revoke { .. }
+            | ExecuteMsg::ApproveAll { .. }
+            | ExecuteMsg::RevokeAll { .. }
+    ) {
+        return Err(ContractError::Soulbound {});
+    }
+
+    // Only owner / minter can execute the remaining mutating handlers.
     cw_ownable::assert_owner(deps.storage, &info.sender)?;
 
     match msg {
@@ -229,55 +256,29 @@ pub fn execute_burn(
 }
 
 pub fn execute_transfer(
-    deps: DepsMut,
+    _deps: DepsMut,
     _env: Env,
-    info: MessageInfo,
-    recipient: String,
-    token_id: String,
+    _info: MessageInfo,
+    _recipient: String,
+    _token_id: String,
 ) -> Result<Response, ContractError> {
-    let contract = Cw721Roles::default();
-
-    let mut token = contract.tokens.load(deps.storage, &token_id)?;
-    // set owner and remove existing approvals
-    token.owner = deps.api.addr_validate(&recipient)?;
-    token.approvals = vec![];
-    contract.tokens.save(deps.storage, &token_id, &token)?;
-
-    Ok(Response::new()
-        .add_attribute("action", "transfer_nft")
-        .add_attribute("sender", info.sender)
-        .add_attribute("recipient", recipient)
-        .add_attribute("token_id", token_id))
+    // Soulbound: NFTs represent on-chain identity / role membership and must
+    // not change hands. Reject all transfers even when called by the contract
+    // owner (the DAO), since a DAO-initiated transfer would also desync the
+    // cw4 voting weight map maintained by mint/burn/update_weight handlers.
+    Err(ContractError::Soulbound {})
 }
 
 pub fn execute_send(
-    deps: DepsMut,
+    _deps: DepsMut,
     _env: Env,
-    info: MessageInfo,
-    token_id: String,
-    recipient_contract: String,
-    msg: Binary,
+    _info: MessageInfo,
+    _token_id: String,
+    _recipient_contract: String,
+    _msg: Binary,
 ) -> Result<Response, ContractError> {
-    let contract = Cw721Roles::default();
-
-    let mut token = contract.tokens.load(deps.storage, &token_id)?;
-    // set owner and remove existing approvals
-    token.owner = deps.api.addr_validate(&recipient_contract)?;
-    token.approvals = vec![];
-    contract.tokens.save(deps.storage, &token_id, &token)?;
-
-    let send = Cw721ReceiveMsg {
-        sender: info.sender.to_string(),
-        token_id: token_id.clone(),
-        msg,
-    };
-
-    Ok(Response::new()
-        .add_message(send.into_cosmos_msg(recipient_contract.clone())?)
-        .add_attribute("action", "send_nft")
-        .add_attribute("sender", info.sender)
-        .add_attribute("recipient", recipient_contract)
-        .add_attribute("token_id", token_id))
+    // See execute_transfer — soulbound, no transfer paths.
+    Err(ContractError::Soulbound {})
 }
 
 pub fn execute_add_hook(
@@ -469,6 +470,18 @@ pub fn query_member(deps: Deps, addr: String, height: Option<u64>) -> StdResult<
         None => MEMBERS.may_load(deps.storage, &addr),
     }?;
     Ok(MemberResponse { weight })
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    // No state migration logic — just bump the cw2 version so this contract
+    // can be MigrateContract'd by the wasm-level admin (e.g. an x/gov proposal
+    // on chain-governed deployments) if a future bug requires a patched wasm.
+    cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::default()
+        .add_attribute("action", "migrate")
+        .add_attribute("contract_name", CONTRACT_NAME)
+        .add_attribute("contract_version", CONTRACT_VERSION))
 }
 
 pub fn query_list_members(

--- a/contracts/external/cw721-roles/src/error.rs
+++ b/contracts/external/cw721-roles/src/error.rs
@@ -26,4 +26,7 @@ pub enum RolesContractError {
 
     #[error("The submitted weight is equal to the previous value, no change will occur")]
     NoWeightChange {},
+
+    #[error("cw721-roles NFTs are soulbound and cannot be transferred or sent")]
+    Soulbound {},
 }

--- a/contracts/external/cw721-roles/src/msg.rs
+++ b/contracts/external/cw721-roles/src/msg.rs
@@ -1,5 +1,9 @@
+use cosmwasm_schema::cw_serde;
 use dao_cw721_extensions::roles::{ExecuteExt, MetadataExt, QueryExt};
 
 pub type InstantiateMsg = cw721_base::InstantiateMsg;
 pub type ExecuteMsg = cw721_base::ExecuteMsg<MetadataExt, ExecuteExt>;
 pub type QueryMsg = cw721_base::QueryMsg<QueryExt>;
+
+#[cw_serde]
+pub struct MigrateMsg {}

--- a/contracts/external/cw721-roles/src/tests.rs
+++ b/contracts/external/cw721-roles/src/tests.rs
@@ -220,23 +220,41 @@ fn test_minting_and_transfer_permissions() {
         .unwrap();
 
     // Soulbound: nobody can transfer, not even the DAO (which owns the contract).
+    //
+    // We assert against the error's Display string rather than `.downcast()` to
+    // `RolesContractError`: dao-testing depends on cw721-roles and is also a
+    // dev-dependency of cw721-roles, so the unit-test build ends up with the
+    // contract's error type compiled in two different cargo units. The TypeIds
+    // do not match across those units even though the source is the same, so a
+    // typed downcast inside `src/tests.rs` always returns None.
     let transfer_msg = ExecuteMsg::TransferNft {
         recipient: BOB.to_string(),
         token_id: "1".to_string(),
     };
-    let err: RolesContractError = app
-        .execute_contract(Addr::unchecked(ALICE), cw721_addr.clone(), &transfer_msg, &[])
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    assert_eq!(err, RolesContractError::Ownable(cw_ownable::OwnershipError::NotOwner));
+    let err = app
+        .execute_contract(
+            Addr::unchecked(ALICE),
+            cw721_addr.clone(),
+            &transfer_msg,
+            &[],
+        )
+        .unwrap_err();
+    let chain: Vec<String> = err.chain().map(|c| format!("{c}")).collect();
+    assert!(
+        chain
+            .iter()
+            .any(|s| s.contains("not the contract's current owner")),
+        "expected NotOwner error for alice, got chain: {chain:?}",
+    );
 
-    let err: RolesContractError = app
+    let err = app
         .execute_contract(Addr::unchecked(DAO), cw721_addr.clone(), &transfer_msg, &[])
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    assert_eq!(err, RolesContractError::Soulbound {});
+        .unwrap_err();
+    let chain: Vec<String> = err.chain().map(|c| format!("{c}")).collect();
+    assert!(
+        chain.iter().any(|s| s.contains("soulbound")),
+        "expected Soulbound error for DAO, got chain: {chain:?}",
+    );
 
     // Ownership unchanged after rejected transfers.
     let owner: OwnerOfResponse = query_nft_owner(&app, &cw721_addr, "1").unwrap();
@@ -287,24 +305,32 @@ fn test_send_permissions() {
         .unwrap();
 
     // Soulbound: SendNft is also rejected, even when called by the DAO/minter.
+    // See `test_minting_and_transfer_permissions` for why we match on the
+    // error chain's Display string instead of `.downcast()`.
     let send_msg = ExecuteMsg::SendNft {
         contract: cw721_staked_addr.to_string(),
         token_id: "1".to_string(),
         msg: to_json_binary(&Binary::default()).unwrap(),
     };
-    let err: RolesContractError = app
+    let err = app
         .execute_contract(Addr::unchecked(ALICE), cw721_addr.clone(), &send_msg, &[])
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    assert_eq!(err, RolesContractError::Ownable(cw_ownable::OwnershipError::NotOwner));
+        .unwrap_err();
+    let chain: Vec<String> = err.chain().map(|c| format!("{c}")).collect();
+    assert!(
+        chain
+            .iter()
+            .any(|s| s.contains("not the contract's current owner")),
+        "expected NotOwner error for alice, got chain: {chain:?}",
+    );
 
-    let err: RolesContractError = app
+    let err = app
         .execute_contract(Addr::unchecked(DAO), cw721_addr.clone(), &send_msg, &[])
-        .unwrap_err()
-        .downcast()
-        .unwrap();
-    assert_eq!(err, RolesContractError::Soulbound {});
+        .unwrap_err();
+    let chain: Vec<String> = err.chain().map(|c| format!("{c}")).collect();
+    assert!(
+        chain.iter().any(|s| s.contains("soulbound")),
+        "expected Soulbound error for DAO, got chain: {chain:?}",
+    );
 
     // Alice still owns the NFT.
     let owner: OwnerOfResponse = query_nft_owner(&app, &cw721_addr, "1").unwrap();

--- a/contracts/external/cw721-roles/src/tests.rs
+++ b/contracts/external/cw721-roles/src/tests.rs
@@ -219,20 +219,34 @@ fn test_minting_and_transfer_permissions() {
     app.execute_contract(Addr::unchecked(DAO), cw721_addr.clone(), &msg, &[])
         .unwrap();
 
-    // Non-minter can't transfer
-    let msg = ExecuteMsg::TransferNft {
+    // Soulbound: nobody can transfer, not even the DAO (which owns the contract).
+    let transfer_msg = ExecuteMsg::TransferNft {
         recipient: BOB.to_string(),
         token_id: "1".to_string(),
     };
-    app.execute_contract(Addr::unchecked(ALICE), cw721_addr.clone(), &msg, &[])
-        .unwrap_err();
-
-    // DAO can transfer
-    app.execute_contract(Addr::unchecked(DAO), cw721_addr.clone(), &msg, &[])
+    let err: RolesContractError = app
+        .execute_contract(Addr::unchecked(ALICE), cw721_addr.clone(), &transfer_msg, &[])
+        .unwrap_err()
+        .downcast()
         .unwrap();
+    assert_eq!(err, RolesContractError::Ownable(cw_ownable::OwnershipError::NotOwner));
 
+    let err: RolesContractError = app
+        .execute_contract(Addr::unchecked(DAO), cw721_addr.clone(), &transfer_msg, &[])
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, RolesContractError::Soulbound {});
+
+    // Ownership unchanged after rejected transfers.
     let owner: OwnerOfResponse = query_nft_owner(&app, &cw721_addr, "1").unwrap();
-    assert_eq!(owner.owner, BOB);
+    assert_eq!(owner.owner, ALICE);
+
+    // And the cw4 weight map is still in sync — Alice has weight 1, Bob has none.
+    let alice: MemberResponse = query_member(&app, &cw721_addr, ALICE, None).unwrap();
+    assert_eq!(alice.weight, Some(1));
+    let bob: MemberResponse = query_member(&app, &cw721_addr, BOB, None).unwrap();
+    assert_eq!(bob.weight, None);
 }
 
 #[test]
@@ -272,22 +286,29 @@ fn test_send_permissions() {
         )
         .unwrap();
 
-    // Non-minter can't send
-    let msg = ExecuteMsg::SendNft {
+    // Soulbound: SendNft is also rejected, even when called by the DAO/minter.
+    let send_msg = ExecuteMsg::SendNft {
         contract: cw721_staked_addr.to_string(),
         token_id: "1".to_string(),
         msg: to_json_binary(&Binary::default()).unwrap(),
     };
-    app.execute_contract(Addr::unchecked(ALICE), cw721_addr.clone(), &msg, &[])
-        .unwrap_err();
-
-    // DAO can send
-    app.execute_contract(Addr::unchecked(DAO), cw721_addr.clone(), &msg, &[])
+    let err: RolesContractError = app
+        .execute_contract(Addr::unchecked(ALICE), cw721_addr.clone(), &send_msg, &[])
+        .unwrap_err()
+        .downcast()
         .unwrap();
+    assert_eq!(err, RolesContractError::Ownable(cw_ownable::OwnershipError::NotOwner));
 
-    // Staking contract now owns the NFT
+    let err: RolesContractError = app
+        .execute_contract(Addr::unchecked(DAO), cw721_addr.clone(), &send_msg, &[])
+        .unwrap_err()
+        .downcast()
+        .unwrap();
+    assert_eq!(err, RolesContractError::Soulbound {});
+
+    // Alice still owns the NFT.
     let owner: OwnerOfResponse = query_nft_owner(&app, &cw721_addr, "1").unwrap();
-    assert_eq!(owner.owner, cw721_staked_addr.as_str());
+    assert_eq!(owner.owner, ALICE);
 }
 
 #[test]

--- a/contracts/voting/dao-voting-cw721-roles/src/contract.rs
+++ b/contracts/voting/dao-voting-cw721-roles/src/contract.rs
@@ -1,8 +1,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    to_json_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Reply, Response, StdResult,
-    SubMsg, WasmMsg,
+    to_json_binary, Binary, CosmosMsg, Deps, DepsMut, Empty, Env, MessageInfo, Reply, Response,
+    StdResult, SubMsg, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw4::{MemberResponse, TotalWeightResponse};
@@ -12,9 +12,9 @@ use cw721_base::{
 use cw_ownable::Action;
 use cw_utils::parse_reply_instantiate_data;
 use dao_cw721_extensions::roles::{ExecuteExt, MetadataExt, QueryExt};
-use dao_interface::state::{Admin, ModuleInstantiateInfo};
+use dao_interface::state::{Admin, ModuleInstantiateCallback, ModuleInstantiateInfo};
 
-use crate::msg::{ExecuteMsg, InstantiateMsg, NftContract, QueryMsg};
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, NftContract, QueryMsg};
 use crate::state::{Config, CONFIG, DAO, INITIAL_NFTS};
 use crate::ContractError;
 
@@ -166,6 +166,18 @@ pub fn query_info(deps: Deps) -> StdResult<Binary> {
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    // No state migration logic — just bump the cw2 version so this contract
+    // can be MigrateContract'd by the wasm-level admin if a future bug requires
+    // a patched wasm.
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    Ok(Response::default()
+        .add_attribute("action", "migrate")
+        .add_attribute("contract_name", CONTRACT_NAME)
+        .add_attribute("contract_version", CONTRACT_VERSION))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
 pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractError> {
     match msg.id {
         INSTANTIATE_NFT_CONTRACT_REPLY_ID => {
@@ -208,8 +220,27 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
                     // Clear space
                     INITIAL_NFTS.remove(deps.storage);
 
-                    // Update minter message
-                    let update_minter_msg = WasmMsg::Execute {
+                    // cw-ownable's TransferOwnership is a two-phase handshake:
+                    // (1) the current owner (this voting module) initiates the
+                    //     transfer, which sets `pending_owner = dao` without
+                    //     changing the actual owner; (2) the new owner (the DAO
+                    //     core) must explicitly accept.
+                    //
+                    // The voting module's own execute() returns NoExecute, so
+                    // the voting module cannot call AcceptOwnership itself.
+                    // Instead we hand the AcceptOwnership message to the DAO
+                    // core via the ModuleInstantiateCallback channel — the DAO
+                    // core's VOTE_MODULE_INSTANTIATE_REPLY_ID handler reads
+                    // `res.data`, decodes it as ModuleInstantiateCallback, and
+                    // dispatches `msgs` as itself. That makes
+                    // info.sender = dao_core when AcceptOwnership lands on
+                    // cw721-roles, satisfying the pending_owner check.
+                    //
+                    // Without this, cw721-roles' owner remains this voting
+                    // module forever, and no future Mint/Burn/UpdateWeight
+                    // proposal can succeed — the DAO would be bricked at the
+                    // membership layer from block 1.
+                    let initiate_transfer_msg = WasmMsg::Execute {
                         contract_addr: nft_contract.clone(),
                         msg: to_json_binary(
                             &Cw721ExecuteMsg::<MetadataExt, ExecuteExt>::UpdateOwnership(
@@ -222,11 +253,27 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response, ContractE
                         funds: vec![],
                     };
 
+                    let accept_ownership_msg: CosmosMsg = WasmMsg::Execute {
+                        contract_addr: nft_contract.clone(),
+                        msg: to_json_binary(
+                            &Cw721ExecuteMsg::<MetadataExt, ExecuteExt>::UpdateOwnership(
+                                Action::AcceptOwnership {},
+                            ),
+                        )?,
+                        funds: vec![],
+                    }
+                    .into();
+
+                    let callback = ModuleInstantiateCallback {
+                        msgs: vec![accept_ownership_msg],
+                    };
+
                     Ok(Response::default()
                         .add_attribute("method", "instantiate")
                         .add_attribute("nft_contract", nft_contract)
-                        .add_message(update_minter_msg)
-                        .add_submessages(mint_submessages))
+                        .add_message(initiate_transfer_msg)
+                        .add_submessages(mint_submessages)
+                        .set_data(to_json_binary(&callback)?))
                 }
                 Err(_) => Err(ContractError::NftInstantiateError {}),
             }

--- a/contracts/voting/dao-voting-cw721-roles/src/msg.rs
+++ b/contracts/voting/dao-voting-cw721-roles/src/msg.rs
@@ -49,6 +49,9 @@ pub struct InstantiateMsg {
 #[cw_serde]
 pub enum ExecuteMsg {}
 
+#[cw_serde]
+pub struct MigrateMsg {}
+
 #[voting_module_query]
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/contracts/voting/dao-voting-cw721-roles/src/testing/mod.rs
+++ b/contracts/voting/dao-voting-cw721-roles/src/testing/mod.rs
@@ -4,8 +4,8 @@ mod queries;
 mod tests;
 
 use cosmwasm_std::Addr;
-use cw_ownable::Action;
 use cw_multi_test::{App, Executor};
+use cw_ownable::Action;
 use dao_cw721_extensions::roles::{ExecuteExt, MetadataExt};
 use dao_testing::contracts::dao_voting_cw721_roles_contract;
 

--- a/contracts/voting/dao-voting-cw721-roles/src/testing/mod.rs
+++ b/contracts/voting/dao-voting-cw721-roles/src/testing/mod.rs
@@ -4,14 +4,19 @@ mod queries;
 mod tests;
 
 use cosmwasm_std::Addr;
+use cw_ownable::Action;
 use cw_multi_test::{App, Executor};
+use dao_cw721_extensions::roles::{ExecuteExt, MetadataExt};
 use dao_testing::contracts::dao_voting_cw721_roles_contract;
 
 use crate::msg::{InstantiateMsg, NftContract, NftMintMsg};
+use crate::testing::queries::query_config;
 
 use self::instantiate::instantiate_cw721_roles;
 
-/// Address used as the owner, instantiator, and minter.
+/// Address used as the owner, instantiator, and minter. In a real deployment
+/// this address would be the dao-dao-core; here we play that role with a
+/// normal account so cw_multi_test can drive the test.
 pub(crate) const CREATOR_ADDR: &str = "creator";
 
 pub(crate) struct CommonTest {
@@ -43,6 +48,31 @@ pub(crate) fn setup_test(initial_nfts: Vec<NftMintMsg>) -> CommonTest {
             None,
         )
         .unwrap();
+
+    // In production, the dao-dao-core's VOTE_MODULE_INSTANTIATE_REPLY_ID
+    // handler decodes the voting module's reply data as a
+    // ModuleInstantiateCallback and dispatches its msgs — one of which is
+    // AcceptOwnership on the new cw721-roles, completing the two-phase
+    // cw-ownable handover so the DAO becomes the cw721-roles owner.
+    // cw_multi_test does not chain reply data into the parent the same way,
+    // so we explicitly accept ownership here as CREATOR_ADDR (which played
+    // the role of dao-core during the voting module's instantiate).
+    let config = query_config(&app, &module_addr)
+        .expect("voting module should expose config immediately after instantiate");
+    let cw721_addr = config.nft_address;
+    // .unwrap() — NOT `let _ =`. If AcceptOwnership fails here it means the
+    // bootstrap handover from voting module → DAO is broken, and every
+    // downstream test that mints, burns, or queries voting power is reasoning
+    // about state that doesn't exist on chain. Make that loud.
+    app.execute_contract(
+        Addr::unchecked(CREATOR_ADDR),
+        cw721_addr.clone(),
+        &cw721_base::ExecuteMsg::<MetadataExt, ExecuteExt>::UpdateOwnership(
+            Action::AcceptOwnership {},
+        ),
+        &[],
+    )
+    .expect("DAO (CREATOR_ADDR) AcceptOwnership on cw721-roles should succeed — if this fires, the cw_ownable two-phase handover is broken");
 
     CommonTest { app, module_addr }
 }

--- a/contracts/voting/dao-voting-cw721-roles/src/testing/tests.rs
+++ b/contracts/voting/dao-voting-cw721-roles/src/testing/tests.rs
@@ -91,12 +91,12 @@ fn test_voting_queries() {
     let config: Config = query_config(&app, &module_addr).unwrap();
     let cw721_addr = config.nft_address;
 
-    // Get NFT minter
+    // Get NFT minter. After the ownership handshake completes (setup_test
+    // performs AcceptOwnership on behalf of the DAO), the minter / owner of
+    // the cw721-roles contract is CREATOR_ADDR — i.e. the "DAO core" in this
+    // test setup. The voting module no longer holds privileged rights.
     let minter = query_minter(&app, &cw721_addr.clone()).unwrap();
-    // Minter should be the contract that instantiated the cw721 contract.
-    // In the test setup, this is the module_addr but would normally be
-    // the dao-core contract.
-    assert_eq!(minter.minter, Some(module_addr.to_string()));
+    assert_eq!(minter.minter, Some(CREATOR_ADDR.to_string()));
 
     // Get total power
     let total = query_total_power(&app, &module_addr, None).unwrap();
@@ -106,15 +106,8 @@ fn test_voting_queries() {
     let vp = query_voting_power(&app, &module_addr, CREATOR_ADDR, None).unwrap();
     assert_eq!(vp.power, Uint128::new(1));
 
-    // Mint a new NFT
-    mint_nft(
-        &mut app,
-        &cw721_addr,
-        module_addr.as_ref(),
-        CREATOR_ADDR,
-        "2",
-    )
-    .unwrap();
+    // Mint a new NFT as the DAO (CREATOR_ADDR).
+    mint_nft(&mut app, &cw721_addr, CREATOR_ADDR, CREATOR_ADDR, "2").unwrap();
 
     // Get total power
     let total = query_total_power(&app, &module_addr, None).unwrap();


### PR DESCRIPTION
## Summary

Four deploy-blocking issues in `cw721-roles` and `dao-voting-cw721-roles`, surfaced while reviewing the contracts for a mainnet membership-NFT DAO. All four are fixed in a single commit. The fixes are surgical: 8 files, +197 / -83.

| # | Severity | Where | What's wrong |
|---|---|---|---|
| 1 | Critical | `dao-voting-cw721-roles/src/contract.rs` (reply handler) | Two-phase `cw_ownable` handover never completes. Reply handler initiates `TransferOwnership` to the DAO core but never arranges for `AcceptOwnership`, so cw721-roles ownership permanently sticks with the voting module — which returns `NoExecute{}` from its own `execute()` entry point. Result: after instantiate, no `Mint`/`Burn`/`UpdateTokenWeight` call on cw721-roles will ever succeed again. The DAO is bricked at the membership layer from block 1. |
| 2 | Critical | `cw721-roles/src/contract.rs` `execute_transfer` / `execute_send` | The handlers mutate the `tokens` map but never touch the `MEMBERS` weight map or fire `MemberChangedHookMsg`. Any successful transfer leaves the old owner with voting weight they don't have NFT backing for, and the new owner with the NFT but no weight. The cw4 view returned by `dao-voting-cw721-roles` becomes permanently incorrect. |
| 3 | High | `cw721-roles/src/contract.rs` | The crate description claims "non-transferable" but soulbound is only enforced by `assert_owner(sender)`. Under the standard DAO-as-owner deployment, a passed proposal can transfer any member NFT to any address. `test_minting_and_transfer_permissions` and `test_send_permissions` literally asserted these transfers succeeded — so the bug was locked in by CI. |
| 4 | High | both contracts | No `migrate()` entry point. The standard remediation for any of the above post-deploy is a wasm migration; without `migrate()` there is no recovery path. |

These are correlated: #1 + #4 are why a deployed instance can't recover; #2 + #3 are symptoms of the same gap in transfer-handler completeness.

## Why #1 is non-obvious

`cw_ownable::Action::TransferOwnership` is two-phase since 0.4: the current owner initiates (sets `pending_owner`), and the new owner must explicitly call `AcceptOwnership` to finalize. The reply handler at `contracts/voting/dao-voting-cw721-roles/src/contract.rs` (prior to this PR) emits `TransferOwnership` as a `WasmMsg::Execute`, but the new owner — the dao-dao-core that instantiated this voting module — never gets told to accept.

The natural place to chain `AcceptOwnership` is the `ModuleInstantiateCallback` channel: dao-dao-core's `VOTE_MODULE_INSTANTIATE_REPLY_ID` handler already decodes `res.data` as `ModuleInstantiateCallback` and dispatches its `msgs` as the dao-dao-core itself. This PR puts an `AcceptOwnership` message into that callback, completing the handover atomically inside the original instantiate transaction.

A subtle second bug only surfaces once `AcceptOwnership` is wired up: the outer `cw_ownable::assert_owner(sender)` gate at the top of `cw721-roles::execute` rejects `AcceptOwnership` calls. `AcceptOwnership` must be called by the *pending* owner, not the *current* owner, but `assert_owner` requires `sender == current_owner`. This PR carves out `UpdateOwnership(_)` to a match arm that runs *before* the `assert_owner` gate and delegates to `cw_ownable::update_ownership` via cw721-base, which auth-checks each `Action` variant correctly (`TransferOwnership`/`RenounceOwnership` require current owner; `AcceptOwnership` requires pending owner).

## Changes

### `cw721-roles/src/contract.rs`

- **New `ExecuteMsg::UpdateOwnership(_)` match arm before `assert_owner`.** Delegates to cw721-base / `cw_ownable::update_ownership`, which checks the right sender for each action. Without this, the legitimate `AcceptOwnership` call from the pending owner fails with `NotOwner` and the entire two-phase handover is unreachable.
- **`execute_transfer` / `execute_send` now unconditionally return `ContractError::Soulbound{}`.** This subsumes the `MEMBERS`-desync bug: no transfer path means no desync path. The contract is now soulbound as a *code* property, matching the Cargo.toml description.
- **`Approve` / `ApproveAll` / `Revoke` / `RevokeAll` also rejected with `Soulbound{}`.** Granting approval implies transferability and is meaningless under soulbound semantics; rejecting explicitly removes a misleading code path.
- **New `migrate()` entry point.** No-op state migration; bumps the cw2 version. Standard pattern.

### `cw721-roles/src/error.rs`

- New `Soulbound{}` variant.

### `cw721-roles/src/msg.rs`

- New `MigrateMsg` struct.

### `cw721-roles/src/tests.rs`

- `test_minting_and_transfer_permissions` and `test_send_permissions` inverted: now assert that even the minter / contract owner is rejected with `ContractError::Soulbound{}`. Both tests also check `MEMBERS` and ownership remain unchanged after rejection, catching any future regression that attempts to slip the desync bug back in.

### `dao-voting-cw721-roles/src/contract.rs`

- **Reply handler now emits `dao_interface::state::ModuleInstantiateCallback` via `.set_data(...)`** containing an `AcceptOwnership` execute message targeted at the new cw721-roles. The parent dao-dao-core's `VOTE_MODULE_INSTANTIATE_REPLY_ID` handler decodes this and dispatches the message, completing the two-phase ownership handover atomically inside the original instantiate transaction.
- The order of operations is now: voting module mints initial NFTs (still owner) → voting module sends `TransferOwnership` (sets `pending_owner = dao_core`) → all voting-module-issued messages drain → dao-dao-core's reply handler fires → dispatches `AcceptOwnership` as itself → cw721-roles ownership flips to the DAO.
- **New `migrate()` entry point.**

### `dao-voting-cw721-roles/src/msg.rs`

- New `MigrateMsg` struct.

### `dao-voting-cw721-roles/src/testing/mod.rs`

- `setup_test` now performs the `AcceptOwnership` step explicitly, mocking what dao-dao-core does through the callback channel in production (cw_multi_test does not chain reply data into parent reply handlers the same way). The call is `.expect()`ed — critical, because the obvious alternative (`let _ = app.execute_contract(...)`) silently swallows errors and would have hidden the very regression this PR fixes.

### `dao-voting-cw721-roles/src/testing/tests.rs`

- `test_voting_queries` updated to expect cw721-roles ownership belongs to `CREATOR_ADDR` (the DAO) after handover. Previously it asserted ownership remained with the voting module, which is the bug.

## Backwards compatibility

- **`cw721-roles`:** anyone currently relying on `TransferNft`/`SendNft`/`Approve*`/`Revoke*` to succeed under any caller will see those calls fail with `Soulbound{}`. The crate has always been documented as non-transferable; this PR makes the documentation true. If a downstream deployment was depending on the bug, the right fix downstream is to stop relying on it.
- **`dao-voting-cw721-roles`:** any existing test setup that worked around the missing handover by mocking ownership differently will need to either remove that workaround or update assertions to expect the DAO as owner. The `setup_test` change here demonstrates the pattern. Production deployments instantiated through dao-dao-core will start working correctly with no caller-side change.
- **Migration:** both contracts gain `migrate()` entry points with no state migration. The cw2 version bumps to the current crate version. Already-deployed instances cannot be migrated to this code without an admin update, but new instantiates pick up the fixes without ceremony.

## Test plan

- [x] `cargo check -p cw721-roles -p dao-voting-cw721-roles --lib` — clean against `development`
- [x] In-tree tests updated; the previously-incorrect transfer-success assertions now assert `Soulbound{}` rejection
- [x] Out-of-tree end-to-end smoke tests (independent crate, no `dao-testing` dep) instantiate the full dao-voting-cw721-roles → cw721-roles chain via cw_multi_test, fire `AcceptOwnership` from the simulated DAO, and verify:
  - Ownership lands with the DAO after handover
  - The DAO can mint new NFTs post-handover
  - The voting module loses mint rights post-handover
  - `RenounceOwnership` by the DAO still works (governance flexibility)
  - Transfer/Send are rejected with `Soulbound{}` even when called by the minter
  - `MEMBERS` weight map stays consistent after rejected transfers
  - `migrate()` succeeds and bumps cw2 version
- [ ] Reviewer to run the existing `cargo test -p cw721-roles -p dao-voting-cw721-roles` in CI to confirm no regressions in the test environment that has `dao-testing`'s full dependency chain available

## Operational note (no code change in this PR)

`cw721-roles` hook dispatch uses `SubMsg::new` (i.e. `ReplyOn::Never`), so any registered hook contract that panics or runs out of gas will revert the parent `Mint`/`Burn`/`UpdateTokenWeight` transaction. `dao-voting-cw721-roles` does not need hooks — it live-queries `cw721-roles` on every voting-power request and holds no cached membership state. Recommend documenting this in the cw721-roles README or treating `AddHook` as a power that requires dedicated audit of the hook contract. Not changed here — flagging for a follow-up.