### PR TITLE
fix(dao-rewards-distributor): apply precision scale before flooring emission (audit Critical 2)

### DIFF
--- a/contracts/distribution/dao-rewards-distributor/src/rewards.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/rewards.rs
@@ -127,8 +127,8 @@ pub fn get_active_total_earned_puvp(
                     new_reward_distribution_duration.ratio(&duration)?;
 
                 let new_rewards_distributed = Uint256::from(amount)
-                    .checked_mul_floor(complete_distribution_periods)?
-                    .checked_mul(scale_factor())?;
+                    .checked_mul(scale_factor())?
+                    .checked_mul_floor(complete_distribution_periods)?;
 
                 // the new rewards per unit voting power that have been
                 // distributed since the last update

--- a/contracts/distribution/dao-rewards-distributor/src/testing/tests.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/testing/tests.rs
@@ -708,6 +708,62 @@ fn test_native_dao_rewards_time_based() {
     suite.stake_native_tokens(ADDR1, addr2_balance);
 }
 
+#[test]
+fn test_small_linear_emission_survives_incremental_accumulator_updates() {
+    let mut suite = SuiteBuilder::base(super::suite::DaoType::CW4)
+        .with_rewards_config(RewardsConfig {
+            amount: 100,
+            denom: UncheckedDenom::Native(GOV_DENOM.to_string()),
+            duration: Duration::Height(200),
+            destination: None,
+            continuous: true,
+        })
+        .with_cw4_members(vec![
+            Member {
+                addr: ADDR0.to_string(),
+                weight: 1,
+            },
+            Member {
+                addr: ADDR1.to_string(),
+                weight: 1,
+            },
+        ])
+        .build();
+
+    // Advance the accumulator once per block through ordinary membership
+    // changes while keeping total voting power constant. Each update emits
+    // half a token, so flooring before applying accumulator precision loses
+    // the entire emission.
+    for height in 0..200 {
+        suite.skip_blocks(1);
+        if height % 2 == 0 {
+            suite.update_members(
+                vec![Member {
+                    addr: ADDR2.to_string(),
+                    weight: 1,
+                }],
+                vec![ADDR1.to_string()],
+            );
+        } else {
+            suite.update_members(
+                vec![Member {
+                    addr: ADDR1.to_string(),
+                    weight: 1,
+                }],
+                vec![ADDR2.to_string()],
+            );
+        }
+    }
+
+    // ADDR0 retained half the voting power throughout the full 100-token
+    // emission. Its accrued share must remain claimable after all incremental
+    // updates consumed the distribution period.
+    suite.assert_pending_rewards(ADDR0, 1, 50);
+    suite.assert_undistributed_rewards(1, 0);
+    suite.claim_rewards(ADDR0, 1);
+    suite.assert_native_balance(ADDR0, GOV_DENOM, 50);
+}
+
 // all of the `+1` corrections highlight rounding
 #[test]
 fn test_native_dao_rewards_time_based_with_rounding() {

--- a/contracts/distribution/dao-rewards-distributor/src/testing/tests.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/testing/tests.rs
@@ -11,6 +11,7 @@ use dao_interface::voting::InfoResponse;
 use dao_testing::{DaoTestingSuite, ADDR0, ADDR1, ADDR2, ADDR3, GOV_DENOM, OWNER};
 
 use crate::contract::{CONTRACT_NAME, CONTRACT_VERSION};
+use crate::helpers::scale_factor;
 use crate::msg::ExecuteMsg;
 use crate::msg::{CreateMsg, FundMsg, InstantiateMsg, MigrateMsg};
 use crate::state::{EmissionRate, Epoch};
@@ -753,13 +754,37 @@ fn test_small_linear_emission_survives_incremental_accumulator_updates() {
                 vec![ADDR2.to_string()],
             );
         }
+
+        if height == 0 {
+            let distribution = suite.get_distribution(1);
+            assert_eq!(
+                distribution.active_epoch.last_updated_total_earned_puvp,
+                Expiration::AtHeight(1)
+            );
+            assert_eq!(
+                distribution.active_epoch.total_earned_puvp,
+                scale_factor().checked_div(Uint256::from(4u8)).unwrap()
+            );
+        }
     }
 
+    let distribution = suite.get_distribution(1);
+    assert_eq!(
+        distribution.active_epoch.last_updated_total_earned_puvp,
+        Expiration::AtHeight(200)
+    );
+    assert_eq!(
+        distribution.active_epoch.total_earned_puvp,
+        scale_factor()
+            .checked_mul(Uint256::from(50u8))
+            .unwrap()
+    );
+
     // ADDR0 retained half the voting power throughout the full 100-token
-    // emission. Its accrued share must remain claimable after all incremental
-    // updates consumed the distribution period.
+    // period. Its accrued share must remain claimable after all incremental
+    // updates consumed that period, even though the much larger funded
+    // distribution remains active.
     suite.assert_pending_rewards(ADDR0, 1, 50);
-    suite.assert_undistributed_rewards(1, 0);
     suite.claim_rewards(ADDR0, 1);
     suite.assert_native_balance(ADDR0, GOV_DENOM, 50);
 }

--- a/contracts/distribution/dao-rewards-distributor/src/testing/tests.rs
+++ b/contracts/distribution/dao-rewards-distributor/src/testing/tests.rs
@@ -775,9 +775,7 @@ fn test_small_linear_emission_survives_incremental_accumulator_updates() {
     );
     assert_eq!(
         distribution.active_epoch.total_earned_puvp,
-        scale_factor()
-            .checked_mul(Uint256::from(50u8))
-            .unwrap()
+        scale_factor().checked_mul(Uint256::from(50u8)).unwrap()
     );
 
     // ADDR0 retained half the voting power throughout the full 100-token


### PR DESCRIPTION
Fixes audit Finding 2 (Critical): "A distribution whose emission is smaller than its duration destroys the emission". This is the surviving failure mode of Oak Security's November 2024 finding 4.

## Root cause

`get_active_total_earned_puvp` computed the rewards emitted since the last update as

```rust
Uint256::from(amount)
    .checked_mul_floor(complete_distribution_periods)?
    .checked_mul(scale_factor())?
```

i.e. it floored to whole tokens **before** applying the 10^39 precision scale factor. Any update covering less than one full emission period (for example an `amount` of 100 over 200 blocks, updated every block by ordinary membership or staking changes) contributed zero, and because the accumulator's clock is advanced unconditionally afterwards, that interval could never contribute again. The emission was destroyed, while `UndistributedRewards` still reported it as distributed.

## Fix

Apply the scale factor before the floor, so truncation happens at the precision the accumulator actually carries:

```rust
Uint256::from(amount)
    .checked_mul(scale_factor())?
    .checked_mul_floor(complete_distribution_periods)?
```

The total credited over any sequence of updates is now within 10^-39 of `amount * elapsed / duration` regardless of update frequency. Claims remain bounded by what `get_rewards_until` reports as distributed (whole-token floor of the same quantity), so `Withdraw` and `UndistributedRewards` cannot pay out more than was credited.

## Tests

`test_small_linear_emission_survives_incremental_accumulator_updates` reproduces the audit scenario: 100 tokens over 200 blocks on a cw4 DAO, with the accumulator advanced once per block by membership changes that keep total voting power constant. It asserts the exact accumulator value after the first block and after 200 blocks, and that a member holding half the voting power can claim 50 tokens. It fails on `development` (accumulator stays at 0) and passes with the fix.

Verified locally: `cargo test -p dao-rewards-distributor` (67 passed), `cargo +nightly-2024-01-08 fmt --all -- --check`, `cargo +nightly-2024-01-08 clippy --all-targets -- -D warnings`.

## Not included (audit follow-ups)

- The audit also suggests optionally rejecting configurations whose emission amount is smaller than its duration. With this fix such configurations work correctly, so no validation is added.
- Finding 12 (High), an interval with no voting power being charged in full, is a separate issue and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBSNZfoCq2XqymbVV9r5rE