### PR TITLE
feat: add production-ready Juno staked voting module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,6 +2702,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dao-voting-juno-staked"
+version = "2.8.0-alpha.2"
+dependencies = [
+ "anyhow",
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-multi-test",
+ "cw-storage-plus 1.2.0",
+ "cw2 1.1.2",
+ "dao-dao-macros 2.8.0-alpha.2",
+ "dao-interface 2.8.0-alpha.2",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "dao-voting-onft-staked"
 version = "2.8.0-alpha.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,7 @@ dao-voting-cw4 = { path = "./contracts/voting/dao-voting-cw4", version = "2.8.0-
 dao-voting-cw721-roles = { path = "./contracts/voting/dao-voting-cw721-roles", version = "2.8.0-alpha.2" }
 dao-voting-cw721-staked = { path = "./contracts/voting/dao-voting-cw721-staked", version = "2.8.0-alpha.2" }
 dao-voting-onft-staked = { path = "./contracts/voting/dao-voting-onft-staked", version = "2.8.0-alpha.2" }
+dao-voting-juno-staked = { path = "./contracts/voting/dao-voting-juno-staked", version = "2.8.0-alpha.2" }
 dao-voting-token-staked = { path = "./contracts/voting/dao-voting-token-staked", version = "2.8.0-alpha.2" }
 nft-controllers = { path = "./packages/nft-controllers", version = "2.8.0-alpha.2" }
 

--- a/contracts/voting/dao-voting-juno-staked/.cargo/config
+++ b/contracts/voting/dao-voting-juno-staked/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+schema = "run --example schema"

--- a/contracts/voting/dao-voting-juno-staked/Cargo.toml
+++ b/contracts/voting/dao-voting-juno-staked/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "dao-voting-juno-staked"
+authors = [
+  "Jake Hartnell <no-reply@no-reply.com>",
+  "Juno AI <juno-ai-dev@users.noreply.github.com>",
+  "Noah Saso <no-reply@no-reply.com>",
+]
+description = "A DAO DAO voting module that derives voting power from Juno's x/voting-snapshot module. Historical staking power with LST exclusion enforced at the chain layer."
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+version = { workspace = true }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[dependencies]
+cosmwasm-std = { workspace = true, features = ["cosmwasm_1_2", "stargate"] }
+cosmwasm-schema = { workspace = true }
+cw-storage-plus = { workspace = true }
+cw2 = { workspace = true }
+dao-dao-macros = { workspace = true }
+dao-interface = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+anyhow = { workspace = true }
+cw-multi-test = { workspace = true }

--- a/contracts/voting/dao-voting-juno-staked/README.md
+++ b/contracts/voting/dao-voting-juno-staked/README.md
@@ -1,0 +1,107 @@
+# dao-voting-juno-staked
+
+A thin DAO DAO voting module that reads staked-JUNO voting power from Juno's
+chain-owned `x/voting-snapshot` module.
+
+## Compatibility
+
+This contract is Juno-specific. It requires the Juno v30 wasm custom-query
+bindings and is intended for the v30 `uni-7` network. Chains and older Juno
+releases without `x/voting-snapshot` cannot answer its queries.
+
+The chain owns voting-power policy and storage:
+
+- DAO DAO treats height `h` as beginning-of-block voting power. Juno persists
+  settled staking snapshots in EndBlock, so both voting-power queries translate
+  DAO height `h` to Juno snapshot height `h - 1` and return the requested DAO
+  height in the response. This keeps proposal totals and later voter queries on
+  one immutable basis even when staking changes later in the proposal block.
+- Omitting `height` uses the beginning of the current block (the previous
+  settled Juno snapshot).
+- Liquid-staking exclusion applies only to addresses in Juno's
+  governance-managed LST allowlist. Juno v30 defaults this allowlist to empty,
+  so no address is excluded until governance configures it. Operators must
+  verify the live parameter; v30 does not generically detect liquid-staking
+  contracts.
+- Juno v30 defaults snapshot retention to `0` (pruning disabled). Governance can
+  change both retention and the LST allowlist after deployment, so neither
+  default should be assumed from the binary alone.
+
+These historical semantics let DAO DAO proposal modules use power fixed at a
+proposal's snapshot height, rather than recomputing from current stake.
+
+## Activation and migration boundaries
+
+Juno seeds its first voting snapshots at the v30 upgrade/backfill height `U`.
+Because DAO height `h` reads Juno snapshot `h - 1`, the first DAO height backed
+by that seed is `U + 1`; queries at `h <= U` can return zero. Before activating
+this voting module:
+
+1. confirm the v30 upgrade/backfill block has committed;
+2. wait until at least `U + 1`;
+3. query `/juno/votingsnapshot/v1/params` and record the live LST allowlist and
+   retention window; and
+4. do not switch an existing DAO while proposals needing pre-activation voting
+   history remain open.
+
+An exported-genesis restart similarly does not preserve earlier snapshot
+history. Treat the restart seed height as a new activation boundary and do not
+carry open proposals that require pre-restart power through such a switch.
+
+This artifact is **fresh-deployment-only with respect to the unreleased
+hook-enabled PR builds**. Those builds used the same `2.8.0-alpha.2` CW2 version
+while exposing different state and wire behavior, so the normal migration guard
+cannot identify them as older releases. Do not migrate an instance created from
+those commits; instantiate this module fresh. The migrate entry point is
+reserved for explicitly versioned, state-compatible future releases with the
+same CW2 contract identity.
+
+## Deploy and instantiate
+
+Store the wasm on a compatible Juno v30 chain, then instantiate it from the DAO
+core with the core contract as admin. The instantiate payload is empty:
+
+```json
+{}
+```
+
+Configure the resulting address as the DAO's voting module. Users continue to
+delegate, undelegate, and redelegate through Juno `x/staking`; this contract has
+no user execute operations. Its standard DAO DAO query surface is:
+
+- `VotingPowerAtHeight`
+- `TotalPowerAtHeight`
+- `Dao` (the DAO core that instantiated this voting module)
+- `Info`
+
+The release-candidate workflow has been exercised on Juno v30 `uni-7`: store,
+instantiate, all four DAO DAO queries, and voter/total-power behavior across a
+real staking change and EndBlock boundary. Release operators must still bind
+that smoke evidence to the exact artifact checksum they intend to deploy.
+
+## Why staking-delta hooks are not exposed
+
+Synchronous hook fanout cannot be implemented correctly with Juno v30's query
+API. `x/cw-hooks` invokes contract sudo synchronously before
+`x/voting-snapshot` persists dirty snapshots in EndBlock, so a current-height
+query from that sudo sees the prior settled value. Delegation-removal events
+also do not identify a delegator's remaining power across other validators,
+and slash or validator bond-status changes can affect many delegators without
+enumerating them.
+
+Consequently this module deliberately exposes no cw-hooks registration, sudo
+staking-event interface, subscriber management, or per-event DAO hooks.
+Downstream consumers must query voting power at the historical height they need
+and must not expect lossless per-delegator callbacks from this module.
+
+## Limitations
+
+- The module is usable only where Juno's v30 custom wasm query API is present.
+- Current queries deliberately use the previous settled Juno snapshot so DAO
+  height semantics remain beginning-of-block and stable throughout the block.
+- Voting-snapshot retention must exceed the maximum proposal lifetime plus an
+  operational margin. Juno v30 defaults retention to `0` (no pruning), but
+  governance can enable a finite window. Pruning retains a carry-forward anchor;
+  queries older than that retained anchor can still return zero.
+- The `Dao` query returns the instantiating address recorded at setup; changing
+  the wasm admin does not change which DAO the voting module belongs to.

--- a/contracts/voting/dao-voting-juno-staked/examples/schema.rs
+++ b/contracts/voting/dao-voting-juno-staked/examples/schema.rs
@@ -1,0 +1,11 @@
+use cosmwasm_schema::write_api;
+use dao_voting_juno_staked::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+
+fn main() {
+    write_api! {
+        instantiate: InstantiateMsg,
+        execute: ExecuteMsg,
+        query: QueryMsg,
+        migrate: MigrateMsg,
+    }
+}

--- a/contracts/voting/dao-voting-juno-staked/schema/dao-voting-juno-staked.json
+++ b/contracts/voting/dao-voting-juno-staked/schema/dao-voting-juno-staked.json
@@ -1,0 +1,206 @@
+{
+  "contract_name": "dao-voting-juno-staked",
+  "contract_version": "2.8.0-alpha.2",
+  "idl_version": "1.0.0",
+  "instantiate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "InstantiateMsg",
+    "type": "object",
+    "additionalProperties": false
+  },
+  "execute": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "ExecuteMsg",
+    "type": "string",
+    "enum": []
+  },
+  "query": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "QueryMsg",
+    "oneOf": [
+      {
+        "description": "Returns the voting power for an address at a given height.",
+        "type": "object",
+        "required": [
+          "voting_power_at_height"
+        ],
+        "properties": {
+          "voting_power_at_height": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "height": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the total voting power at a given block heigh.",
+        "type": "object",
+        "required": [
+          "total_power_at_height"
+        ],
+        "properties": {
+          "total_power_at_height": {
+            "type": "object",
+            "properties": {
+              "height": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns the address of the DAO this module belongs to.",
+        "type": "object",
+        "required": [
+          "dao"
+        ],
+        "properties": {
+          "dao": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Returns contract version info.",
+        "type": "object",
+        "required": [
+          "info"
+        ],
+        "properties": {
+          "info": {
+            "type": "object",
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  },
+  "migrate": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MigrateMsg",
+    "type": "object",
+    "additionalProperties": false
+  },
+  "sudo": null,
+  "responses": {
+    "dao": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Addr",
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "info": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "InfoResponse",
+      "type": "object",
+      "required": [
+        "info"
+      ],
+      "properties": {
+        "info": {
+          "$ref": "#/definitions/ContractVersion"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "ContractVersion": {
+          "type": "object",
+          "required": [
+            "contract",
+            "version"
+          ],
+          "properties": {
+            "contract": {
+              "description": "contract is the crate name of the implementing contract, eg. `crate:cw20-base` we will use other prefixes for other languages, and their standard global namespacing",
+              "type": "string"
+            },
+            "version": {
+              "description": "version is any string that this implementation knows. It may be simple counter \"1\", \"2\". or semantic version on release tags \"v0.7.0\", or some custom feature flag list. the only code that needs to understand the version parsing is code that knows how to migrate from the given contract (and is tied to it's implementation somehow)",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "total_power_at_height": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "TotalPowerAtHeightResponse",
+      "type": "object",
+      "required": [
+        "height",
+        "power"
+      ],
+      "properties": {
+        "height": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "power": {
+          "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "voting_power_at_height": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "VotingPowerAtHeightResponse",
+      "type": "object",
+      "required": [
+        "height",
+        "power"
+      ],
+      "properties": {
+        "height": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "power": {
+          "$ref": "#/definitions/Uint128"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/contracts/voting/dao-voting-juno-staked/src/bindings.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/bindings.rs
@@ -1,0 +1,110 @@
+//! Juno-specific custom wasm bindings consumed by this contract.
+//!
+//! These types mirror the JSON shape produced by
+//! `juno/wasmbindings/types/query.go` byte-for-byte. The chain registers a
+//! `QueryPlugin` that dispatches based on the tagged variant; anything that
+//! doesn't match results in a wasm query error.
+
+use cosmwasm_schema::cw_serde;
+use cosmwasm_std::{CustomQuery, QuerierWrapper, QueryRequest, StdResult, Uint128};
+
+/// Top-level custom query enum. Variants are tagged exactly as the chain
+/// expects (lowercase snake_case via `cw_serde`).
+#[cw_serde]
+#[derive(Eq)]
+pub enum JunoQuery {
+    /// Bonded voting power for `address` at-or-before `height`, excluding
+    /// addresses on Juno's governance-managed LST allowlist. The chain returns
+    /// the most recent snapshot whose recorded height is `<= height`; zero if
+    /// no snapshot exists.
+    VotingPowerAt(VotingPowerAt),
+    /// Total bonded voting power at-or-before `height`.
+    TotalVotingPowerAt(TotalVotingPowerAt),
+    /// Every recorded snapshot for `address` in `[from_height, to_height]`.
+    /// Not used by the voting module itself but exposed here so consumers
+    /// in this workspace can share the binding types.
+    VotingPowerOverRange(VotingPowerOverRange),
+}
+
+impl CustomQuery for JunoQuery {}
+
+#[cw_serde]
+#[derive(Eq)]
+pub struct VotingPowerAt {
+    pub address: String,
+    pub height: i64,
+}
+
+#[cw_serde]
+#[derive(Eq)]
+pub struct TotalVotingPowerAt {
+    pub height: i64,
+}
+
+#[cw_serde]
+#[derive(Eq)]
+pub struct VotingPowerOverRange {
+    pub address: String,
+    pub from_height: i64,
+    pub to_height: i64,
+}
+
+/// Response for both `VotingPowerAt` and `TotalVotingPowerAt`. The chain
+/// emits the bonded amount as a base-10 string sized for uint256 — we
+/// parse to `Uint128` and surface overflow as a query error.
+#[cw_serde]
+pub struct VotingPowerResponse {
+    pub power: String,
+}
+
+#[cw_serde]
+pub struct VotingPowerOverRangeResponse {
+    pub rows: Vec<HeightPower>,
+}
+
+#[cw_serde]
+pub struct HeightPower {
+    pub height: i64,
+    pub power: String,
+}
+
+/// Helpers wrapping the raw `QuerierWrapper<JunoQuery>` so call sites read
+/// like ordinary querier calls.
+pub trait JunoQuerier {
+    fn voting_power_at(&self, address: String, height: u64) -> StdResult<Uint128>;
+    fn total_voting_power_at(&self, height: u64) -> StdResult<Uint128>;
+}
+
+impl<'a> JunoQuerier for QuerierWrapper<'a, JunoQuery> {
+    fn voting_power_at(&self, address: String, height: u64) -> StdResult<Uint128> {
+        let height = query_height(height)?;
+        let req: QueryRequest<JunoQuery> =
+            QueryRequest::Custom(JunoQuery::VotingPowerAt(VotingPowerAt { address, height }));
+        let resp: VotingPowerResponse = self.query(&req)?;
+        parse_power(&resp.power)
+    }
+
+    fn total_voting_power_at(&self, height: u64) -> StdResult<Uint128> {
+        let height = query_height(height)?;
+        let req: QueryRequest<JunoQuery> =
+            QueryRequest::Custom(JunoQuery::TotalVotingPowerAt(TotalVotingPowerAt { height }));
+        let resp: VotingPowerResponse = self.query(&req)?;
+        parse_power(&resp.power)
+    }
+}
+
+fn query_height(height: u64) -> StdResult<i64> {
+    i64::try_from(height).map_err(|_| {
+        cosmwasm_std::StdError::generic_err(format!(
+            "voting-snapshot query height {height} exceeds i64::MAX"
+        ))
+    })
+}
+
+fn parse_power(raw: &str) -> StdResult<Uint128> {
+    raw.parse::<Uint128>().map_err(|e| {
+        cosmwasm_std::StdError::generic_err(format!(
+            "voting-snapshot returned unparseable power '{raw}': {e}"
+        ))
+    })
+}

--- a/contracts/voting/dao-voting-juno-staked/src/contract.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/contract.rs
@@ -1,0 +1,117 @@
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+
+use cosmwasm_std::{to_json_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
+use cw2::{ensure_from_older_version, set_contract_version};
+use dao_interface::voting::{
+    InfoResponse, TotalPowerAtHeightResponse, VotingPowerAtHeightResponse,
+};
+
+use crate::bindings::{JunoQuerier, JunoQuery};
+use crate::error::ContractError;
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+use crate::state::DAO;
+
+pub(crate) const CONTRACT_NAME: &str = "crates.io:dao-voting-juno-staked";
+pub(crate) const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut<JunoQuery>,
+    _env: Env,
+    info: MessageInfo,
+    _msg: InstantiateMsg,
+) -> Result<Response, ContractError> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    DAO.save(deps.storage, &info.sender)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "instantiate")
+        .add_attribute("dao", info.sender))
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(
+    _deps: DepsMut<JunoQuery>,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: ExecuteMsg,
+) -> Result<Response, ContractError> {
+    Err(ContractError::NoExecute {})
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps<JunoQuery>, env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::VotingPowerAtHeight { address, height } => {
+            to_json_binary(&query_voting_power_at_height(deps, env, address, height)?)
+        }
+        QueryMsg::TotalPowerAtHeight { height } => {
+            to_json_binary(&query_total_power_at_height(deps, env, height)?)
+        }
+        QueryMsg::Dao {} => to_json_binary(&DAO.load(deps.storage)?),
+        QueryMsg::Info {} => to_json_binary(&InfoResponse {
+            info: cw2::get_contract_version(deps.storage)?,
+        }),
+    }
+}
+
+fn query_voting_power_at_height(
+    deps: Deps<JunoQuery>,
+    env: Env,
+    address: String,
+    height: Option<u64>,
+) -> StdResult<VotingPowerAtHeightResponse> {
+    let height = height.unwrap_or(env.block.height);
+    let address = deps.api.addr_validate(&address)?;
+    let power = deps
+        .querier
+        .voting_power_at(address.to_string(), snapshot_height(height)?)?;
+    Ok(VotingPowerAtHeightResponse { power, height })
+}
+
+fn query_total_power_at_height(
+    deps: Deps<JunoQuery>,
+    env: Env,
+    height: Option<u64>,
+) -> StdResult<TotalPowerAtHeightResponse> {
+    let height = height.unwrap_or(env.block.height);
+    let power = deps
+        .querier
+        .total_voting_power_at(snapshot_height(height)?)?;
+    Ok(TotalPowerAtHeightResponse { power, height })
+}
+
+/// DAO DAO fixes proposal power at the beginning of proposal block `h`.
+/// Juno records settled staking state at the end of each block, so the
+/// equivalent chain snapshot is `h - 1`. Height zero is retained as zero for
+/// defensive genesis-boundary queries.
+fn snapshot_height(dao_height: u64) -> StdResult<u64> {
+    let snapshot_height = dao_height.saturating_sub(1);
+    i64::try_from(snapshot_height).map_err(|_| {
+        cosmwasm_std::StdError::generic_err(format!(
+            "DAO query height {dao_height} translates to snapshot height \
+             {snapshot_height}, which exceeds i64::MAX"
+        ))
+    })?;
+    Ok(snapshot_height)
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(
+    deps: DepsMut<JunoQuery>,
+    _env: Env,
+    _msg: MigrateMsg,
+) -> Result<Response, ContractError> {
+    let previous = ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+    if previous.to_string() == CONTRACT_VERSION {
+        return Err(cosmwasm_std::StdError::generic_err(format!(
+            "cannot migrate from the current version {CONTRACT_VERSION}"
+        ))
+        .into());
+    }
+    Ok(Response::new()
+        .add_attribute("action", "migrate")
+        .add_attribute("from_version", previous.to_string())
+        .add_attribute("to_version", CONTRACT_VERSION))
+}

--- a/contracts/voting/dao-voting-juno-staked/src/error.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/error.rs
@@ -1,0 +1,11 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ContractError {
+    #[error(transparent)]
+    Std(#[from] StdError),
+
+    #[error("Contract has no execute variants for end users; delegation happens via x/staking")]
+    NoExecute {},
+}

--- a/contracts/voting/dao-voting-juno-staked/src/lib.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/lib.rs
@@ -1,0 +1,13 @@
+#![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
+
+pub mod bindings;
+pub mod contract;
+mod error;
+pub mod msg;
+pub mod state;
+
+#[cfg(test)]
+mod tests;
+
+pub use crate::error::ContractError;
+pub use contract::{execute, instantiate, migrate, query};

--- a/contracts/voting/dao-voting-juno-staked/src/msg.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/msg.rs
@@ -1,0 +1,16 @@
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use dao_dao_macros::voting_module_query;
+
+#[cw_serde]
+pub struct InstantiateMsg {}
+
+#[cw_serde]
+pub enum ExecuteMsg {}
+
+#[voting_module_query]
+#[cw_serde]
+#[derive(QueryResponses)]
+pub enum QueryMsg {}
+
+#[cw_serde]
+pub struct MigrateMsg {}

--- a/contracts/voting/dao-voting-juno-staked/src/state.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/state.rs
@@ -1,0 +1,5 @@
+use cosmwasm_std::Addr;
+use cw_storage_plus::Item;
+
+/// The address of the DAO that instantiated this voting module.
+pub const DAO: Item<Addr> = Item::new("dao");

--- a/contracts/voting/dao-voting-juno-staked/src/tests/mod.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/tests/mod.rs
@@ -1,0 +1,12 @@
+//! Unit tests for `dao-voting-juno-staked`.
+//!
+//! cw-multi-test has no first-class support for our `JunoQuery` custom
+//! binding (the chain's `x/voting-snapshot` keeper isn't present in
+//! integration test stubs), so we wire a small `MockQuerier`-derived
+//! `JunoMockQuerier` that intercepts `QueryRequest::Custom(JunoQuery::..)`
+//! and returns canned snapshot values. That's enough to exercise the
+//! full query paths without needing a chain binary or multitest
+//! module shim.
+
+mod support;
+mod surface;

--- a/contracts/voting/dao-voting-juno-staked/src/tests/support.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/tests/support.rs
@@ -1,0 +1,118 @@
+use std::collections::{BTreeMap, HashMap};
+
+use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage};
+use cosmwasm_std::{
+    from_json, to_json_binary, ContractResult, OwnedDeps, Querier, QuerierResult, QueryRequest,
+    SystemError, SystemResult, Uint128,
+};
+
+use crate::bindings::{JunoQuery, VotingPowerResponse};
+
+pub const DAO_ADDR: &str = "dao-core";
+pub const VOTER_A: &str = "voter-a";
+
+#[derive(Default, Clone)]
+pub struct SnapshotStore {
+    per_addr: HashMap<String, BTreeMap<u64, String>>,
+    total_at: BTreeMap<u64, String>,
+}
+
+impl SnapshotStore {
+    pub fn set_power(&mut self, addr: &str, height: u64, power: u128) {
+        self.set_raw_power(addr, height, &power.to_string());
+    }
+
+    pub fn set_raw_power(&mut self, addr: &str, height: u64, power: &str) {
+        self.per_addr
+            .entry(addr.to_string())
+            .or_default()
+            .insert(height, power.to_string());
+    }
+
+    pub fn set_total(&mut self, height: u64, power: u128) {
+        self.total_at.insert(height, power.to_string());
+    }
+
+    pub fn set_raw_total(&mut self, height: u64, power: &str) {
+        self.total_at.insert(height, power.to_string());
+    }
+
+    fn lookup_addr(&self, addr: &str, height: u64) -> String {
+        self.per_addr
+            .get(addr)
+            .and_then(|snapshots| snapshots.range(..=height).next_back())
+            .map(|(_, power)| power.clone())
+            .unwrap_or_else(|| Uint128::zero().to_string())
+    }
+
+    fn lookup_total(&self, height: u64) -> String {
+        self.total_at
+            .range(..=height)
+            .next_back()
+            .map(|(_, power)| power.clone())
+            .unwrap_or_else(|| Uint128::zero().to_string())
+    }
+}
+
+pub struct JunoMockQuerier {
+    base: MockQuerier,
+    store: SnapshotStore,
+}
+
+impl JunoMockQuerier {
+    pub fn new(store: SnapshotStore) -> Self {
+        let base = MockQuerier::new(&[]);
+        Self { base, store }
+    }
+}
+
+impl Querier for JunoMockQuerier {
+    fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
+        let request: QueryRequest<JunoQuery> = match from_json(bin_request) {
+            Ok(req) => req,
+            Err(e) => {
+                return SystemResult::Err(SystemError::InvalidRequest {
+                    error: format!("parsing query: {e}"),
+                    request: bin_request.into(),
+                })
+            }
+        };
+        match request {
+            QueryRequest::Custom(custom) => self.handle_custom(custom, bin_request),
+            other => self
+                .base
+                .raw_query(&cosmwasm_std::to_json_vec(&other).unwrap()),
+        }
+    }
+}
+
+impl JunoMockQuerier {
+    fn handle_custom(&self, query: JunoQuery, raw: &[u8]) -> QuerierResult {
+        let power = match query {
+            JunoQuery::VotingPowerAt(params) => self
+                .store
+                .lookup_addr(&params.address, params.height as u64),
+            JunoQuery::TotalVotingPowerAt(params) => self.store.lookup_total(params.height as u64),
+            JunoQuery::VotingPowerOverRange(_) => {
+                return SystemResult::Err(SystemError::InvalidRequest {
+                    error: "VotingPowerOverRange not stubbed in tests".to_string(),
+                    request: raw.into(),
+                })
+            }
+        };
+        SystemResult::Ok(ContractResult::Ok(
+            to_json_binary(&VotingPowerResponse { power }).unwrap(),
+        ))
+    }
+}
+
+pub fn juno_deps_with(
+    store: SnapshotStore,
+) -> OwnedDeps<MockStorage, MockApi, JunoMockQuerier, JunoQuery> {
+    OwnedDeps {
+        storage: MockStorage::default(),
+        api: MockApi::default(),
+        querier: JunoMockQuerier::new(store),
+        custom_query_type: std::marker::PhantomData,
+    }
+}

--- a/contracts/voting/dao-voting-juno-staked/src/tests/surface.rs
+++ b/contracts/voting/dao-voting-juno-staked/src/tests/surface.rs
@@ -1,0 +1,292 @@
+use cosmwasm_std::testing::{mock_env, mock_info};
+use cosmwasm_std::{from_json, to_json_vec, Addr, Uint128};
+use cw2::{get_contract_version, set_contract_version};
+use dao_interface::voting::{
+    InfoResponse, TotalPowerAtHeightResponse, VotingPowerAtHeightResponse,
+};
+
+use crate::bindings::{JunoQuery, TotalVotingPowerAt, VotingPowerAt};
+use crate::contract::{instantiate, migrate, query, CONTRACT_NAME, CONTRACT_VERSION};
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg};
+
+use super::support::{juno_deps_with, SnapshotStore, DAO_ADDR, VOTER_A};
+
+fn instantiate_module(
+    deps: &mut cosmwasm_std::OwnedDeps<
+        cosmwasm_std::testing::MockStorage,
+        cosmwasm_std::testing::MockApi,
+        super::support::JunoMockQuerier,
+        crate::bindings::JunoQuery,
+    >,
+) {
+    let response = instantiate(
+        deps.as_mut(),
+        mock_env(),
+        mock_info(DAO_ADDR, &[]),
+        InstantiateMsg {},
+    )
+    .unwrap();
+    assert_eq!(response.attributes[0].value, "instantiate");
+}
+
+#[test]
+fn custom_query_json_matches_juno_v30_wire_format() {
+    assert_eq!(
+        to_json_vec(&JunoQuery::VotingPowerAt(VotingPowerAt {
+            address: VOTER_A.to_string(),
+            height: 41,
+        }))
+        .unwrap(),
+        br#"{"voting_power_at":{"address":"voter-a","height":41}}"#
+    );
+    assert_eq!(
+        to_json_vec(&JunoQuery::TotalVotingPowerAt(TotalVotingPowerAt {
+            height: 41,
+        }))
+        .unwrap(),
+        br#"{"total_voting_power_at":{"height":41}}"#
+    );
+}
+
+#[test]
+fn instantiate_sets_version_and_queries_instantiating_dao_and_info() {
+    let mut deps = juno_deps_with(SnapshotStore::default());
+    instantiate_module(&mut deps);
+
+    assert_eq!(
+        get_contract_version(&deps.storage).unwrap(),
+        cw2::ContractVersion {
+            contract: CONTRACT_NAME.to_string(),
+            version: CONTRACT_VERSION.to_string(),
+        }
+    );
+
+    let dao: Addr = from_json(query(deps.as_ref(), mock_env(), QueryMsg::Dao {}).unwrap()).unwrap();
+    assert_eq!(dao, Addr::unchecked(DAO_ADDR));
+
+    let info: InfoResponse =
+        from_json(query(deps.as_ref(), mock_env(), QueryMsg::Info {}).unwrap()).unwrap();
+    assert_eq!(info.info.contract, CONTRACT_NAME);
+    assert_eq!(info.info.version, CONTRACT_VERSION);
+}
+
+#[test]
+fn all_power_queries_use_beginning_of_block_snapshots() {
+    let mut store = SnapshotStore::default();
+    store.set_power(VOTER_A, 99, 250_000_000);
+    store.set_power(VOTER_A, 249, 300_000_000);
+    store.set_total(99, 1_000_000_000);
+    store.set_total(249, 1_200_000_000);
+    let mut deps = juno_deps_with(store);
+    instantiate_module(&mut deps);
+
+    let mut env = mock_env();
+    env.block.height = 250;
+
+    let historical: VotingPowerAtHeightResponse = from_json(
+        query(
+            deps.as_ref(),
+            env.clone(),
+            QueryMsg::VotingPowerAtHeight {
+                address: VOTER_A.to_string(),
+                height: Some(100),
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(historical.power, Uint128::new(250_000_000));
+    assert_eq!(historical.height, 100);
+
+    let current: VotingPowerAtHeightResponse = from_json(
+        query(
+            deps.as_ref(),
+            env.clone(),
+            QueryMsg::VotingPowerAtHeight {
+                address: VOTER_A.to_string(),
+                height: None,
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(current.power, Uint128::new(300_000_000));
+    assert_eq!(current.height, 250);
+
+    let historical_total: TotalPowerAtHeightResponse = from_json(
+        query(
+            deps.as_ref(),
+            env.clone(),
+            QueryMsg::TotalPowerAtHeight { height: Some(100) },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(historical_total.power, Uint128::new(1_000_000_000));
+    assert_eq!(historical_total.height, 100);
+
+    let current_total: TotalPowerAtHeightResponse = from_json(
+        query(
+            deps.as_ref(),
+            env,
+            QueryMsg::TotalPowerAtHeight { height: None },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(current_total.power, Uint128::new(1_200_000_000));
+    assert_eq!(current_total.height, 250);
+}
+
+#[test]
+fn sparse_snapshots_carry_forward_at_or_before_the_requested_height() {
+    let mut store = SnapshotStore::default();
+    store.set_power(VOTER_A, 99, 250_000_000);
+    store.set_total(99, 1_000_000_000);
+    let deps = juno_deps_with(store);
+
+    let voter: VotingPowerAtHeightResponse = from_json(
+        query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::VotingPowerAtHeight {
+                address: VOTER_A.to_string(),
+                height: Some(150),
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let total: TotalPowerAtHeightResponse = from_json(
+        query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::TotalPowerAtHeight { height: Some(150) },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(voter.power, Uint128::new(250_000_000));
+    assert_eq!(total.power, Uint128::new(1_000_000_000));
+}
+
+#[test]
+fn genesis_boundary_does_not_underflow() {
+    let mut store = SnapshotStore::default();
+    store.set_power(VOTER_A, 0, 7);
+    store.set_total(0, 11);
+    let deps = juno_deps_with(store);
+
+    let voter: VotingPowerAtHeightResponse = from_json(
+        query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::VotingPowerAtHeight {
+                address: VOTER_A.to_string(),
+                height: Some(0),
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let total: TotalPowerAtHeightResponse = from_json(
+        query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::TotalPowerAtHeight { height: Some(0) },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(voter.power, Uint128::new(7));
+    assert_eq!(voter.height, 0);
+    assert_eq!(total.power, Uint128::new(11));
+    assert_eq!(total.height, 0);
+}
+
+#[test]
+fn malformed_overflow_and_out_of_range_chain_values_are_rejected() {
+    let mut malformed = SnapshotStore::default();
+    malformed.set_raw_power(VOTER_A, 6, "not-a-number");
+    let deps = juno_deps_with(malformed);
+    let err = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::VotingPowerAtHeight {
+            address: VOTER_A.to_string(),
+            height: Some(7),
+        },
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("unparseable power"));
+
+    let mut overflow = SnapshotStore::default();
+    overflow.set_raw_total(6, "340282366920938463463374607431768211456");
+    let deps = juno_deps_with(overflow);
+    let err = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::TotalPowerAtHeight { height: Some(7) },
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("unparseable power"));
+
+    let mut boundary = SnapshotStore::default();
+    boundary.set_total(i64::MAX as u64, 42);
+    let deps = juno_deps_with(boundary);
+    let response: TotalPowerAtHeightResponse = from_json(
+        query(
+            deps.as_ref(),
+            mock_env(),
+            QueryMsg::TotalPowerAtHeight {
+                height: Some(i64::MAX as u64 + 1),
+            },
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(response.power, Uint128::new(42));
+
+    let deps = juno_deps_with(SnapshotStore::default());
+    let err = query(
+        deps.as_ref(),
+        mock_env(),
+        QueryMsg::TotalPowerAtHeight {
+            height: Some(i64::MAX as u64 + 2),
+        },
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("exceeds i64::MAX"));
+}
+
+#[test]
+fn execute_schema_has_no_supported_messages() {
+    assert!(from_json::<ExecuteMsg>(br#"{}"#).is_err());
+    assert!(from_json::<ExecuteMsg>(br#"{"add_hook":{"addr":"hook"}}"#).is_err());
+}
+
+#[test]
+fn migration_requires_an_older_matching_contract_and_updates_cw2() {
+    let mut deps = juno_deps_with(SnapshotStore::default());
+    set_contract_version(&mut deps.storage, CONTRACT_NAME, "2.7.0").unwrap();
+    let response = migrate(deps.as_mut(), mock_env(), MigrateMsg {}).unwrap();
+    assert_eq!(response.attributes[0].value, "migrate");
+    assert_eq!(
+        get_contract_version(&deps.storage).unwrap().version,
+        CONTRACT_VERSION
+    );
+
+    let mut mismatch = juno_deps_with(SnapshotStore::default());
+    set_contract_version(&mut mismatch.storage, "wrong-contract", "2.7.0").unwrap();
+    assert!(migrate(mismatch.as_mut(), mock_env(), MigrateMsg {}).is_err());
+
+    let mut same = juno_deps_with(SnapshotStore::default());
+    set_contract_version(&mut same.storage, CONTRACT_NAME, CONTRACT_VERSION).unwrap();
+    assert!(migrate(same.as_mut(), mock_env(), MigrateMsg {}).is_err());
+
+    let mut newer = juno_deps_with(SnapshotStore::default());
+    set_contract_version(&mut newer.storage, CONTRACT_NAME, "99.0.0").unwrap();
+    assert!(migrate(newer.as_mut(), mock_env(), MigrateMsg {}).is_err());
+}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -178,6 +178,10 @@ cd contracts/voting/dao-voting-cw20-staked
 cargo hack publish --no-dev-deps --allow-dirty
 cd "$START_DIR"
 
+cd contracts/voting/dao-voting-juno-staked
+cargo hack publish --no-dev-deps --allow-dirty
+cd "$START_DIR"
+
 cd contracts/voting/dao-voting-cw721-roles
 cargo hack publish --no-dev-deps --allow-dirty
 cd "$START_DIR"


### PR DESCRIPTION
## Summary

Adds a production-hardened `dao-voting-juno-staked` module backed by Juno v30's chain-owned `x/voting-snapshot` history.

This supersedes #929. The original implementation established the custom-query approach, but its synchronous staking hooks could not represent Juno's actual settlement model safely: voting snapshots are finalized in EndBlock, and validator-wide changes cannot be translated losslessly into per-delegator callbacks. This version removes that misleading surface and keeps the contract focused on the thing the chain can answer authoritatively—historical voting power.

## Design

- Exposes the standard DAO DAO voting-module queries: `VotingPowerAtHeight`, `TotalPowerAtHeight`, `Dao`, and `Info`.
- Maps DAO DAO beginning-of-block height `h` to Juno's settled EndBlock snapshot at `h - 1`.
- Preserves the requested DAO height in responses.
- Stores the instantiating DAO and guards migration with CW2 identity/version checks.
- Validates addresses and height conversions and fails closed on malformed or overflowing chain responses.
- Exposes no staking `sudo`, subscriber registry, or synchronous stake-delta hooks.
- Includes Juno v30 wire-format coverage and sparse at-or-before snapshot mocks.
- Documents activation/backfill, exported-genesis, retention, LST allowlist, and fresh-deployment boundaries.
- Registers the crate in the workspace and release publication flow, with repository-standard consolidated schema handling.

## Why `h - 1`

DAO DAO proposal heights represent state at the beginning of block `h`. Juno writes voting snapshots after staking settles in EndBlock. Querying snapshot `h` directly can therefore return different results during and after the same block. Always querying `h - 1` makes proposal creation and later voting deterministic.

## Verification

On this upstream-base branch:

- [x] Rust `1.81.0` formatting check
- [x] `cargo test --locked -p dao-voting-juno-staked` — 8/8 passed
- [x] package clippy with `--all-targets -- -D warnings`
- [x] release Wasm build
- [x] schema regeneration with no tracked drift
- [x] `git diff --check`

The contract tree is byte-for-byte identical to the independently reviewed candidate merged into [`juno-ai-dev/dao-contracts:v3`](https://github.com/juno-ai-dev/dao-contracts/pull/4). That candidate also passed isolated pinned-nightly workspace tests, workspace Wasm, fmt, clippy, schema-clean checks, and reproducible artifact verification.

## Live Juno v30 evidence

The exact contract artifact was exercised on `uni-7`:

- Code ID: `84`
- Contract: `juno1vcawp0gtjghm3wdrr7038z2lkwmx3pj45lefmnx4rt3y4s3xjfzqh83qk7`
- Wasm SHA-256: `a3fea0efb99b408fb57c62efdf0370ccf8321b57dd955faeb0aa471b98a3a456`
- Store tx: `CD905F4B14A30DEB82402A02F17062E6DF1610D18027DEAF923F81D443C70875`
- Instantiate tx: `0C8F10FB2825B6C79B9657114D4A4CA6B811C541DAEC87B70ABB5856EF620118`
- Staking-boundary tx: `4FACCDA038F87A07112131A3E88AE10A3D67094AE64D870502580629CB623AD8`

All four voting-module queries passed. Across the real staking transition at block `D`, native Juno power at `D-1 / D` exactly matched contract power at DAO heights `D / D+1`, for both voter and total power.

## Deployment boundaries

- Treat this as a fresh-deployment module; do not migrate unreleased same-version hook builds.
- If Juno backfills at upgrade height `U`, the earliest supported DAO height is `U + 1`.
- Do not switch an existing DAO while proposals requiring pre-activation history remain open.
- Verify live LST allowlist and snapshot-retention parameters before deployment.
